### PR TITLE
feat(icons): add camera group icons for camera select action (#171)

### DIFF
--- a/packages/icons/camera-select/blimp.svg
+++ b/packages/icons/camera-select/blimp.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- Blimp with gondola -->
+    <g stroke="{{graphic1Color}}" fill="none">
+      <ellipse cx="72" cy="48" rx="40" ry="18" stroke-width="3.5"/>
+      <rect x="60" y="68" width="24" height="10" stroke-width="2.5"/>
+      <line x1="66" y1="66" x2="68" y2="68" stroke-width="2"/>
+      <line x1="78" y1="66" x2="76" y2="68" stroke-width="2"/>
+      <path d="M 108,40 L 118,34 L 118,48 L 112,48" stroke-width="2.5"/>
+      <path d="M 108,56 L 118,62 L 118,48" stroke-width="2.5"/>
+    </g>
+    <circle cx="72" cy="80" r="4" fill="{{graphic1Color}}"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/chase.svg
+++ b/packages/icons/camera-select/chase.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- Car rear view -->
+    <g stroke="{{graphic1Color}}" fill="none">
+      <path d="M 44,42 L 44,66 L 100,66 L 100,42 L 88,28 L 56,28 Z" stroke-width="3"/>
+      <path d="M 58,30 L 86,30 L 94,42 L 50,42 Z" stroke-width="2" opacity="0.5"/>
+      <rect x="48" y="54" width="8" height="4" stroke-width="2"/>
+      <rect x="88" y="54" width="8" height="4" stroke-width="2"/>
+    </g>
+    <!-- Filled tires -->
+    <rect x="42" y="64" width="10" height="18" fill="{{graphic1Color}}"/>
+    <rect x="92" y="64" width="10" height="18" fill="{{graphic1Color}}"/>
+    <line x1="28" y1="84" x2="116" y2="84" stroke="{{graphic1Color}}" stroke-width="2" opacity="0.4"/>
+    <circle cx="72" cy="90" r="4" fill="{{graphic1Color}}"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/chopper.svg
+++ b/packages/icons/camera-select/chopper.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- Helicopter -->
+    <g stroke="{{graphic1Color}}" fill="none">
+      <ellipse cx="62" cy="54" rx="24" ry="14" stroke-width="3"/>
+      <line x1="86" y1="50" x2="114" y2="38" stroke-width="3"/>
+      <line x1="114" y1="30" x2="114" y2="46" stroke-width="2.5"/>
+      <line x1="62" y1="40" x2="62" y2="34" stroke-width="2.5"/>
+      <line x1="26" y1="32" x2="98" y2="36" stroke-width="2.5"/>
+      <line x1="44" y1="72" x2="80" y2="72" stroke-width="2.5"/>
+      <line x1="50" y1="68" x2="48" y2="72" stroke-width="2"/>
+      <line x1="74" y1="68" x2="76" y2="72" stroke-width="2"/>
+    </g>
+    <circle cx="44" cy="60" r="4" fill="{{graphic1Color}}"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="18" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/cockpit.svg
+++ b/packages/icons/camera-select/cockpit.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- Steering wheel -->
+    <g stroke="{{graphic1Color}}" fill="none">
+      <circle cx="72" cy="50" r="30" stroke-width="3.5"/>
+      <circle cx="72" cy="50" r="8" stroke-width="3"/>
+      <line x1="42" y1="50" x2="64" y2="50" stroke-width="3"/>
+      <line x1="80" y1="50" x2="102" y2="50" stroke-width="3"/>
+      <line x1="72" y1="58" x2="72" y2="80" stroke-width="3"/>
+    </g>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="18" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/far-chase.svg
+++ b/packages/icons/camera-select/far-chase.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- Smaller car rear view (further away) -->
+    <g stroke="{{graphic1Color}}" fill="none">
+      <path d="M 52,40 L 52,58 L 92,58 L 92,40 L 83,30 L 61,30 Z" stroke-width="2.5"/>
+      <path d="M 63,32 L 81,32 L 88,40 L 56,40 Z" stroke-width="1.8" opacity="0.5"/>
+    </g>
+    <!-- Filled tires -->
+    <rect x="50" y="56" width="8" height="14" fill="{{graphic1Color}}"/>
+    <rect x="86" y="56" width="8" height="14" fill="{{graphic1Color}}"/>
+    <line x1="36" y1="72" x2="108" y2="72" stroke="{{graphic1Color}}" stroke-width="2" opacity="0.4"/>
+    <circle cx="72" cy="82" r="4" fill="{{graphic1Color}}"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="16" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/gearbox.svg
+++ b/packages/icons/camera-select/gearbox.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- Top-down car with camera at rear/gearbox -->
+    <g stroke="{{graphic1Color}}" stroke-width="3.5" fill="none">
+      <path d="M 52,32 L 52,72 Q 52,80 72,84 Q 92,80 92,72 L 92,32"/>
+      <line x1="52" y1="32" x2="92" y2="32"/>
+      <rect x="38" y="34" width="8" height="22"/>
+      <rect x="98" y="34" width="8" height="22"/>
+    </g>
+    <circle cx="72" cy="80" r="5" fill="{{graphic1Color}}"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="18" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/gyro.svg
+++ b/packages/icons/camera-select/gyro.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- Gimbal rings -->
+    <g stroke="{{graphic1Color}}" fill="none">
+      <ellipse cx="72" cy="52" rx="36" ry="28" stroke-width="3"/>
+      <ellipse cx="72" cy="52" rx="26" ry="22" stroke-width="2.5" transform="rotate(20, 72, 52)"/>
+      <ellipse cx="72" cy="52" rx="14" ry="14" stroke-width="2"/>
+    </g>
+    <circle cx="72" cy="52" r="5" fill="{{graphic1Color}}"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/lf-susp.svg
+++ b/packages/icons/camera-select/lf-susp.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- Top-down car with LF corner highlighted -->
+    <g stroke="{{graphic1Color}}" stroke-width="3" fill="none">
+      <rect x="46" y="28" width="52" height="56"/>
+      <rect x="34" y="28" width="8" height="22" opacity="0.4"/>
+      <rect x="102" y="28" width="8" height="22" opacity="0.4"/>
+      <rect x="34" y="62" width="8" height="22" opacity="0.4"/>
+      <rect x="102" y="62" width="8" height="22" opacity="0.4"/>
+    </g>
+    <rect x="34" y="28" width="8" height="22" stroke="{{graphic1Color}}" stroke-width="3.5" fill="none"/>
+    <circle cx="38" cy="39" r="4" fill="{{graphic1Color}}"/>
+    <text x="38" y="20" text-anchor="middle" fill="{{graphic1Color}}" font-family="Arial, sans-serif" font-size="11" font-weight="bold">LF</text>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="18" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/lr-susp.svg
+++ b/packages/icons/camera-select/lr-susp.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- Top-down car with LR corner highlighted -->
+    <g stroke="{{graphic1Color}}" stroke-width="3" fill="none">
+      <rect x="46" y="28" width="52" height="56"/>
+      <rect x="34" y="28" width="8" height="22" opacity="0.4"/>
+      <rect x="102" y="28" width="8" height="22" opacity="0.4"/>
+      <rect x="34" y="62" width="8" height="22" opacity="0.4"/>
+      <rect x="102" y="62" width="8" height="22" opacity="0.4"/>
+    </g>
+    <rect x="34" y="62" width="8" height="22" stroke="{{graphic1Color}}" stroke-width="3.5" fill="none"/>
+    <circle cx="38" cy="73" r="4" fill="{{graphic1Color}}"/>
+    <text x="38" y="58" text-anchor="middle" fill="{{graphic1Color}}" font-family="Arial, sans-serif" font-size="11" font-weight="bold">LR</text>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="18" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/nose.svg
+++ b/packages/icons/camera-select/nose.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- Top-down car with camera at nose -->
+    <g stroke="{{graphic1Color}}" stroke-width="3.5" fill="none">
+      <path d="M 52,72 L 52,40 Q 52,28 72,24 Q 92,28 92,40 L 92,72"/>
+      <line x1="52" y1="72" x2="92" y2="72"/>
+      <rect x="38" y="48" width="8" height="22"/>
+      <rect x="98" y="48" width="8" height="22"/>
+    </g>
+    <circle cx="72" cy="28" r="5" fill="{{graphic1Color}}"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/pit-lane-2.svg
+++ b/packages/icons/camera-select/pit-lane-2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- Pit lane with stalls -->
+    <g stroke="{{graphic1Color}}" fill="none">
+      <line x1="20" y1="76" x2="124" y2="76" stroke-width="3"/>
+      <line x1="20" y1="52" x2="124" y2="52" stroke-width="2.5"/>
+      <line x1="40" y1="52" x2="40" y2="76" stroke-width="2" opacity="0.5"/>
+      <line x1="64" y1="52" x2="64" y2="76" stroke-width="2" opacity="0.5"/>
+      <line x1="88" y1="52" x2="88" y2="76" stroke-width="2" opacity="0.5"/>
+      <line x1="112" y1="52" x2="112" y2="76" stroke-width="2" opacity="0.5"/>
+      <rect x="68" y="56" width="16" height="10" stroke-width="2"/>
+    </g>
+    <circle cx="96" cy="42" r="4" fill="{{graphic1Color}}"/>
+    <text x="120" y="34" text-anchor="middle" fill="{{graphic1Color}}" font-family="Arial, sans-serif" font-size="18" font-weight="bold">2</text>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="14" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/pit-lane.svg
+++ b/packages/icons/camera-select/pit-lane.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- Pit lane with stalls -->
+    <g stroke="{{graphic1Color}}" fill="none">
+      <line x1="20" y1="76" x2="124" y2="76" stroke-width="3"/>
+      <line x1="20" y1="52" x2="124" y2="52" stroke-width="2.5"/>
+      <line x1="40" y1="52" x2="40" y2="76" stroke-width="2" opacity="0.5"/>
+      <line x1="64" y1="52" x2="64" y2="76" stroke-width="2" opacity="0.5"/>
+      <line x1="88" y1="52" x2="88" y2="76" stroke-width="2" opacity="0.5"/>
+      <line x1="112" y1="52" x2="112" y2="76" stroke-width="2" opacity="0.5"/>
+      <rect x="68" y="56" width="16" height="10" stroke-width="2"/>
+    </g>
+    <circle cx="52" cy="42" r="4" fill="{{graphic1Color}}"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="18" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/rear-chase.svg
+++ b/packages/icons/camera-select/rear-chase.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- Car front view -->
+    <g stroke="{{graphic1Color}}" fill="none">
+      <path d="M 44,42 L 44,66 L 100,66 L 100,42 L 88,28 L 56,28 Z" stroke-width="3"/>
+      <path d="M 58,30 L 86,30 L 94,42 L 50,42 Z" stroke-width="2" opacity="0.5"/>
+      <circle cx="54" cy="54" r="3" stroke-width="2"/>
+      <circle cx="90" cy="54" r="3" stroke-width="2"/>
+    </g>
+    <!-- Filled tires -->
+    <rect x="42" y="64" width="10" height="18" fill="{{graphic1Color}}"/>
+    <rect x="92" y="64" width="10" height="18" fill="{{graphic1Color}}"/>
+    <line x1="28" y1="84" x2="116" y2="84" stroke="{{graphic1Color}}" stroke-width="2" opacity="0.4"/>
+    <circle cx="72" cy="90" r="4" fill="{{graphic1Color}}"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="14" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/rf-susp.svg
+++ b/packages/icons/camera-select/rf-susp.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- Top-down car with RF corner highlighted -->
+    <g stroke="{{graphic1Color}}" stroke-width="3" fill="none">
+      <rect x="46" y="28" width="52" height="56"/>
+      <rect x="34" y="28" width="8" height="22" opacity="0.4"/>
+      <rect x="102" y="28" width="8" height="22" opacity="0.4"/>
+      <rect x="34" y="62" width="8" height="22" opacity="0.4"/>
+      <rect x="102" y="62" width="8" height="22" opacity="0.4"/>
+    </g>
+    <rect x="102" y="28" width="8" height="22" stroke="{{graphic1Color}}" stroke-width="3.5" fill="none"/>
+    <circle cx="106" cy="39" r="4" fill="{{graphic1Color}}"/>
+    <text x="106" y="20" text-anchor="middle" fill="{{graphic1Color}}" font-family="Arial, sans-serif" font-size="11" font-weight="bold">RF</text>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="18" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/roll-bar.svg
+++ b/packages/icons/camera-select/roll-bar.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- Side-profile car with roll bar camera -->
+    <g stroke="{{graphic1Color}}" stroke-width="3.5" fill="none">
+      <path d="M 24,68 L 32,68 L 44,44 L 76,40 L 88,44 L 100,68 L 120,68"/>
+      <path d="M 48,44 L 48,36 L 84,36 L 84,44"/>
+      <circle cx="42" cy="72" r="10"/>
+      <circle cx="102" cy="72" r="10"/>
+      <line x1="20" y1="82" x2="124" y2="82"/>
+    </g>
+    <circle cx="66" cy="36" r="5" fill="{{graphic1Color}}"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="18" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/rr-susp.svg
+++ b/packages/icons/camera-select/rr-susp.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- Top-down car with RR corner highlighted -->
+    <g stroke="{{graphic1Color}}" stroke-width="3" fill="none">
+      <rect x="46" y="28" width="52" height="56"/>
+      <rect x="34" y="28" width="8" height="22" opacity="0.4"/>
+      <rect x="102" y="28" width="8" height="22" opacity="0.4"/>
+      <rect x="34" y="62" width="8" height="22" opacity="0.4"/>
+      <rect x="102" y="62" width="8" height="22" opacity="0.4"/>
+    </g>
+    <rect x="102" y="62" width="8" height="22" stroke="{{graphic1Color}}" stroke-width="3.5" fill="none"/>
+    <circle cx="106" cy="73" r="4" fill="{{graphic1Color}}"/>
+    <text x="106" y="58" text-anchor="middle" fill="{{graphic1Color}}" font-family="Arial, sans-serif" font-size="11" font-weight="bold">RR</text>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="18" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/scenic.svg
+++ b/packages/icons/camera-select/scenic.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- Mountain landscape -->
+    <polygon points="60,80 88,44 124,80" fill="{{backgroundColor}}" stroke="{{graphic1Color}}" stroke-width="3"/>
+    <polygon points="16,80 56,28 96,80" fill="{{backgroundColor}}" stroke="{{graphic1Color}}" stroke-width="3"/>
+
+    <!-- Sun with 8 rays -->
+    <g stroke="{{graphic1Color}}" fill="none">
+      <circle cx="108" cy="28" r="10" stroke-width="2.5"/>
+      <line x1="108" y1="14" x2="108" y2="8" stroke-width="2"/>
+      <line x1="108" y1="42" x2="108" y2="48" stroke-width="2"/>
+      <line x1="94" y1="28" x2="88" y2="28" stroke-width="2"/>
+      <line x1="122" y1="28" x2="128" y2="28" stroke-width="2"/>
+      <line x1="118" y1="18" x2="122" y2="14" stroke-width="2"/>
+      <line x1="98" y1="18" x2="94" y2="14" stroke-width="2"/>
+      <line x1="118" y1="38" x2="122" y2="42" stroke-width="2"/>
+      <line x1="98" y1="38" x2="94" y2="42" stroke-width="2"/>
+    </g>
+
+    <!-- Horizon -->
+    <line x1="16" y1="80" x2="128" y2="80" stroke="{{graphic1Color}}" stroke-width="2.5"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/tv1.svg
+++ b/packages/icons/camera-select/tv1.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- TV camera on tripod with number inside -->
+    <g stroke="{{graphic1Color}}" fill="none">
+      <rect x="36" y="28" width="52" height="32" stroke-width="3.5"/>
+      <path d="M 88,34 L 108,26 L 108,54 L 88,46" stroke-width="3"/>
+      <rect x="46" y="20" width="14" height="10" stroke-width="2.5"/>
+      <line x1="62" y1="60" x2="40" y2="86" stroke-width="2.5"/>
+      <line x1="62" y1="60" x2="62" y2="86" stroke-width="2.5"/>
+      <line x1="62" y1="60" x2="84" y2="86" stroke-width="2.5"/>
+    </g>
+    <text x="62" y="44" text-anchor="middle" dominant-baseline="central" fill="{{graphic1Color}}" font-family="Arial, sans-serif" font-size="22" font-weight="bold">1</text>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/tv2.svg
+++ b/packages/icons/camera-select/tv2.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- TV camera on tripod with number inside -->
+    <g stroke="{{graphic1Color}}" fill="none">
+      <rect x="36" y="28" width="52" height="32" stroke-width="3.5"/>
+      <path d="M 88,34 L 108,26 L 108,54 L 88,46" stroke-width="3"/>
+      <rect x="46" y="20" width="14" height="10" stroke-width="2.5"/>
+      <line x1="62" y1="60" x2="40" y2="86" stroke-width="2.5"/>
+      <line x1="62" y1="60" x2="62" y2="86" stroke-width="2.5"/>
+      <line x1="62" y1="60" x2="84" y2="86" stroke-width="2.5"/>
+    </g>
+    <text x="62" y="44" text-anchor="middle" dominant-baseline="central" fill="{{graphic1Color}}" font-family="Arial, sans-serif" font-size="22" font-weight="bold">2</text>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/camera-select/tv3.svg
+++ b/packages/icons/camera-select/tv3.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>
+
+    <!-- TV camera on tripod with number inside -->
+    <g stroke="{{graphic1Color}}" fill="none">
+      <rect x="36" y="28" width="52" height="32" stroke-width="3.5"/>
+      <path d="M 88,34 L 108,26 L 108,54 L 88,46" stroke-width="3"/>
+      <rect x="46" y="20" width="14" height="10" stroke-width="2.5"/>
+      <line x1="62" y1="60" x2="40" y2="86" stroke-width="2.5"/>
+      <line x1="62" y1="60" x2="62" y2="86" stroke-width="2.5"/>
+      <line x1="62" y1="60" x2="84" y2="86" stroke-width="2.5"/>
+    </g>
+    <text x="62" y="44" text-anchor="middle" dominant-baseline="central" fill="{{graphic1Color}}" font-family="Arial, sans-serif" font-size="22" font-weight="bold">3</text>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/blimp.svg
+++ b/packages/icons/preview/camera-select/blimp.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- Blimp with gondola -->
+    <g stroke="#ffffff" fill="none">
+      <ellipse cx="72" cy="48" rx="40" ry="18" stroke-width="3.5"/>
+      <rect x="60" y="68" width="24" height="10" stroke-width="2.5"/>
+      <line x1="66" y1="66" x2="68" y2="68" stroke-width="2"/>
+      <line x1="78" y1="66" x2="76" y2="68" stroke-width="2"/>
+      <path d="M 108,40 L 118,34 L 118,48 L 112,48" stroke-width="2.5"/>
+      <path d="M 108,56 L 118,62 L 118,48" stroke-width="2.5"/>
+    </g>
+    <circle cx="72" cy="80" r="4" fill="#ffffff"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/chase.svg
+++ b/packages/icons/preview/camera-select/chase.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- Car rear view -->
+    <g stroke="#ffffff" fill="none">
+      <path d="M 44,42 L 44,66 L 100,66 L 100,42 L 88,28 L 56,28 Z" stroke-width="3"/>
+      <path d="M 58,30 L 86,30 L 94,42 L 50,42 Z" stroke-width="2" opacity="0.5"/>
+      <rect x="48" y="54" width="8" height="4" stroke-width="2"/>
+      <rect x="88" y="54" width="8" height="4" stroke-width="2"/>
+    </g>
+    <!-- Filled tires -->
+    <rect x="42" y="64" width="10" height="18" fill="#ffffff"/>
+    <rect x="92" y="64" width="10" height="18" fill="#ffffff"/>
+    <line x1="28" y1="84" x2="116" y2="84" stroke="#ffffff" stroke-width="2" opacity="0.4"/>
+    <circle cx="72" cy="90" r="4" fill="#ffffff"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/chopper.svg
+++ b/packages/icons/preview/camera-select/chopper.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- Helicopter -->
+    <g stroke="#ffffff" fill="none">
+      <ellipse cx="62" cy="54" rx="24" ry="14" stroke-width="3"/>
+      <line x1="86" y1="50" x2="114" y2="38" stroke-width="3"/>
+      <line x1="114" y1="30" x2="114" y2="46" stroke-width="2.5"/>
+      <line x1="62" y1="40" x2="62" y2="34" stroke-width="2.5"/>
+      <line x1="26" y1="32" x2="98" y2="36" stroke-width="2.5"/>
+      <line x1="44" y1="72" x2="80" y2="72" stroke-width="2.5"/>
+      <line x1="50" y1="68" x2="48" y2="72" stroke-width="2"/>
+      <line x1="74" y1="68" x2="76" y2="72" stroke-width="2"/>
+    </g>
+    <circle cx="44" cy="60" r="4" fill="#ffffff"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="18" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/cockpit.svg
+++ b/packages/icons/preview/camera-select/cockpit.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- Steering wheel -->
+    <g stroke="#ffffff" fill="none">
+      <circle cx="72" cy="50" r="30" stroke-width="3.5"/>
+      <circle cx="72" cy="50" r="8" stroke-width="3"/>
+      <line x1="42" y1="50" x2="64" y2="50" stroke-width="3"/>
+      <line x1="80" y1="50" x2="102" y2="50" stroke-width="3"/>
+      <line x1="72" y1="58" x2="72" y2="80" stroke-width="3"/>
+    </g>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="18" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/far-chase.svg
+++ b/packages/icons/preview/camera-select/far-chase.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- Smaller car rear view (further away) -->
+    <g stroke="#ffffff" fill="none">
+      <path d="M 52,40 L 52,58 L 92,58 L 92,40 L 83,30 L 61,30 Z" stroke-width="2.5"/>
+      <path d="M 63,32 L 81,32 L 88,40 L 56,40 Z" stroke-width="1.8" opacity="0.5"/>
+    </g>
+    <!-- Filled tires -->
+    <rect x="50" y="56" width="8" height="14" fill="#ffffff"/>
+    <rect x="86" y="56" width="8" height="14" fill="#ffffff"/>
+    <line x1="36" y1="72" x2="108" y2="72" stroke="#ffffff" stroke-width="2" opacity="0.4"/>
+    <circle cx="72" cy="82" r="4" fill="#ffffff"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="16" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/gearbox.svg
+++ b/packages/icons/preview/camera-select/gearbox.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- Top-down car with camera at rear/gearbox -->
+    <g stroke="#ffffff" stroke-width="3.5" fill="none">
+      <path d="M 52,32 L 52,72 Q 52,80 72,84 Q 92,80 92,72 L 92,32"/>
+      <line x1="52" y1="32" x2="92" y2="32"/>
+      <rect x="38" y="34" width="8" height="22"/>
+      <rect x="98" y="34" width="8" height="22"/>
+    </g>
+    <circle cx="72" cy="80" r="5" fill="#ffffff"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="18" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/gyro.svg
+++ b/packages/icons/preview/camera-select/gyro.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- Gimbal rings -->
+    <g stroke="#ffffff" fill="none">
+      <ellipse cx="72" cy="52" rx="36" ry="28" stroke-width="3"/>
+      <ellipse cx="72" cy="52" rx="26" ry="22" stroke-width="2.5" transform="rotate(20, 72, 52)"/>
+      <ellipse cx="72" cy="52" rx="14" ry="14" stroke-width="2"/>
+    </g>
+    <circle cx="72" cy="52" r="5" fill="#ffffff"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/lf-susp.svg
+++ b/packages/icons/preview/camera-select/lf-susp.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- Top-down car with LF corner highlighted -->
+    <g stroke="#ffffff" stroke-width="3" fill="none">
+      <rect x="46" y="28" width="52" height="56"/>
+      <rect x="34" y="28" width="8" height="22" opacity="0.4"/>
+      <rect x="102" y="28" width="8" height="22" opacity="0.4"/>
+      <rect x="34" y="62" width="8" height="22" opacity="0.4"/>
+      <rect x="102" y="62" width="8" height="22" opacity="0.4"/>
+    </g>
+    <rect x="34" y="28" width="8" height="22" stroke="#ffffff" stroke-width="3.5" fill="none"/>
+    <circle cx="38" cy="39" r="4" fill="#ffffff"/>
+    <text x="38" y="20" text-anchor="middle" fill="#ffffff" font-family="Arial, sans-serif" font-size="11" font-weight="bold">LF</text>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="18" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/lr-susp.svg
+++ b/packages/icons/preview/camera-select/lr-susp.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- Top-down car with LR corner highlighted -->
+    <g stroke="#ffffff" stroke-width="3" fill="none">
+      <rect x="46" y="28" width="52" height="56"/>
+      <rect x="34" y="28" width="8" height="22" opacity="0.4"/>
+      <rect x="102" y="28" width="8" height="22" opacity="0.4"/>
+      <rect x="34" y="62" width="8" height="22" opacity="0.4"/>
+      <rect x="102" y="62" width="8" height="22" opacity="0.4"/>
+    </g>
+    <rect x="34" y="62" width="8" height="22" stroke="#ffffff" stroke-width="3.5" fill="none"/>
+    <circle cx="38" cy="73" r="4" fill="#ffffff"/>
+    <text x="38" y="58" text-anchor="middle" fill="#ffffff" font-family="Arial, sans-serif" font-size="11" font-weight="bold">LR</text>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="18" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/nose.svg
+++ b/packages/icons/preview/camera-select/nose.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- Top-down car with camera at nose -->
+    <g stroke="#ffffff" stroke-width="3.5" fill="none">
+      <path d="M 52,72 L 52,40 Q 52,28 72,24 Q 92,28 92,40 L 92,72"/>
+      <line x1="52" y1="72" x2="92" y2="72"/>
+      <rect x="38" y="48" width="8" height="22"/>
+      <rect x="98" y="48" width="8" height="22"/>
+    </g>
+    <circle cx="72" cy="28" r="5" fill="#ffffff"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/pit-lane-2.svg
+++ b/packages/icons/preview/camera-select/pit-lane-2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- Pit lane with stalls -->
+    <g stroke="#ffffff" fill="none">
+      <line x1="20" y1="76" x2="124" y2="76" stroke-width="3"/>
+      <line x1="20" y1="52" x2="124" y2="52" stroke-width="2.5"/>
+      <line x1="40" y1="52" x2="40" y2="76" stroke-width="2" opacity="0.5"/>
+      <line x1="64" y1="52" x2="64" y2="76" stroke-width="2" opacity="0.5"/>
+      <line x1="88" y1="52" x2="88" y2="76" stroke-width="2" opacity="0.5"/>
+      <line x1="112" y1="52" x2="112" y2="76" stroke-width="2" opacity="0.5"/>
+      <rect x="68" y="56" width="16" height="10" stroke-width="2"/>
+    </g>
+    <circle cx="96" cy="42" r="4" fill="#ffffff"/>
+    <text x="120" y="34" text-anchor="middle" fill="#ffffff" font-family="Arial, sans-serif" font-size="18" font-weight="bold">2</text>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="14" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/pit-lane.svg
+++ b/packages/icons/preview/camera-select/pit-lane.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- Pit lane with stalls -->
+    <g stroke="#ffffff" fill="none">
+      <line x1="20" y1="76" x2="124" y2="76" stroke-width="3"/>
+      <line x1="20" y1="52" x2="124" y2="52" stroke-width="2.5"/>
+      <line x1="40" y1="52" x2="40" y2="76" stroke-width="2" opacity="0.5"/>
+      <line x1="64" y1="52" x2="64" y2="76" stroke-width="2" opacity="0.5"/>
+      <line x1="88" y1="52" x2="88" y2="76" stroke-width="2" opacity="0.5"/>
+      <line x1="112" y1="52" x2="112" y2="76" stroke-width="2" opacity="0.5"/>
+      <rect x="68" y="56" width="16" height="10" stroke-width="2"/>
+    </g>
+    <circle cx="52" cy="42" r="4" fill="#ffffff"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="18" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/rear-chase.svg
+++ b/packages/icons/preview/camera-select/rear-chase.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- Car front view -->
+    <g stroke="#ffffff" fill="none">
+      <path d="M 44,42 L 44,66 L 100,66 L 100,42 L 88,28 L 56,28 Z" stroke-width="3"/>
+      <path d="M 58,30 L 86,30 L 94,42 L 50,42 Z" stroke-width="2" opacity="0.5"/>
+      <circle cx="54" cy="54" r="3" stroke-width="2"/>
+      <circle cx="90" cy="54" r="3" stroke-width="2"/>
+    </g>
+    <!-- Filled tires -->
+    <rect x="42" y="64" width="10" height="18" fill="#ffffff"/>
+    <rect x="92" y="64" width="10" height="18" fill="#ffffff"/>
+    <line x1="28" y1="84" x2="116" y2="84" stroke="#ffffff" stroke-width="2" opacity="0.4"/>
+    <circle cx="72" cy="90" r="4" fill="#ffffff"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="14" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/rf-susp.svg
+++ b/packages/icons/preview/camera-select/rf-susp.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- Top-down car with RF corner highlighted -->
+    <g stroke="#ffffff" stroke-width="3" fill="none">
+      <rect x="46" y="28" width="52" height="56"/>
+      <rect x="34" y="28" width="8" height="22" opacity="0.4"/>
+      <rect x="102" y="28" width="8" height="22" opacity="0.4"/>
+      <rect x="34" y="62" width="8" height="22" opacity="0.4"/>
+      <rect x="102" y="62" width="8" height="22" opacity="0.4"/>
+    </g>
+    <rect x="102" y="28" width="8" height="22" stroke="#ffffff" stroke-width="3.5" fill="none"/>
+    <circle cx="106" cy="39" r="4" fill="#ffffff"/>
+    <text x="106" y="20" text-anchor="middle" fill="#ffffff" font-family="Arial, sans-serif" font-size="11" font-weight="bold">RF</text>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="18" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/roll-bar.svg
+++ b/packages/icons/preview/camera-select/roll-bar.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- Side-profile car with roll bar camera -->
+    <g stroke="#ffffff" stroke-width="3.5" fill="none">
+      <path d="M 24,68 L 32,68 L 44,44 L 76,40 L 88,44 L 100,68 L 120,68"/>
+      <path d="M 48,44 L 48,36 L 84,36 L 84,44"/>
+      <circle cx="42" cy="72" r="10"/>
+      <circle cx="102" cy="72" r="10"/>
+      <line x1="20" y1="82" x2="124" y2="82"/>
+    </g>
+    <circle cx="66" cy="36" r="5" fill="#ffffff"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="18" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/rr-susp.svg
+++ b/packages/icons/preview/camera-select/rr-susp.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- Top-down car with RR corner highlighted -->
+    <g stroke="#ffffff" stroke-width="3" fill="none">
+      <rect x="46" y="28" width="52" height="56"/>
+      <rect x="34" y="28" width="8" height="22" opacity="0.4"/>
+      <rect x="102" y="28" width="8" height="22" opacity="0.4"/>
+      <rect x="34" y="62" width="8" height="22" opacity="0.4"/>
+      <rect x="102" y="62" width="8" height="22" opacity="0.4"/>
+    </g>
+    <rect x="102" y="62" width="8" height="22" stroke="#ffffff" stroke-width="3.5" fill="none"/>
+    <circle cx="106" cy="73" r="4" fill="#ffffff"/>
+    <text x="106" y="58" text-anchor="middle" fill="#ffffff" font-family="Arial, sans-serif" font-size="11" font-weight="bold">RR</text>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="18" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/scenic.svg
+++ b/packages/icons/preview/camera-select/scenic.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- Mountain landscape -->
+    <polygon points="60,80 88,44 124,80" fill="#2a4a5a" stroke="#ffffff" stroke-width="3"/>
+    <polygon points="16,80 56,28 96,80" fill="#2a4a5a" stroke="#ffffff" stroke-width="3"/>
+
+    <!-- Sun with 8 rays -->
+    <g stroke="#ffffff" fill="none">
+      <circle cx="108" cy="28" r="10" stroke-width="2.5"/>
+      <line x1="108" y1="14" x2="108" y2="8" stroke-width="2"/>
+      <line x1="108" y1="42" x2="108" y2="48" stroke-width="2"/>
+      <line x1="94" y1="28" x2="88" y2="28" stroke-width="2"/>
+      <line x1="122" y1="28" x2="128" y2="28" stroke-width="2"/>
+      <line x1="118" y1="18" x2="122" y2="14" stroke-width="2"/>
+      <line x1="98" y1="18" x2="94" y2="14" stroke-width="2"/>
+      <line x1="118" y1="38" x2="122" y2="42" stroke-width="2"/>
+      <line x1="98" y1="38" x2="94" y2="42" stroke-width="2"/>
+    </g>
+
+    <!-- Horizon -->
+    <line x1="16" y1="80" x2="128" y2="80" stroke="#ffffff" stroke-width="2.5"/>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/tv1.svg
+++ b/packages/icons/preview/camera-select/tv1.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- TV camera on tripod with number inside -->
+    <g stroke="#ffffff" fill="none">
+      <rect x="36" y="28" width="52" height="32" stroke-width="3.5"/>
+      <path d="M 88,34 L 108,26 L 108,54 L 88,46" stroke-width="3"/>
+      <rect x="46" y="20" width="14" height="10" stroke-width="2.5"/>
+      <line x1="62" y1="60" x2="40" y2="86" stroke-width="2.5"/>
+      <line x1="62" y1="60" x2="62" y2="86" stroke-width="2.5"/>
+      <line x1="62" y1="60" x2="84" y2="86" stroke-width="2.5"/>
+    </g>
+    <text x="62" y="44" text-anchor="middle" dominant-baseline="central" fill="#ffffff" font-family="Arial, sans-serif" font-size="22" font-weight="bold">1</text>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/tv2.svg
+++ b/packages/icons/preview/camera-select/tv2.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- TV camera on tripod with number inside -->
+    <g stroke="#ffffff" fill="none">
+      <rect x="36" y="28" width="52" height="32" stroke-width="3.5"/>
+      <path d="M 88,34 L 108,26 L 108,54 L 88,46" stroke-width="3"/>
+      <rect x="46" y="20" width="14" height="10" stroke-width="2.5"/>
+      <line x1="62" y1="60" x2="40" y2="86" stroke-width="2.5"/>
+      <line x1="62" y1="60" x2="62" y2="86" stroke-width="2.5"/>
+      <line x1="62" y1="60" x2="84" y2="86" stroke-width="2.5"/>
+    </g>
+    <text x="62" y="44" text-anchor="middle" dominant-baseline="central" fill="#ffffff" font-family="Arial, sans-serif" font-size="22" font-weight="bold">2</text>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/icons/preview/camera-select/tv3.svg
+++ b/packages/icons/preview/camera-select/tv3.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a4a5a","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>
+  <g filter="url(#activity-state)">
+    <rect x="0" y="0" width="144" height="144" fill="#2a4a5a"/>
+
+    <!-- TV camera on tripod with number inside -->
+    <g stroke="#ffffff" fill="none">
+      <rect x="36" y="28" width="52" height="32" stroke-width="3.5"/>
+      <path d="M 88,34 L 108,26 L 108,54 L 88,46" stroke-width="3"/>
+      <rect x="46" y="20" width="14" height="10" stroke-width="2.5"/>
+      <line x1="62" y1="60" x2="40" y2="86" stroke-width="2.5"/>
+      <line x1="62" y1="60" x2="62" y2="86" stroke-width="2.5"/>
+      <line x1="62" y1="60" x2="84" y2="86" stroke-width="2.5"/>
+    </g>
+    <text x="62" y="44" text-anchor="middle" dominant-baseline="central" fill="#ffffff" font-family="Arial, sans-serif" font-size="22" font-weight="bold">3</text>
+
+    <!-- Label -->
+    <text x="72" y="122" text-anchor="middle" dominant-baseline="central"
+          fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="bold">{{mainLabel}}</text>
+  </g>
+</svg>

--- a/packages/stream-deck-plugin/src/pi/data/color-defaults.json
+++ b/packages/stream-deck-plugin/src/pi/data/color-defaults.json
@@ -33,6 +33,11 @@
     "textColor": "#ffffff",
     "graphic1Color": "#ffffff"
   },
+  "camera-select": {
+    "backgroundColor": "#2a4a5a",
+    "textColor": "#ffffff",
+    "graphic1Color": "#ffffff"
+  },
   "car-control": {
     "backgroundColor": "#2a3a2a",
     "textColor": "#ffffff",
@@ -41,8 +46,7 @@
   "chat": {
     "backgroundColor": "#2a3a4a",
     "textColor": "#ffffff",
-    "graphic1Color": "#4a90d9",
-    "graphic2Color": "#000000"
+    "graphic1Color": "#ffffff"
   },
   "cockpit-misc": {
     "backgroundColor": "#2a2a3a",
@@ -135,10 +139,6 @@
     "backgroundColor": "#3a2a3a",
     "textColor": "#ffffff",
     "graphic1Color": "#ffffff"
-  },
-  "telemetry-display": {
-    "backgroundColor": "#2a3444",
-    "textColor": "#ffffff"
   },
   "tire-service": {
     "backgroundColor": "#3a2a2a",


### PR DESCRIPTION
## Related Issue

Fixes #171

## What changed?

Added 20 standalone 144×144 SVG icons for all iRacing camera groups, for use by a future direct camera select action:

**On-car cameras (9):** Nose, Gearbox, Roll Bar, Gyro, Cockpit, LF/RF/LR/RR Suspension
**External cameras (8):** Blimp, Chopper, Chase, Far Chase, Rear Chase, Pit Lane, Pit Lane 2, Scenic
**Broadcast cameras (3):** TV1, TV2, TV3

Design details:
- Background color: `#2a4a5a` (distinct from existing camera actions)
- 2 color slots: `textColor` + `graphic1Color` (both white default)
- Single-line labels with camera name only
- No rounded corners, no FOV lines
- Suspension icons share a common car outline with highlighted corner
- TV cameras have number inside the camera body
- Chase cars have filled tires tucked under the body

Also includes generated preview files and updated `color-defaults.json`.

## How to test

- Browse SVG files in `packages/icons/camera-select/` and `packages/icons/preview/camera-select/`
- Run `pnpm test` — preview freshness test should pass (346 tests)
- Verify `color-defaults.json` includes `camera-select` entry with `#2a4a5a` background

## Checklist

- [x] Linked to an approved issue
- [ ] New code has unit tests (icons only — covered by preview freshness test)
- [x] Changes registered in all applicable plugins (Stream Deck, Stream Dock)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added color configuration for the camera select component to ensure consistent visual styling
  * Updated color scheme for the chat component with revised color values
  * Removed color configuration for the telemetry display component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->