### PR TITLE
fix(actions): update Telemetry Display defaults (#175)

### DIFF
--- a/packages/actions/src/actions/telemetry-display.ts
+++ b/packages/actions/src/actions/telemetry-display.ts
@@ -16,9 +16,9 @@ import z from "zod";
 import telemetryDisplayTemplate from "../../icons/telemetry-display.svg";
 
 const TelemetryDisplaySettings = CommonSettings.extend({
-  template: z.string().default("{{sessionInfo.DriverInfo.DriverCarIdx}}"),
-  title: z.string().default("CAR #"),
-  fontSize: z.coerce.number().default(18),
+  template: z.string().default("#{{self.car_number}}\n{{self.first_name}}"),
+  title: z.string().default("I AM"),
+  fontSize: z.coerce.number().default(15),
 });
 
 type TelemetryDisplaySettings = z.infer<typeof TelemetryDisplaySettings>;

--- a/packages/stream-deck-plugin/src/pi/telemetry-display.ejs
+++ b/packages/stream-deck-plugin/src/pi/telemetry-display.ejs
@@ -5,11 +5,11 @@
 	</head>
 	<body>
 		<sdpi-item label="Title">
-			<sdpi-textfield setting="title" default="CAR #"></sdpi-textfield>
+			<sdpi-textfield setting="title" default="I AM"></sdpi-textfield>
 		</sdpi-item>
 
 		<sdpi-item label="Template">
-			<sdpi-textarea setting="template" rows="3" default="{{sessionInfo.DriverInfo.DriverCarIdx}}"></sdpi-textarea>
+			<sdpi-textarea setting="template" rows="3" default="#{{self.car_number}}&#10;{{self.first_name}}"></sdpi-textarea>
 		</sdpi-item>
 
 		<sdpi-item>
@@ -22,7 +22,7 @@
 		</sdpi-item>
 
 		<sdpi-item label="Font Size">
-			<sdpi-textfield setting="fontSize" default="18" type="number" min="5" max="36"></sdpi-textfield>
+			<sdpi-textfield setting="fontSize" default="15" type="number" min="5" max="36"></sdpi-textfield>
 		</sdpi-item>
 
 		<%- include('common-settings') %>


### PR DESCRIPTION
## Related Issue

Fixes #175

## What changed?

Updated the Telemetry Display action's default settings:
- **Template**: `{{sessionInfo.DriverInfo.DriverCarIdx}}` → `#{{self.car_number}}\n{{self.first_name}}`
- **Title**: `CAR #` → `I AM`
- **Font size**: `18` → `15`

The PI template uses `&#10;` (HTML newline entity) in the default attribute so the textarea receives a real newline character, matching the behavior of user-entered newlines.

## How to test

1. Remove any existing Telemetry Display action from the Stream Deck
2. Add a new Telemetry Display action
3. Verify the PI shows title "I AM", template with two lines (`#{{self.car_number}}` and `{{self.first_name}}`), and font size 15
4. Connect to an iRacing session and verify the key displays the car number and first name on separate lines

## Checklist

- [x] Linked to an approved issue
- [ ] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Stream Dock)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default telemetry display settings
    * Display template now renders car number and driver name
    * Title label changed to "I AM"
    * Default font size reduced from 18 to 15 points

<!-- end of auto-generated comment: release notes by coderabbit.ai -->