### PR TITLE
feat(stream-deck-plugin-core): add Car Control action

### DIFF
--- a/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/imgs/actions/car-control/icon.svg
+++ b/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/imgs/actions/car-control/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="#ffffff">
+  <!-- Key/ignition shape -->
+  <circle cx="10" cy="7" r="4" stroke-width="1" fill="none"/>
+  <line x1="10" y1="11" x2="10" y2="18" stroke-width="1.5"/>
+  <line x1="10" y1="14" x2="13" y2="14" stroke-width="1"/>
+  <line x1="10" y1="16" x2="12" y2="16" stroke-width="1"/>
+</svg>

--- a/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/imgs/actions/car-control/key.svg
+++ b/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/imgs/actions/car-control/key.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+  <!-- Main background -->
+  <rect x="0" y="0" width="72" height="72" rx="8" fill="#2a3a2a"/>
+
+  <!-- Key/ignition icon (starter default) -->
+  <circle cx="36" cy="22" r="10" fill="none" stroke="#ffffff" stroke-width="1.5"/>
+  <circle cx="36" cy="22" r="3" fill="#ffffff"/>
+  <path d="M46 22 A10 10 0 0 1 36 32" fill="none" stroke="#f1c40f" stroke-width="2" stroke-linecap="round"/>
+  <path d="M36 32 L38 28 M36 32 L32 30" fill="none" stroke="#f1c40f" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Two-line label -->
+  <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">CAR</text>
+  <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
+        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">CONTROL</text>
+</svg>

--- a/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/manifest.json
+++ b/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/manifest.json
@@ -89,6 +89,27 @@
       ]
     },
     {
+      "Name": "Car Control",
+      "UUID": "com.iracedeck.sd.core.car-control",
+      "Icon": "imgs/actions/car-control/icon",
+      "Tooltip": "Control car operations (starter, ignition, pit limiter, and more)",
+      "PropertyInspectorPath": "ui/car-control.html",
+      "Controllers": ["Keypad", "Encoder"],
+      "Encoder": {
+        "layout": "$B1",
+        "TriggerDescription": {
+          "Press": "Activate car control"
+        }
+      },
+      "States": [
+        {
+          "Image": "imgs/actions/car-control/key",
+          "TitleAlignment": "bottom",
+          "FontSize": 14
+        }
+      ]
+    },
+    {
       "Name": "View Adjustment",
       "UUID": "com.iracedeck.sd.core.view-adjustment",
       "Icon": "imgs/actions/view-adjustment/icon",

--- a/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/ui/car-control.html
+++ b/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/ui/car-control.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+<script src="sdpi-components.js"></script>
+<script src="pi-components.js"></script>
+<style>
+  .hidden {
+    display: none !important;
+  }
+
+  /* Collapsible section styles */
+  .ird-collapsible {
+    margin-top: 12px;
+  }
+
+  .ird-collapsible-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 0 4px 0;
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+    border-top: 1px solid #3a3a3a;
+  }
+
+  .ird-collapsible-header::-webkit-details-marker {
+    display: none;
+  }
+
+  .ird-collapsible-icon {
+    font-size: 8px;
+    color: #808080;
+    transition: transform 0.15s ease;
+    flex-shrink: 0;
+  }
+
+  .ird-collapsible[open] .ird-collapsible-icon {
+    transform: rotate(90deg);
+  }
+
+  .ird-collapsible-title {
+    font-family: "Segoe UI", Arial, Roboto, Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 9pt;
+    font-weight: 600;
+    color: #ffffff;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .ird-collapsible-content {
+    padding-top: 4px;
+  }
+
+  .ird-section-subtitle {
+    font-family: "Segoe UI", Arial, Roboto, Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 9pt;
+    color: #d0d0d0;
+    margin: 8px 0 4px 14px;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+  }
+
+  /* Key bindings section styles */
+  .ird-key-bindings-section {
+    margin-top: 12px;
+  }
+
+  .ird-section-heading {
+    padding: 8px 0 4px 0;
+    border-top: 1px solid #3a3a3a;
+    font-family: "Segoe UI", Arial, Roboto, Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 9pt;
+    font-weight: 600;
+    color: #ffffff;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+</style>
+
+	</head>
+	<body>
+		<sdpi-item label="Control">
+			<sdpi-select setting="control" default="starter">
+				<option value="starter">Starter</option>
+				<option value="ignition">Ignition</option>
+				<option value="pit-speed-limiter">Pit Speed Limiter</option>
+				<option value="enter-exit-tow">Enter/Exit/Tow Car</option>
+				<option value="pause-sim">Pause Sim</option>
+			</sdpi-select>
+		</sdpi-item>
+
+		<!--
+  Global Key Bindings Component
+
+  Displays key binding inputs in a "Related Key Bindings" section.
+  Key bindings are stored in global settings (shared across all action instances).
+
+  Parameters:
+    - keyBindings: Array with objects containing id, label, default, setting
+-->
+<div class="ird-key-bindings-section">
+  <div class="ird-section-heading">Related Key Bindings</div>
+  
+  <sdpi-item label="Starter">
+    <ird-key-binding setting="carControlStarter" default="S" global></ird-key-binding>
+  </sdpi-item>
+  
+  <sdpi-item label="Ignition">
+    <ird-key-binding setting="carControlIgnition" default="I" global></ird-key-binding>
+  </sdpi-item>
+  
+  <sdpi-item label="Pit Speed Limiter">
+    <ird-key-binding setting="carControlPitSpeedLimiter" default="A" global></ird-key-binding>
+  </sdpi-item>
+  
+  <sdpi-item label="Enter/Exit/Tow Car">
+    <ird-key-binding setting="carControlEnterExitTow" default="Shift+R" global></ird-key-binding>
+  </sdpi-item>
+  
+  <sdpi-item label="Pause Sim">
+    <ird-key-binding setting="carControlPauseSim" default="Shift+P" global></ird-key-binding>
+  </sdpi-item>
+  
+</div>
+
+	</body>
+</html>

--- a/packages/stream-deck-plugin-core/icons/car-control.svg
+++ b/packages/stream-deck-plugin-core/icons/car-control.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+  <g filter="url(#activity-state)">
+    <!-- Main background -->
+    <rect x="0" y="0" width="72" height="72" rx="8" fill="#2a3a2a"/>
+
+    <!-- Icon content area: y=9 to y=43 -->
+{{iconContent}}
+
+    <!-- Two-line label -->
+    <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">{{labelLine1}}</text>
+    <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
+          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">{{labelLine2}}</text>
+  </g>
+</svg>

--- a/packages/stream-deck-plugin-core/src/actions/car-control.test.ts
+++ b/packages/stream-deck-plugin-core/src/actions/car-control.test.ts
@@ -1,0 +1,364 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CAR_CONTROL_GLOBAL_KEYS, CarControl, generateCarControlSvg } from "./car-control.js";
+
+const {
+  mockPressKeyCombination,
+  mockReleaseKeyCombination,
+  mockSendKeyCombination,
+  mockParseKeyBinding,
+  mockGetGlobalSettings,
+} = vi.hoisted(() => ({
+  mockPressKeyCombination: vi.fn().mockResolvedValue(true),
+  mockReleaseKeyCombination: vi.fn().mockResolvedValue(true),
+  mockSendKeyCombination: vi.fn().mockResolvedValue(true),
+  mockParseKeyBinding: vi.fn(),
+  mockGetGlobalSettings: vi.fn(() => ({})),
+}));
+
+vi.mock("@elgato/streamdeck", () => ({
+  default: {
+    logger: {
+      createScope: vi.fn(() => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trace: vi.fn(),
+      })),
+    },
+  },
+  action: () => (target: unknown) => target,
+}));
+
+vi.mock("@iracedeck/stream-deck-shared", () => ({
+  ConnectionStateAwareAction: class MockConnectionStateAwareAction {
+    sdkController = { subscribe: vi.fn(), unsubscribe: vi.fn(), getCurrentTelemetry: vi.fn() };
+    updateConnectionState = vi.fn();
+    setKeyImage = vi.fn();
+    async onWillDisappear() {}
+  },
+  createSDLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+  })),
+  formatKeyBinding: vi.fn((b: { key: string; modifiers: string[] }) => {
+    if (b.modifiers?.length) {
+      return `${b.modifiers.join("+")}+${b.key}`;
+    }
+
+    return b.key;
+  }),
+  getGlobalSettings: mockGetGlobalSettings,
+  getKeyboard: vi.fn(() => ({
+    sendKeyCombination: mockSendKeyCombination,
+    pressKeyCombination: mockPressKeyCombination,
+    releaseKeyCombination: mockReleaseKeyCombination,
+  })),
+  LogLevel: { Info: 2 },
+  parseKeyBinding: mockParseKeyBinding,
+  renderIconTemplate: vi.fn((_template: string, data: Record<string, string>) => {
+    return `<svg>${data.iconContent || ""}${data.labelLine1 || ""}${data.labelLine2 || ""}</svg>`;
+  }),
+  svgToDataUri: vi.fn((svg: string) => `data:image/svg+xml,${encodeURIComponent(svg)}`),
+}));
+
+/** Create a minimal fake event with the given action ID and settings. */
+function fakeEvent(actionId: string, settings: Record<string, unknown> = {}) {
+  return {
+    action: { id: actionId, setTitle: vi.fn(), setImage: vi.fn() },
+    payload: { settings },
+  };
+}
+
+describe("CarControl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("CAR_CONTROL_GLOBAL_KEYS", () => {
+    it("should have correct mapping for starter", () => {
+      expect(CAR_CONTROL_GLOBAL_KEYS["starter"]).toBe("carControlStarter");
+    });
+
+    it("should have correct mapping for ignition", () => {
+      expect(CAR_CONTROL_GLOBAL_KEYS["ignition"]).toBe("carControlIgnition");
+    });
+
+    it("should have correct mapping for pit-speed-limiter", () => {
+      expect(CAR_CONTROL_GLOBAL_KEYS["pit-speed-limiter"]).toBe("carControlPitSpeedLimiter");
+    });
+
+    it("should have correct mapping for enter-exit-tow", () => {
+      expect(CAR_CONTROL_GLOBAL_KEYS["enter-exit-tow"]).toBe("carControlEnterExitTow");
+    });
+
+    it("should have correct mapping for pause-sim", () => {
+      expect(CAR_CONTROL_GLOBAL_KEYS["pause-sim"]).toBe("carControlPauseSim");
+    });
+
+    it("should have exactly 5 entries", () => {
+      expect(Object.keys(CAR_CONTROL_GLOBAL_KEYS)).toHaveLength(5);
+    });
+  });
+
+  describe("generateCarControlSvg", () => {
+    it("should generate a valid data URI for starter", () => {
+      const result = generateCarControlSvg({ control: "starter" });
+
+      expect(result).toContain("data:image/svg+xml");
+    });
+
+    it("should generate a valid data URI for ignition", () => {
+      const result = generateCarControlSvg({ control: "ignition" });
+
+      expect(result).toContain("data:image/svg+xml");
+    });
+
+    it("should generate valid data URIs for all controls", () => {
+      const controls = [
+        "starter",
+        "ignition",
+        "pit-speed-limiter",
+        "enter-exit-tow",
+        "pause-sim",
+      ] as const;
+
+      for (const control of controls) {
+        const result = generateCarControlSvg({ control });
+        expect(result).toContain("data:image/svg+xml");
+      }
+    });
+
+    it("should produce different icons for different controls", () => {
+      const starter = generateCarControlSvg({ control: "starter" });
+      const ignition = generateCarControlSvg({ control: "ignition" });
+
+      expect(starter).not.toBe(ignition);
+    });
+
+    it("should include correct labels for all controls", () => {
+      const expectedLabels: Record<string, { line1: string; line2: string }> = {
+        starter: { line1: "STARTER", line2: "HOLD" },
+        ignition: { line1: "IGNITION", line2: "TOGGLE" },
+        "pit-speed-limiter": { line1: "PIT", line2: "LIMITER" },
+        "enter-exit-tow": { line1: "ENTER/EXIT", line2: "TOW" },
+        "pause-sim": { line1: "PAUSE", line2: "SIM" },
+      };
+
+      for (const [control, labels] of Object.entries(expectedLabels)) {
+        const result = generateCarControlSvg({ control: control as any });
+        const decoded = decodeURIComponent(result);
+
+        expect(decoded).toContain(labels.line1);
+        expect(decoded).toContain(labels.line2);
+      }
+    });
+  });
+
+  describe("tap behavior (non-starter controls)", () => {
+    let action: CarControl;
+
+    function setupKeyBinding(key: string, modifiers: string[] = [], code?: string) {
+      mockGetGlobalSettings.mockReturnValue({ carControlIgnition: "bound" });
+      mockParseKeyBinding.mockReturnValue({ key, modifiers, code });
+    }
+
+    beforeEach(() => {
+      action = new CarControl();
+    });
+
+    it("should call sendKeyCombination on keyDown for ignition", async () => {
+      setupKeyBinding("i", [], "KeyI");
+
+      await action.onKeyDown(fakeEvent("action-1", { control: "ignition" }) as any);
+
+      expect(mockSendKeyCombination).toHaveBeenCalledWith({
+        key: "i",
+        modifiers: undefined,
+        code: "KeyI",
+      });
+      expect(mockPressKeyCombination).not.toHaveBeenCalled();
+    });
+
+    it("should call sendKeyCombination on keyDown for pit-speed-limiter", async () => {
+      mockGetGlobalSettings.mockReturnValue({ carControlPitSpeedLimiter: "bound" });
+      mockParseKeyBinding.mockReturnValue({ key: "a", modifiers: [], code: "KeyA" });
+
+      await action.onKeyDown(fakeEvent("action-1", { control: "pit-speed-limiter" }) as any);
+
+      expect(mockSendKeyCombination).toHaveBeenCalledOnce();
+      expect(mockPressKeyCombination).not.toHaveBeenCalled();
+    });
+
+    it("should call sendKeyCombination on keyDown for enter-exit-tow", async () => {
+      mockGetGlobalSettings.mockReturnValue({ carControlEnterExitTow: "bound" });
+      mockParseKeyBinding.mockReturnValue({ key: "r", modifiers: ["shift"], code: "KeyR" });
+
+      await action.onKeyDown(fakeEvent("action-1", { control: "enter-exit-tow" }) as any);
+
+      expect(mockSendKeyCombination).toHaveBeenCalledWith({
+        key: "r",
+        modifiers: ["shift"],
+        code: "KeyR",
+      });
+    });
+
+    it("should call sendKeyCombination on keyDown for pause-sim", async () => {
+      mockGetGlobalSettings.mockReturnValue({ carControlPauseSim: "bound" });
+      mockParseKeyBinding.mockReturnValue({ key: "p", modifiers: ["shift"], code: "KeyP" });
+
+      await action.onKeyDown(fakeEvent("action-1", { control: "pause-sim" }) as any);
+
+      expect(mockSendKeyCombination).toHaveBeenCalledOnce();
+      expect(mockPressKeyCombination).not.toHaveBeenCalled();
+    });
+
+    it("should call sendKeyCombination on dialDown for non-starter controls", async () => {
+      setupKeyBinding("i", [], "KeyI");
+
+      await action.onDialDown(fakeEvent("action-1", { control: "ignition" }) as any);
+
+      expect(mockSendKeyCombination).toHaveBeenCalledOnce();
+      expect(mockPressKeyCombination).not.toHaveBeenCalled();
+    });
+
+    it("should handle missing key binding gracefully for tap controls", async () => {
+      mockGetGlobalSettings.mockReturnValue({});
+      mockParseKeyBinding.mockReturnValue(undefined);
+
+      await action.onKeyDown(fakeEvent("action-1", { control: "ignition" }) as any);
+
+      expect(mockSendKeyCombination).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("long-press behavior (starter)", () => {
+    let action: CarControl;
+
+    function setupKeyBinding(key: string, modifiers: string[] = [], code?: string) {
+      mockGetGlobalSettings.mockReturnValue({ carControlStarter: "bound" });
+      mockParseKeyBinding.mockReturnValue({ key, modifiers, code });
+    }
+
+    beforeEach(() => {
+      action = new CarControl();
+    });
+
+    it("should press key on keyDown and release on keyUp", async () => {
+      setupKeyBinding("s", [], "KeyS");
+
+      await action.onKeyDown(fakeEvent("action-1", { control: "starter" }) as any);
+
+      expect(mockPressKeyCombination).toHaveBeenCalledWith({
+        key: "s",
+        modifiers: undefined,
+        code: "KeyS",
+      });
+      expect(mockSendKeyCombination).not.toHaveBeenCalled();
+
+      await action.onKeyUp(fakeEvent("action-1") as any);
+
+      expect(mockReleaseKeyCombination).toHaveBeenCalledWith({
+        key: "s",
+        modifiers: undefined,
+        code: "KeyS",
+      });
+    });
+
+    it("should press key on dialDown and release on dialUp", async () => {
+      setupKeyBinding("s", [], "KeyS");
+
+      await action.onDialDown(fakeEvent("action-1", { control: "starter" }) as any);
+
+      expect(mockPressKeyCombination).toHaveBeenCalledOnce();
+
+      await action.onDialUp(fakeEvent("action-1") as any);
+
+      expect(mockReleaseKeyCombination).toHaveBeenCalledOnce();
+    });
+
+    it("should track concurrent presses on different action contexts independently", async () => {
+      mockGetGlobalSettings.mockReturnValue({
+        carControlStarter: "bound",
+      });
+      mockParseKeyBinding.mockImplementation((val: unknown) => {
+        if (val === "bound") {
+          return { key: "s", modifiers: [], code: "KeyS" };
+        }
+
+        return undefined;
+      });
+
+      // Press starter on action-1
+      await action.onKeyDown(fakeEvent("action-1", { control: "starter" }) as any);
+      // Press starter on action-2
+      await action.onKeyDown(fakeEvent("action-2", { control: "starter" }) as any);
+
+      expect(mockPressKeyCombination).toHaveBeenCalledTimes(2);
+
+      // Release action-1 — should release action-1's combination only
+      await action.onKeyUp(fakeEvent("action-1") as any);
+
+      expect(mockReleaseKeyCombination).toHaveBeenCalledTimes(1);
+
+      // Release action-2
+      await action.onKeyUp(fakeEvent("action-2") as any);
+
+      expect(mockReleaseKeyCombination).toHaveBeenCalledTimes(2);
+    });
+
+    it("should release held key on onWillDisappear", async () => {
+      setupKeyBinding("s", [], "KeyS");
+
+      await action.onKeyDown(fakeEvent("action-1", { control: "starter" }) as any);
+      await action.onWillDisappear(fakeEvent("action-1") as any);
+
+      expect(mockReleaseKeyCombination).toHaveBeenCalledOnce();
+    });
+
+    it("should not store combination when press fails", async () => {
+      setupKeyBinding("s", [], "KeyS");
+      mockPressKeyCombination.mockResolvedValueOnce(false);
+
+      await action.onKeyDown(fakeEvent("action-1", { control: "starter" }) as any);
+
+      expect(mockPressKeyCombination).toHaveBeenCalledOnce();
+
+      // Release should be a no-op since press failed
+      await action.onKeyUp(fakeEvent("action-1") as any);
+
+      expect(mockReleaseKeyCombination).not.toHaveBeenCalled();
+    });
+
+    it("should not call release if no key is held", async () => {
+      await action.onKeyUp(fakeEvent("action-1") as any);
+
+      expect(mockReleaseKeyCombination).not.toHaveBeenCalled();
+    });
+
+    it("should include modifiers in the combination when present", async () => {
+      setupKeyBinding("s", ["ctrl", "shift"], "KeyS");
+
+      await action.onKeyDown(fakeEvent("action-1", { control: "starter" }) as any);
+
+      expect(mockPressKeyCombination).toHaveBeenCalledWith({
+        key: "s",
+        modifiers: ["ctrl", "shift"],
+        code: "KeyS",
+      });
+    });
+
+    it("should not press key when no binding is configured", async () => {
+      mockGetGlobalSettings.mockReturnValue({});
+      mockParseKeyBinding.mockReturnValue(undefined);
+
+      await action.onKeyDown(fakeEvent("action-1", { control: "starter" }) as any);
+
+      expect(mockPressKeyCombination).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/stream-deck-plugin-core/src/actions/car-control.ts
+++ b/packages/stream-deck-plugin-core/src/actions/car-control.ts
@@ -1,0 +1,292 @@
+import streamDeck, {
+  action,
+  DialDownEvent,
+  DialUpEvent,
+  DidReceiveSettingsEvent,
+  KeyDownEvent,
+  KeyUpEvent,
+  WillAppearEvent,
+  WillDisappearEvent,
+} from "@elgato/streamdeck";
+import {
+  ConnectionStateAwareAction,
+  createSDLogger,
+  formatKeyBinding,
+  getGlobalSettings,
+  getKeyboard,
+  type KeyBindingValue,
+  type KeyboardKey,
+  type KeyboardModifier,
+  type KeyCombination,
+  LogLevel,
+  parseKeyBinding,
+  renderIconTemplate,
+  svgToDataUri,
+} from "@iracedeck/stream-deck-shared";
+import z from "zod";
+
+import carControlTemplate from "../../icons/car-control.svg";
+
+const WHITE = "#ffffff";
+const GRAY = "#888888";
+const YELLOW = "#f1c40f";
+const RED = "#e74c3c";
+
+type CarControlType = "starter" | "ignition" | "pit-speed-limiter" | "enter-exit-tow" | "pause-sim";
+
+/**
+ * Label configuration for each car control (line1 bold, line2 subdued)
+ */
+const CAR_CONTROL_LABELS: Record<CarControlType, { line1: string; line2: string }> = {
+  starter: { line1: "STARTER", line2: "HOLD" },
+  ignition: { line1: "IGNITION", line2: "TOGGLE" },
+  "pit-speed-limiter": { line1: "PIT", line2: "LIMITER" },
+  "enter-exit-tow": { line1: "ENTER/EXIT", line2: "TOW" },
+  "pause-sim": { line1: "PAUSE", line2: "SIM" },
+};
+
+/**
+ * SVG icon content for each car control
+ */
+const CAR_CONTROL_ICONS: Record<CarControlType, string> = {
+  // Starter: Circular keyhole with crank arrow
+  starter: `
+    <circle cx="36" cy="22" r="10" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <circle cx="36" cy="22" r="3" fill="${WHITE}"/>
+    <path d="M46 22 A10 10 0 0 1 36 32" fill="none" stroke="${YELLOW}" stroke-width="2" stroke-linecap="round"/>
+    <path d="M36 32 L38 28 M36 32 L32 30" fill="none" stroke="${YELLOW}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>`,
+
+  // Ignition: Power symbol
+  ignition: `
+    <circle cx="36" cy="24" r="11" fill="none" stroke="${WHITE}" stroke-width="2"/>
+    <rect x="33" y="10" width="6" height="6" fill="#2a3a2a"/>
+    <line x1="36" y1="12" x2="36" y2="26" stroke="${WHITE}" stroke-width="2.5" stroke-linecap="round"/>`,
+
+  // Pit Speed Limiter: Speed limit circle with "PIT"
+  "pit-speed-limiter": `
+    <circle cx="36" cy="22" r="12" fill="none" stroke="${RED}" stroke-width="2"/>
+    <line x1="44" y1="14" x2="28" y2="30" stroke="${RED}" stroke-width="2"/>
+    <text x="36" y="24" text-anchor="middle" dominant-baseline="central"
+          fill="${WHITE}" font-family="Arial, sans-serif" font-size="8" font-weight="bold">PIT</text>`,
+
+  // Enter/Exit/Tow: Car body with bidirectional arrow
+  "enter-exit-tow": `
+    <rect x="20" y="16" width="32" height="14" rx="4" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <circle cx="28" cy="30" r="3" fill="none" stroke="${GRAY}" stroke-width="1.5"/>
+    <circle cx="44" cy="30" r="3" fill="none" stroke="${GRAY}" stroke-width="1.5"/>
+    <path d="M24 38 L48 38" stroke="${GRAY}" stroke-width="1.5" stroke-linecap="round"/>
+    <path d="M24 38 L28 35 M24 38 L28 41" fill="none" stroke="${GRAY}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M48 38 L44 35 M48 38 L44 41" fill="none" stroke="${GRAY}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>`,
+
+  // Pause Sim: Pause bars
+  "pause-sim": `
+    <rect x="27" y="14" width="6" height="20" rx="1" fill="${WHITE}"/>
+    <rect x="39" y="14" width="6" height="20" rx="1" fill="${WHITE}"/>`,
+};
+
+/**
+ * @internal Exported for testing
+ *
+ * Mapping from car control setting values (kebab-case) to global settings keys.
+ */
+export const CAR_CONTROL_GLOBAL_KEYS: Record<CarControlType, string> = {
+  starter: "carControlStarter",
+  ignition: "carControlIgnition",
+  "pit-speed-limiter": "carControlPitSpeedLimiter",
+  "enter-exit-tow": "carControlEnterExitTow",
+  "pause-sim": "carControlPauseSim",
+};
+
+const CarControlSettings = z.object({
+  control: z.enum(["starter", "ignition", "pit-speed-limiter", "enter-exit-tow", "pause-sim"]).default("starter"),
+});
+
+type CarControlSettings = z.infer<typeof CarControlSettings>;
+
+/**
+ * @internal Exported for testing
+ *
+ * Generates an SVG data URI icon for the car control action.
+ */
+export function generateCarControlSvg(settings: CarControlSettings): string {
+  const { control } = settings;
+
+  const iconContent = CAR_CONTROL_ICONS[control] || CAR_CONTROL_ICONS["starter"];
+  const labels = CAR_CONTROL_LABELS[control] || CAR_CONTROL_LABELS["starter"];
+
+  const svg = renderIconTemplate(carControlTemplate, {
+    iconContent,
+    labelLine1: labels.line1,
+    labelLine2: labels.line2,
+  });
+
+  return svgToDataUri(svg);
+}
+
+/**
+ * Car Control Action
+ * Provides core car operation controls (starter, ignition, pit limiter, enter/exit/tow, pause).
+ * Starter uses long-press (hold to crank); all others use tap.
+ */
+@action({ UUID: "com.iracedeck.sd.core.car-control" })
+export class CarControl extends ConnectionStateAwareAction<CarControlSettings> {
+  protected override logger = createSDLogger(streamDeck.logger.createScope("CarControl"), LogLevel.Info);
+
+  /** Currently held key combinations per action context, tracked for cleanup on release/disappear */
+  private heldCombinations = new Map<string, KeyCombination>();
+
+  override async onWillAppear(ev: WillAppearEvent<CarControlSettings>): Promise<void> {
+    const settings = this.parseSettings(ev.payload.settings);
+    await this.updateDisplay(ev, settings);
+
+    this.sdkController.subscribe(ev.action.id, () => {
+      this.updateConnectionState();
+    });
+  }
+
+  override async onWillDisappear(ev: WillDisappearEvent<CarControlSettings>): Promise<void> {
+    await this.releaseHeldKey(ev.action.id);
+    await super.onWillDisappear(ev);
+    this.sdkController.unsubscribe(ev.action.id);
+  }
+
+  override async onDidReceiveSettings(ev: DidReceiveSettingsEvent<CarControlSettings>): Promise<void> {
+    const settings = this.parseSettings(ev.payload.settings);
+    await this.updateDisplay(ev, settings);
+  }
+
+  override async onKeyDown(ev: KeyDownEvent<CarControlSettings>): Promise<void> {
+    this.logger.info("Key down received");
+    const settings = this.parseSettings(ev.payload.settings);
+    await this.executeControl(ev.action.id, settings);
+  }
+
+  override async onKeyUp(ev: KeyUpEvent<CarControlSettings>): Promise<void> {
+    this.logger.info("Key up received");
+    await this.releaseHeldKey(ev.action.id);
+  }
+
+  override async onDialDown(ev: DialDownEvent<CarControlSettings>): Promise<void> {
+    this.logger.info("Dial down received");
+    const settings = this.parseSettings(ev.payload.settings);
+    await this.executeControl(ev.action.id, settings);
+  }
+
+  override async onDialUp(ev: DialUpEvent<CarControlSettings>): Promise<void> {
+    this.logger.info("Dial up received");
+    await this.releaseHeldKey(ev.action.id);
+  }
+
+  private parseSettings(settings: unknown): CarControlSettings {
+    const parsed = CarControlSettings.safeParse(settings);
+
+    return parsed.success ? parsed.data : CarControlSettings.parse({});
+  }
+
+  private async executeControl(actionId: string, settings: CarControlSettings): Promise<void> {
+    if (settings.control === "starter") {
+      await this.pressAndHold(actionId, settings.control);
+    } else {
+      await this.tapControl(settings.control);
+    }
+  }
+
+  private async pressAndHold(actionId: string, control: CarControlType): Promise<void> {
+    const resolved = this.resolveCombination(control);
+
+    if (!resolved) {
+      return;
+    }
+
+    const { combination, binding } = resolved;
+
+    const success = await getKeyboard().pressKeyCombination(combination);
+
+    if (success) {
+      this.heldCombinations.set(actionId, combination);
+      this.logger.info("Key pressed (holding)");
+      this.logger.debug(`Key combination: ${formatKeyBinding(binding)}`);
+    } else {
+      this.logger.warn("Failed to press key");
+    }
+  }
+
+  private async tapControl(control: CarControlType): Promise<void> {
+    const resolved = this.resolveCombination(control);
+
+    if (!resolved) {
+      return;
+    }
+
+    const { combination, binding } = resolved;
+
+    const success = await getKeyboard().sendKeyCombination(combination);
+
+    if (success) {
+      this.logger.info("Key sent successfully");
+      this.logger.debug(`Key combination: ${formatKeyBinding(binding)}`);
+    } else {
+      this.logger.warn("Failed to send key");
+      this.logger.debug(`Failed key combination: ${formatKeyBinding(binding)}`);
+    }
+  }
+
+  private async releaseHeldKey(actionId: string): Promise<void> {
+    const combination = this.heldCombinations.get(actionId);
+
+    if (!combination) {
+      return;
+    }
+
+    this.heldCombinations.delete(actionId);
+
+    const success = await getKeyboard().releaseKeyCombination(combination);
+
+    if (success) {
+      this.logger.info("Key released");
+    } else {
+      this.logger.warn("Failed to release key");
+    }
+  }
+
+  private resolveCombination(
+    control: CarControlType,
+  ): { combination: KeyCombination; binding: KeyBindingValue } | null {
+    const settingKey = CAR_CONTROL_GLOBAL_KEYS[control];
+
+    if (!settingKey) {
+      this.logger.warn(`No global key mapping for control: ${control}`);
+
+      return null;
+    }
+
+    const globalSettings = getGlobalSettings() as Record<string, unknown>;
+    const binding = parseKeyBinding(globalSettings[settingKey]);
+
+    if (!binding?.key) {
+      this.logger.warn(`No key binding configured for ${settingKey}`);
+
+      return null;
+    }
+
+    return {
+      combination: {
+        key: binding.key as KeyboardKey,
+        modifiers: binding.modifiers.length > 0 ? (binding.modifiers as KeyboardModifier[]) : undefined,
+        code: binding.code,
+      },
+      binding,
+    };
+  }
+
+  private async updateDisplay(
+    ev: WillAppearEvent<CarControlSettings> | DidReceiveSettingsEvent<CarControlSettings>,
+    settings: CarControlSettings,
+  ): Promise<void> {
+    this.updateConnectionState();
+
+    const svgDataUri = generateCarControlSvg(settings);
+    await ev.action.setTitle("");
+    await this.setKeyImage(ev, svgDataUri);
+  }
+}

--- a/packages/stream-deck-plugin-core/src/pi/car-control.ejs
+++ b/packages/stream-deck-plugin-core/src/pi/car-control.ejs
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<%- include('head-common') %>
+	</head>
+	<body>
+		<sdpi-item label="Control">
+			<sdpi-select setting="control" default="starter">
+				<option value="starter">Starter</option>
+				<option value="ignition">Ignition</option>
+				<option value="pit-speed-limiter">Pit Speed Limiter</option>
+				<option value="enter-exit-tow">Enter/Exit/Tow Car</option>
+				<option value="pause-sim">Pause Sim</option>
+			</sdpi-select>
+		</sdpi-item>
+
+		<%- include('global-key-bindings', {
+			subtitle: 'Car Control Key Bindings',
+			keyBindings: require('./data/key-bindings.json').carControl
+		}) %>
+	</body>
+</html>

--- a/packages/stream-deck-plugin-core/src/pi/data/key-bindings.json
+++ b/packages/stream-deck-plugin-core/src/pi/data/key-bindings.json
@@ -39,6 +39,23 @@
     { "id": "up", "label": "Look Up", "default": "", "setting": "lookDirectionUp" },
     { "id": "down", "label": "Look Down", "default": "", "setting": "lookDirectionDown" }
   ],
+  "carControl": [
+    { "id": "starter", "label": "Starter", "default": "S", "setting": "carControlStarter" },
+    { "id": "ignition", "label": "Ignition", "default": "I", "setting": "carControlIgnition" },
+    {
+      "id": "pitSpeedLimiter",
+      "label": "Pit Speed Limiter",
+      "default": "A",
+      "setting": "carControlPitSpeedLimiter"
+    },
+    {
+      "id": "enterExitTow",
+      "label": "Enter/Exit/Tow Car",
+      "default": "Shift+R",
+      "setting": "carControlEnterExitTow"
+    },
+    { "id": "pauseSim", "label": "Pause Sim", "default": "Shift+P", "setting": "carControlPauseSim" }
+  ],
   "viewAdjustment": [
     { "id": "fovIncrease", "label": "FOV Increase", "default": "]", "setting": "viewAdjustFovIncrease" },
     { "id": "fovDecrease", "label": "FOV Decrease", "default": "[", "setting": "viewAdjustFovDecrease" },

--- a/packages/stream-deck-plugin-core/src/plugin.ts
+++ b/packages/stream-deck-plugin-core/src/plugin.ts
@@ -9,6 +9,7 @@ import {
 } from "@iracedeck/stream-deck-shared";
 
 import { BlackBoxSelector } from "./actions/black-box-selector.js";
+import { CarControl } from "./actions/car-control.js";
 import { LookDirection } from "./actions/look-direction.js";
 import { SplitsDeltaCycle } from "./actions/splits-delta-cycle.js";
 import { ToggleUiElements } from "./actions/toggle-ui-elements.js";
@@ -31,6 +32,7 @@ initializeKeyboard(
 
 // Register core actions
 streamDeck.actions.registerAction(new BlackBoxSelector());
+streamDeck.actions.registerAction(new CarControl());
 streamDeck.actions.registerAction(new LookDirection());
 streamDeck.actions.registerAction(new SplitsDeltaCycle());
 streamDeck.actions.registerAction(new ToggleUiElements());


### PR DESCRIPTION
## Summary

- Add a **Car Control** action to the core plugin (`com.iracedeck.sd.core`) with 5 sub-actions: Starter, Ignition, Pit Speed Limiter, Enter/Exit/Tow Car, and Pause Sim
- Starter uses long-press (hold to crank); all other controls use tap
- All key bindings are user-configurable via global settings in the Property Inspector
- Supports both Keypad and Encoder controllers (press to activate; rotation is no-op)
- Icons update dynamically to reflect the selected control

Closes #4

## Test plan

- [ ] Verify all 25 unit tests pass (`pnpm test`)
- [ ] Verify build succeeds (`pnpm build`)
- [ ] Verify Car Control action appears in Stream Deck with correct category icon
- [ ] Verify dropdown shows all 5 control options in Property Inspector
- [ ] Verify key bindings section appears with correct defaults (S, I, A, Shift+R, Shift+P)
- [ ] Verify Starter holds key while button is pressed and releases on button release
- [ ] Verify non-starter controls send a single key tap on press
- [ ] Verify icon updates when switching between control options
- [ ] Verify action is disabled when iRacing is not connected