### PR TITLE
feat(stream-deck-plugin-core): add Camera Cycle action

### DIFF
--- a/packages/iracing-sdk/src/commands/CameraCommand.test.ts
+++ b/packages/iracing-sdk/src/commands/CameraCommand.test.ts
@@ -219,6 +219,108 @@ describe("CameraCommand", () => {
     });
   });
 
+  describe("cycleCamera", () => {
+    it("should send CamSwitchPos with incremented group for next", () => {
+      cameraCommand.cycleCamera(5, 3, 1);
+
+      expect(mockNative.broadcastMsg).toHaveBeenCalledWith(BroadcastMsg.CamSwitchPos, 5, 4, 0);
+    });
+
+    it("should send CamSwitchPos with decremented group for previous", () => {
+      cameraCommand.cycleCamera(5, 3, -1);
+
+      expect(mockNative.broadcastMsg).toHaveBeenCalledWith(BroadcastMsg.CamSwitchPos, 5, 2, 0);
+    });
+
+    it("should pass camera=0 to keep current sub-camera", () => {
+      cameraCommand.cycleCamera(2, 1, 1);
+
+      expect(mockNative.broadcastMsg).toHaveBeenCalledWith(BroadcastMsg.CamSwitchPos, 2, 2, 0);
+    });
+
+    it("should return true", () => {
+      expect(cameraCommand.cycleCamera(1, 1, 1)).toBe(true);
+    });
+  });
+
+  describe("cycleSubCamera", () => {
+    it("should send CamSwitchPos with incremented camera for next", () => {
+      cameraCommand.cycleSubCamera(5, 3, 2, 1);
+
+      expect(mockNative.broadcastMsg).toHaveBeenCalledWith(BroadcastMsg.CamSwitchPos, 5, 3, 3);
+    });
+
+    it("should send CamSwitchPos with decremented camera for previous", () => {
+      cameraCommand.cycleSubCamera(5, 3, 2, -1);
+
+      expect(mockNative.broadcastMsg).toHaveBeenCalledWith(BroadcastMsg.CamSwitchPos, 5, 3, 1);
+    });
+
+    it("should preserve current group", () => {
+      cameraCommand.cycleSubCamera(0, 7, 4, 1);
+
+      expect(mockNative.broadcastMsg).toHaveBeenCalledWith(BroadcastMsg.CamSwitchPos, 0, 7, 5);
+    });
+
+    it("should return true", () => {
+      expect(cameraCommand.cycleSubCamera(1, 1, 1, 1)).toBe(true);
+    });
+  });
+
+  describe("cycleCar", () => {
+    it("should send CamSwitchPos with incremented car position for next", () => {
+      cameraCommand.cycleCar(5, 1);
+
+      expect(mockNative.broadcastMsg).toHaveBeenCalledWith(BroadcastMsg.CamSwitchPos, 6, 0, 0);
+    });
+
+    it("should send CamSwitchPos with decremented car position for previous", () => {
+      cameraCommand.cycleCar(5, -1);
+
+      expect(mockNative.broadcastMsg).toHaveBeenCalledWith(BroadcastMsg.CamSwitchPos, 4, 0, 0);
+    });
+
+    it("should pass group=0 and camera=0 to keep current camera", () => {
+      cameraCommand.cycleCar(3, 1);
+
+      expect(mockNative.broadcastMsg).toHaveBeenCalledWith(BroadcastMsg.CamSwitchPos, 4, 0, 0);
+    });
+
+    it("should return true", () => {
+      expect(cameraCommand.cycleCar(1, 1)).toBe(true);
+    });
+  });
+
+  describe("cycleDrivingCamera", () => {
+    it("should send CamSwitchPos with incremented group for next", () => {
+      cameraCommand.cycleDrivingCamera(5, 3, 1);
+
+      expect(mockNative.broadcastMsg).toHaveBeenCalledWith(BroadcastMsg.CamSwitchPos, 5, 4, 0);
+    });
+
+    it("should send CamSwitchPos with decremented group for previous", () => {
+      cameraCommand.cycleDrivingCamera(5, 3, -1);
+
+      expect(mockNative.broadcastMsg).toHaveBeenCalledWith(BroadcastMsg.CamSwitchPos, 5, 2, 0);
+    });
+
+    it("should behave identically to cycleCamera", () => {
+      cameraCommand.cycleCamera(10, 5, 1);
+      const cameraCycleArgs = (mockNative.broadcastMsg as ReturnType<typeof vi.fn>).mock.calls[0];
+
+      (mockNative.broadcastMsg as ReturnType<typeof vi.fn>).mockClear();
+
+      cameraCommand.cycleDrivingCamera(10, 5, 1);
+      const drivingCycleArgs = (mockNative.broadcastMsg as ReturnType<typeof vi.fn>).mock.calls[0];
+
+      expect(drivingCycleArgs).toEqual(cameraCycleArgs);
+    });
+
+    it("should return true", () => {
+      expect(cameraCommand.cycleDrivingCamera(1, 1, 1)).toBe(true);
+    });
+  });
+
   describe("return values", () => {
     it("all methods should return true", () => {
       expect(cameraCommand.switchPos(1, 1, 1)).toBe(true);
@@ -229,6 +331,10 @@ describe("CameraCommand", () => {
       expect(cameraCommand.focusOnLeader(1, 1)).toBe(true);
       expect(cameraCommand.focusOnIncident(1, 1)).toBe(true);
       expect(cameraCommand.focusOnExiting(1, 1)).toBe(true);
+      expect(cameraCommand.cycleCamera(1, 1, 1)).toBe(true);
+      expect(cameraCommand.cycleSubCamera(1, 1, 1, 1)).toBe(true);
+      expect(cameraCommand.cycleCar(1, 1)).toBe(true);
+      expect(cameraCommand.cycleDrivingCamera(1, 1, 1)).toBe(true);
     });
   });
 });

--- a/packages/iracing-sdk/src/commands/CameraCommand.ts
+++ b/packages/iracing-sdk/src/commands/CameraCommand.ts
@@ -107,4 +107,64 @@ export class CameraCommand extends BroadcastCommand {
   focusOnExiting(group: number, camera: number): boolean {
     return this.switchPos(CameraFocusMode.FocusAtExiting, group, camera);
   }
+
+  /**
+   * Cycle to the next or previous camera group.
+   * iRacing wraps automatically when the value goes out of range.
+   * @param currentCarIdx Current car index from telemetry (CamCarIdx)
+   * @param currentGroup Current camera group from telemetry (CamGroupNumber)
+   * @param direction 1 for next, -1 for previous
+   */
+  cycleCamera(currentCarIdx: number, currentGroup: number, direction: 1 | -1): boolean {
+    this.logger.info("Cycle camera group");
+    this.logger.debug(`carIdx=${currentCarIdx}, group=${currentGroup}, direction=${direction}`);
+
+    return this.switchPos(currentCarIdx, currentGroup + direction, 0);
+  }
+
+  /**
+   * Cycle to the next or previous sub-camera within the current group.
+   * iRacing wraps automatically when the value goes out of range.
+   * @param currentCarIdx Current car index from telemetry (CamCarIdx)
+   * @param currentGroup Current camera group from telemetry (CamGroupNumber)
+   * @param currentCamera Current camera number from telemetry (CamCameraNumber)
+   * @param direction 1 for next, -1 for previous
+   */
+  cycleSubCamera(currentCarIdx: number, currentGroup: number, currentCamera: number, direction: 1 | -1): boolean {
+    this.logger.info("Cycle sub-camera");
+    this.logger.debug(
+      `carIdx=${currentCarIdx}, group=${currentGroup}, camera=${currentCamera}, direction=${direction}`,
+    );
+
+    return this.switchPos(currentCarIdx, currentGroup, currentCamera + direction);
+  }
+
+  /**
+   * Cycle to the next or previous car.
+   * Pass 0 for group and camera to keep current camera settings.
+   * iRacing wraps automatically when the value goes out of range.
+   * @param currentCarIdx Current car index from telemetry (CamCarIdx)
+   * @param direction 1 for next, -1 for previous
+   */
+  cycleCar(currentCarIdx: number, direction: 1 | -1): boolean {
+    this.logger.info("Cycle car");
+    this.logger.debug(`carIdx=${currentCarIdx}, direction=${direction}`);
+
+    return this.switchPos(currentCarIdx + direction, 0, 0);
+  }
+
+  /**
+   * Cycle to the next or previous driving camera.
+   * Semantically identical to cycleCamera — both cycle camera groups.
+   * The distinction exists for user clarity (driving cameras are specific camera groups).
+   * @param currentCarIdx Current car index from telemetry (CamCarIdx)
+   * @param currentGroup Current camera group from telemetry (CamGroupNumber)
+   * @param direction 1 for next, -1 for previous
+   */
+  cycleDrivingCamera(currentCarIdx: number, currentGroup: number, direction: 1 | -1): boolean {
+    this.logger.info("Cycle driving camera");
+    this.logger.debug(`carIdx=${currentCarIdx}, group=${currentGroup}, direction=${direction}`);
+
+    return this.switchPos(currentCarIdx, currentGroup + direction, 0);
+  }
 }

--- a/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/imgs/actions/camera-cycle/icon.svg
+++ b/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/imgs/actions/camera-cycle/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="#ffffff">
+  <!-- Movie camera icon -->
+  <rect x="3" y="6" width="10" height="8" rx="1" stroke-width="1.5"/>
+  <polygon points="13,8 17,5 17,15 13,12" stroke-width="1.5" stroke-linejoin="round"/>
+</svg>

--- a/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/imgs/actions/camera-cycle/key.svg
+++ b/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/imgs/actions/camera-cycle/key.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+  <!-- Main background -->
+  <rect x="0" y="0" width="72" height="72" rx="8" fill="#2a3a4a"/>
+
+  <!-- Movie camera icon -->
+  <rect x="20" y="14" width="20" height="16" rx="2" fill="none" stroke="#ffffff" stroke-width="2"/>
+  <polygon points="40,17 52,12 52,36 40,31" fill="none" stroke="#ffffff" stroke-width="2" stroke-linejoin="round"/>
+
+  <!-- Right chevron (next indicator) -->
+  <polyline points="56,20 62,24 56,28" fill="none" stroke="#2ecc71" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Two-line label -->
+  <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">NEXT</text>
+  <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
+        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">CAMERA</text>
+</svg>

--- a/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/manifest.json
+++ b/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/manifest.json
@@ -305,6 +305,28 @@
       ]
     },
     {
+      "Name": "Camera Cycle",
+      "UUID": "com.iracedeck.sd.core.camera-cycle",
+      "Icon": "imgs/actions/camera-cycle/icon",
+      "Tooltip": "Cycle through cameras, sub-cameras, cars, and driving cameras",
+      "PropertyInspectorPath": "ui/camera-cycle.html",
+      "Controllers": ["Keypad", "Encoder"],
+      "Encoder": {
+        "layout": "$B1",
+        "TriggerDescription": {
+          "Rotate": "Next/Previous camera",
+          "Press": "Activate camera cycle"
+        }
+      },
+      "States": [
+        {
+          "Image": "imgs/actions/camera-cycle/key",
+          "TitleAlignment": "bottom",
+          "FontSize": 14
+        }
+      ]
+    },
+    {
       "Name": "Replay Navigation",
       "UUID": "com.iracedeck.sd.core.replay-navigation",
       "Icon": "imgs/actions/replay-navigation/icon",

--- a/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/ui/camera-cycle.html
+++ b/packages/stream-deck-plugin-core/com.iracedeck.sd.core.sdPlugin/ui/camera-cycle.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+<script src="sdpi-components.js"></script>
+<script src="pi-components.js"></script>
+<style>
+  .hidden {
+    display: none !important;
+  }
+
+  /* Collapsible section styles */
+  .ird-collapsible {
+    margin-top: 12px;
+  }
+
+  .ird-collapsible-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 0 4px 0;
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+    border-top: 1px solid #3a3a3a;
+  }
+
+  .ird-collapsible-header::-webkit-details-marker {
+    display: none;
+  }
+
+  .ird-collapsible-icon {
+    font-size: 8px;
+    color: #808080;
+    transition: transform 0.15s ease;
+    flex-shrink: 0;
+  }
+
+  .ird-collapsible[open] .ird-collapsible-icon {
+    transform: rotate(90deg);
+  }
+
+  .ird-collapsible-title {
+    font-family: "Segoe UI", Arial, Roboto, Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 9pt;
+    font-weight: 600;
+    color: #ffffff;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .ird-collapsible-content {
+    padding-top: 4px;
+  }
+
+  .ird-section-subtitle {
+    font-family: "Segoe UI", Arial, Roboto, Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 9pt;
+    color: #d0d0d0;
+    margin: 8px 0 4px 14px;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+  }
+
+  /* Key bindings section styles */
+  .ird-key-bindings-section {
+    margin-top: 12px;
+  }
+
+  .ird-section-heading {
+    padding: 8px 0 4px 0;
+    border-top: 1px solid #3a3a3a;
+    font-family: "Segoe UI", Arial, Roboto, Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 9pt;
+    font-weight: 600;
+    color: #ffffff;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+</style>
+
+	</head>
+	<body>
+		<sdpi-item label="Camera">
+			<sdpi-select setting="cameraType" default="camera">
+				<option value="camera">Camera</option>
+				<option value="sub-camera">Sub-Camera</option>
+				<option value="car">Car</option>
+				<option value="driving">Driving Camera</option>
+			</sdpi-select>
+		</sdpi-item>
+
+		<sdpi-item label="Direction">
+			<sdpi-select setting="direction" default="next">
+				<option value="next">Next</option>
+				<option value="previous">Previous</option>
+			</sdpi-select>
+		</sdpi-item>
+	</body>
+</html>

--- a/packages/stream-deck-plugin-core/icons/camera-cycle.svg
+++ b/packages/stream-deck-plugin-core/icons/camera-cycle.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+  <g filter="url(#activity-state)">
+    <!-- Main background -->
+    <rect x="0" y="0" width="72" height="72" rx="8" fill="#2a3a4a"/>
+
+    <!-- Icon content area: y=9 to y=43 -->
+{{iconContent}}
+
+    <!-- Two-line label -->
+    <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">{{labelLine1}}</text>
+    <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
+          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">{{labelLine2}}</text>
+  </g>
+</svg>

--- a/packages/stream-deck-plugin-core/src/actions/camera-cycle.test.ts
+++ b/packages/stream-deck-plugin-core/src/actions/camera-cycle.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { generateCameraCycleSvg } from "./camera-cycle.js";
+
+vi.mock("@elgato/streamdeck", () => ({
+  default: {
+    logger: {
+      createScope: vi.fn(() => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trace: vi.fn(),
+      })),
+    },
+  },
+  action: () => (target: unknown) => target,
+}));
+
+vi.mock("@iracedeck/stream-deck-shared", () => ({
+  ConnectionStateAwareAction: class MockConnectionStateAwareAction {
+    sdkController = { subscribe: vi.fn(), unsubscribe: vi.fn(), getCurrentTelemetry: vi.fn() };
+    updateConnectionState = vi.fn();
+    setKeyImage = vi.fn();
+  },
+  createSDLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+  })),
+  getCommands: vi.fn(() => ({
+    camera: {
+      cycleCamera: vi.fn(() => true),
+      cycleSubCamera: vi.fn(() => true),
+      cycleCar: vi.fn(() => true),
+      cycleDrivingCamera: vi.fn(() => true),
+    },
+  })),
+  LogLevel: { Info: 2 },
+  renderIconTemplate: vi.fn((_template: string, data: Record<string, string>) => {
+    return `<svg>${data.iconContent || ""}${data.labelLine1 || ""}${data.labelLine2 || ""}</svg>`;
+  }),
+  svgToDataUri: vi.fn((svg: string) => `data:image/svg+xml,${encodeURIComponent(svg)}`),
+}));
+
+describe("CameraCycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("generateCameraCycleSvg", () => {
+    const ALL_CAMERA_TYPES = ["camera", "sub-camera", "car", "driving"] as const;
+    const ALL_DIRECTIONS = ["next", "previous"] as const;
+
+    const ALL_COMBINATIONS = ALL_CAMERA_TYPES.flatMap((cameraType) =>
+      ALL_DIRECTIONS.map((direction) => ({ cameraType, direction })),
+    );
+
+    it.each(ALL_COMBINATIONS)(
+      "should generate a valid data URI for $cameraType / $direction",
+      ({ cameraType, direction }) => {
+        const result = generateCameraCycleSvg({ cameraType, direction });
+
+        expect(result).toContain("data:image/svg+xml");
+      },
+    );
+
+    it("should produce different icons for all 8 combinations", () => {
+      const results = ALL_COMBINATIONS.map(({ cameraType, direction }) =>
+        generateCameraCycleSvg({ cameraType, direction }),
+      );
+
+      const uniqueResults = new Set(results);
+      expect(uniqueResults.size).toBe(ALL_COMBINATIONS.length);
+    });
+
+    it("should include NEXT label for camera/next", () => {
+      const result = generateCameraCycleSvg({ cameraType: "camera", direction: "next" });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain("NEXT");
+      expect(decoded).toContain("CAMERA");
+    });
+
+    it("should include PREV label for camera/previous", () => {
+      const result = generateCameraCycleSvg({ cameraType: "camera", direction: "previous" });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain("PREV");
+      expect(decoded).toContain("CAMERA");
+    });
+
+    it("should include NEXT label for sub-camera/next", () => {
+      const result = generateCameraCycleSvg({ cameraType: "sub-camera", direction: "next" });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain("NEXT");
+      expect(decoded).toContain("SUB CAM");
+    });
+
+    it("should include PREV label for sub-camera/previous", () => {
+      const result = generateCameraCycleSvg({ cameraType: "sub-camera", direction: "previous" });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain("PREV");
+      expect(decoded).toContain("SUB CAM");
+    });
+
+    it("should include NEXT label for car/next", () => {
+      const result = generateCameraCycleSvg({ cameraType: "car", direction: "next" });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain("NEXT");
+      expect(decoded).toContain("CAR");
+    });
+
+    it("should include PREV label for car/previous", () => {
+      const result = generateCameraCycleSvg({ cameraType: "car", direction: "previous" });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain("PREV");
+      expect(decoded).toContain("CAR");
+    });
+
+    it("should include NEXT label for driving/next", () => {
+      const result = generateCameraCycleSvg({ cameraType: "driving", direction: "next" });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain("NEXT");
+      expect(decoded).toContain("DRIVING");
+    });
+
+    it("should include PREV label for driving/previous", () => {
+      const result = generateCameraCycleSvg({ cameraType: "driving", direction: "previous" });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain("PREV");
+      expect(decoded).toContain("DRIVING");
+    });
+  });
+});

--- a/packages/stream-deck-plugin-core/src/actions/camera-cycle.ts
+++ b/packages/stream-deck-plugin-core/src/actions/camera-cycle.ts
@@ -1,0 +1,236 @@
+import streamDeck, {
+  action,
+  DialDownEvent,
+  DialRotateEvent,
+  DidReceiveSettingsEvent,
+  KeyDownEvent,
+  WillAppearEvent,
+  WillDisappearEvent,
+} from "@elgato/streamdeck";
+import {
+  ConnectionStateAwareAction,
+  createSDLogger,
+  getCommands,
+  LogLevel,
+  renderIconTemplate,
+  svgToDataUri,
+} from "@iracedeck/stream-deck-shared";
+import z from "zod";
+
+import cameraCycleTemplate from "../../icons/camera-cycle.svg";
+
+const WHITE = "#ffffff";
+const GREEN = "#2ecc71";
+const RED = "#e74c3c";
+
+const CAMERA_TYPE_VALUES = ["camera", "sub-camera", "car", "driving"] as const;
+
+type CameraType = (typeof CAMERA_TYPE_VALUES)[number];
+type Direction = "next" | "previous";
+
+/**
+ * Label configuration for each camera type + direction combination
+ */
+const CAMERA_CYCLE_LABELS: Record<CameraType, Record<Direction, { line1: string; line2: string }>> = {
+  camera: { next: { line1: "NEXT", line2: "CAMERA" }, previous: { line1: "PREV", line2: "CAMERA" } },
+  "sub-camera": { next: { line1: "NEXT", line2: "SUB CAM" }, previous: { line1: "PREV", line2: "SUB CAM" } },
+  car: { next: { line1: "NEXT", line2: "CAR" }, previous: { line1: "PREV", line2: "CAR" } },
+  driving: { next: { line1: "NEXT", line2: "DRIVING" }, previous: { line1: "PREV", line2: "DRIVING" } },
+};
+
+/**
+ * SVG icon content for each camera type + direction combination
+ */
+const CAMERA_CYCLE_ICONS: Record<CameraType, Record<Direction, string>> = {
+  camera: {
+    // Movie camera + right chevron
+    next: `
+    <rect x="18" y="14" width="22" height="18" rx="2" fill="none" stroke="${WHITE}" stroke-width="2"/>
+    <polygon points="40,17 52,12 52,36 40,31" fill="none" stroke="${WHITE}" stroke-width="2" stroke-linejoin="round"/>
+    <polyline points="56,20 62,24 56,28" fill="none" stroke="${GREEN}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>`,
+    // Movie camera + left chevron
+    previous: `
+    <rect x="22" y="14" width="22" height="18" rx="2" fill="none" stroke="${WHITE}" stroke-width="2"/>
+    <polygon points="44,17 56,12 56,36 44,31" fill="none" stroke="${WHITE}" stroke-width="2" stroke-linejoin="round"/>
+    <polyline points="16,20 10,24 16,28" fill="none" stroke="${RED}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>`,
+  },
+  "sub-camera": {
+    // Small camera with inner frame + right chevron
+    next: `
+    <rect x="18" y="14" width="22" height="18" rx="2" fill="none" stroke="${WHITE}" stroke-width="2"/>
+    <rect x="22" y="18" width="14" height="10" rx="1" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <polyline points="56,20 62,24 56,28" fill="none" stroke="${GREEN}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>`,
+    // Small camera with inner frame + left chevron
+    previous: `
+    <rect x="22" y="14" width="22" height="18" rx="2" fill="none" stroke="${WHITE}" stroke-width="2"/>
+    <rect x="26" y="18" width="14" height="10" rx="1" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <polyline points="16,20 10,24 16,28" fill="none" stroke="${RED}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>`,
+  },
+  car: {
+    // Car silhouette + right chevron
+    next: `
+    <path d="M 16,30 L 20,20 L 44,20 L 50,30 Z" fill="none" stroke="${WHITE}" stroke-width="2" stroke-linejoin="round"/>
+    <circle cx="24" cy="32" r="3" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <circle cx="42" cy="32" r="3" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <polyline points="56,20 62,24 56,28" fill="none" stroke="${GREEN}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>`,
+    // Car silhouette + left chevron
+    previous: `
+    <path d="M 20,30 L 24,20 L 48,20 L 54,30 Z" fill="none" stroke="${WHITE}" stroke-width="2" stroke-linejoin="round"/>
+    <circle cx="28" cy="32" r="3" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <circle cx="46" cy="32" r="3" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <polyline points="16,20 10,24 16,28" fill="none" stroke="${RED}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>`,
+  },
+  driving: {
+    // Steering wheel + right chevron
+    next: `
+    <circle cx="33" cy="24" r="12" fill="none" stroke="${WHITE}" stroke-width="2"/>
+    <circle cx="33" cy="24" r="4" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <line x1="33" y1="28" x2="33" y2="36" stroke="${WHITE}" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="21" y1="24" x2="29" y2="24" stroke="${WHITE}" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="37" y1="24" x2="45" y2="24" stroke="${WHITE}" stroke-width="1.5" stroke-linecap="round"/>
+    <polyline points="56,20 62,24 56,28" fill="none" stroke="${GREEN}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>`,
+    // Steering wheel + left chevron
+    previous: `
+    <circle cx="37" cy="24" r="12" fill="none" stroke="${WHITE}" stroke-width="2"/>
+    <circle cx="37" cy="24" r="4" fill="none" stroke="${WHITE}" stroke-width="1.5"/>
+    <line x1="37" y1="28" x2="37" y2="36" stroke="${WHITE}" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="25" y1="24" x2="33" y2="24" stroke="${WHITE}" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="41" y1="24" x2="49" y2="24" stroke="${WHITE}" stroke-width="1.5" stroke-linecap="round"/>
+    <polyline points="16,20 10,24 16,28" fill="none" stroke="${RED}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>`,
+  },
+};
+
+const CameraCycleSettings = z.object({
+  cameraType: z.enum(CAMERA_TYPE_VALUES).default("camera"),
+  direction: z.enum(["next", "previous"]).default("next"),
+});
+
+type CameraCycleSettings = z.infer<typeof CameraCycleSettings>;
+
+/**
+ * @internal Exported for testing
+ *
+ * Generates an SVG data URI icon for the camera cycle action.
+ */
+export function generateCameraCycleSvg(settings: { cameraType: CameraType; direction: Direction }): string {
+  const { cameraType, direction } = settings;
+
+  const iconContent = CAMERA_CYCLE_ICONS[cameraType]?.[direction] || CAMERA_CYCLE_ICONS["camera"]["next"];
+  const labels = CAMERA_CYCLE_LABELS[cameraType]?.[direction] || CAMERA_CYCLE_LABELS["camera"]["next"];
+
+  const svg = renderIconTemplate(cameraCycleTemplate, {
+    iconContent,
+    labelLine1: labels.line1,
+    labelLine2: labels.line2,
+  });
+
+  return svgToDataUri(svg);
+}
+
+/**
+ * Camera Cycle
+ * Cycles through cameras, sub-cameras, cars, and driving cameras
+ * during replays or spectating via iRacing SDK commands.
+ */
+@action({ UUID: "com.iracedeck.sd.core.camera-cycle" })
+export class CameraCycle extends ConnectionStateAwareAction<CameraCycleSettings> {
+  protected override logger = createSDLogger(streamDeck.logger.createScope("CameraCycle"), LogLevel.Info);
+
+  override async onWillAppear(ev: WillAppearEvent<CameraCycleSettings>): Promise<void> {
+    const settings = this.parseSettings(ev.payload.settings);
+    await this.updateDisplay(ev, settings);
+
+    this.sdkController.subscribe(ev.action.id, () => {
+      this.updateConnectionState();
+    });
+  }
+
+  override async onWillDisappear(ev: WillDisappearEvent<CameraCycleSettings>): Promise<void> {
+    await super.onWillDisappear(ev);
+    this.sdkController.unsubscribe(ev.action.id);
+  }
+
+  override async onDidReceiveSettings(ev: DidReceiveSettingsEvent<CameraCycleSettings>): Promise<void> {
+    const settings = this.parseSettings(ev.payload.settings);
+    await this.updateDisplay(ev, settings);
+  }
+
+  override async onKeyDown(ev: KeyDownEvent<CameraCycleSettings>): Promise<void> {
+    this.logger.info("Key down received");
+    const settings = this.parseSettings(ev.payload.settings);
+    this.executeCycle(settings.cameraType, settings.direction);
+  }
+
+  override async onDialDown(ev: DialDownEvent<CameraCycleSettings>): Promise<void> {
+    this.logger.info("Dial down received");
+    const settings = this.parseSettings(ev.payload.settings);
+    this.executeCycle(settings.cameraType, settings.direction);
+  }
+
+  override async onDialRotate(ev: DialRotateEvent<CameraCycleSettings>): Promise<void> {
+    this.logger.info("Dial rotated");
+    const settings = this.parseSettings(ev.payload.settings);
+    const direction: Direction = ev.payload.ticks > 0 ? "next" : "previous";
+    this.executeCycle(settings.cameraType, direction);
+  }
+
+  private parseSettings(settings: unknown): CameraCycleSettings {
+    const parsed = CameraCycleSettings.safeParse(settings);
+
+    return parsed.success ? parsed.data : CameraCycleSettings.parse({});
+  }
+
+  private executeCycle(cameraType: CameraType, direction: Direction): void {
+    const telemetry = this.sdkController.getCurrentTelemetry();
+
+    if (!telemetry) {
+      this.logger.warn("No telemetry available for camera cycle");
+
+      return;
+    }
+
+    const camera = getCommands().camera;
+    const carIdx = telemetry.CamCarIdx ?? 0;
+    const groupNum = telemetry.CamGroupNumber ?? 1;
+    const cameraNum = telemetry.CamCameraNumber ?? 1;
+    const dir = direction === "next" ? 1 : -1;
+
+    switch (cameraType) {
+      case "camera": {
+        const success = camera.cycleCamera(carIdx, groupNum, dir);
+        this.logger.info("Camera group cycled");
+        this.logger.debug(`Result: ${success}, direction: ${direction}`);
+        break;
+      }
+      case "sub-camera": {
+        const success = camera.cycleSubCamera(carIdx, groupNum, cameraNum, dir);
+        this.logger.info("Sub-camera cycled");
+        this.logger.debug(`Result: ${success}, direction: ${direction}`);
+        break;
+      }
+      case "car": {
+        const success = camera.cycleCar(carIdx, dir);
+        this.logger.info("Car cycled");
+        this.logger.debug(`Result: ${success}, direction: ${direction}`);
+        break;
+      }
+      case "driving": {
+        const success = camera.cycleDrivingCamera(carIdx, groupNum, dir);
+        this.logger.info("Driving camera cycled");
+        this.logger.debug(`Result: ${success}, direction: ${direction}`);
+        break;
+      }
+    }
+  }
+
+  private async updateDisplay(
+    ev: WillAppearEvent<CameraCycleSettings> | DidReceiveSettingsEvent<CameraCycleSettings>,
+    settings: CameraCycleSettings,
+  ): Promise<void> {
+    this.updateConnectionState();
+
+    const svgDataUri = generateCameraCycleSvg(settings);
+    await ev.action.setTitle("");
+    await this.setKeyImage(ev, svgDataUri);
+  }
+}

--- a/packages/stream-deck-plugin-core/src/pi/camera-cycle.ejs
+++ b/packages/stream-deck-plugin-core/src/pi/camera-cycle.ejs
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<%- include('head-common') %>
+	</head>
+	<body>
+		<sdpi-item label="Camera">
+			<sdpi-select setting="cameraType" default="camera">
+				<option value="camera">Camera</option>
+				<option value="sub-camera">Sub-Camera</option>
+				<option value="car">Car</option>
+				<option value="driving">Driving Camera</option>
+			</sdpi-select>
+		</sdpi-item>
+
+		<sdpi-item label="Direction">
+			<sdpi-select setting="direction" default="next">
+				<option value="next">Next</option>
+				<option value="previous">Previous</option>
+			</sdpi-select>
+		</sdpi-item>
+	</body>
+</html>

--- a/packages/stream-deck-plugin-core/src/plugin.ts
+++ b/packages/stream-deck-plugin-core/src/plugin.ts
@@ -10,6 +10,7 @@ import {
 
 import { AudioControls } from "./actions/audio-controls.js";
 import { BlackBoxSelector } from "./actions/black-box-selector.js";
+import { CameraCycle } from "./actions/camera-cycle.js";
 import { CarControl } from "./actions/car-control.js";
 import { Chat } from "./actions/chat.js";
 import { CockpitMisc } from "./actions/cockpit-misc.js";
@@ -42,6 +43,7 @@ initializeKeyboard(
 // Register core actions
 streamDeck.actions.registerAction(new AudioControls());
 streamDeck.actions.registerAction(new BlackBoxSelector());
+streamDeck.actions.registerAction(new CameraCycle());
 streamDeck.actions.registerAction(new CarControl());
 streamDeck.actions.registerAction(new Chat());
 streamDeck.actions.registerAction(new CockpitMisc());


### PR DESCRIPTION
## Summary

- Add **Camera Cycle** action (`com.iracedeck.sd.core.camera-cycle`) to the core plugin for cycling through cameras, sub-cameras, cars, and driving cameras during replays or spectating
- Add `cycleCamera`, `cycleSubCamera`, `cycleCar`, and `cycleDrivingCamera` methods to `CameraCommand` in `@iracedeck/iracing-sdk`
- All sub-actions are fully SDK-driven via `getCommands().camera.*` — no keyboard shortcuts needed
- Support Keypad and Encoder (dial rotation = next/previous, dial press = activate configured cycle)
- Property Inspector with Camera type (4 options) and Direction (next/previous) dropdowns
- 8 distinct icon variants (4 camera types x 2 directions) with two-line label system

Closes #16

## Test plan

- [x] Unit tests for all 4 new `CameraCommand` cycle methods (correct broadcast parameters, return values)
- [x] Unit tests for `generateCameraCycleSvg` (all 8 combinations produce valid, unique data URIs with correct labels)
- [x] All 945 tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)
- [x] Lint and format pass (`pnpm lint:fix && pnpm format:fix`)
- [ ] Manual test: verify action appears in Stream Deck and cycles cameras in iRacing replay