### PR TITLE
feat(stream-deck-plugin-core): add Tire Service action

### DIFF
--- a/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/imgs/actions/tire-service/icon.svg
+++ b/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/imgs/actions/tire-service/icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="#ffffff">
+  <!-- Tire circle (outer) -->
+  <circle cx="10" cy="10" r="7" stroke-width="1.5"/>
+  <!-- Inner hub -->
+  <circle cx="10" cy="10" r="3" stroke-width="1.2"/>
+  <!-- Spokes -->
+  <line x1="10" y1="3" x2="10" y2="7" stroke-width="1"/>
+  <line x1="10" y1="13" x2="10" y2="17" stroke-width="1"/>
+  <line x1="3" y1="10" x2="7" y2="10" stroke-width="1"/>
+  <line x1="13" y1="10" x2="17" y2="10" stroke-width="1"/>
+</svg>

--- a/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/imgs/actions/tire-service/key.svg
+++ b/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/imgs/actions/tire-service/key.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+  <rect x="0" y="0" width="72" height="72" rx="8" fill="#3a2a2a"/>
+  <!-- Four tire circles representing "all tires" -->
+  <circle cx="28" cy="16" r="5" fill="none" stroke="#2ecc71" stroke-width="1.5"/>
+  <circle cx="44" cy="16" r="5" fill="none" stroke="#2ecc71" stroke-width="1.5"/>
+  <circle cx="28" cy="32" r="5" fill="none" stroke="#2ecc71" stroke-width="1.5"/>
+  <circle cx="44" cy="32" r="5" fill="none" stroke="#2ecc71" stroke-width="1.5"/>
+  <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">ALL</text>
+  <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
+        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">TIRES</text>
+</svg>

--- a/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/manifest.json
+++ b/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/manifest.json
@@ -175,6 +175,27 @@
       ]
     },
     {
+      "Name": "Tire Service",
+      "UUID": "com.iracedeck.sd.core.tire-service",
+      "Icon": "imgs/actions/tire-service/icon",
+      "Tooltip": "Tire management for pit stops (request tires, change compound, clear)",
+      "PropertyInspectorPath": "ui/tire-service.html",
+      "Controllers": ["Keypad", "Encoder"],
+      "Encoder": {
+        "layout": "$B1",
+        "TriggerDescription": {
+          "Press": "Activate tire action"
+        }
+      },
+      "States": [
+        {
+          "Image": "imgs/actions/tire-service/key",
+          "TitleAlignment": "bottom",
+          "FontSize": 14
+        }
+      ]
+    },
+    {
       "Name": "View Adjustment",
       "UUID": "com.iracedeck.sd.core.view-adjustment",
       "Icon": "imgs/actions/view-adjustment/icon",

--- a/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/ui/tire-service.html
+++ b/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/ui/tire-service.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+<script src="sdpi-components.js"></script>
+<script src="pi-components.js"></script>
+<style>
+  .hidden {
+    display: none !important;
+  }
+
+  /* Collapsible section styles */
+  .ird-collapsible {
+    margin-top: 12px;
+  }
+
+  .ird-collapsible-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 0 4px 0;
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+    border-top: 1px solid #3a3a3a;
+  }
+
+  .ird-collapsible-header::-webkit-details-marker {
+    display: none;
+  }
+
+  .ird-collapsible-icon {
+    font-size: 8px;
+    color: #808080;
+    transition: transform 0.15s ease;
+    flex-shrink: 0;
+  }
+
+  .ird-collapsible[open] .ird-collapsible-icon {
+    transform: rotate(90deg);
+  }
+
+  .ird-collapsible-title {
+    font-family: "Segoe UI", Arial, Roboto, Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 9pt;
+    font-weight: 600;
+    color: #ffffff;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .ird-collapsible-content {
+    padding-top: 4px;
+  }
+
+  .ird-section-subtitle {
+    font-family: "Segoe UI", Arial, Roboto, Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 9pt;
+    color: #d0d0d0;
+    margin: 8px 0 4px 14px;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+  }
+
+  /* Key bindings section styles */
+  .ird-key-bindings-section {
+    margin-top: 12px;
+  }
+
+  .ird-section-heading {
+    padding: 8px 0 4px 0;
+    border-top: 1px solid #3a3a3a;
+    font-family: "Segoe UI", Arial, Roboto, Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 9pt;
+    font-weight: 600;
+    color: #ffffff;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+</style>
+
+	</head>
+	<body>
+		<sdpi-item label="Action">
+			<sdpi-select setting="action" default="request-all">
+				<option value="request-lf">Request Left Front</option>
+				<option value="request-rf">Request Right Front</option>
+				<option value="request-lr">Request Left Rear</option>
+				<option value="request-rr">Request Right Rear</option>
+				<option value="request-all">Request All Tires</option>
+				<option value="change-compound">Change Compound</option>
+				<option value="clear-tires">Clear Tires Checkbox</option>
+			</sdpi-select>
+		</sdpi-item>
+	</body>
+</html>

--- a/packages/stream-deck-plugin-core/icons/tire-service.svg
+++ b/packages/stream-deck-plugin-core/icons/tire-service.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+  <g filter="url(#activity-state)">
+    <!-- Main background -->
+    <rect x="0" y="0" width="72" height="72" rx="8" fill="#3a2a2a"/>
+
+    <!-- Icon content area: y=9 to y=43 -->
+{{iconContent}}
+
+    <!-- Two-line label -->
+    <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">{{labelLine1}}</text>
+    <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
+          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">{{labelLine2}}</text>
+  </g>
+</svg>

--- a/packages/stream-deck-plugin-core/src/actions/tire-service.test.ts
+++ b/packages/stream-deck-plugin-core/src/actions/tire-service.test.ts
@@ -1,0 +1,312 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { generateTireServiceSvg, TireService } from "./tire-service.js";
+
+const {
+  mockPitLeftFront,
+  mockPitRightFront,
+  mockPitLeftRear,
+  mockPitRightRear,
+  mockPitAllTires,
+  mockPitTireCompound,
+  mockPitClearTires,
+  mockGetCommands,
+} = vi.hoisted(() => ({
+  mockPitLeftFront: vi.fn(() => true),
+  mockPitRightFront: vi.fn(() => true),
+  mockPitLeftRear: vi.fn(() => true),
+  mockPitRightRear: vi.fn(() => true),
+  mockPitAllTires: vi.fn(() => true),
+  mockPitTireCompound: vi.fn(() => true),
+  mockPitClearTires: vi.fn(() => true),
+  mockGetCommands: vi.fn(() => ({
+    pit: {
+      leftFront: mockPitLeftFront,
+      rightFront: mockPitRightFront,
+      leftRear: mockPitLeftRear,
+      rightRear: mockPitRightRear,
+      allTires: mockPitAllTires,
+      tireCompound: mockPitTireCompound,
+      clearTires: mockPitClearTires,
+    },
+  })),
+}));
+
+vi.mock("@elgato/streamdeck", () => ({
+  default: {
+    logger: {
+      createScope: vi.fn(() => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trace: vi.fn(),
+      })),
+    },
+  },
+  action: () => (target: unknown) => target,
+}));
+
+vi.mock("@iracedeck/stream-deck-shared", () => ({
+  ConnectionStateAwareAction: class MockConnectionStateAwareAction {
+    sdkController = { subscribe: vi.fn(), unsubscribe: vi.fn(), getCurrentTelemetry: vi.fn() };
+    updateConnectionState = vi.fn();
+    setKeyImage = vi.fn();
+    async onWillDisappear() {}
+  },
+  createSDLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+  })),
+  getCommands: mockGetCommands,
+  LogLevel: { Info: 2 },
+  renderIconTemplate: vi.fn((_template: string, data: Record<string, string>) => {
+    return `<svg>${data.iconContent || ""}${data.labelLine1 || ""}${data.labelLine2 || ""}</svg>`;
+  }),
+  svgToDataUri: vi.fn((svg: string) => `data:image/svg+xml,${encodeURIComponent(svg)}`),
+}));
+
+/** Create a minimal fake event with the given action ID and settings. */
+function fakeEvent(actionId: string, settings: Record<string, unknown> = {}) {
+  return {
+    action: { id: actionId, setTitle: vi.fn(), setImage: vi.fn() },
+    payload: { settings },
+  };
+}
+
+describe("TireService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("generateTireServiceSvg", () => {
+    it("should generate a valid data URI for request-lf", () => {
+      const result = generateTireServiceSvg({ action: "request-lf" });
+
+      expect(result).toContain("data:image/svg+xml");
+    });
+
+    it("should generate a valid data URI for request-rf", () => {
+      const result = generateTireServiceSvg({ action: "request-rf" });
+
+      expect(result).toContain("data:image/svg+xml");
+    });
+
+    it("should generate a valid data URI for request-lr", () => {
+      const result = generateTireServiceSvg({ action: "request-lr" });
+
+      expect(result).toContain("data:image/svg+xml");
+    });
+
+    it("should generate a valid data URI for request-rr", () => {
+      const result = generateTireServiceSvg({ action: "request-rr" });
+
+      expect(result).toContain("data:image/svg+xml");
+    });
+
+    it("should generate a valid data URI for request-all", () => {
+      const result = generateTireServiceSvg({ action: "request-all" });
+
+      expect(result).toContain("data:image/svg+xml");
+    });
+
+    it("should generate a valid data URI for change-compound", () => {
+      const result = generateTireServiceSvg({ action: "change-compound" });
+
+      expect(result).toContain("data:image/svg+xml");
+    });
+
+    it("should generate a valid data URI for clear-tires", () => {
+      const result = generateTireServiceSvg({ action: "clear-tires" });
+
+      expect(result).toContain("data:image/svg+xml");
+    });
+
+    it("should produce different icons for different action types", () => {
+      const lf = generateTireServiceSvg({ action: "request-lf" });
+      const rf = generateTireServiceSvg({ action: "request-rf" });
+      const lr = generateTireServiceSvg({ action: "request-lr" });
+      const rr = generateTireServiceSvg({ action: "request-rr" });
+      const all = generateTireServiceSvg({ action: "request-all" });
+      const compound = generateTireServiceSvg({ action: "change-compound" });
+      const clear = generateTireServiceSvg({ action: "clear-tires" });
+
+      const icons = [lf, rf, lr, rr, all, compound, clear];
+      const unique = new Set(icons);
+      expect(unique.size).toBe(icons.length);
+    });
+
+    it("should include correct labels for all action types", () => {
+      const expectedLabels: Record<string, { line1: string; line2: string }> = {
+        "request-lf": { line1: "LEFT", line2: "FRONT" },
+        "request-rf": { line1: "RIGHT", line2: "FRONT" },
+        "request-lr": { line1: "LEFT", line2: "REAR" },
+        "request-rr": { line1: "RIGHT", line2: "REAR" },
+        "request-all": { line1: "ALL", line2: "TIRES" },
+        "change-compound": { line1: "TIRE", line2: "COMPOUND" },
+        "clear-tires": { line1: "CLEAR", line2: "TIRES" },
+      };
+
+      for (const [actionType, labels] of Object.entries(expectedLabels)) {
+        const result = generateTireServiceSvg({ action: actionType as any });
+        const decoded = decodeURIComponent(result);
+
+        expect(decoded).toContain(labels.line1);
+        expect(decoded).toContain(labels.line2);
+      }
+    });
+  });
+
+  describe("key press behavior", () => {
+    let action: TireService;
+
+    beforeEach(() => {
+      action = new TireService();
+    });
+
+    it("should call pit.leftFront() on keyDown for request-lf", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { action: "request-lf" }) as any);
+
+      expect(mockPitLeftFront).toHaveBeenCalledOnce();
+      expect(mockPitRightFront).not.toHaveBeenCalled();
+      expect(mockPitLeftRear).not.toHaveBeenCalled();
+      expect(mockPitRightRear).not.toHaveBeenCalled();
+      expect(mockPitAllTires).not.toHaveBeenCalled();
+      expect(mockPitTireCompound).not.toHaveBeenCalled();
+      expect(mockPitClearTires).not.toHaveBeenCalled();
+    });
+
+    it("should call pit.rightFront() on keyDown for request-rf", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { action: "request-rf" }) as any);
+
+      expect(mockPitRightFront).toHaveBeenCalledOnce();
+      expect(mockPitLeftFront).not.toHaveBeenCalled();
+      expect(mockPitLeftRear).not.toHaveBeenCalled();
+      expect(mockPitRightRear).not.toHaveBeenCalled();
+      expect(mockPitAllTires).not.toHaveBeenCalled();
+      expect(mockPitTireCompound).not.toHaveBeenCalled();
+      expect(mockPitClearTires).not.toHaveBeenCalled();
+    });
+
+    it("should call pit.leftRear() on keyDown for request-lr", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { action: "request-lr" }) as any);
+
+      expect(mockPitLeftRear).toHaveBeenCalledOnce();
+      expect(mockPitLeftFront).not.toHaveBeenCalled();
+      expect(mockPitRightFront).not.toHaveBeenCalled();
+      expect(mockPitRightRear).not.toHaveBeenCalled();
+      expect(mockPitAllTires).not.toHaveBeenCalled();
+      expect(mockPitTireCompound).not.toHaveBeenCalled();
+      expect(mockPitClearTires).not.toHaveBeenCalled();
+    });
+
+    it("should call pit.rightRear() on keyDown for request-rr", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { action: "request-rr" }) as any);
+
+      expect(mockPitRightRear).toHaveBeenCalledOnce();
+      expect(mockPitLeftFront).not.toHaveBeenCalled();
+      expect(mockPitRightFront).not.toHaveBeenCalled();
+      expect(mockPitLeftRear).not.toHaveBeenCalled();
+      expect(mockPitAllTires).not.toHaveBeenCalled();
+      expect(mockPitTireCompound).not.toHaveBeenCalled();
+      expect(mockPitClearTires).not.toHaveBeenCalled();
+    });
+
+    it("should call pit.allTires() on keyDown for request-all", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { action: "request-all" }) as any);
+
+      expect(mockPitAllTires).toHaveBeenCalledOnce();
+      expect(mockPitLeftFront).not.toHaveBeenCalled();
+      expect(mockPitRightFront).not.toHaveBeenCalled();
+      expect(mockPitLeftRear).not.toHaveBeenCalled();
+      expect(mockPitRightRear).not.toHaveBeenCalled();
+      expect(mockPitTireCompound).not.toHaveBeenCalled();
+      expect(mockPitClearTires).not.toHaveBeenCalled();
+    });
+
+    it("should call pit.tireCompound(0) on keyDown for change-compound", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { action: "change-compound" }) as any);
+
+      expect(mockPitTireCompound).toHaveBeenCalledOnce();
+      expect(mockPitTireCompound).toHaveBeenCalledWith(0);
+      expect(mockPitLeftFront).not.toHaveBeenCalled();
+      expect(mockPitRightFront).not.toHaveBeenCalled();
+      expect(mockPitLeftRear).not.toHaveBeenCalled();
+      expect(mockPitRightRear).not.toHaveBeenCalled();
+      expect(mockPitAllTires).not.toHaveBeenCalled();
+      expect(mockPitClearTires).not.toHaveBeenCalled();
+    });
+
+    it("should call pit.clearTires() on keyDown for clear-tires", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { action: "clear-tires" }) as any);
+
+      expect(mockPitClearTires).toHaveBeenCalledOnce();
+      expect(mockPitLeftFront).not.toHaveBeenCalled();
+      expect(mockPitRightFront).not.toHaveBeenCalled();
+      expect(mockPitLeftRear).not.toHaveBeenCalled();
+      expect(mockPitRightRear).not.toHaveBeenCalled();
+      expect(mockPitAllTires).not.toHaveBeenCalled();
+      expect(mockPitTireCompound).not.toHaveBeenCalled();
+    });
+
+    it("should default to request-all when no action is specified", async () => {
+      await action.onKeyDown(fakeEvent("action-1", {}) as any);
+
+      expect(mockPitAllTires).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("encoder behavior", () => {
+    let action: TireService;
+
+    beforeEach(() => {
+      action = new TireService();
+    });
+
+    it("should call pit.leftFront() on dialDown for request-lf", async () => {
+      await action.onDialDown(fakeEvent("action-1", { action: "request-lf" }) as any);
+
+      expect(mockPitLeftFront).toHaveBeenCalledOnce();
+    });
+
+    it("should call pit.rightFront() on dialDown for request-rf", async () => {
+      await action.onDialDown(fakeEvent("action-1", { action: "request-rf" }) as any);
+
+      expect(mockPitRightFront).toHaveBeenCalledOnce();
+    });
+
+    it("should call pit.leftRear() on dialDown for request-lr", async () => {
+      await action.onDialDown(fakeEvent("action-1", { action: "request-lr" }) as any);
+
+      expect(mockPitLeftRear).toHaveBeenCalledOnce();
+    });
+
+    it("should call pit.rightRear() on dialDown for request-rr", async () => {
+      await action.onDialDown(fakeEvent("action-1", { action: "request-rr" }) as any);
+
+      expect(mockPitRightRear).toHaveBeenCalledOnce();
+    });
+
+    it("should call pit.allTires() on dialDown for request-all", async () => {
+      await action.onDialDown(fakeEvent("action-1", { action: "request-all" }) as any);
+
+      expect(mockPitAllTires).toHaveBeenCalledOnce();
+    });
+
+    it("should call pit.tireCompound(0) on dialDown for change-compound", async () => {
+      await action.onDialDown(fakeEvent("action-1", { action: "change-compound" }) as any);
+
+      expect(mockPitTireCompound).toHaveBeenCalledOnce();
+      expect(mockPitTireCompound).toHaveBeenCalledWith(0);
+    });
+
+    it("should call pit.clearTires() on dialDown for clear-tires", async () => {
+      await action.onDialDown(fakeEvent("action-1", { action: "clear-tires" }) as any);
+
+      expect(mockPitClearTires).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/packages/stream-deck-plugin-core/src/actions/tire-service.ts
+++ b/packages/stream-deck-plugin-core/src/actions/tire-service.ts
@@ -1,0 +1,252 @@
+import streamDeck, {
+  action,
+  DialDownEvent,
+  DidReceiveSettingsEvent,
+  KeyDownEvent,
+  WillAppearEvent,
+  WillDisappearEvent,
+} from "@elgato/streamdeck";
+import {
+  ConnectionStateAwareAction,
+  createSDLogger,
+  getCommands,
+  LogLevel,
+  renderIconTemplate,
+  svgToDataUri,
+} from "@iracedeck/stream-deck-shared";
+import z from "zod";
+
+import tireServiceTemplate from "../../icons/tire-service.svg";
+
+const WHITE = "#ffffff";
+const GREEN = "#2ecc71";
+const RED = "#e74c3c";
+const YELLOW = "#f1c40f";
+const GRAY = "#888888";
+
+type TireServiceAction =
+  | "request-lf"
+  | "request-rf"
+  | "request-lr"
+  | "request-rr"
+  | "request-all"
+  | "change-compound"
+  | "clear-tires";
+
+/**
+ * Label configuration for each tire service action (line1 bold, line2 subdued)
+ */
+const TIRE_SERVICE_LABELS: Record<TireServiceAction, { line1: string; line2: string }> = {
+  "request-lf": { line1: "LEFT", line2: "FRONT" },
+  "request-rf": { line1: "RIGHT", line2: "FRONT" },
+  "request-lr": { line1: "LEFT", line2: "REAR" },
+  "request-rr": { line1: "RIGHT", line2: "REAR" },
+  "request-all": { line1: "ALL", line2: "TIRES" },
+  "change-compound": { line1: "TIRE", line2: "COMPOUND" },
+  "clear-tires": { line1: "CLEAR", line2: "TIRES" },
+};
+
+/**
+ * SVG icon content for each tire service action.
+ * Uses a bird's-eye car outline with tire positions to distinguish from fuel service icons.
+ */
+const TIRE_SERVICE_ICONS: Record<TireServiceAction, string> = {
+  // Request Left Front: car body with LF tire highlighted
+  "request-lf": `
+    <rect x="26" y="12" width="20" height="28" rx="3" fill="none" stroke="${GRAY}" stroke-width="1.2"/>
+    <circle cx="23" cy="16" r="4" fill="none" stroke="${WHITE}" stroke-width="2"/>
+    <circle cx="49" cy="16" r="4" fill="none" stroke="${GRAY}" stroke-width="1"/>
+    <circle cx="23" cy="36" r="4" fill="none" stroke="${GRAY}" stroke-width="1"/>
+    <circle cx="49" cy="36" r="4" fill="none" stroke="${GRAY}" stroke-width="1"/>`,
+
+  // Request Right Front: car body with RF tire highlighted
+  "request-rf": `
+    <rect x="26" y="12" width="20" height="28" rx="3" fill="none" stroke="${GRAY}" stroke-width="1.2"/>
+    <circle cx="23" cy="16" r="4" fill="none" stroke="${GRAY}" stroke-width="1"/>
+    <circle cx="49" cy="16" r="4" fill="none" stroke="${WHITE}" stroke-width="2"/>
+    <circle cx="23" cy="36" r="4" fill="none" stroke="${GRAY}" stroke-width="1"/>
+    <circle cx="49" cy="36" r="4" fill="none" stroke="${GRAY}" stroke-width="1"/>`,
+
+  // Request Left Rear: car body with LR tire highlighted
+  "request-lr": `
+    <rect x="26" y="12" width="20" height="28" rx="3" fill="none" stroke="${GRAY}" stroke-width="1.2"/>
+    <circle cx="23" cy="16" r="4" fill="none" stroke="${GRAY}" stroke-width="1"/>
+    <circle cx="49" cy="16" r="4" fill="none" stroke="${GRAY}" stroke-width="1"/>
+    <circle cx="23" cy="36" r="4" fill="none" stroke="${WHITE}" stroke-width="2"/>
+    <circle cx="49" cy="36" r="4" fill="none" stroke="${GRAY}" stroke-width="1"/>`,
+
+  // Request Right Rear: car body with RR tire highlighted
+  "request-rr": `
+    <rect x="26" y="12" width="20" height="28" rx="3" fill="none" stroke="${GRAY}" stroke-width="1.2"/>
+    <circle cx="23" cy="16" r="4" fill="none" stroke="${GRAY}" stroke-width="1"/>
+    <circle cx="49" cy="16" r="4" fill="none" stroke="${GRAY}" stroke-width="1"/>
+    <circle cx="23" cy="36" r="4" fill="none" stroke="${GRAY}" stroke-width="1"/>
+    <circle cx="49" cy="36" r="4" fill="none" stroke="${WHITE}" stroke-width="2"/>`,
+
+  // Request All Tires: car body with all tires highlighted in green
+  "request-all": `
+    <rect x="26" y="12" width="20" height="28" rx="3" fill="none" stroke="${GRAY}" stroke-width="1.2"/>
+    <circle cx="23" cy="16" r="4" fill="none" stroke="${GREEN}" stroke-width="2"/>
+    <circle cx="49" cy="16" r="4" fill="none" stroke="${GREEN}" stroke-width="2"/>
+    <circle cx="23" cy="36" r="4" fill="none" stroke="${GREEN}" stroke-width="2"/>
+    <circle cx="49" cy="36" r="4" fill="none" stroke="${GREEN}" stroke-width="2"/>`,
+
+  // Change Compound: tire circle with swap arrows in yellow
+  "change-compound": `
+    <circle cx="36" cy="24" r="10" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <circle cx="36" cy="24" r="4" fill="none" stroke="${GRAY}" stroke-width="1"/>
+    <path d="M28 36 L24 40 L28 44" fill="none" stroke="${YELLOW}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="24" y1="40" x2="48" y2="40" stroke="${YELLOW}" stroke-width="2" stroke-linecap="round"/>
+    <path d="M44 36 L48 32 L44 28" fill="none" stroke="${YELLOW}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="48" y1="32" x2="24" y2="32" stroke="${YELLOW}" stroke-width="2" stroke-linecap="round"/>`,
+
+  // Clear Tires: tire circle with X overlay in red
+  "clear-tires": `
+    <circle cx="36" cy="26" r="10" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <circle cx="36" cy="26" r="4" fill="none" stroke="${GRAY}" stroke-width="1"/>
+    <line x1="29" y1="19" x2="43" y2="33" stroke="${RED}" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="43" y1="19" x2="29" y2="33" stroke="${RED}" stroke-width="2.5" stroke-linecap="round"/>`,
+};
+
+const TireServiceSettings = z.object({
+  action: z
+    .enum([
+      "request-lf",
+      "request-rf",
+      "request-lr",
+      "request-rr",
+      "request-all",
+      "change-compound",
+      "clear-tires",
+    ])
+    .default("request-all"),
+});
+
+type TireServiceSettings = z.infer<typeof TireServiceSettings>;
+
+/**
+ * @internal Exported for testing
+ *
+ * Generates an SVG data URI icon for the tire service action.
+ */
+export function generateTireServiceSvg(settings: TireServiceSettings): string {
+  const { action: actionType } = settings;
+
+  const iconContent = TIRE_SERVICE_ICONS[actionType] || TIRE_SERVICE_ICONS["request-all"];
+  const labels = TIRE_SERVICE_LABELS[actionType] || TIRE_SERVICE_LABELS["request-all"];
+
+  const svg = renderIconTemplate(tireServiceTemplate, {
+    iconContent,
+    labelLine1: labels.line1,
+    labelLine2: labels.line2,
+  });
+
+  return svgToDataUri(svg);
+}
+
+/**
+ * Tire Service
+ * Provides tire management for pit stops (request tires, change compound, clear)
+ * via iRacing SDK commands.
+ */
+@action({ UUID: "com.iracedeck.sd.core.tire-service" })
+export class TireService extends ConnectionStateAwareAction<TireServiceSettings> {
+  protected override logger = createSDLogger(streamDeck.logger.createScope("TireService"), LogLevel.Info);
+
+  override async onWillAppear(ev: WillAppearEvent<TireServiceSettings>): Promise<void> {
+    const settings = this.parseSettings(ev.payload.settings);
+    await this.updateDisplay(ev, settings);
+
+    this.sdkController.subscribe(ev.action.id, () => {
+      this.updateConnectionState();
+    });
+  }
+
+  override async onWillDisappear(ev: WillDisappearEvent<TireServiceSettings>): Promise<void> {
+    await super.onWillDisappear(ev);
+    this.sdkController.unsubscribe(ev.action.id);
+  }
+
+  override async onDidReceiveSettings(ev: DidReceiveSettingsEvent<TireServiceSettings>): Promise<void> {
+    const settings = this.parseSettings(ev.payload.settings);
+    await this.updateDisplay(ev, settings);
+  }
+
+  override async onKeyDown(ev: KeyDownEvent<TireServiceSettings>): Promise<void> {
+    this.logger.info("Key down received");
+    const settings = this.parseSettings(ev.payload.settings);
+    this.executeAction(settings.action);
+  }
+
+  override async onDialDown(ev: DialDownEvent<TireServiceSettings>): Promise<void> {
+    this.logger.info("Dial down received");
+    const settings = this.parseSettings(ev.payload.settings);
+    this.executeAction(settings.action);
+  }
+
+  private parseSettings(settings: unknown): TireServiceSettings {
+    const parsed = TireServiceSettings.safeParse(settings);
+
+    return parsed.success ? parsed.data : TireServiceSettings.parse({});
+  }
+
+  private executeAction(actionType: TireServiceAction): void {
+    const pit = getCommands().pit;
+
+    switch (actionType) {
+      case "request-lf": {
+        const success = pit.leftFront();
+        this.logger.info("Request left front tire executed");
+        this.logger.debug(`Result: ${success}`);
+        break;
+      }
+      case "request-rf": {
+        const success = pit.rightFront();
+        this.logger.info("Request right front tire executed");
+        this.logger.debug(`Result: ${success}`);
+        break;
+      }
+      case "request-lr": {
+        const success = pit.leftRear();
+        this.logger.info("Request left rear tire executed");
+        this.logger.debug(`Result: ${success}`);
+        break;
+      }
+      case "request-rr": {
+        const success = pit.rightRear();
+        this.logger.info("Request right rear tire executed");
+        this.logger.debug(`Result: ${success}`);
+        break;
+      }
+      case "request-all": {
+        const success = pit.allTires();
+        this.logger.info("Request all tires executed");
+        this.logger.debug(`Result: ${success}`);
+        break;
+      }
+      case "change-compound": {
+        const success = pit.tireCompound(0);
+        this.logger.info("Change tire compound executed");
+        this.logger.debug(`Result: ${success}`);
+        break;
+      }
+      case "clear-tires": {
+        const success = pit.clearTires();
+        this.logger.info("Clear tires checkbox executed");
+        this.logger.debug(`Result: ${success}`);
+        break;
+      }
+    }
+  }
+
+  private async updateDisplay(
+    ev: WillAppearEvent<TireServiceSettings> | DidReceiveSettingsEvent<TireServiceSettings>,
+    settings: TireServiceSettings,
+  ): Promise<void> {
+    this.updateConnectionState();
+
+    const svgDataUri = generateTireServiceSvg(settings);
+    await ev.action.setTitle("");
+    await this.setKeyImage(ev, svgDataUri);
+  }
+}

--- a/packages/stream-deck-plugin-core/src/pi/tire-service.ejs
+++ b/packages/stream-deck-plugin-core/src/pi/tire-service.ejs
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<%- include('head-common') %>
+	</head>
+	<body>
+		<sdpi-item label="Action">
+			<sdpi-select setting="action" default="request-all">
+				<option value="request-lf">Request Left Front</option>
+				<option value="request-rf">Request Right Front</option>
+				<option value="request-lr">Request Left Rear</option>
+				<option value="request-rr">Request Right Rear</option>
+				<option value="request-all">Request All Tires</option>
+				<option value="change-compound">Change Compound</option>
+				<option value="clear-tires">Clear Tires Checkbox</option>
+			</sdpi-select>
+		</sdpi-item>
+	</body>
+</html>

--- a/packages/stream-deck-plugin-core/src/plugin.ts
+++ b/packages/stream-deck-plugin-core/src/plugin.ts
@@ -15,6 +15,7 @@ import { FuelService } from "./actions/fuel-service.js";
 import { LookDirection } from "./actions/look-direction.js";
 import { PitQuickActions } from "./actions/pit-quick-actions.js";
 import { SplitsDeltaCycle } from "./actions/splits-delta-cycle.js";
+import { TireService } from "./actions/tire-service.js";
 import { ToggleUiElements } from "./actions/toggle-ui-elements.js";
 import { ViewAdjustment } from "./actions/view-adjustment.js";
 
@@ -41,6 +42,7 @@ streamDeck.actions.registerAction(new FuelService());
 streamDeck.actions.registerAction(new LookDirection());
 streamDeck.actions.registerAction(new PitQuickActions());
 streamDeck.actions.registerAction(new SplitsDeltaCycle());
+streamDeck.actions.registerAction(new TireService());
 streamDeck.actions.registerAction(new ToggleUiElements());
 streamDeck.actions.registerAction(new ViewAdjustment());
 


### PR DESCRIPTION
## Summary

- Add Tire Service action (`com.iracedeck.sd.core.tire-service`) with 7 sub-actions: request individual tires (LF, RF, LR, RR), request all tires, change tire compound, and clear tires checkbox
- All sub-actions use iRacing SDK pit commands (no keyboard shortcuts)
- Supports both Keypad and Encoder controllers (press to activate, rotation is no-op)
- Includes bird's-eye car outline icons with tire position highlighting per mode

Closes #10

## Test plan

- [x] 24 unit tests covering icon generation, key press behavior (all 7 actions), and encoder behavior
- [x] All 800 workspace tests pass
- [x] Build succeeds
- [x] Lint and formatting clean