### PR TITLE
fix(stream-deck-plugin): show default sub-options on initial PI load (#81)

### DIFF
--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/ui/fuel-service.html
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/ui/fuel-service.html
@@ -161,15 +161,17 @@
 				}
 
 				if (modeSelect) {
+					updateVisibility(modeSelect.value || "add-fuel");
+
 					modeSelect.addEventListener("change", (ev) => {
-						updateVisibility(ev.target.value);
+						updateVisibility(ev.target.value || "add-fuel");
 					});
 					modeSelect.addEventListener("input", (ev) => {
-						updateVisibility(ev.target.value);
+						updateVisibility(ev.target.value || "add-fuel");
 					});
 
-					// Poll until value is populated, then keep polling for changes
-					let lastMode = "";
+					// Polling fallback for reliable detection
+					let lastMode = modeSelect.value || "add-fuel";
 					setInterval(() => {
 						const currentMode = modeSelect.value;
 						if (currentMode && currentMode !== lastMode) {

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/ui/tire-service.html
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/ui/tire-service.html
@@ -110,15 +110,17 @@
 
 				const actionSelect = document.getElementById("action-select");
 				if (actionSelect) {
+					updateVisibility(actionSelect.value || "toggle-tires");
+
 					actionSelect.addEventListener("change", (ev) => {
-						updateVisibility(ev.target.value);
+						updateVisibility(ev.target.value || "toggle-tires");
 					});
 					actionSelect.addEventListener("input", (ev) => {
-						updateVisibility(ev.target.value);
+						updateVisibility(ev.target.value || "toggle-tires");
 					});
 
-					// Poll until value is populated, then keep polling for changes
-					let lastAction = "";
+					// Polling fallback for reliable detection
+					let lastAction = actionSelect.value || "toggle-tires";
 					setInterval(() => {
 						const currentAction = actionSelect.value;
 						if (currentAction && currentAction !== lastAction) {

--- a/packages/stream-deck-plugin/src/pi/fuel-service.ejs
+++ b/packages/stream-deck-plugin/src/pi/fuel-service.ejs
@@ -62,15 +62,17 @@
 				}
 
 				if (modeSelect) {
+					updateVisibility(modeSelect.value || "add-fuel");
+
 					modeSelect.addEventListener("change", (ev) => {
-						updateVisibility(ev.target.value);
+						updateVisibility(ev.target.value || "add-fuel");
 					});
 					modeSelect.addEventListener("input", (ev) => {
-						updateVisibility(ev.target.value);
+						updateVisibility(ev.target.value || "add-fuel");
 					});
 
-					// Poll until value is populated, then keep polling for changes
-					let lastMode = "";
+					// Polling fallback for reliable detection
+					let lastMode = modeSelect.value || "add-fuel";
 					setInterval(() => {
 						const currentMode = modeSelect.value;
 						if (currentMode && currentMode !== lastMode) {

--- a/packages/stream-deck-plugin/src/pi/tire-service.ejs
+++ b/packages/stream-deck-plugin/src/pi/tire-service.ejs
@@ -33,15 +33,17 @@
 
 				const actionSelect = document.getElementById("action-select");
 				if (actionSelect) {
+					updateVisibility(actionSelect.value || "toggle-tires");
+
 					actionSelect.addEventListener("change", (ev) => {
-						updateVisibility(ev.target.value);
+						updateVisibility(ev.target.value || "toggle-tires");
 					});
 					actionSelect.addEventListener("input", (ev) => {
-						updateVisibility(ev.target.value);
+						updateVisibility(ev.target.value || "toggle-tires");
 					});
 
-					// Poll until value is populated, then keep polling for changes
-					let lastAction = "";
+					// Polling fallback for reliable detection
+					let lastAction = actionSelect.value || "toggle-tires";
 					setInterval(() => {
 						const currentAction = actionSelect.value;
 						if (currentAction && currentAction !== lastAction) {


### PR DESCRIPTION
## Related Issue

Fixes #81

## What changed?

Added initial `updateVisibility()` call in `tire-service.ejs` and `fuel-service.ejs` Property Inspector templates. When a new action button is added to Stream Deck, the default mode's sub-settings (e.g., tire checkboxes for "Toggle Tires", amount/unit fields for "Add Fuel") now appear immediately instead of staying hidden.

Both templates were missing the initial visibility update that the other 4 PI templates with conditional visibility (session-info, camera-focus, replay-navigation, chat) already had. Also added default value fallbacks in event handlers and initialized the polling `lastValue` from the current select value.

## How to test

1. In Stream Deck, add a new **Tire Service** action
2. Verify the tire checkboxes (LF, RF, LR, RR) are visible immediately with the default "Toggle Tires" mode
3. Switch to "Change Compound" or "Clear Tires" — checkboxes should hide
4. Switch back to "Toggle Tires" — checkboxes should reappear
5. Repeat with **Fuel Service**: add a new action, verify Amount/Unit fields are visible with default "Add Fuel" mode

## Checklist

- [x] Linked to an approved issue
- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] `pnpm lint:fix` and `pnpm format:fix` run with no remaining issues
- [ ] New code has unit tests
- [x] No unrelated changes included