### PR TITLE
feat(stream-deck-plugin): improve Color Overrides preset buttons

### DIFF
--- a/packages/stream-deck-plugin/src/pi-templates/partials/color-overrides.ejs
+++ b/packages/stream-deck-plugin/src/pi-templates/partials/color-overrides.ejs
@@ -33,14 +33,13 @@ var defaultG2 = (defaults && defaults.graphic2Color) || '#ffffff';
     '</div>' +
     '</sdpi-item>' +
     slots.map(function(slot) {
-      var defaultColor = (defaults && defaults[slot]) || '#000000';
       var inputId = 'color-override-' + slot;
       return '<sdpi-item label="' + slotLabels[slot] + '">' +
         '<div style="display:flex;align-items:center;gap:6px;">' +
         '<sdpi-color id="' + inputId + '" setting="colorOverrides.' + slot + '" default="#000001"></sdpi-color>' +
         '<a href="#" class="ird-color-reset" data-input="' + inputId + '" data-default="#000001" ' +
           'style="font-size:10px;color:#808080;text-decoration:none;white-space:nowrap;" ' +
-          'title="Reset to default">&#x21BA;</a>' +
+          'title="Reset to global">&#x21BA;</a>' +
         '</div>' +
         '</sdpi-item>';
     }).join('\n')


### PR DESCRIPTION
## Related Issue

Fixes #152

## What changed?

- **Default** button now sets the icon's actual default colors (from `<desc>` metadata), letting users exempt specific buttons from a global color scheme
- **Global** button added with `#000001` sentinel values (what "Default" previously did — defers to global settings)
- Color pickers now default to `#000001` so new action instances follow the global scheme instead of showing icon defaults
- White and Black preset buttons unchanged

## How to test

1. Set global colors to a Black or White preset
2. Add a new action instance — verify its color pickers show `#000001` (defers to global)
3. Open Color Overrides on any action, click **Default** — verify it shows the icon's original colors, ignoring the global scheme
4. Click **Global** — verify it reverts to following the global scheme

## Checklist

- [x] Linked to an approved issue
- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] `pnpm lint:fix` and `pnpm format:fix` run with no remaining issues
- [ ] New code has unit tests
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Global" preset option for color configuration

* **UI Improvements**
  * Presets container now supports wrapping for improved responsiveness
  * Default preset now applies calculated color values instead of fixed defaults

* **Bug Fixes**
  * Reset action and tooltip updated to clearly reset colors to the global default
<!-- end of auto-generated comment: release notes by coderabbit.ai -->