### PR TITLE
chore(website): add Google Analytics tracking

### DIFF
--- a/packages/website/public_html/index.html
+++ b/packages/website/public_html/index.html
@@ -21,6 +21,15 @@
   <meta name="twitter:description" content="Free, open-source Stream Deck plugin for iRacing. Hundreds of controls, one tap away.">
   <meta name="twitter:image" content="https://iracedeck.com/images/iracedeck-logo-full-white.png">
 
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-HKB3F7KB00"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-HKB3F7KB00');
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">


### PR DESCRIPTION
## Related Issue

N/A

## What changed?

Added Google Analytics (gtag.js) tracking snippet with measurement ID `G-HKB3F7KB00` to the website `<head>`.

## How to test

- Visit https://iracedeck.com and verify the gtag.js script loads in DevTools Network tab
- Check Google Analytics real-time dashboard for incoming data

## Checklist

- [x] ~~Linked to an approved issue~~ N/A
- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] `pnpm lint:fix` and `pnpm format:fix` run with no remaining issues
- [x] ~~New code has unit tests~~ N/A — HTML-only change
- [x] No unrelated changes included