### PR TITLE
docs: add PR template usage guidance to rules and agents

### DIFF
--- a/.claude/agents/git-commit-prep.md
+++ b/.claude/agents/git-commit-prep.md
@@ -110,6 +110,14 @@ Before finalizing any commit, verify:
 - [ ] No AI/Claude references in commit message
 - [ ] Only relevant files are staged
 
+## Pull Request Creation
+
+When creating a PR with `gh pr create`, use the PR template (`.github/pull_request_template.md`) as the body structure:
+
+- Fill in all sections: **Related Issue**, **What changed?**, **How to test**, and **Checklist**
+- Mark checklist items as complete (`[x]`) or incomplete (`[ ]`) as appropriate
+- Use `N/A` for sections that don't apply (e.g., "Related Issue" for infra work with no issue)
+
 ## Squash Merge Awareness
 
 PRs in this project are **squash-merged** into `master`. The squash commit subject is the PR title, so:

--- a/.claude/rules/build-and-commit.md
+++ b/.claude/rules/build-and-commit.md
@@ -74,6 +74,13 @@ Committing
 - Do not reference Claude or other AI tools in commit messages.
 - Do not add AI co-authors such as `Co-Authored-By: Claude Opus`.
 
+Pull Requests
+
+- When creating a PR, use the PR template at `.github/pull_request_template.md` as the body structure.
+- Fill in all sections: Related Issue, What changed?, How to test, and Checklist.
+- Mark checklist items as complete (`[x]`) or incomplete (`[ ]`) as appropriate.
+- Use `N/A` for sections that don't apply (e.g., "Related Issue" for infra work with no issue).
+
 Merging
 
 - PRs are squash-merged into `master` via `gh pr merge --squash`.


### PR DESCRIPTION
## Related Issue

N/A — documentation improvement

## What changed?

Added guidance to use the PR template (`.github/pull_request_template.md`) when creating pull requests:
- **`.claude/rules/build-and-commit.md`** — new "Pull Requests" section before Merging
- **`.claude/agents/git-commit-prep.md`** — new "Pull Request Creation" section before Squash Merge Awareness

## How to test

- Review the updated files for correctness
- No runtime behavior changes — documentation only

## Checklist

- [ ] Linked to an approved issue
- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] `pnpm lint:fix` and `pnpm format:fix` run with no remaining issues
- [ ] New code has unit tests
- [x] No unrelated changes included