### PR TITLE
fix(deck-core): normalize empty string SimHub settings to defaults

### DIFF
--- a/packages/deck-core/src/global-settings.ts
+++ b/packages/deck-core/src/global-settings.ts
@@ -79,12 +79,15 @@ export const GlobalSettingsSchema = z
      * Hostname or IP address of the SimHub instance for Control Mapper integration.
      * Default: "127.0.0.1"
      */
-    simHubHost: z.string().default("127.0.0.1"),
+    simHubHost: z.preprocess((val) => (val === "" ? undefined : val), z.string().default("127.0.0.1")),
     /**
      * HTTP port for SimHub's REST API (Control Mapper).
      * Default: 8888
      */
-    simHubPort: z.coerce.number().min(1).max(65535).default(8888),
+    simHubPort: z.preprocess(
+      (val) => (val === "" ? undefined : val),
+      z.coerce.number().min(1).max(65535).default(8888),
+    ),
   })
   .passthrough();
 


### PR DESCRIPTION
## Related Issue

Addresses CodeRabbit feedback on #185

## What changed?

Empty strings from the Property Inspector bypassed Zod defaults for `simHubHost` and `simHubPort` since `z.default()` only applies to `undefined`. Added `z.preprocess()` to convert empty strings to `undefined` before parsing so the defaults (`"127.0.0.1"` and `8888`) take effect.

## How to test

1. Open Global Settings in any action's Property Inspector
2. Clear the SimHub host field (leave it empty) and save
3. Verify the plugin uses `127.0.0.1` (check logs) instead of an empty string

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests — N/A (schema-level fix, covered by existing integration)
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — N/A (shared deck-core)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SimHub configuration handling to properly treat empty inputs for host and port settings as invalid, ensuring default values (127.0.0.1 for host, 8888 for port) are correctly applied when no valid configuration is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->