### PR TITLE
chore: add .sdignore, change build script to trim Stream Deck plugin

### DIFF
--- a/.github/workflows/release-pack.yml
+++ b/.github/workflows/release-pack.yml
@@ -1,6 +1,7 @@
 name: Release - Build Stream Deck Plugin
 
 on:
+  workflow_dispatch:
   push:
     tags: ["v*"]
 
@@ -26,14 +27,24 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Remove dev dependencies
+        run: pnpm install --prod --no-frozen-lockfile
+
       - name: Pack Stream Deck plugin
         run: |
-          $version = "${{ github.ref_name }}".TrimStart("v")
+          $version = if ("${{ github.ref_name }}".StartsWith("v")) { "${{ github.ref_name }}".TrimStart("v") } else { "dev" }
           npx @elgato/cli@latest pack packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin
           Rename-Item "com.iracedeck.sd.core.streamDeckPlugin" "iracedeck-v${version}.streamDeckPlugin"
         shell: pwsh
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: streamdeck-plugin
+          path: iracedeck-v*.streamDeckPlugin
+
       - name: Attach plugin to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           files: iracedeck-v*.streamDeckPlugin

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "watch:stream-deck": "pnpm --filter \"@iracedeck/stream-deck-plugin\" run watch",
     "release": "node scripts/release.mjs",
     "release:dry": "node scripts/release.mjs --dry-run",
-    "prepare": "husky"
+    "prepare": "husky || exit 0"
   },
   "devDependencies": {
     "@elgato/eslint-config": "0.3.2",

--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/.sdignore
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/.sdignore
@@ -1,0 +1,41 @@
+# Build intermediate objects
+**/build/Release/obj/
+
+# MSVC debug symbols
+*.pdb
+
+# MSVC incremental linking cache
+*.iobj
+*.ipdb
+
+# MSVC linker artifacts
+*.exp
+*.lib
+
+# MSBuild tracking logs
+*.tlog
+
+# Python bytecode cache (node-gyp)
+**/__pycache__/
+
+# Dev dependencies (nested in native modules)
+**/node_modules/typescript/
+**/node_modules/@types/
+**/node_modules/vitest/
+**/node_modules/node-gyp/
+**/node_modules/rimraf/
+
+# Source files (already compiled)
+*/node_modules//src/
+*/node_modules/@/*/src/
+
+# Dev/build config files
+**/tsconfig.json
+**/package-lock.json
+**/binding.gyp
+**/.gitignore
+**/.npmignore
+**/CLAUDE.md
+
+# Compiled object files
+*.obj


### PR DESCRIPTION
## Related Issue

N/A

## What changed?

This PR adds .sdignore file, and removes dev dependecies prior to packing the Stream Deck plugin. This should reduce the file size, and reduce the installation issues some users are expressing.

## How to test

Run action manually.

## Checklist

- [ ] Linked to an approved issue
- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] `pnpm lint:fix` and `pnpm format:fix` run with no remaining issues
- [ ] New code has unit tests
- [ ] No unrelated changes included
