### PR TITLE
Add View Adjustment action

### DIFF
--- a/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/imgs/actions/view-adjustment/icon.svg
+++ b/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/imgs/actions/view-adjustment/icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="#ffffff">
+  <!-- Camera lens -->
+  <circle cx="10" cy="9" r="5" stroke-width="1" fill="none"/>
+  <circle cx="10" cy="9" r="2" stroke-width="0.8" fill="none"/>
+  <circle cx="10" cy="9" r="0.8" fill="#ffffff" stroke="none"/>
+  <!-- Adjustment arrows (up/down) -->
+  <path d="M16 6 L16 3 L14.5 4.5" stroke-width="0.8" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M16 12 L16 15 L17.5 13.5" stroke-width="0.8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/imgs/actions/view-adjustment/key.svg
+++ b/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/imgs/actions/view-adjustment/key.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+  <!-- Main background -->
+  <rect x="0" y="0" width="72" height="72" rx="8" fill="#1a2a3a"/>
+
+  <!-- Camera lens -->
+  <circle cx="36" cy="22" r="12" fill="none" stroke="#ffffff" stroke-width="1.5"/>
+  <circle cx="36" cy="22" r="6" fill="none" stroke="#888888" stroke-width="1"/>
+  <circle cx="36" cy="22" r="2" fill="#ffffff"/>
+
+  <!-- Adjustment arrows -->
+  <path d="M56 16 L56 10 L52 14" fill="none" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M56 10 L60 14" fill="none" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M56 28 L56 34 L52 30" fill="none" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M56 34 L60 30" fill="none" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Two-line label -->
+  <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">VIEW</text>
+  <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
+        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">ADJUST</text>
+</svg>

--- a/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/manifest.json
+++ b/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/manifest.json
@@ -66,6 +66,28 @@
           "FontSize": 14
         }
       ]
+    },
+    {
+      "Name": "View Adjustment",
+      "UUID": "com.iracedeck.sd.core.view-adjustment",
+      "Icon": "imgs/actions/view-adjustment/icon",
+      "Tooltip": "Adjust camera and view settings (FOV, horizon, driver height, VR recenter, UI size)",
+      "PropertyInspectorPath": "ui/view-adjustment.html",
+      "Controllers": ["Keypad", "Encoder"],
+      "Encoder": {
+        "layout": "$B1",
+        "TriggerDescription": {
+          "Rotate": "Increase/Decrease adjustment",
+          "Press": "Activate adjustment"
+        }
+      },
+      "States": [
+        {
+          "Image": "imgs/actions/view-adjustment/key",
+          "TitleAlignment": "bottom",
+          "FontSize": 14
+        }
+      ]
     }
   ],
   "Category": "iRaceDeck Core",

--- a/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/ui/view-adjustment.html
+++ b/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/ui/view-adjustment.html
@@ -1,0 +1,164 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+<script src="sdpi-components.js"></script>
+<script src="pi-components.js"></script>
+<style>
+  .hidden {
+    display: none !important;
+  }
+
+  /* Collapsible section styles */
+  .ird-collapsible {
+    margin-top: 12px;
+  }
+
+  .ird-collapsible-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 0 4px 0;
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+    border-top: 1px solid #3a3a3a;
+  }
+
+  .ird-collapsible-header::-webkit-details-marker {
+    display: none;
+  }
+
+  .ird-collapsible-icon {
+    font-size: 8px;
+    color: #808080;
+    transition: transform 0.15s ease;
+    flex-shrink: 0;
+  }
+
+  .ird-collapsible[open] .ird-collapsible-icon {
+    transform: rotate(90deg);
+  }
+
+  .ird-collapsible-title {
+    font-family: "Segoe UI", Arial, Roboto, Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 9pt;
+    font-weight: 600;
+    color: #ffffff;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .ird-collapsible-content {
+    padding-top: 4px;
+  }
+
+  .ird-section-subtitle {
+    font-family: "Segoe UI", Arial, Roboto, Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 9pt;
+    color: #d0d0d0;
+    margin: 8px 0 4px 14px;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+  }
+</style>
+
+	</head>
+	<body>
+		<sdpi-item label="Adjustment">
+			<sdpi-select id="adjustment-select" setting="adjustment" default="fov">
+				<option value="fov">FOV</option>
+				<option value="horizon">Horizon</option>
+				<option value="driver-height">Driver Height</option>
+				<option value="recenter-vr">Recenter VR</option>
+				<option value="ui-size">UI Size</option>
+			</sdpi-select>
+		</sdpi-item>
+
+		<sdpi-item label="Direction" id="direction-item">
+			<sdpi-select setting="direction" default="increase">
+				<option value="increase">Increase</option>
+				<option value="decrease">Decrease</option>
+			</sdpi-select>
+		</sdpi-item>
+
+		<!-- Global Key Bindings section -->
+		<!--
+  Global Key Bindings Component
+
+  Displays key binding inputs in a collapsible "Global Settings" section.
+  Key bindings are stored in global settings (shared across all action instances).
+
+  Parameters:
+    - subtitle: String (optional) - Section subtitle (e.g., "Black Box Key Bindings")
+    - keyBindings: Array with objects containing id, label, default, setting
+    - open: Boolean (optional) - Whether to start expanded (default: false)
+-->
+
+
+
+<!--
+  Collapsible Component - A collapsible section with divider and arrow.
+  Parameters: title (String), content (HTML String), open (Boolean, optional)
+-->
+<details class="ird-collapsible" >
+  <summary class="ird-collapsible-header">
+    <span class="ird-collapsible-icon">&#9654;</span>
+    <span class="ird-collapsible-title">Global Settings</span>
+  </summary>
+  <div class="ird-collapsible-content">
+    <div class="ird-section-subtitle">View Adjustment Key Bindings</div><sdpi-item label="FOV Increase"><ird-key-binding setting="viewAdjustFovIncrease" default="]" global></ird-key-binding></sdpi-item><sdpi-item label="FOV Decrease"><ird-key-binding setting="viewAdjustFovDecrease" default="[" global></ird-key-binding></sdpi-item><sdpi-item label="Horizon Up"><ird-key-binding setting="viewAdjustHorizonUp" default="Shift+]" global></ird-key-binding></sdpi-item><sdpi-item label="Horizon Down"><ird-key-binding setting="viewAdjustHorizonDown" default="Shift+[" global></ird-key-binding></sdpi-item><sdpi-item label="Driver Height Up"><ird-key-binding setting="viewAdjustDriverHeightUp" default="Ctrl+]" global></ird-key-binding></sdpi-item><sdpi-item label="Driver Height Down"><ird-key-binding setting="viewAdjustDriverHeightDown" default="Ctrl+[" global></ird-key-binding></sdpi-item><sdpi-item label="Recenter VR"><ird-key-binding setting="viewAdjustRecenterVr" default=";" global></ird-key-binding></sdpi-item><sdpi-item label="UI Size Increase"><ird-key-binding setting="viewAdjustUiSizeIncrease" default="Ctrl+PageUp" global></ird-key-binding></sdpi-item><sdpi-item label="UI Size Decrease"><ird-key-binding setting="viewAdjustUiSizeDecrease" default="Ctrl+PageDown" global></ird-key-binding></sdpi-item>
+  </div>
+</details>
+
+
+
+		<script>
+			function updateVisibility(adjustment) {
+				const directionItem = document.getElementById("direction-item");
+				if (!directionItem) return;
+
+				// Hide direction dropdown when Recenter VR is selected
+				directionItem.classList.toggle("hidden", adjustment === "recenter-vr");
+			}
+
+			async function initialize() {
+				await customElements.whenDefined("sdpi-select");
+
+				const adjustmentSelect = document.getElementById("adjustment-select");
+
+				if (adjustmentSelect) {
+					const initialValue = adjustmentSelect.value || "fov";
+					updateVisibility(initialValue);
+
+					adjustmentSelect.addEventListener("change", (ev) => {
+						updateVisibility(ev.target.value || "fov");
+					});
+					adjustmentSelect.addEventListener("input", (ev) => {
+						updateVisibility(ev.target.value || "fov");
+					});
+
+					// Polling fallback for reliable detection
+					let lastValue = adjustmentSelect.value || "fov";
+					setInterval(() => {
+						const currentValue = adjustmentSelect.value;
+						if (currentValue && currentValue !== lastValue) {
+							lastValue = currentValue;
+							updateVisibility(currentValue);
+						}
+					}, 100);
+				}
+			}
+
+			if (document.readyState === "loading") {
+				document.addEventListener("DOMContentLoaded", initialize);
+			} else {
+				initialize();
+			}
+		</script>
+
+		<style>
+			.hidden { display: none !important; }
+		</style>
+	</body>
+</html>

--- a/packages/stream-deck-plugin-core/icons/view-adjustment.svg
+++ b/packages/stream-deck-plugin-core/icons/view-adjustment.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+  <g filter="url(#activity-state)">
+    <!-- Main background -->
+    <rect x="0" y="0" width="72" height="72" rx="8" fill="#1a2a3a"/>
+
+    <!-- Icon content area: y=8 to y=40 -->
+{{iconContent}}
+
+    <!-- Two-line label: line1 primary on top, line2 secondary on bottom -->
+    <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">{{labelLine1}}</text>
+    <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
+          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">{{labelLine2}}</text>
+  </g>
+</svg>

--- a/packages/stream-deck-plugin-core/src/actions/view-adjustment.test.ts
+++ b/packages/stream-deck-plugin-core/src/actions/view-adjustment.test.ts
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { generateViewAdjustmentSvg, VIEW_ADJUSTMENT_GLOBAL_KEYS } from "./view-adjustment.js";
+
+vi.mock("@elgato/streamdeck", () => ({
+  default: {
+    logger: {
+      createScope: vi.fn(() => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trace: vi.fn(),
+      })),
+    },
+  },
+  action: () => (target: unknown) => target,
+}));
+
+vi.mock("@iracedeck/stream-deck-shared", () => ({
+  ConnectionStateAwareAction: class MockConnectionStateAwareAction {
+    sdkController = { subscribe: vi.fn(), unsubscribe: vi.fn(), getCurrentTelemetry: vi.fn() };
+    updateConnectionState = vi.fn();
+    setKeyImage = vi.fn();
+  },
+  createSDLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+  })),
+  formatKeyBinding: vi.fn((b: { key: string; modifiers: string[] }) => {
+    if (b.modifiers?.length) {
+      return `${b.modifiers.join("+")}+${b.key}`;
+    }
+
+    return b.key;
+  }),
+  getGlobalSettings: vi.fn(() => ({})),
+  getKeyboard: vi.fn(() => ({
+    sendKeyCombination: vi.fn().mockResolvedValue(true),
+  })),
+  LogLevel: { Info: 2 },
+  parseKeyBinding: vi.fn(),
+  renderIconTemplate: vi.fn((_template: string, data: Record<string, string>) => {
+    return `<svg>${data.iconContent || ""}${data.labelLine1 || ""}${data.labelLine2 || ""}</svg>`;
+  }),
+  svgToDataUri: vi.fn((svg: string) => `data:image/svg+xml,${encodeURIComponent(svg)}`),
+}));
+
+describe("ViewAdjustment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("VIEW_ADJUSTMENT_GLOBAL_KEYS", () => {
+    it("should have correct mapping for fov increase", () => {
+      expect(VIEW_ADJUSTMENT_GLOBAL_KEYS.fov.increase).toBe("viewAdjustFovIncrease");
+    });
+
+    it("should have correct mapping for fov decrease", () => {
+      expect(VIEW_ADJUSTMENT_GLOBAL_KEYS.fov.decrease).toBe("viewAdjustFovDecrease");
+    });
+
+    it("should have correct mapping for horizon up", () => {
+      expect(VIEW_ADJUSTMENT_GLOBAL_KEYS.horizon.increase).toBe("viewAdjustHorizonUp");
+    });
+
+    it("should have correct mapping for horizon down", () => {
+      expect(VIEW_ADJUSTMENT_GLOBAL_KEYS.horizon.decrease).toBe("viewAdjustHorizonDown");
+    });
+
+    it("should have correct mapping for driver height up", () => {
+      expect(VIEW_ADJUSTMENT_GLOBAL_KEYS["driver-height"].increase).toBe("viewAdjustDriverHeightUp");
+    });
+
+    it("should have correct mapping for driver height down", () => {
+      expect(VIEW_ADJUSTMENT_GLOBAL_KEYS["driver-height"].decrease).toBe("viewAdjustDriverHeightDown");
+    });
+
+    it("should have correct mapping for recenter VR", () => {
+      expect(VIEW_ADJUSTMENT_GLOBAL_KEYS["recenter-vr"].increase).toBe("viewAdjustRecenterVr");
+      expect(VIEW_ADJUSTMENT_GLOBAL_KEYS["recenter-vr"].decrease).toBe("viewAdjustRecenterVr");
+    });
+
+    it("should have correct mapping for UI size increase", () => {
+      expect(VIEW_ADJUSTMENT_GLOBAL_KEYS["ui-size"].increase).toBe("viewAdjustUiSizeIncrease");
+    });
+
+    it("should have correct mapping for UI size decrease", () => {
+      expect(VIEW_ADJUSTMENT_GLOBAL_KEYS["ui-size"].decrease).toBe("viewAdjustUiSizeDecrease");
+    });
+
+    it("should have exactly 5 adjustment types", () => {
+      expect(Object.keys(VIEW_ADJUSTMENT_GLOBAL_KEYS)).toHaveLength(5);
+    });
+
+    it("should have increase and decrease for each adjustment type", () => {
+      for (const adjustment of Object.values(VIEW_ADJUSTMENT_GLOBAL_KEYS)) {
+        expect(adjustment).toHaveProperty("increase");
+        expect(adjustment).toHaveProperty("decrease");
+      }
+    });
+  });
+
+  describe("generateViewAdjustmentSvg", () => {
+    it("should generate a valid data URI for fov increase", () => {
+      const result = generateViewAdjustmentSvg({ adjustment: "fov", direction: "increase" });
+
+      expect(result).toContain("data:image/svg+xml");
+    });
+
+    it("should generate a valid data URI for recenter-vr", () => {
+      const result = generateViewAdjustmentSvg({
+        adjustment: "recenter-vr",
+        direction: "increase",
+      });
+
+      expect(result).toContain("data:image/svg+xml");
+    });
+
+    it("should generate valid data URIs for all adjustment + direction combinations", () => {
+      const adjustments = ["fov", "horizon", "driver-height", "recenter-vr", "ui-size"] as const;
+      const directions = ["increase", "decrease"] as const;
+
+      for (const adjustment of adjustments) {
+        for (const direction of directions) {
+          const result = generateViewAdjustmentSvg({ adjustment, direction });
+          expect(result).toContain("data:image/svg+xml");
+        }
+      }
+    });
+
+    it("should produce different icons for different adjustments", () => {
+      const fov = generateViewAdjustmentSvg({ adjustment: "fov", direction: "increase" });
+      const horizon = generateViewAdjustmentSvg({ adjustment: "horizon", direction: "increase" });
+
+      expect(fov).not.toBe(horizon);
+    });
+
+    it("should produce different icons for increase vs decrease", () => {
+      const increase = generateViewAdjustmentSvg({ adjustment: "fov", direction: "increase" });
+      const decrease = generateViewAdjustmentSvg({ adjustment: "fov", direction: "decrease" });
+
+      expect(increase).not.toBe(decrease);
+    });
+
+    it("should produce the same icon for recenter-vr regardless of direction", () => {
+      const increase = generateViewAdjustmentSvg({
+        adjustment: "recenter-vr",
+        direction: "increase",
+      });
+      const decrease = generateViewAdjustmentSvg({
+        adjustment: "recenter-vr",
+        direction: "decrease",
+      });
+
+      expect(increase).toBe(decrease);
+    });
+
+    it("should include correct labels for FOV increase", () => {
+      const result = generateViewAdjustmentSvg({ adjustment: "fov", direction: "increase" });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain("FOV");
+      expect(decoded).toContain("INCREASE");
+    });
+
+    it("should include correct labels for horizon down", () => {
+      const result = generateViewAdjustmentSvg({ adjustment: "horizon", direction: "decrease" });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain("HORIZON");
+      expect(decoded).toContain("DOWN");
+    });
+
+    it("should include correct labels for recenter VR", () => {
+      const result = generateViewAdjustmentSvg({
+        adjustment: "recenter-vr",
+        direction: "increase",
+      });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain("RECENTER");
+      expect(decoded).toContain("VR");
+    });
+
+    it("should include correct labels for all combinations", () => {
+      const expectedLabels: Record<string, Record<string, { line1: string; line2: string }>> = {
+        fov: {
+          increase: { line1: "FOV", line2: "INCREASE" },
+          decrease: { line1: "FOV", line2: "DECREASE" },
+        },
+        horizon: {
+          increase: { line1: "HORIZON", line2: "UP" },
+          decrease: { line1: "HORIZON", line2: "DOWN" },
+        },
+        "driver-height": {
+          increase: { line1: "DRIVER", line2: "HEIGHT UP" },
+          decrease: { line1: "DRIVER", line2: "HEIGHT DN" },
+        },
+        "recenter-vr": {
+          increase: { line1: "RECENTER", line2: "VR" },
+          decrease: { line1: "RECENTER", line2: "VR" },
+        },
+        "ui-size": {
+          increase: { line1: "UI SIZE", line2: "INCREASE" },
+          decrease: { line1: "UI SIZE", line2: "DECREASE" },
+        },
+      };
+
+      for (const [adjustment, directions] of Object.entries(expectedLabels)) {
+        for (const [direction, labels] of Object.entries(directions)) {
+          const result = generateViewAdjustmentSvg({
+            adjustment: adjustment as any,
+            direction: direction as any,
+          });
+          const decoded = decodeURIComponent(result);
+
+          expect(decoded).toContain(labels.line1);
+          expect(decoded).toContain(labels.line2);
+        }
+      }
+    });
+  });
+});

--- a/packages/stream-deck-plugin-core/src/actions/view-adjustment.ts
+++ b/packages/stream-deck-plugin-core/src/actions/view-adjustment.ts
@@ -1,0 +1,312 @@
+import streamDeck, {
+  action,
+  DialDownEvent,
+  DialRotateEvent,
+  DidReceiveSettingsEvent,
+  KeyDownEvent,
+  WillAppearEvent,
+  WillDisappearEvent,
+} from "@elgato/streamdeck";
+import {
+  ConnectionStateAwareAction,
+  createSDLogger,
+  formatKeyBinding,
+  getGlobalSettings,
+  getKeyboard,
+  type KeyBindingValue,
+  type KeyboardKey,
+  type KeyboardModifier,
+  type KeyCombination,
+  LogLevel,
+  parseKeyBinding,
+  renderIconTemplate,
+  svgToDataUri,
+} from "@iracedeck/stream-deck-shared";
+import z from "zod";
+
+import viewAdjustmentTemplate from "../../icons/view-adjustment.svg";
+
+const WHITE = "#ffffff";
+const GRAY = "#888888";
+
+type AdjustmentType = "fov" | "horizon" | "driver-height" | "recenter-vr" | "ui-size";
+type DirectionType = "increase" | "decrease";
+
+/**
+ * Label configuration for each adjustment + direction combination (line1 bold, line2 subdued)
+ */
+const VIEW_ADJUSTMENT_LABELS: Record<AdjustmentType, Record<DirectionType, { line1: string; line2: string }>> = {
+  fov: {
+    increase: { line1: "FOV", line2: "INCREASE" },
+    decrease: { line1: "FOV", line2: "DECREASE" },
+  },
+  horizon: {
+    increase: { line1: "HORIZON", line2: "UP" },
+    decrease: { line1: "HORIZON", line2: "DOWN" },
+  },
+  "driver-height": {
+    increase: { line1: "DRIVER", line2: "HEIGHT UP" },
+    decrease: { line1: "DRIVER", line2: "HEIGHT DN" },
+  },
+  "recenter-vr": {
+    increase: { line1: "RECENTER", line2: "VR" },
+    decrease: { line1: "RECENTER", line2: "VR" },
+  },
+  "ui-size": {
+    increase: { line1: "UI SIZE", line2: "INCREASE" },
+    decrease: { line1: "UI SIZE", line2: "DECREASE" },
+  },
+};
+
+/**
+ * SVG icon content for each adjustment type.
+ * FOV, Horizon, and Driver Height show directional arrows; Recenter VR and UI Size are non-directional.
+ */
+const VIEW_ADJUSTMENT_ICONS: Record<AdjustmentType, Record<DirectionType, string>> = {
+  // FOV: Camera lens with zoom in/out arrows
+  fov: {
+    increase: `
+    <circle cx="36" cy="22" r="12" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <circle cx="36" cy="22" r="6" fill="none" stroke="${GRAY}" stroke-width="1"/>
+    <circle cx="36" cy="22" r="2" fill="${WHITE}"/>
+    <path d="M52 30 L58 36" stroke="${WHITE}" stroke-width="2" stroke-linecap="round"/>
+    <line x1="54" y1="38" x2="60" y2="38" stroke="${GRAY}" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="57" y1="35" x2="57" y2="41" stroke="${GRAY}" stroke-width="1.5" stroke-linecap="round"/>`,
+    decrease: `
+    <circle cx="36" cy="22" r="12" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <circle cx="36" cy="22" r="6" fill="none" stroke="${GRAY}" stroke-width="1"/>
+    <circle cx="36" cy="22" r="2" fill="${WHITE}"/>
+    <path d="M52 30 L58 36" stroke="${WHITE}" stroke-width="2" stroke-linecap="round"/>
+    <line x1="54" y1="38" x2="60" y2="38" stroke="${GRAY}" stroke-width="1.5" stroke-linecap="round"/>`,
+  },
+  // Horizon: Horizon line with up/down arrow
+  horizon: {
+    increase: `
+    <line x1="10" y1="24" x2="62" y2="24" stroke="${GRAY}" stroke-width="1.5"/>
+    <line x1="14" y1="30" x2="58" y2="30" stroke="${GRAY}" stroke-width="1" opacity="0.5"/>
+    <path d="M36 20 L32 16 M36 20 L40 16" fill="none" stroke="${WHITE}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="36" y1="20" x2="36" y2="36" stroke="${WHITE}" stroke-width="2" stroke-linecap="round"/>`,
+    decrease: `
+    <line x1="10" y1="24" x2="62" y2="24" stroke="${GRAY}" stroke-width="1.5"/>
+    <line x1="14" y1="18" x2="58" y2="18" stroke="${GRAY}" stroke-width="1" opacity="0.5"/>
+    <path d="M36 32 L32 36 M36 32 L40 36" fill="none" stroke="${WHITE}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="36" y1="16" x2="36" y2="32" stroke="${WHITE}" stroke-width="2" stroke-linecap="round"/>`,
+  },
+  // Driver Height: Seat silhouette with up/down arrow
+  "driver-height": {
+    increase: `
+    <rect x="26" y="18" width="20" height="20" rx="3" fill="none" stroke="${GRAY}" stroke-width="1.5"/>
+    <circle cx="36" cy="14" r="4" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <line x1="36" y1="18" x2="36" y2="30" stroke="${WHITE}" stroke-width="1.5"/>
+    <path d="M14 20 L10 16 M14 20 L18 16" fill="none" stroke="${WHITE}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="14" y1="20" x2="14" y2="36" stroke="${WHITE}" stroke-width="2" stroke-linecap="round"/>`,
+    decrease: `
+    <rect x="26" y="18" width="20" height="20" rx="3" fill="none" stroke="${GRAY}" stroke-width="1.5"/>
+    <circle cx="36" cy="14" r="4" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <line x1="36" y1="18" x2="36" y2="30" stroke="${WHITE}" stroke-width="1.5"/>
+    <path d="M14 32 L10 36 M14 32 L18 36" fill="none" stroke="${WHITE}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="14" y1="16" x2="14" y2="32" stroke="${WHITE}" stroke-width="2" stroke-linecap="round"/>`,
+  },
+  // Recenter VR: VR headset with crosshair (same for both directions)
+  "recenter-vr": {
+    increase: `
+    <rect x="16" y="14" width="40" height="20" rx="6" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <line x1="36" y1="14" x2="36" y2="34" stroke="${GRAY}" stroke-width="0.5"/>
+    <circle cx="28" cy="24" r="6" fill="none" stroke="${GRAY}" stroke-width="1"/>
+    <circle cx="44" cy="24" r="6" fill="none" stroke="${GRAY}" stroke-width="1"/>
+    <line x1="36" y1="8" x2="36" y2="12" stroke="${WHITE}" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="36" y1="36" x2="36" y2="40" stroke="${WHITE}" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="10" y1="24" x2="14" y2="24" stroke="${WHITE}" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="58" y1="24" x2="62" y2="24" stroke="${WHITE}" stroke-width="1.5" stroke-linecap="round"/>`,
+    decrease: `
+    <rect x="16" y="14" width="40" height="20" rx="6" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <line x1="36" y1="14" x2="36" y2="34" stroke="${GRAY}" stroke-width="0.5"/>
+    <circle cx="28" cy="24" r="6" fill="none" stroke="${GRAY}" stroke-width="1"/>
+    <circle cx="44" cy="24" r="6" fill="none" stroke="${GRAY}" stroke-width="1"/>
+    <line x1="36" y1="8" x2="36" y2="12" stroke="${WHITE}" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="36" y1="36" x2="36" y2="40" stroke="${WHITE}" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="10" y1="24" x2="14" y2="24" stroke="${WHITE}" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="58" y1="24" x2="62" y2="24" stroke="${WHITE}" stroke-width="1.5" stroke-linecap="round"/>`,
+  },
+  // UI Size: Window frame with scale arrows
+  "ui-size": {
+    increase: `
+    <rect x="16" y="12" width="40" height="26" rx="2" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <line x1="16" y1="18" x2="56" y2="18" stroke="${GRAY}" stroke-width="1"/>
+    <circle cx="20" cy="15" r="1" fill="${GRAY}"/>
+    <circle cx="24" cy="15" r="1" fill="${GRAY}"/>
+    <path d="M54 36 L60 42 M60 36 L60 42 L54 42" fill="none" stroke="${WHITE}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>`,
+    decrease: `
+    <rect x="16" y="12" width="40" height="26" rx="2" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <line x1="16" y1="18" x2="56" y2="18" stroke="${GRAY}" stroke-width="1"/>
+    <circle cx="20" cy="15" r="1" fill="${GRAY}"/>
+    <circle cx="24" cy="15" r="1" fill="${GRAY}"/>
+    <path d="M60 42 L54 36 M54 42 L54 36 L60 36" fill="none" stroke="${WHITE}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>`,
+  },
+};
+
+/**
+ * @internal Exported for testing
+ *
+ * Mapping from adjustment + direction to global settings keys.
+ */
+export const VIEW_ADJUSTMENT_GLOBAL_KEYS: Record<AdjustmentType, Record<DirectionType, string>> = {
+  fov: {
+    increase: "viewAdjustFovIncrease",
+    decrease: "viewAdjustFovDecrease",
+  },
+  horizon: {
+    increase: "viewAdjustHorizonUp",
+    decrease: "viewAdjustHorizonDown",
+  },
+  "driver-height": {
+    increase: "viewAdjustDriverHeightUp",
+    decrease: "viewAdjustDriverHeightDown",
+  },
+  "recenter-vr": {
+    increase: "viewAdjustRecenterVr",
+    decrease: "viewAdjustRecenterVr",
+  },
+  "ui-size": {
+    increase: "viewAdjustUiSizeIncrease",
+    decrease: "viewAdjustUiSizeDecrease",
+  },
+};
+
+const ViewAdjustmentSettings = z.object({
+  adjustment: z.enum(["fov", "horizon", "driver-height", "recenter-vr", "ui-size"]).default("fov"),
+  direction: z.enum(["increase", "decrease"]).default("increase"),
+});
+
+type ViewAdjustmentSettings = z.infer<typeof ViewAdjustmentSettings>;
+
+/**
+ * @internal Exported for testing
+ *
+ * Generates an SVG data URI icon for the view adjustment action.
+ */
+export function generateViewAdjustmentSvg(settings: ViewAdjustmentSettings): string {
+  const { adjustment, direction } = settings;
+
+  const iconContent = VIEW_ADJUSTMENT_ICONS[adjustment]?.[direction] || VIEW_ADJUSTMENT_ICONS.fov.increase;
+  const labels = VIEW_ADJUSTMENT_LABELS[adjustment]?.[direction] || VIEW_ADJUSTMENT_LABELS.fov.increase;
+
+  const svg = renderIconTemplate(viewAdjustmentTemplate, {
+    iconContent,
+    labelLine1: labels.line1,
+    labelLine2: labels.line2,
+  });
+
+  return svgToDataUri(svg);
+}
+
+/**
+ * View Adjustment Action
+ * Adjusts camera/view settings (FOV, horizon, driver height, VR recentering, UI size) via keyboard shortcuts.
+ */
+@action({ UUID: "com.iracedeck.sd.core.view-adjustment" })
+export class ViewAdjustment extends ConnectionStateAwareAction<ViewAdjustmentSettings> {
+  protected override logger = createSDLogger(streamDeck.logger.createScope("ViewAdjustment"), LogLevel.Info);
+
+  override async onWillAppear(ev: WillAppearEvent<ViewAdjustmentSettings>): Promise<void> {
+    const settings = this.parseSettings(ev.payload.settings);
+    await this.updateDisplay(ev, settings);
+
+    this.sdkController.subscribe(ev.action.id, () => {
+      this.updateConnectionState();
+    });
+  }
+
+  override async onWillDisappear(ev: WillDisappearEvent<ViewAdjustmentSettings>): Promise<void> {
+    await super.onWillDisappear(ev);
+    this.sdkController.unsubscribe(ev.action.id);
+  }
+
+  override async onDidReceiveSettings(ev: DidReceiveSettingsEvent<ViewAdjustmentSettings>): Promise<void> {
+    const settings = this.parseSettings(ev.payload.settings);
+    await this.updateDisplay(ev, settings);
+  }
+
+  override async onKeyDown(ev: KeyDownEvent<ViewAdjustmentSettings>): Promise<void> {
+    this.logger.info("Key down received");
+    const settings = this.parseSettings(ev.payload.settings);
+    await this.executeAdjustment(settings.adjustment, settings.direction);
+  }
+
+  override async onDialDown(ev: DialDownEvent<ViewAdjustmentSettings>): Promise<void> {
+    this.logger.info("Dial down received");
+    const settings = this.parseSettings(ev.payload.settings);
+    await this.executeAdjustment(settings.adjustment, settings.direction);
+  }
+
+  override async onDialRotate(ev: DialRotateEvent<ViewAdjustmentSettings>): Promise<void> {
+    this.logger.info("Dial rotated");
+    const settings = this.parseSettings(ev.payload.settings);
+
+    // Recenter VR has no directional adjustment — ignore rotation
+    if (settings.adjustment === "recenter-vr") {
+      this.logger.debug("Rotation ignored for Recenter VR");
+
+      return;
+    }
+
+    // Clockwise (ticks > 0) = increase, Counter-clockwise (ticks < 0) = decrease
+    const direction: DirectionType = ev.payload.ticks > 0 ? "increase" : "decrease";
+    await this.executeAdjustment(settings.adjustment, direction);
+  }
+
+  private parseSettings(settings: unknown): ViewAdjustmentSettings {
+    const parsed = ViewAdjustmentSettings.safeParse(settings);
+
+    return parsed.success ? parsed.data : ViewAdjustmentSettings.parse({});
+  }
+
+  private async executeAdjustment(adjustment: AdjustmentType, direction: DirectionType): Promise<void> {
+    const settingKey = VIEW_ADJUSTMENT_GLOBAL_KEYS[adjustment]?.[direction];
+
+    if (!settingKey) {
+      this.logger.warn(`No global key mapping for ${adjustment} ${direction}`);
+
+      return;
+    }
+
+    const globalSettings = getGlobalSettings() as Record<string, unknown>;
+    const binding = parseKeyBinding(globalSettings[settingKey]);
+
+    if (!binding?.key) {
+      this.logger.warn(`No key binding configured for ${settingKey}`);
+
+      return;
+    }
+
+    await this.sendKeyBinding(binding);
+  }
+
+  private async sendKeyBinding(binding: KeyBindingValue): Promise<void> {
+    const combination: KeyCombination = {
+      key: binding.key as KeyboardKey,
+      modifiers: binding.modifiers.length > 0 ? (binding.modifiers as KeyboardModifier[]) : undefined,
+    };
+
+    const success = await getKeyboard().sendKeyCombination(combination);
+
+    if (success) {
+      this.logger.info("Key sent successfully");
+      this.logger.debug(`Key combination: ${formatKeyBinding(binding)}`);
+    } else {
+      this.logger.warn("Failed to send key");
+      this.logger.debug(`Failed key combination: ${formatKeyBinding(binding)}`);
+    }
+  }
+
+  private async updateDisplay(
+    ev: WillAppearEvent<ViewAdjustmentSettings> | DidReceiveSettingsEvent<ViewAdjustmentSettings>,
+    settings: ViewAdjustmentSettings,
+  ): Promise<void> {
+    this.updateConnectionState();
+
+    const svgDataUri = generateViewAdjustmentSvg(settings);
+    await ev.action.setTitle("");
+    await this.setKeyImage(ev, svgDataUri);
+  }
+}

--- a/packages/stream-deck-plugin-core/src/pi/data/key-bindings.json
+++ b/packages/stream-deck-plugin-core/src/pi/data/key-bindings.json
@@ -32,5 +32,36 @@
     { "id": "virtualMirror", "label": "Virtual Mirror", "default": "Alt+M", "setting": "toggleUiVirtualMirror" },
     { "id": "uiEditMode", "label": "UI Edit Mode", "default": "Alt+K", "setting": "toggleUiEditMode" },
     { "id": "displayRefCar", "label": "Display Reference Car", "default": "Ctrl+C", "setting": "toggleUiDisplayRefCar" }
+  ],
+  "viewAdjustment": [
+    { "id": "fovIncrease", "label": "FOV Increase", "default": "]", "setting": "viewAdjustFovIncrease" },
+    { "id": "fovDecrease", "label": "FOV Decrease", "default": "[", "setting": "viewAdjustFovDecrease" },
+    { "id": "horizonUp", "label": "Horizon Up", "default": "Shift+]", "setting": "viewAdjustHorizonUp" },
+    { "id": "horizonDown", "label": "Horizon Down", "default": "Shift+[", "setting": "viewAdjustHorizonDown" },
+    {
+      "id": "driverHeightUp",
+      "label": "Driver Height Up",
+      "default": "Ctrl+]",
+      "setting": "viewAdjustDriverHeightUp"
+    },
+    {
+      "id": "driverHeightDown",
+      "label": "Driver Height Down",
+      "default": "Ctrl+[",
+      "setting": "viewAdjustDriverHeightDown"
+    },
+    { "id": "recenterVr", "label": "Recenter VR", "default": ";", "setting": "viewAdjustRecenterVr" },
+    {
+      "id": "uiSizeIncrease",
+      "label": "UI Size Increase",
+      "default": "Ctrl+PageUp",
+      "setting": "viewAdjustUiSizeIncrease"
+    },
+    {
+      "id": "uiSizeDecrease",
+      "label": "UI Size Decrease",
+      "default": "Ctrl+PageDown",
+      "setting": "viewAdjustUiSizeDecrease"
+    }
   ]
 }

--- a/packages/stream-deck-plugin-core/src/pi/view-adjustment.ejs
+++ b/packages/stream-deck-plugin-core/src/pi/view-adjustment.ejs
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<%- include('head-common') %>
+	</head>
+	<body>
+		<sdpi-item label="Adjustment">
+			<sdpi-select id="adjustment-select" setting="adjustment" default="fov">
+				<option value="fov">FOV</option>
+				<option value="horizon">Horizon</option>
+				<option value="driver-height">Driver Height</option>
+				<option value="recenter-vr">Recenter VR</option>
+				<option value="ui-size">UI Size</option>
+			</sdpi-select>
+		</sdpi-item>
+
+		<sdpi-item label="Direction" id="direction-item">
+			<sdpi-select setting="direction" default="increase">
+				<option value="increase">Increase</option>
+				<option value="decrease">Decrease</option>
+			</sdpi-select>
+		</sdpi-item>
+
+		<!-- Global Key Bindings section -->
+		<%- include('global-key-bindings', {
+			subtitle: 'View Adjustment Key Bindings',
+			keyBindings: require('./data/key-bindings.json').viewAdjustment
+		}) %>
+
+		<script>
+			function updateVisibility(adjustment) {
+				const directionItem = document.getElementById("direction-item");
+				if (!directionItem) return;
+
+				// Hide direction dropdown when Recenter VR is selected
+				directionItem.classList.toggle("hidden", adjustment === "recenter-vr");
+			}
+
+			async function initialize() {
+				await customElements.whenDefined("sdpi-select");
+
+				const adjustmentSelect = document.getElementById("adjustment-select");
+
+				if (adjustmentSelect) {
+					const initialValue = adjustmentSelect.value || "fov";
+					updateVisibility(initialValue);
+
+					adjustmentSelect.addEventListener("change", (ev) => {
+						updateVisibility(ev.target.value || "fov");
+					});
+					adjustmentSelect.addEventListener("input", (ev) => {
+						updateVisibility(ev.target.value || "fov");
+					});
+
+					// Polling fallback for reliable detection
+					let lastValue = adjustmentSelect.value || "fov";
+					setInterval(() => {
+						const currentValue = adjustmentSelect.value;
+						if (currentValue && currentValue !== lastValue) {
+							lastValue = currentValue;
+							updateVisibility(currentValue);
+						}
+					}, 100);
+				}
+			}
+
+			if (document.readyState === "loading") {
+				document.addEventListener("DOMContentLoaded", initialize);
+			} else {
+				initialize();
+			}
+		</script>
+
+		<style>
+			.hidden { display: none !important; }
+		</style>
+	</body>
+</html>

--- a/packages/stream-deck-plugin-core/src/plugin.ts
+++ b/packages/stream-deck-plugin-core/src/plugin.ts
@@ -10,6 +10,7 @@ import {
 import { BlackBoxSelector } from "./actions/black-box-selector.js";
 import { SplitsDeltaCycle } from "./actions/splits-delta-cycle.js";
 import { ToggleUiElements } from "./actions/toggle-ui-elements.js";
+import { ViewAdjustment } from "./actions/view-adjustment.js";
 
 // Enable trace logging
 streamDeck.logger.setLevel("trace");
@@ -24,6 +25,7 @@ initializeKeyboard(createSDLogger(streamDeck.logger.createScope("Keyboard")));
 streamDeck.actions.registerAction(new BlackBoxSelector());
 streamDeck.actions.registerAction(new SplitsDeltaCycle());
 streamDeck.actions.registerAction(new ToggleUiElements());
+streamDeck.actions.registerAction(new ViewAdjustment());
 
 // Initialize global settings listener BEFORE connect - handlers must be registered first
 // Pass the SDK instance to ensure we use the same instance as the plugin


### PR DESCRIPTION
## Summary

- Adds a **View Adjustment** action to the core plugin that provides camera/view position adjustments via keyboard shortcuts
- Supports 5 adjustment types: FOV, Horizon, Driver Height, Recenter VR, UI Size
- Each adjustment has configurable increase/decrease directions (except Recenter VR which is a single action)
- All 9 sub-actions use global key bindings with iRacing defaults
- Encoder support: press activates the selected adjustment, rotation adjusts increase/decrease
- Direction dropdown conditionally hidden when Recenter VR is selected

## Test plan

- [x] Verify build succeeds (`pnpm build`)
- [x] Verify all tests pass (`pnpm test`) — 21 new tests for view-adjustment
- [x] Verify FOV increase/decrease sends correct keys (] and [)
- [x] Verify Horizon up/down sends Shift+] and Shift+[
- [x] Verify Driver Height up/down sends Ctrl+] and Ctrl+[
- [x] Verify Recenter VR sends ;
- [x] Verify UI Size increase/decrease sends Ctrl+PageUp and Ctrl+PageDown
- [x] Verify direction dropdown hides when Recenter VR is selected in PI
- [x] Verify encoder rotation adjusts increase/decrease for non-VR adjustments
- [x] Verify encoder rotation is ignored for Recenter VR
- [x] Verify icons update correctly for each adjustment + direction combination

Closes #6