### PR TITLE
fix(icons): change subLabel text color to white for readability

### DIFF
--- a/.claude/rules/black-box-icons.md
+++ b/.claude/rules/black-box-icons.md
@@ -40,7 +40,7 @@ All icons use a consistent inner frame:
 
 Two-line labels at bottom:
 - **Line 1** (name): y=52, font-size 10px, white (#ffffff), bold, Arial
-- **Line 2** (action): y=63, font-size 8px, light gray (#aaaaaa), Arial
+- **Line 2** (action): y=63, font-size 8px, white (#ffffff), Arial
 
 Label configurations:
 | Black Box | Line 1 | Line 2 |
@@ -164,7 +164,7 @@ const RED = "#e74c3c";     // Hot temperatures
     <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">{{mainLabel}}</text>
     <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="8">{{subLabel}}</text>
   </g>
 </svg>
 ```

--- a/.claude/rules/icons.md
+++ b/.claude/rules/icons.md
@@ -31,7 +31,7 @@ packages/icons/{action-name}/
 
     <!-- Labels -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>
@@ -49,7 +49,7 @@ The Rollup `svgPlugin` resolves `@iracedeck/icons/` to `packages/icons/`.
 ### Label placeholders
 
 - **`{{mainLabel}}`** — prominent label (larger, bold, white `#ffffff`)
-- **`{{subLabel}}`** — secondary label (smaller, subdued `#aaaaaa`)
+- **`{{subLabel}}`** — secondary label (smaller, white `#ffffff`)
 
 ## Dynamic Templates (for telemetry-driven content)
 

--- a/.claude/rules/key-icon-types.md
+++ b/.claude/rules/key-icon-types.md
@@ -40,7 +40,7 @@ Labels use two lines with primary (bold, prominent) and secondary (subdued) styl
 | Label Type | Font Size (144) | Font Size (72) | Weight | Color |
 |------------|-----------------|-----------------|--------|-------|
 | Primary (`{{mainLabel}}`) | 20px | 10px | bold | #ffffff |
-| Secondary (`{{subLabel}}`) | 16px | 8px | normal | #aaaaaa |
+| Secondary (`{{subLabel}}`) | 16px | 8px | normal | #ffffff |
 
 Both lines are centered horizontally (text-anchor="middle").
 
@@ -97,7 +97,7 @@ Use these colors consistently across all icons (literal hex values in SVG, no co
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>
 ```
@@ -117,7 +117,7 @@ Used when the action word (e.g., NEXT/PREVIOUS) should be more prominent than th
 
     <!-- Inverted label: subLabel secondary on top, mainLabel primary on bottom -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>
@@ -147,7 +147,7 @@ Uses the Inverted label layout where the action word is prominent (bottom, bold)
 
 Optimized for showing live telemetry values. Small title at top, large centered value. No icon content area — the value IS the content. Uses dynamic 72x72 template.
 
-- **Title**: Small gray label at y=16 (#aaaaaa, 9px)
+- **Title**: Small white label at y=16 (#ffffff, 9px)
 - **Value**: Large bold centered text at y=50 (#ffffff, dynamic font size)
 - **Background**: Dynamic — can change color for alert effects (e.g., flash red on incident)
 - **Placeholders**: `{{backgroundColor}}`, `{{titleLabel}}`, `{{value}}`, `{{valueFontSize}}`

--- a/packages/icons/audio-controls/master-mute.svg
+++ b/packages/icons/audio-controls/master-mute.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/audio-controls/master-volume-down.svg
+++ b/packages/icons/audio-controls/master-volume-down.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/audio-controls/master-volume-up.svg
+++ b/packages/icons/audio-controls/master-volume-up.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/audio-controls/spotter-mute.svg
+++ b/packages/icons/audio-controls/spotter-mute.svg
@@ -11,6 +11,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/audio-controls/spotter-volume-down.svg
+++ b/packages/icons/audio-controls/spotter-volume-down.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/audio-controls/spotter-volume-up.svg
+++ b/packages/icons/audio-controls/spotter-volume-up.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/audio-controls/voice-chat-mute.svg
+++ b/packages/icons/audio-controls/voice-chat-mute.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/audio-controls/voice-chat-volume-down.svg
+++ b/packages/icons/audio-controls/voice-chat-volume-down.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/audio-controls/voice-chat-volume-up.svg
+++ b/packages/icons/audio-controls/voice-chat-volume-up.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/black-box-selector/fuel.svg
+++ b/packages/icons/black-box-selector/fuel.svg
@@ -16,6 +16,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/black-box-selector/in-car.svg
+++ b/packages/icons/black-box-selector/in-car.svg
@@ -17,6 +17,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/black-box-selector/lap-timing.svg
+++ b/packages/icons/black-box-selector/lap-timing.svg
@@ -16,6 +16,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/black-box-selector/mirror.svg
+++ b/packages/icons/black-box-selector/mirror.svg
@@ -16,6 +16,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/black-box-selector/next.svg
+++ b/packages/icons/black-box-selector/next.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/black-box-selector/pit-stop.svg
+++ b/packages/icons/black-box-selector/pit-stop.svg
@@ -15,6 +15,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/black-box-selector/previous.svg
+++ b/packages/icons/black-box-selector/previous.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/black-box-selector/radio.svg
+++ b/packages/icons/black-box-selector/radio.svg
@@ -16,6 +16,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/black-box-selector/relative.svg
+++ b/packages/icons/black-box-selector/relative.svg
@@ -19,6 +19,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/black-box-selector/standings.svg
+++ b/packages/icons/black-box-selector/standings.svg
@@ -21,6 +21,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/black-box-selector/tire-info.svg
+++ b/packages/icons/black-box-selector/tire-info.svg
@@ -17,6 +17,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/black-box-selector/tires.svg
+++ b/packages/icons/black-box-selector/tires.svg
@@ -15,6 +15,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/black-box-selector/weather.svg
+++ b/packages/icons/black-box-selector/weather.svg
@@ -16,6 +16,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/camera-cycle/camera-next.svg
+++ b/packages/icons/camera-cycle/camera-next.svg
@@ -11,6 +11,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/camera-cycle/camera-previous.svg
+++ b/packages/icons/camera-cycle/camera-previous.svg
@@ -11,6 +11,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/camera-cycle/car-next.svg
+++ b/packages/icons/camera-cycle/car-next.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/camera-cycle/car-previous.svg
+++ b/packages/icons/camera-cycle/car-previous.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/camera-cycle/driving-next.svg
+++ b/packages/icons/camera-cycle/driving-next.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/camera-cycle/driving-previous.svg
+++ b/packages/icons/camera-cycle/driving-previous.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/camera-cycle/sub-camera-next.svg
+++ b/packages/icons/camera-cycle/sub-camera-next.svg
@@ -11,6 +11,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/camera-cycle/sub-camera-previous.svg
+++ b/packages/icons/camera-cycle/sub-camera-previous.svg
@@ -11,6 +11,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/camera-editor-adjustments/altitude-decrease.svg
+++ b/packages/icons/camera-editor-adjustments/altitude-decrease.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/altitude-increase.svg
+++ b/packages/icons/camera-editor-adjustments/altitude-increase.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/auto-set-mic-gain-decrease.svg
+++ b/packages/icons/camera-editor-adjustments/auto-set-mic-gain-decrease.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/auto-set-mic-gain-increase.svg
+++ b/packages/icons/camera-editor-adjustments/auto-set-mic-gain-increase.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/blimp-radius-decrease.svg
+++ b/packages/icons/camera-editor-adjustments/blimp-radius-decrease.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/blimp-radius-increase.svg
+++ b/packages/icons/camera-editor-adjustments/blimp-radius-increase.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/blimp-velocity-decrease.svg
+++ b/packages/icons/camera-editor-adjustments/blimp-velocity-decrease.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/blimp-velocity-increase.svg
+++ b/packages/icons/camera-editor-adjustments/blimp-velocity-increase.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/f-number-decrease.svg
+++ b/packages/icons/camera-editor-adjustments/f-number-decrease.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/f-number-increase.svg
+++ b/packages/icons/camera-editor-adjustments/f-number-increase.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/focus-depth-decrease.svg
+++ b/packages/icons/camera-editor-adjustments/focus-depth-decrease.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/focus-depth-increase.svg
+++ b/packages/icons/camera-editor-adjustments/focus-depth-increase.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/fov-zoom-decrease.svg
+++ b/packages/icons/camera-editor-adjustments/fov-zoom-decrease.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/fov-zoom-increase.svg
+++ b/packages/icons/camera-editor-adjustments/fov-zoom-increase.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/key-step-decrease.svg
+++ b/packages/icons/camera-editor-adjustments/key-step-decrease.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/key-step-increase.svg
+++ b/packages/icons/camera-editor-adjustments/key-step-increase.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/latitude-decrease.svg
+++ b/packages/icons/camera-editor-adjustments/latitude-decrease.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/latitude-increase.svg
+++ b/packages/icons/camera-editor-adjustments/latitude-increase.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/longitude-decrease.svg
+++ b/packages/icons/camera-editor-adjustments/longitude-decrease.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/longitude-increase.svg
+++ b/packages/icons/camera-editor-adjustments/longitude-increase.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/mic-gain-decrease.svg
+++ b/packages/icons/camera-editor-adjustments/mic-gain-decrease.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/mic-gain-increase.svg
+++ b/packages/icons/camera-editor-adjustments/mic-gain-increase.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/pitch-decrease.svg
+++ b/packages/icons/camera-editor-adjustments/pitch-decrease.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/pitch-increase.svg
+++ b/packages/icons/camera-editor-adjustments/pitch-increase.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/vanish-x-decrease.svg
+++ b/packages/icons/camera-editor-adjustments/vanish-x-decrease.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/vanish-x-increase.svg
+++ b/packages/icons/camera-editor-adjustments/vanish-x-increase.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/vanish-y-decrease.svg
+++ b/packages/icons/camera-editor-adjustments/vanish-y-decrease.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/vanish-y-increase.svg
+++ b/packages/icons/camera-editor-adjustments/vanish-y-increase.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/yaw-decrease.svg
+++ b/packages/icons/camera-editor-adjustments/yaw-decrease.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-adjustments/yaw-increase.svg
+++ b/packages/icons/camera-editor-adjustments/yaw-increase.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/acquire-end.svg
+++ b/packages/icons/camera-editor-controls/acquire-end.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/acquire-start.svg
+++ b/packages/icons/camera-editor-controls/acquire-start.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/beyond-fence-toggle.svg
+++ b/packages/icons/camera-editor-controls/beyond-fence-toggle.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/copy-camera.svg
+++ b/packages/icons/camera-editor-controls/copy-camera.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/copy-group.svg
+++ b/packages/icons/camera-editor-controls/copy-group.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/cycle-aim-type.svg
+++ b/packages/icons/camera-editor-controls/cycle-aim-type.svg
@@ -15,7 +15,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/cycle-position-type.svg
+++ b/packages/icons/camera-editor-controls/cycle-position-type.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/dampening-toggle.svg
+++ b/packages/icons/camera-editor-controls/dampening-toggle.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/in-cockpit-toggle.svg
+++ b/packages/icons/camera-editor-controls/in-cockpit-toggle.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/insert-camera.svg
+++ b/packages/icons/camera-editor-controls/insert-camera.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/key-10x-toggle.svg
+++ b/packages/icons/camera-editor-controls/key-10x-toggle.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/key-acceleration-toggle.svg
+++ b/packages/icons/camera-editor-controls/key-acceleration-toggle.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/limit-shot-range-toggle.svg
+++ b/packages/icons/camera-editor-controls/limit-shot-range-toggle.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/load-car-camera.svg
+++ b/packages/icons/camera-editor-controls/load-car-camera.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/load-track-camera.svg
+++ b/packages/icons/camera-editor-controls/load-track-camera.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/manual-focus-toggle.svg
+++ b/packages/icons/camera-editor-controls/manual-focus-toggle.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/mouse-navigation-toggle.svg
+++ b/packages/icons/camera-editor-controls/mouse-navigation-toggle.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/open-camera-tool.svg
+++ b/packages/icons/camera-editor-controls/open-camera-tool.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/parabolic-mic-toggle.svg
+++ b/packages/icons/camera-editor-controls/parabolic-mic-toggle.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/paste-camera.svg
+++ b/packages/icons/camera-editor-controls/paste-camera.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/paste-group.svg
+++ b/packages/icons/camera-editor-controls/paste-group.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/pitch-gyro-toggle.svg
+++ b/packages/icons/camera-editor-controls/pitch-gyro-toggle.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/remove-camera.svg
+++ b/packages/icons/camera-editor-controls/remove-camera.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/roll-gyro-toggle.svg
+++ b/packages/icons/camera-editor-controls/roll-gyro-toggle.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/save-car-camera.svg
+++ b/packages/icons/camera-editor-controls/save-car-camera.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/save-track-camera.svg
+++ b/packages/icons/camera-editor-controls/save-track-camera.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/shot-selection-toggle.svg
+++ b/packages/icons/camera-editor-controls/shot-selection-toggle.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/show-camera-toggle.svg
+++ b/packages/icons/camera-editor-controls/show-camera-toggle.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/temporary-edits-toggle.svg
+++ b/packages/icons/camera-editor-controls/temporary-edits-toggle.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-editor-controls/zoom-toggle.svg
+++ b/packages/icons/camera-editor-controls/zoom-toggle.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-focus/focus-on-exiting.svg
+++ b/packages/icons/camera-focus/focus-on-exiting.svg
@@ -14,7 +14,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-focus/focus-on-incident.svg
+++ b/packages/icons/camera-focus/focus-on-incident.svg
@@ -15,7 +15,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-focus/focus-on-leader.svg
+++ b/packages/icons/camera-focus/focus-on-leader.svg
@@ -15,7 +15,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-focus/focus-your-car.svg
+++ b/packages/icons/camera-focus/focus-your-car.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-focus/set-camera-state.svg
+++ b/packages/icons/camera-focus/set-camera-state.svg
@@ -17,7 +17,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-focus/switch-by-car-number.svg
+++ b/packages/icons/camera-focus/switch-by-car-number.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/camera-focus/switch-by-position.svg
+++ b/packages/icons/camera-focus/switch-by-position.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/car-control/enter-exit-tow.svg
+++ b/packages/icons/car-control/enter-exit-tow.svg
@@ -15,6 +15,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/car-control/ignition.svg
+++ b/packages/icons/car-control/ignition.svg
@@ -11,6 +11,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/car-control/pause-sim.svg
+++ b/packages/icons/car-control/pause-sim.svg
@@ -11,6 +11,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/car-control/starter.svg
+++ b/packages/icons/car-control/starter.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/chat/cancel.svg
+++ b/packages/icons/chat/cancel.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/chat/open-chat.svg
+++ b/packages/icons/chat/open-chat.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/chat/reply.svg
+++ b/packages/icons/chat/reply.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/chat/respond-pm.svg
+++ b/packages/icons/chat/respond-pm.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/chat/whisper.svg
+++ b/packages/icons/chat/whisper.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/cockpit-misc/dash-page-1-decrease.svg
+++ b/packages/icons/cockpit-misc/dash-page-1-decrease.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/cockpit-misc/dash-page-1-increase.svg
+++ b/packages/icons/cockpit-misc/dash-page-1-increase.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/cockpit-misc/dash-page-2-decrease.svg
+++ b/packages/icons/cockpit-misc/dash-page-2-decrease.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/cockpit-misc/dash-page-2-increase.svg
+++ b/packages/icons/cockpit-misc/dash-page-2-increase.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/cockpit-misc/ffb-max-force-decrease.svg
+++ b/packages/icons/cockpit-misc/ffb-max-force-decrease.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/cockpit-misc/ffb-max-force-increase.svg
+++ b/packages/icons/cockpit-misc/ffb-max-force-increase.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/cockpit-misc/in-lap-mode.svg
+++ b/packages/icons/cockpit-misc/in-lap-mode.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/cockpit-misc/report-latency.svg
+++ b/packages/icons/cockpit-misc/report-latency.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/cockpit-misc/trigger-wipers.svg
+++ b/packages/icons/cockpit-misc/trigger-wipers.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/fuel-service/add-fuel.svg
+++ b/packages/icons/fuel-service/add-fuel.svg
@@ -18,7 +18,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/fuel-service/clear-fuel.svg
+++ b/packages/icons/fuel-service/clear-fuel.svg
@@ -15,7 +15,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/fuel-service/lap-margin-decrease.svg
+++ b/packages/icons/fuel-service/lap-margin-decrease.svg
@@ -14,7 +14,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/fuel-service/lap-margin-increase.svg
+++ b/packages/icons/fuel-service/lap-margin-increase.svg
@@ -14,7 +14,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/fuel-service/reduce-fuel.svg
+++ b/packages/icons/fuel-service/reduce-fuel.svg
@@ -15,7 +15,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/fuel-service/set-fuel-amount.svg
+++ b/packages/icons/fuel-service/set-fuel-amount.svg
@@ -15,7 +15,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/fuel-service/toggle-autofuel.svg
+++ b/packages/icons/fuel-service/toggle-autofuel.svg
@@ -15,7 +15,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/look-direction/look-down.svg
+++ b/packages/icons/look-direction/look-down.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/look-direction/look-left.svg
+++ b/packages/icons/look-direction/look-left.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/look-direction/look-right.svg
+++ b/packages/icons/look-direction/look-right.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/look-direction/look-up.svg
+++ b/packages/icons/look-direction/look-up.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/media-capture/reload-all-textures.svg
+++ b/packages/icons/media-capture/reload-all-textures.svg
@@ -15,7 +15,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/media-capture/reload-car-textures.svg
+++ b/packages/icons/media-capture/reload-car-textures.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/media-capture/start-stop-video.svg
+++ b/packages/icons/media-capture/start-stop-video.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/media-capture/take-giant-screenshot.svg
+++ b/packages/icons/media-capture/take-giant-screenshot.svg
@@ -16,7 +16,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/media-capture/take-screenshot.svg
+++ b/packages/icons/media-capture/take-screenshot.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/media-capture/toggle-video-capture.svg
+++ b/packages/icons/media-capture/toggle-video-capture.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/media-capture/video-timer.svg
+++ b/packages/icons/media-capture/video-timer.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/pit-quick-actions/clear-all-checkboxes.svg
+++ b/packages/icons/pit-quick-actions/clear-all-checkboxes.svg
@@ -15,7 +15,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/pit-quick-actions/request-fast-repair.svg
+++ b/packages/icons/pit-quick-actions/request-fast-repair.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/pit-quick-actions/windshield-tearoff.svg
+++ b/packages/icons/pit-quick-actions/windshield-tearoff.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-navigation/erase-tape.svg
+++ b/packages/icons/replay-navigation/erase-tape.svg
@@ -9,7 +9,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-navigation/jump-to-end.svg
+++ b/packages/icons/replay-navigation/jump-to-end.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-navigation/jump-to-start.svg
+++ b/packages/icons/replay-navigation/jump-to-start.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-navigation/next-incident.svg
+++ b/packages/icons/replay-navigation/next-incident.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-navigation/next-lap.svg
+++ b/packages/icons/replay-navigation/next-lap.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-navigation/next-session.svg
+++ b/packages/icons/replay-navigation/next-session.svg
@@ -9,7 +9,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-navigation/prev-incident.svg
+++ b/packages/icons/replay-navigation/prev-incident.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-navigation/prev-lap.svg
+++ b/packages/icons/replay-navigation/prev-lap.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-navigation/prev-session.svg
+++ b/packages/icons/replay-navigation/prev-session.svg
@@ -9,7 +9,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-navigation/search-session-time.svg
+++ b/packages/icons/replay-navigation/search-session-time.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-navigation/set-play-position.svg
+++ b/packages/icons/replay-navigation/set-play-position.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-speed/decrease.svg
+++ b/packages/icons/replay-speed/decrease.svg
@@ -9,7 +9,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-speed/increase.svg
+++ b/packages/icons/replay-speed/increase.svg
@@ -9,7 +9,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-transport/fast-forward.svg
+++ b/packages/icons/replay-transport/fast-forward.svg
@@ -9,7 +9,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-transport/frame-backward.svg
+++ b/packages/icons/replay-transport/frame-backward.svg
@@ -9,7 +9,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-transport/frame-forward.svg
+++ b/packages/icons/replay-transport/frame-forward.svg
@@ -9,7 +9,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-transport/pause.svg
+++ b/packages/icons/replay-transport/pause.svg
@@ -9,7 +9,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-transport/play.svg
+++ b/packages/icons/replay-transport/play.svg
@@ -8,7 +8,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-transport/rewind.svg
+++ b/packages/icons/replay-transport/rewind.svg
@@ -9,7 +9,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-transport/slow-motion.svg
+++ b/packages/icons/replay-transport/slow-motion.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/replay-transport/stop.svg
+++ b/packages/icons/replay-transport/stop.svg
@@ -8,7 +8,7 @@
 
     <!-- Two-line label (subLabel on top subdued, mainLabel on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/setup-aero/front-wing-decrease.svg
+++ b/packages/icons/setup-aero/front-wing-decrease.svg
@@ -11,6 +11,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-aero/front-wing-increase.svg
+++ b/packages/icons/setup-aero/front-wing-increase.svg
@@ -11,6 +11,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-aero/qualifying-tape-decrease.svg
+++ b/packages/icons/setup-aero/qualifying-tape-decrease.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-aero/qualifying-tape-increase.svg
+++ b/packages/icons/setup-aero/qualifying-tape-increase.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-aero/rear-wing-decrease.svg
+++ b/packages/icons/setup-aero/rear-wing-decrease.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-aero/rear-wing-increase.svg
+++ b/packages/icons/setup-aero/rear-wing-increase.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-aero/rf-brake-attached.svg
+++ b/packages/icons/setup-aero/rf-brake-attached.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-brakes/abs-adjust-decrease.svg
+++ b/packages/icons/setup-brakes/abs-adjust-decrease.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-brakes/abs-adjust-increase.svg
+++ b/packages/icons/setup-brakes/abs-adjust-increase.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-brakes/abs-toggle.svg
+++ b/packages/icons/setup-brakes/abs-toggle.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-brakes/brake-bias-decrease.svg
+++ b/packages/icons/setup-brakes/brake-bias-decrease.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-brakes/brake-bias-fine-decrease.svg
+++ b/packages/icons/setup-brakes/brake-bias-fine-decrease.svg
@@ -16,6 +16,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-brakes/brake-bias-fine-increase.svg
+++ b/packages/icons/setup-brakes/brake-bias-fine-increase.svg
@@ -16,6 +16,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-brakes/brake-bias-increase.svg
+++ b/packages/icons/setup-brakes/brake-bias-increase.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-brakes/brake-misc-decrease.svg
+++ b/packages/icons/setup-brakes/brake-misc-decrease.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-brakes/brake-misc-increase.svg
+++ b/packages/icons/setup-brakes/brake-misc-increase.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-brakes/engine-braking-decrease.svg
+++ b/packages/icons/setup-brakes/engine-braking-decrease.svg
@@ -15,6 +15,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-brakes/engine-braking-increase.svg
+++ b/packages/icons/setup-brakes/engine-braking-increase.svg
@@ -15,6 +15,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-brakes/peak-brake-bias-decrease.svg
+++ b/packages/icons/setup-brakes/peak-brake-bias-decrease.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-brakes/peak-brake-bias-increase.svg
+++ b/packages/icons/setup-brakes/peak-brake-bias-increase.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/differential-entry-decrease.svg
+++ b/packages/icons/setup-chassis/differential-entry-decrease.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/differential-entry-increase.svg
+++ b/packages/icons/setup-chassis/differential-entry-increase.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/differential-exit-decrease.svg
+++ b/packages/icons/setup-chassis/differential-exit-decrease.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/differential-exit-increase.svg
+++ b/packages/icons/setup-chassis/differential-exit-increase.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/differential-middle-decrease.svg
+++ b/packages/icons/setup-chassis/differential-middle-decrease.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/differential-middle-increase.svg
+++ b/packages/icons/setup-chassis/differential-middle-increase.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/differential-preload-decrease.svg
+++ b/packages/icons/setup-chassis/differential-preload-decrease.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/differential-preload-increase.svg
+++ b/packages/icons/setup-chassis/differential-preload-increase.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/front-arb-decrease.svg
+++ b/packages/icons/setup-chassis/front-arb-decrease.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/front-arb-increase.svg
+++ b/packages/icons/setup-chassis/front-arb-increase.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/left-spring-decrease.svg
+++ b/packages/icons/setup-chassis/left-spring-decrease.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/left-spring-increase.svg
+++ b/packages/icons/setup-chassis/left-spring-increase.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/lf-shock-decrease.svg
+++ b/packages/icons/setup-chassis/lf-shock-decrease.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/lf-shock-increase.svg
+++ b/packages/icons/setup-chassis/lf-shock-increase.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/lr-shock-decrease.svg
+++ b/packages/icons/setup-chassis/lr-shock-decrease.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/lr-shock-increase.svg
+++ b/packages/icons/setup-chassis/lr-shock-increase.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/power-steering-decrease.svg
+++ b/packages/icons/setup-chassis/power-steering-decrease.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/power-steering-increase.svg
+++ b/packages/icons/setup-chassis/power-steering-increase.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/rear-arb-decrease.svg
+++ b/packages/icons/setup-chassis/rear-arb-decrease.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/rear-arb-increase.svg
+++ b/packages/icons/setup-chassis/rear-arb-increase.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/rf-shock-decrease.svg
+++ b/packages/icons/setup-chassis/rf-shock-decrease.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/rf-shock-increase.svg
+++ b/packages/icons/setup-chassis/rf-shock-increase.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/right-spring-decrease.svg
+++ b/packages/icons/setup-chassis/right-spring-decrease.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/right-spring-increase.svg
+++ b/packages/icons/setup-chassis/right-spring-increase.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/rr-shock-decrease.svg
+++ b/packages/icons/setup-chassis/rr-shock-decrease.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-chassis/rr-shock-increase.svg
+++ b/packages/icons/setup-chassis/rr-shock-increase.svg
@@ -14,6 +14,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-engine/boost-level-decrease.svg
+++ b/packages/icons/setup-engine/boost-level-decrease.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-engine/boost-level-increase.svg
+++ b/packages/icons/setup-engine/boost-level-increase.svg
@@ -13,6 +13,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-engine/engine-power-decrease.svg
+++ b/packages/icons/setup-engine/engine-power-decrease.svg
@@ -15,6 +15,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-engine/engine-power-increase.svg
+++ b/packages/icons/setup-engine/engine-power-increase.svg
@@ -15,6 +15,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-engine/launch-rpm-decrease.svg
+++ b/packages/icons/setup-engine/launch-rpm-decrease.svg
@@ -17,6 +17,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-engine/launch-rpm-increase.svg
+++ b/packages/icons/setup-engine/launch-rpm-increase.svg
@@ -17,6 +17,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-engine/throttle-shaping-decrease.svg
+++ b/packages/icons/setup-engine/throttle-shaping-decrease.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-engine/throttle-shaping-increase.svg
+++ b/packages/icons/setup-engine/throttle-shaping-increase.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-fuel/disable-fuel-cut.svg
+++ b/packages/icons/setup-fuel/disable-fuel-cut.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-fuel/fcy-mode-toggle.svg
+++ b/packages/icons/setup-fuel/fcy-mode-toggle.svg
@@ -11,6 +11,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-fuel/fuel-cut-position-decrease.svg
+++ b/packages/icons/setup-fuel/fuel-cut-position-decrease.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-fuel/fuel-cut-position-increase.svg
+++ b/packages/icons/setup-fuel/fuel-cut-position-increase.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-fuel/fuel-mixture-decrease.svg
+++ b/packages/icons/setup-fuel/fuel-mixture-decrease.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-fuel/fuel-mixture-increase.svg
+++ b/packages/icons/setup-fuel/fuel-mixture-increase.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-fuel/low-fuel-accept.svg
+++ b/packages/icons/setup-fuel/low-fuel-accept.svg
@@ -12,6 +12,6 @@
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/icons/setup-hybrid/hys-boost.svg
+++ b/packages/icons/setup-hybrid/hys-boost.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/setup-hybrid/hys-no-boost.svg
+++ b/packages/icons/setup-hybrid/hys-no-boost.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/setup-hybrid/hys-regen.svg
+++ b/packages/icons/setup-hybrid/hys-regen.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/setup-hybrid/mguk-deploy-mode-decrease.svg
+++ b/packages/icons/setup-hybrid/mguk-deploy-mode-decrease.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/setup-hybrid/mguk-deploy-mode-increase.svg
+++ b/packages/icons/setup-hybrid/mguk-deploy-mode-increase.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/setup-hybrid/mguk-fixed-deploy-decrease.svg
+++ b/packages/icons/setup-hybrid/mguk-fixed-deploy-decrease.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/setup-hybrid/mguk-fixed-deploy-increase.svg
+++ b/packages/icons/setup-hybrid/mguk-fixed-deploy-increase.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/setup-hybrid/mguk-regen-gain-decrease.svg
+++ b/packages/icons/setup-hybrid/mguk-regen-gain-decrease.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/setup-hybrid/mguk-regen-gain-increase.svg
+++ b/packages/icons/setup-hybrid/mguk-regen-gain-increase.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/setup-traction/tc-slot-1-decrease.svg
+++ b/packages/icons/setup-traction/tc-slot-1-decrease.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/setup-traction/tc-slot-1-increase.svg
+++ b/packages/icons/setup-traction/tc-slot-1-increase.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/setup-traction/tc-slot-2-decrease.svg
+++ b/packages/icons/setup-traction/tc-slot-2-decrease.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/setup-traction/tc-slot-2-increase.svg
+++ b/packages/icons/setup-traction/tc-slot-2-increase.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/setup-traction/tc-slot-3-decrease.svg
+++ b/packages/icons/setup-traction/tc-slot-3-decrease.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/setup-traction/tc-slot-3-increase.svg
+++ b/packages/icons/setup-traction/tc-slot-3-increase.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/setup-traction/tc-slot-4-decrease.svg
+++ b/packages/icons/setup-traction/tc-slot-4-decrease.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/setup-traction/tc-slot-4-increase.svg
+++ b/packages/icons/setup-traction/tc-slot-4-increase.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/setup-traction/tc-toggle.svg
+++ b/packages/icons/setup-traction/tc-toggle.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/splits-delta-cycle/next.svg
+++ b/packages/icons/splits-delta-cycle/next.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label (line2 on top subdued, line1 on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/splits-delta-cycle/previous.svg
+++ b/packages/icons/splits-delta-cycle/previous.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label (line2 on top subdued, line1 on bottom prominent) -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/telemetry-control/mark-event.svg
+++ b/packages/icons/telemetry-control/mark-event.svg
@@ -12,7 +12,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/telemetry-control/restart-recording.svg
+++ b/packages/icons/telemetry-control/restart-recording.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/telemetry-control/start-recording.svg
+++ b/packages/icons/telemetry-control/start-recording.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/telemetry-control/stop-recording.svg
+++ b/packages/icons/telemetry-control/stop-recording.svg
@@ -10,7 +10,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/telemetry-control/toggle-logging.svg
+++ b/packages/icons/telemetry-control/toggle-logging.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/tire-service/clear-tires.svg
+++ b/packages/icons/tire-service/clear-tires.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/toggle-ui-elements/dash-box.svg
+++ b/packages/icons/toggle-ui-elements/dash-box.svg
@@ -14,7 +14,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/toggle-ui-elements/display-ref-car.svg
+++ b/packages/icons/toggle-ui-elements/display-ref-car.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/toggle-ui-elements/fps-network-display.svg
+++ b/packages/icons/toggle-ui-elements/fps-network-display.svg
@@ -14,7 +14,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/toggle-ui-elements/radio-display.svg
+++ b/packages/icons/toggle-ui-elements/radio-display.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/toggle-ui-elements/replay-ui.svg
+++ b/packages/icons/toggle-ui-elements/replay-ui.svg
@@ -11,7 +11,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/toggle-ui-elements/speed-gear-pedals.svg
+++ b/packages/icons/toggle-ui-elements/speed-gear-pedals.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/toggle-ui-elements/ui-edit-mode.svg
+++ b/packages/icons/toggle-ui-elements/ui-edit-mode.svg
@@ -14,7 +14,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/toggle-ui-elements/virtual-mirror.svg
+++ b/packages/icons/toggle-ui-elements/virtual-mirror.svg
@@ -13,7 +13,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/toggle-ui-elements/weather-radar.svg
+++ b/packages/icons/toggle-ui-elements/weather-radar.svg
@@ -14,7 +14,7 @@
 
     <!-- Two-line label -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/view-adjustment/driver-height-decrease.svg
+++ b/packages/icons/view-adjustment/driver-height-decrease.svg
@@ -18,7 +18,7 @@
 
     <!-- Inverted label: subLabel on top, mainLabel on bottom -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/view-adjustment/driver-height-increase.svg
+++ b/packages/icons/view-adjustment/driver-height-increase.svg
@@ -18,7 +18,7 @@
 
     <!-- Inverted label: subLabel on top, mainLabel on bottom -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/view-adjustment/fov-decrease.svg
+++ b/packages/icons/view-adjustment/fov-decrease.svg
@@ -10,7 +10,7 @@
 
     <!-- Inverted label: subLabel on top, mainLabel on bottom -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/view-adjustment/fov-increase.svg
+++ b/packages/icons/view-adjustment/fov-increase.svg
@@ -10,7 +10,7 @@
 
     <!-- Inverted label: subLabel on top, mainLabel on bottom -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/view-adjustment/horizon-decrease.svg
+++ b/packages/icons/view-adjustment/horizon-decrease.svg
@@ -10,7 +10,7 @@
 
     <!-- Inverted label: subLabel on top, mainLabel on bottom -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/view-adjustment/horizon-increase.svg
+++ b/packages/icons/view-adjustment/horizon-increase.svg
@@ -10,7 +10,7 @@
 
     <!-- Inverted label: subLabel on top, mainLabel on bottom -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/view-adjustment/recenter-vr.svg
+++ b/packages/icons/view-adjustment/recenter-vr.svg
@@ -14,7 +14,7 @@
 
     <!-- Inverted label: subLabel on top, mainLabel on bottom -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/view-adjustment/ui-size-decrease.svg
+++ b/packages/icons/view-adjustment/ui-size-decrease.svg
@@ -11,7 +11,7 @@
 
     <!-- Inverted label: subLabel on top, mainLabel on bottom -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/icons/view-adjustment/ui-size-increase.svg
+++ b/packages/icons/view-adjustment/ui-size-increase.svg
@@ -11,7 +11,7 @@
 
     <!-- Inverted label: subLabel on top, mainLabel on bottom -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>

--- a/packages/stream-deck-plugin/CLAUDE.md
+++ b/packages/stream-deck-plugin/CLAUDE.md
@@ -135,7 +135,7 @@ Standalone 144x144 SVGs with Mustache label placeholders. One file per variant (
 
     <!-- Labels -->
     <text x="72" y="104" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16">{{subLabel}}</text>
     <text x="72" y="126" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
   </g>
@@ -145,7 +145,7 @@ Standalone 144x144 SVGs with Mustache label placeholders. One file per variant (
 - Background color must be unique per action (check existing actions to avoid duplicates)
 - All coordinates doubled from 72x72 (Stream Deck downscales as needed)
 - Use literal hex color values, not constants
-- Placeholders: `{{mainLabel}}` (bold, white), `{{subLabel}}` (subdued, gray)
+- Placeholders: `{{mainLabel}}` (bold, white), `{{subLabel}}` (white, smaller)
 
 #### 4. Category icon — `com.iracedeck.sd.core.sdPlugin/imgs/actions/{action-name}/icon.svg`
 

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/audio-controls/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/audio-controls/key.svg
@@ -14,5 +14,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">SPOTTER</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">VOL UP</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">VOL UP</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/black-box-selector/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/black-box-selector/key.svg
@@ -19,5 +19,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">BLACK BOX</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">SELECTOR</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">SELECTOR</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/camera-cycle/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/camera-cycle/key.svg
@@ -13,5 +13,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">NEXT</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">CAMERA</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">CAMERA</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/camera-editor-adjustments/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/camera-editor-adjustments/key.svg
@@ -11,7 +11,7 @@
 
   <!-- Two-line label (inverted: secondary top, primary bottom) -->
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">LATITUDE</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">LATITUDE</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">+</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/camera-editor-controls/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/camera-editor-controls/key.svg
@@ -6,7 +6,7 @@
   <circle cx="30" cy="21" r="5" fill="none" stroke="#888888" stroke-width="1"/>
   <circle cx="30" cy="21" r="2" fill="#ffffff"/>
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">CAM TOOL</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">CAM TOOL</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">OPEN</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/camera-focus/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/camera-focus/key.svg
@@ -11,5 +11,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">FOCUS</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">YOUR CAR</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">YOUR CAR</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/car-control/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/car-control/key.svg
@@ -12,5 +12,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">CAR</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">CONTROL</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">CONTROL</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/chat/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/chat/key.svg
@@ -9,5 +9,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">OPEN</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">CHAT</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">CHAT</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/cockpit-misc/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/cockpit-misc/key.svg
@@ -11,5 +11,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">COCKPIT</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">MISC</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">MISC</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/fuel-service/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/fuel-service/key.svg
@@ -8,5 +8,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">ADD FUEL</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">PIT</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">PIT</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/look-direction/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/look-direction/key.svg
@@ -15,5 +15,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">LOOK</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">DIRECTION</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">DIRECTION</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/media-capture/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/media-capture/key.svg
@@ -6,7 +6,7 @@
   <circle cx="31" cy="21" r="5" fill="none" stroke="#888888" stroke-width="1"/>
   <circle cx="31" cy="21" r="2.5" fill="#e74c3c"/>
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">VIDEO</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">VIDEO</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">START/STOP</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/pit-quick-actions/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/pit-quick-actions/key.svg
@@ -16,5 +16,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">PIT</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">QUICK ACTIONS</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">QUICK ACTIONS</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/replay-navigation/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/replay-navigation/key.svg
@@ -10,5 +10,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">NEXT</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">SESSION</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">SESSION</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/replay-speed/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/replay-speed/key.svg
@@ -6,5 +6,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">SPEED UP</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">REPLAY</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">REPLAY</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/replay-transport/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/replay-transport/key.svg
@@ -9,5 +9,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">PLAY</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">REPLAY</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">REPLAY</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/session-info/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/session-info/key.svg
@@ -4,7 +4,7 @@
 
   <!-- Title label at top -->
   <text x="36" y="16" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="9">INCIDENTS</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="9">INCIDENTS</text>
 
   <!-- Large centered value -->
   <text x="36" y="50" text-anchor="middle" dominant-baseline="central"

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/setup-aero/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/setup-aero/key.svg
@@ -11,5 +11,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">FRONT WING</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">INCREASE</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">INCREASE</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/setup-brakes/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/setup-brakes/key.svg
@@ -12,5 +12,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">BRAKE BIAS</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">INCREASE</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">INCREASE</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/setup-chassis/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/setup-chassis/key.svg
@@ -11,5 +11,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">DIFF PRELOAD</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">INCREASE</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">INCREASE</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/setup-engine/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/setup-engine/key.svg
@@ -12,5 +12,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">ENG POWER</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">INCREASE</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">INCREASE</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/setup-fuel/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/setup-fuel/key.svg
@@ -12,5 +12,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">FUEL MIX</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">INCREASE</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">INCREASE</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/setup-hybrid/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/setup-hybrid/key.svg
@@ -12,5 +12,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">REGEN GAIN</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">INCREASE</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">INCREASE</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/setup-traction/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/setup-traction/key.svg
@@ -12,5 +12,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">TC</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">TOGGLE</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">TOGGLE</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/splits-delta-cycle/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/splits-delta-cycle/key.svg
@@ -11,5 +11,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">SPLITS DELTA</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">CYCLE</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">CYCLE</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/telemetry-control/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/telemetry-control/key.svg
@@ -8,5 +8,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">LOGGING</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">TOGGLE</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">TOGGLE</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/telemetry-display/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/telemetry-display/key.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
   <rect x="0" y="0" width="72" height="72" rx="8" fill="#2a3444"/>
   <text x="36" y="16" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="9">SPEED</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="9">SPEED</text>
   <text x="36" y="50" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="18" font-weight="bold">---</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/toggle-ui-elements/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/toggle-ui-elements/key.svg
@@ -11,5 +11,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">TOGGLE UI</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">ELEMENTS</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">ELEMENTS</text>
 </svg>

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/view-adjustment/key.svg
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/imgs/actions/view-adjustment/key.svg
@@ -17,5 +17,5 @@
   <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
         fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">VIEW</text>
   <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-        fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">ADJUST</text>
+        fill="#ffffff" font-family="Arial, sans-serif" font-size="8">ADJUST</text>
 </svg>

--- a/packages/stream-deck-plugin/icons/car-control.svg
+++ b/packages/stream-deck-plugin/icons/car-control.svg
@@ -10,6 +10,6 @@
     <text x="36" y="52" text-anchor="middle" dominant-baseline="central"
           fill="#ffffff" font-family="Arial, sans-serif" font-size="10" font-weight="bold">{{mainLabel}}</text>
     <text x="36" y="63" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="8">{{subLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="8">{{subLabel}}</text>
   </g>
 </svg>

--- a/packages/stream-deck-plugin/icons/session-info.svg
+++ b/packages/stream-deck-plugin/icons/session-info.svg
@@ -5,7 +5,7 @@
 
     <!-- Title label at top -->
     <text x="36" y="16" text-anchor="middle" dominant-baseline="central"
-          fill="#aaaaaa" font-family="Arial, sans-serif" font-size="9">{{titleLabel}}</text>
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="9">{{titleLabel}}</text>
 
     <!-- Large centered value -->
     <text x="36" y="{{valueY}}" text-anchor="middle" dominant-baseline="central"


### PR DESCRIPTION
## Related Issue

N/A

## What changed?

- Changed all icon subLabel/secondary text `fill` color from `#aaaaaa` (gray) to `#ffffff` (white) across ~295 SVG files for improved readability on dark Stream Deck backgrounds
- Updated documentation (`.claude/rules/icons.md`, `.claude/rules/key-icon-types.md`, `.claude/rules/black-box-icons.md`, `packages/stream-deck-plugin/CLAUDE.md`) to reflect the new color

## How to test

- Build with `pnpm build` and verify success
- Load the plugin in Stream Deck and confirm subLabels are now white and readable on all action icons

## Checklist

- [x] Linked to an approved issue
- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] `pnpm lint:fix` and `pnpm format:fix` run with no remaining issues
- [ ] New code has unit tests
- [x] No unrelated changes included