### PR TITLE
fix(actions): toggle windshield tearoff and fast repair via PitSvFlags (#161)

### DIFF
--- a/packages/actions/src/actions/pit-quick-actions.test.ts
+++ b/packages/actions/src/actions/pit-quick-actions.test.ts
@@ -2,17 +2,33 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { generatePitQuickActionsSvg, PitQuickActions } from "./pit-quick-actions.js";
 
-const { mockPitClear, mockPitWindshield, mockPitFastRepair, mockGetCommands } = vi.hoisted(() => ({
+const {
+  mockPitClear,
+  mockPitWindshield,
+  mockPitClearWindshield,
+  mockPitFastRepair,
+  mockPitClearFastRepair,
+  mockGetCommands,
+} = vi.hoisted(() => ({
   mockPitClear: vi.fn(() => true),
   mockPitWindshield: vi.fn(() => true),
+  mockPitClearWindshield: vi.fn(() => true),
   mockPitFastRepair: vi.fn(() => true),
+  mockPitClearFastRepair: vi.fn(() => true),
   mockGetCommands: vi.fn(() => ({
     pit: {
       clear: mockPitClear,
       windshield: mockPitWindshield,
+      clearWindshield: mockPitClearWindshield,
       fastRepair: mockPitFastRepair,
+      clearFastRepair: mockPitClearFastRepair,
     },
   })),
+}));
+
+vi.mock("@iracedeck/iracing-sdk", () => ({
+  PitSvFlags: { WindshieldTearoff: 0x0020, FastRepair: 0x0040 },
+  hasFlag: (value: number | undefined, flag: number) => value !== undefined && (value & flag) !== 0,
 }));
 
 vi.mock("@iracedeck/icons/pit-quick-actions/clear-all-checkboxes.svg", () => ({
@@ -139,20 +155,52 @@ describe("PitQuickActions", () => {
       expect(mockPitFastRepair).not.toHaveBeenCalled();
     });
 
-    it("should call pit.windshield() on keyDown for windshield-tearoff", async () => {
+    it("should call pit.windshield() on keyDown when windshield is not set", async () => {
+      action.sdkController.getCurrentTelemetry.mockReturnValue({ PitSvFlags: 0 });
       await action.onKeyDown(fakeEvent("action-1", { action: "windshield-tearoff" }) as any);
 
       expect(mockPitWindshield).toHaveBeenCalledOnce();
-      expect(mockPitClear).not.toHaveBeenCalled();
-      expect(mockPitFastRepair).not.toHaveBeenCalled();
+      expect(mockPitClearWindshield).not.toHaveBeenCalled();
     });
 
-    it("should call pit.fastRepair() on keyDown for request-fast-repair", async () => {
+    it("should call pit.clearWindshield() on keyDown when windshield is already set", async () => {
+      action.sdkController.getCurrentTelemetry.mockReturnValue({ PitSvFlags: 0x0020 });
+      await action.onKeyDown(fakeEvent("action-1", { action: "windshield-tearoff" }) as any);
+
+      expect(mockPitClearWindshield).toHaveBeenCalledOnce();
+      expect(mockPitWindshield).not.toHaveBeenCalled();
+    });
+
+    it("should call pit.fastRepair() on keyDown when fast repair is not set", async () => {
+      action.sdkController.getCurrentTelemetry.mockReturnValue({ PitSvFlags: 0 });
       await action.onKeyDown(fakeEvent("action-1", { action: "request-fast-repair" }) as any);
 
       expect(mockPitFastRepair).toHaveBeenCalledOnce();
-      expect(mockPitClear).not.toHaveBeenCalled();
+      expect(mockPitClearFastRepair).not.toHaveBeenCalled();
+    });
+
+    it("should call pit.clearFastRepair() on keyDown when fast repair is already set", async () => {
+      action.sdkController.getCurrentTelemetry.mockReturnValue({ PitSvFlags: 0x0040 });
+      await action.onKeyDown(fakeEvent("action-1", { action: "request-fast-repair" }) as any);
+
+      expect(mockPitClearFastRepair).toHaveBeenCalledOnce();
+      expect(mockPitFastRepair).not.toHaveBeenCalled();
+    });
+
+    it("should not call any pit command when telemetry is null for windshield-tearoff", async () => {
+      action.sdkController.getCurrentTelemetry.mockReturnValue(null);
+      await action.onKeyDown(fakeEvent("action-1", { action: "windshield-tearoff" }) as any);
+
       expect(mockPitWindshield).not.toHaveBeenCalled();
+      expect(mockPitClearWindshield).not.toHaveBeenCalled();
+    });
+
+    it("should not call any pit command when telemetry is null for request-fast-repair", async () => {
+      action.sdkController.getCurrentTelemetry.mockReturnValue(null);
+      await action.onKeyDown(fakeEvent("action-1", { action: "request-fast-repair" }) as any);
+
+      expect(mockPitFastRepair).not.toHaveBeenCalled();
+      expect(mockPitClearFastRepair).not.toHaveBeenCalled();
     });
 
     it("should default to clear-all-checkboxes when no action is specified", async () => {
@@ -175,16 +223,36 @@ describe("PitQuickActions", () => {
       expect(mockPitClear).toHaveBeenCalledOnce();
     });
 
-    it("should call pit.windshield() on dialDown for windshield-tearoff", async () => {
+    it("should call pit.windshield() on dialDown when windshield is not set", async () => {
+      action.sdkController.getCurrentTelemetry.mockReturnValue({ PitSvFlags: 0 });
       await action.onDialDown(fakeEvent("action-1", { action: "windshield-tearoff" }) as any);
 
       expect(mockPitWindshield).toHaveBeenCalledOnce();
+      expect(mockPitClearWindshield).not.toHaveBeenCalled();
     });
 
-    it("should call pit.fastRepair() on dialDown for request-fast-repair", async () => {
+    it("should call pit.clearWindshield() on dialDown when windshield is already set", async () => {
+      action.sdkController.getCurrentTelemetry.mockReturnValue({ PitSvFlags: 0x0020 });
+      await action.onDialDown(fakeEvent("action-1", { action: "windshield-tearoff" }) as any);
+
+      expect(mockPitClearWindshield).toHaveBeenCalledOnce();
+      expect(mockPitWindshield).not.toHaveBeenCalled();
+    });
+
+    it("should call pit.fastRepair() on dialDown when fast repair is not set", async () => {
+      action.sdkController.getCurrentTelemetry.mockReturnValue({ PitSvFlags: 0 });
       await action.onDialDown(fakeEvent("action-1", { action: "request-fast-repair" }) as any);
 
       expect(mockPitFastRepair).toHaveBeenCalledOnce();
+      expect(mockPitClearFastRepair).not.toHaveBeenCalled();
+    });
+
+    it("should call pit.clearFastRepair() on dialDown when fast repair is already set", async () => {
+      action.sdkController.getCurrentTelemetry.mockReturnValue({ PitSvFlags: 0x0040 });
+      await action.onDialDown(fakeEvent("action-1", { action: "request-fast-repair" }) as any);
+
+      expect(mockPitClearFastRepair).toHaveBeenCalledOnce();
+      expect(mockPitFastRepair).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/actions/src/actions/pit-quick-actions.ts
+++ b/packages/actions/src/actions/pit-quick-actions.ts
@@ -15,6 +15,7 @@ import {
 import clearAllCheckboxesIconSvg from "@iracedeck/icons/pit-quick-actions/clear-all-checkboxes.svg";
 import requestFastRepairIconSvg from "@iracedeck/icons/pit-quick-actions/request-fast-repair.svg";
 import windshieldTearoffIconSvg from "@iracedeck/icons/pit-quick-actions/windshield-tearoff.svg";
+import { hasFlag, PitSvFlags } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
 type PitQuickActionType = "clear-all-checkboxes" | "windshield-tearoff" | "request-fast-repair";
@@ -119,15 +120,31 @@ export class PitQuickActions extends ConnectionStateAwareAction<PitQuickActionsS
         break;
       }
       case "windshield-tearoff": {
-        const success = pit.windshield();
-        this.logger.info("Windshield tearoff executed");
-        this.logger.debug(`Result: ${success}`);
+        const telemetry = this.sdkController.getCurrentTelemetry();
+
+        if (!telemetry) {
+          this.logger.warn("No telemetry available for windshield tearoff toggle");
+          break;
+        }
+
+        const isSet = hasFlag(telemetry.PitSvFlags, PitSvFlags.WindshieldTearoff);
+        const success = isSet ? pit.clearWindshield() : pit.windshield();
+        this.logger.info("Windshield tearoff toggled");
+        this.logger.debug(`Action: ${isSet ? "cleared" : "requested"}, result: ${success}`);
         break;
       }
       case "request-fast-repair": {
-        const success = pit.fastRepair();
-        this.logger.info("Fast repair executed");
-        this.logger.debug(`Result: ${success}`);
+        const telemetry = this.sdkController.getCurrentTelemetry();
+
+        if (!telemetry) {
+          this.logger.warn("No telemetry available for fast repair toggle");
+          break;
+        }
+
+        const isSet = hasFlag(telemetry.PitSvFlags, PitSvFlags.FastRepair);
+        const success = isSet ? pit.clearFastRepair() : pit.fastRepair();
+        this.logger.info("Fast repair toggled");
+        this.logger.debug(`Action: ${isSet ? "cleared" : "requested"}, result: ${success}`);
         break;
       }
     }


### PR DESCRIPTION
## Related Issue

Fixes #161

## What changed?

Windshield Tearoff and Fast Repair in the Pit Quick Actions action now toggle based on current pit service state instead of always enabling.

- Reads `PitSvFlags` telemetry via `getCurrentTelemetry()` to check if the checkbox is already set
- Calls the clear command (`pit.clearWindshield()` / `pit.clearFastRepair()`) when the flag is set, the set command otherwise
- Adds null telemetry guard to skip the command when disconnected (prevents acting on stale cached state)
- Fixes info-level logging to follow project conventions (event only, no parameters)

## How to test

1. In iRacing, enter a car and open the pit service menu
2. Press the Windshield Tearoff button — checkbox should enable
3. Press again — checkbox should clear
4. Repeat for Fast Repair
5. Verify Clear All Checkboxes still works as before (one-directional)

## Checklist

- [x] Linked to an approved issue
- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [ ] `pnpm lint:fix` and `pnpm format:fix` run with no remaining issues
- [x] New code has unit tests
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windshield tearoff and fast repair pit commands now intelligently toggle based on current pit status, automatically switching between request and clear operations depending on the current state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->