### PR TITLE
fix(stream-deck-plugin): include rebuilt chat.html from #116

### DIFF
--- a/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/ui/chat.html
+++ b/packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/ui/chat.html
@@ -93,14 +93,14 @@
 	</head>
 	<body>
 		<sdpi-item label="Mode">
-			<sdpi-select id="mode-select" setting="mode" default="open-chat">
-				<option value="open-chat">Open Chat</option>
-				<option value="reply">Reply to Chat</option>
-				<option value="whisper">Whisper</option>
-				<option value="respond-pm">Respond to Last PM</option>
-				<option value="cancel">Cancel Chat</option>
+			<sdpi-select id="mode-select" setting="mode" default="send-message">
 				<option value="send-message">Send Message</option>
 				<option value="macro">Macro (1-15)</option>
+				<option value="reply">Reply to Chat</option>
+				<option value="respond-pm">Respond to Last PM</option>
+				<option value="whisper">Whisper</option>
+				<option value="open-chat">Open Chat</option>
+				<option value="cancel">Cancel Chat</option>
 			</sdpi-select>
 		</sdpi-item>
 
@@ -210,18 +210,18 @@
 
 				const modeSelect = document.getElementById("mode-select");
 				if (modeSelect) {
-					const initialValue = modeSelect.value || "open-chat";
+					const initialValue = modeSelect.value || "send-message";
 					updateVisibility(initialValue);
 
 					modeSelect.addEventListener("change", (ev) => {
-						updateVisibility(ev.target.value || "open-chat");
+						updateVisibility(ev.target.value || "send-message");
 					});
 					modeSelect.addEventListener("input", (ev) => {
-						updateVisibility(ev.target.value || "open-chat");
+						updateVisibility(ev.target.value || "send-message");
 					});
 
 					// Polling fallback for reliable detection
-					let lastMode = modeSelect.value || "open-chat";
+					let lastMode = modeSelect.value || "send-message";
 					setInterval(() => {
 						const currentMode = modeSelect.value;
 						if (currentMode && currentMode !== lastMode) {


### PR DESCRIPTION
## Related Issue

Related to #112 / PR #116

## What changed?

- Committed the compiled `chat.html` build output that was missed in PR #116. The EJS source template was updated but the generated HTML in `ui/` was not included in that PR.

## How to test

1. Open Stream Deck, add a Chat action
2. Verify the mode dropdown shows: Send Message (default), Macro, Reply to Chat, Respond to Last PM, Whisper, Open Chat, Cancel Chat

## Checklist

- [x] Linked to an approved issue
- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] `pnpm lint:fix` and `pnpm format:fix` run with no remaining issues
- [ ] New code has unit tests — N/A (build output only)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Added Macro (1-15) mode option, enabling users to execute numbered macros directly from the plugin interface
* Added Open Chat mode option for direct chat functionality and interactions

**Improvements**
* Changed the default operating mode to Send Message for an optimized workflow
* Reorganized the mode selector options for improved usability and clearer logical ordering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->