### PR TITLE
docs(website): add download links, version requirement, and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ See the existing actions for reference, or check the package-level docs in `pack
 
 | Problem | Solution |
 |---------|----------|
+| Double-clicking `.streamDeckPlugin` doesn't install | Rename the file to add `.zip` at the end, extract the contents to `%APPDATA%\Elgato\StreamDeck\Plugins`, and restart Stream Deck |
 | Plugin doesn't connect | Make sure iRacing is running and you're in a session (on track) |
 | Buttons show nothing | iRacing telemetry is only available while driving; the plugin reconnects automatically |
 | Native addon build fails | Install Python 3.x and VS Build Tools with C++ workload. Try `npm config set msvs_version 2022` |

--- a/packages/website/public_html/index.html
+++ b/packages/website/public_html/index.html
@@ -47,7 +47,7 @@
       <li><a href="#features">Features</a></li>
       <li><a href="#support">Support</a></li>
       <li><a href="#contributing">Contribute</a></li>
-      <li><a href="#install">Install</a></li>
+      <li><a href="#install">Download</a></li>
       <li><a href="https://discord.gg/c6nRYywpah" target="_blank">Discord</a></li>
       <li><a href="https://github.com/niklam/iracedeck" target="_blank">GitHub</a></li>
     </ul>
@@ -63,11 +63,11 @@
           of controls, all one tap away without leaving the cockpit.
         </p>
         <div class="hero-buttons">
-          <a href="#install" class="btn btn-primary">
+          <a href="https://github.com/niklam/iracedeck/releases/download/v0.10.1/iracedeck-v0.10.1.streamDeckPlugin" class="btn btn-primary">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
               <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z" />
             </svg>
-            Install for Stream Deck
+            Download for Stream Deck
           </a>
           <a href="https://github.com/niklam/iracedeck" class="btn btn-secondary" target="_blank">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -77,6 +77,7 @@
             View Source
           </a>
         </div>
+        <p class="hero-requirement">Requires Stream Deck software 7.1 or newer</p>
       </div>
     </div>
   </section>
@@ -283,18 +284,38 @@
       <h2 class="cta-title">Ready to Upgrade Your Cockpit?</h2>
       <p class="cta-description">
         Free, open-source, and ready to install. Works with Stream Deck, Stream Deck Mini,
-        Stream Deck XL, and Stream Deck+.
+        Stream Deck XL, and Stream Deck+. Requires Stream Deck software 7.1 or newer.
       </p>
       <div class="hero-buttons" style="justify-content: center;">
-        <a href="#" class="btn btn-primary">
+        <a href="https://github.com/niklam/iracedeck/releases/download/v0.10.1/iracedeck-v0.10.1.streamDeckPlugin" class="btn btn-primary">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
             <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z" />
           </svg>
-          Install for Stream Deck
+          Download for Stream Deck
         </a>
         <a href="https://github.com/niklam/iracedeck" class="btn btn-secondary" target="_blank">
           Documentation
         </a>
+      </div>
+      <p class="hero-requirement">Requires Stream Deck software 7.1 or newer</p>
+    </div>
+  </section>
+
+  <section class="troubleshooting" id="troubleshooting">
+    <div class="section-header">
+      <p class="section-label">Need Help?</p>
+      <h2 class="section-title">Troubleshooting</h2>
+    </div>
+
+    <div class="troubleshooting-content">
+      <div class="troubleshooting-item">
+        <h3>Installation not working?</h3>
+        <p>If double-clicking the downloaded <code>.streamDeckPlugin</code> file doesn't install the plugin, you can install it manually:</p>
+        <ol>
+          <li>Rename the downloaded file to add <code>.zip</code> at the end<br>(e.g. <code>iracedeck-v0.10.1.streamDeckPlugin.zip</code>)</li>
+          <li>Extract the contents to your Stream Deck plugins folder:<br><code>%APPDATA%\Elgato\StreamDeck\Plugins</code></li>
+          <li>Restart the Stream Deck software</li>
+        </ol>
       </div>
     </div>
   </section>

--- a/packages/website/public_html/styles.css
+++ b/packages/website/public_html/styles.css
@@ -187,6 +187,13 @@ nav::after {
   justify-content: center;
 }
 
+.hero-requirement {
+  margin-top: 0.75rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-weight: 400;
+}
+
 /* Buttons */
 .btn {
   display: inline-flex;
@@ -533,6 +540,58 @@ nav::after {
   margin-bottom: 2rem;
 }
 
+/* Troubleshooting Section */
+.troubleshooting {
+  position: relative;
+  padding: 6rem 3rem;
+  background: var(--surface);
+}
+
+.troubleshooting-content {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.troubleshooting-item {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+  padding: 2rem;
+}
+
+.troubleshooting-item h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.troubleshooting-item p {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+
+.troubleshooting-item ol {
+  padding-left: 1.25rem;
+  margin-top: 0.75rem;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+
+.troubleshooting-item li {
+  margin-bottom: 0.5rem;
+}
+
+.troubleshooting-item code {
+  background: rgba(205, 34, 39, 0.06);
+  border: 1px solid rgba(205, 34, 39, 0.12);
+  border-radius: 4px;
+  padding: 0.15rem 0.4rem;
+  font-size: 0.85rem;
+  word-break: break-all;
+}
+
 /* Footer */
 footer {
   position: relative;
@@ -630,6 +689,7 @@ footer {
     display: none;
   }
 
+  .troubleshooting,
   .support,
   .contributing {
     padding: 4rem 1.5rem;


### PR DESCRIPTION
## Related Issue

N/A

## What changed?

- Download buttons now link to the v0.10.1 `.streamDeckPlugin` release artifact
- Renamed "Install" to "Download" on buttons and nav link
- Added "Requires Stream Deck software 7.1 or newer" note below both download button groups and in the install section description
- Added a Troubleshooting section to the website with manual installation steps (rename to `.zip`, extract to `%APPDATA%\Elgato\StreamDeck\Plugins`)
- Added the same troubleshooting info to the README troubleshooting table
- Site already deployed to Firebase Hosting

## How to test

1. Visit https://iracedeck.com/
2. Verify download buttons link to the correct release
3. Check the "Requires Stream Deck 7.1 or newer" notes appear
4. Scroll to the Troubleshooting section and verify it renders correctly

## Checklist

- [x] Linked to an approved issue
- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] `pnpm lint:fix` and `pnpm format:fix` run with no remaining issues
- [ ] New code has unit tests
- [x] No unrelated changes included