### PR TITLE
fix(icons): update fuel-service icon designs

### DIFF
--- a/packages/icons/fuel-service/add-fuel.svg
+++ b/packages/icons/fuel-service/add-fuel.svg
@@ -4,11 +4,17 @@
     <rect x="0" y="0" width="144" height="144" rx="16" fill="#3a2a2a"/>
 
     <!-- Gas pump with + indicator (green) -->
-    <rect x="48" y="20" width="32" height="48" rx="4" fill="none" stroke="#ffffff" stroke-width="3"/>
-    <rect x="56" y="12" width="16" height="12" rx="2" fill="none" stroke="#ffffff" stroke-width="3"/>
-    <path d="M80 28 L88 28 L88 56 L80 56" fill="none" stroke="#888888" stroke-width="3" stroke-linecap="round"/>
-    <line x1="104" y1="36" x2="104" y2="60" stroke="#2ecc71" stroke-width="5" stroke-linecap="round"/>
-    <line x1="92" y1="48" x2="116" y2="48" stroke="#2ecc71" stroke-width="5" stroke-linecap="round"/>
+      <g id="Plus_and_minus" data-name="Plus and minus">
+    <g>
+      <path d="M37.27,79.51h48.05c1.28,0,2.32-1.05,2.31-2.33l-.08-6.52c-.01-1.27-1.06-2.29-2.33-2.28-1.54.02-3.56.05-5.11.07-1.29.02-2.33-1.02-2.33-2.31l.06-24.72.06-27.1c0-1.28-1.03-2.31-2.31-2.31h-28.59c-1.27,0-2.31,1.03-2.31,2.3l-.03,51.88c0,1.27-1.03,2.3-2.3,2.3h-5.05c-1.26,0-2.29,1.01-2.31,2.27-.02,1.89-.05,4.56-.04,6.46,0,1.27,1.04,2.29,2.31,2.29Z" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+      <rect x="51.47" y="19.44" width="19.64" height="12.32" rx="2" ry="2" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+      <polyline points="78.24 43.83 83.91 43.83 83.91 62.06 89.36 62.06 89.36 27 83.62 21.26" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+    </g>
+    <g>
+      <line x1="110.04" y1="54" x2="110.04" y2="34" fill="none" stroke="#5aba47" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"/>
+      <line x1="100.04" y1="44" x2="120.04" y2="44" fill="none" stroke="#5aba47" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"/>
+    </g>
+  </g>
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"

--- a/packages/icons/fuel-service/clear-fuel.svg
+++ b/packages/icons/fuel-service/clear-fuel.svg
@@ -4,9 +4,12 @@
     <rect x="0" y="0" width="144" height="144" rx="16" fill="#3a2a2a"/>
 
     <!-- Gas pump with X overlay (red) -->
-    <rect x="48" y="20" width="32" height="48" rx="4" fill="none" stroke="#ffffff" stroke-width="3"/>
-    <rect x="56" y="12" width="16" height="12" rx="2" fill="none" stroke="#ffffff" stroke-width="3"/>
-    <path d="M80 28 L88 28 L88 56 L80 56" fill="none" stroke="#888888" stroke-width="3" stroke-linecap="round"/>
+  <g>
+      <path d="M37.27,79.51h48.05c1.28,0,2.32-1.05,2.31-2.33l-.08-6.52c-.01-1.27-1.06-2.29-2.33-2.28-1.54.02-3.56.05-5.11.07-1.29.02-2.33-1.02-2.33-2.31l.06-24.72.06-27.1c0-1.28-1.03-2.31-2.31-2.31h-28.59c-1.27,0-2.31,1.03-2.31,2.3l-.03,51.88c0,1.27-1.03,2.3-2.3,2.3h-5.05c-1.26,0-2.29,1.01-2.31,2.27-.02,1.89-.05,4.56-.04,6.46,0,1.27,1.04,2.29,2.31,2.29Z" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+      <rect x="51.47" y="19.44" width="19.64" height="12.32" rx="2" ry="2" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+      <polyline points="78.24 43.83 83.91 43.83 83.91 62.06 89.36 62.06 89.36 27 83.62 21.26" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+    </g>
+
     <line x1="96" y1="36" x2="116" y2="60" stroke="#e74c3c" stroke-width="5" stroke-linecap="round"/>
     <line x1="116" y1="36" x2="96" y2="60" stroke="#e74c3c" stroke-width="5" stroke-linecap="round"/>
 

--- a/packages/icons/fuel-service/reduce-fuel.svg
+++ b/packages/icons/fuel-service/reduce-fuel.svg
@@ -4,10 +4,14 @@
     <rect x="0" y="0" width="144" height="144" rx="16" fill="#3a2a2a"/>
 
     <!-- Gas pump with - indicator (red) -->
-    <rect x="48" y="20" width="32" height="48" rx="4" fill="none" stroke="#ffffff" stroke-width="3"/>
-    <rect x="56" y="12" width="16" height="12" rx="2" fill="none" stroke="#ffffff" stroke-width="3"/>
-    <path d="M80 28 L88 28 L88 56 L80 56" fill="none" stroke="#888888" stroke-width="3" stroke-linecap="round"/>
-    <line x1="92" y1="48" x2="116" y2="48" stroke="#e74c3c" stroke-width="5" stroke-linecap="round"/>
+  <g id="Plus_and_minus" data-name="Plus and minus">
+    <g>
+      <path d="M37.27,79.51h48.05c1.28,0,2.32-1.05,2.31-2.33l-.08-6.52c-.01-1.27-1.06-2.29-2.33-2.28-1.54.02-3.56.05-5.11.07-1.29.02-2.33-1.02-2.33-2.31l.06-24.72.06-27.1c0-1.28-1.03-2.31-2.31-2.31h-28.59c-1.27,0-2.31,1.03-2.31,2.3l-.03,51.88c0,1.27-1.03,2.3-2.3,2.3h-5.05c-1.26,0-2.29,1.01-2.31,2.27-.02,1.89-.05,4.56-.04,6.46,0,1.27,1.04,2.29,2.31,2.29Z" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+      <rect x="51.47" y="19.44" width="19.64" height="12.32" rx="2" ry="2" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+      <polyline points="78.24 43.83 83.91 43.83 83.91 62.06 89.36 62.06 89.36 27 83.62 21.26" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+    </g>
+    <line x1="100.04" y1="44" x2="120.04" y2="44" fill="none" stroke="#e71e25" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"/>
+  </g>
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"

--- a/packages/icons/fuel-service/set-fuel-amount.svg
+++ b/packages/icons/fuel-service/set-fuel-amount.svg
@@ -4,9 +4,12 @@
     <rect x="0" y="0" width="144" height="144" rx="16" fill="#3a2a2a"/>
 
     <!-- Gas pump with = indicator (yellow) -->
-    <rect x="48" y="20" width="32" height="48" rx="4" fill="none" stroke="#ffffff" stroke-width="3"/>
-    <rect x="56" y="12" width="16" height="12" rx="2" fill="none" stroke="#ffffff" stroke-width="3"/>
-    <path d="M80 28 L88 28 L88 56 L80 56" fill="none" stroke="#888888" stroke-width="3" stroke-linecap="round"/>
+    <g>
+      <path d="M37.27,79.51h48.05c1.28,0,2.32-1.05,2.31-2.33l-.08-6.52c-.01-1.27-1.06-2.29-2.33-2.28-1.54.02-3.56.05-5.11.07-1.29.02-2.33-1.02-2.33-2.31l.06-24.72.06-27.1c0-1.28-1.03-2.31-2.31-2.31h-28.59c-1.27,0-2.31,1.03-2.31,2.3l-.03,51.88c0,1.27-1.03,2.3-2.3,2.3h-5.05c-1.26,0-2.29,1.01-2.31,2.27-.02,1.89-.05,4.56-.04,6.46,0,1.27,1.04,2.29,2.31,2.29Z" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+      <rect x="51.47" y="19.44" width="19.64" height="12.32" rx="2" ry="2" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+      <polyline points="78.24 43.83 83.91 43.83 83.91 62.06 89.36 62.06 89.36 27 83.62 21.26" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+    </g>
+
     <line x1="96" y1="40" x2="112" y2="40" stroke="#f1c40f" stroke-width="4" stroke-linecap="round"/>
     <line x1="96" y1="52" x2="112" y2="52" stroke="#f1c40f" stroke-width="4" stroke-linecap="round"/>
 

--- a/packages/icons/fuel-service/toggle-autofuel.svg
+++ b/packages/icons/fuel-service/toggle-autofuel.svg
@@ -4,9 +4,12 @@
     <rect x="0" y="0" width="144" height="144" rx="16" fill="#3a2a2a"/>
 
     <!-- Gas pump with circular auto/recycle arrow -->
-    <rect x="40" y="20" width="32" height="48" rx="4" fill="none" stroke="#ffffff" stroke-width="3"/>
-    <rect x="48" y="12" width="16" height="12" rx="2" fill="none" stroke="#ffffff" stroke-width="3"/>
-    <path d="M72 28 L80 28 L80 56 L72 56" fill="none" stroke="#888888" stroke-width="3" stroke-linecap="round"/>
+    <g>
+      <path d="M37.27,79.51h48.05c1.28,0,2.32-1.05,2.31-2.33l-.08-6.52c-.01-1.27-1.06-2.29-2.33-2.28-1.54.02-3.56.05-5.11.07-1.29.02-2.33-1.02-2.33-2.31l.06-24.72.06-27.1c0-1.28-1.03-2.31-2.31-2.31h-28.59c-1.27,0-2.31,1.03-2.31,2.3l-.03,51.88c0,1.27-1.03,2.3-2.3,2.3h-5.05c-1.26,0-2.29,1.01-2.31,2.27-.02,1.89-.05,4.56-.04,6.46,0,1.27,1.04,2.29,2.31,2.29Z" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+      <rect x="51.47" y="19.44" width="19.64" height="12.32" rx="2" ry="2" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+      <polyline points="78.24 43.83 83.91 43.83 83.91 62.06 89.36 62.06 89.36 27 83.62 21.26" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+    </g>
+
     <path d="M100 28 A16 16 0 1 1 100 60" fill="none" stroke="#2ecc71" stroke-width="4" stroke-linecap="round"/>
     <polyline points="100,20 100,28 108,28" fill="none" stroke="#2ecc71" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
 


### PR DESCRIPTION
## Related Issue

N/A

## What changed?

- Updated 5 fuel-service icon SVGs with improved designs: add-fuel, clear-fuel, reduce-fuel, set-fuel-amount, toggle-autofuel

## How to test

- Verify fuel-service icons render correctly on Stream Deck

## Checklist

- [ ] Linked to an approved issue
- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] `pnpm lint:fix` and `pnpm format:fix` run with no remaining issues
- [ ] New code has unit tests
- [x] No unrelated changes included