### PR TITLE
chore: anchor dist/ and build/ gitignore patterns to repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,10 @@ yarn.lock
 # Note: pnpm-lock.yaml should be committed
 
 # Build output
-dist/
+/dist/
+/packages/*/dist/
+/build/
+/packages/*/build/
 
 # Stream Deck plugin packages (built artifacts)
 *.streamDeckPlugin


### PR DESCRIPTION
## Related Issue

N/A

## What changed?

- Anchored `dist/` and `build/` gitignore patterns with leading `/` so they only match at the repo root and package roots
- Added `/packages/*/dist/` and `/packages/*/build/` for package-level build output
- Prevents accidentally ignoring `build/` or `dist/` directories deeper in the tree

## How to test

- Verify `git status` still ignores root and package-level build/dist directories
- Verify a hypothetical nested `build/` directory (e.g., inside a non-package subfolder) would not be ignored

## Checklist

- [x] Linked to an approved issue
- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] `pnpm lint:fix` and `pnpm format:fix` run with no remaining issues
- [ ] New code has unit tests
- [x] No unrelated changes included