### PR TITLE
fix(actions): add enter-exit-tow to hold controls for long-press support

### DIFF
--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -61,7 +61,7 @@ When asked about actions or controls:
 | Audio Controls | 6 | 2 categories (voice-chat, master) x 3 actions (volume-up, volume-down, mute) |
 | Black Box Selector | 13 | 11 direct selections + next/previous cycle |
 | Look Direction | 4 | look-left, look-right, look-up, look-down (hold pattern) |
-| Car Control | 9 | starter, ignition, pit-speed-limiter (telemetry-aware), enter-exit-tow, pause-sim, headlight-flash (hold), push-to-pass (telemetry-aware), drs (telemetry-aware), tear-off-visor |
+| Car Control | 9 | starter (hold), ignition, pit-speed-limiter (telemetry-aware), enter-exit-tow (hold), pause-sim, headlight-flash (hold), push-to-pass (telemetry-aware), drs (telemetry-aware), tear-off-visor |
 
 ### Cockpit & Interface
 

--- a/docs/plugins/core/actions/enter-exit-tow-car.md
+++ b/docs/plugins/core/actions/enter-exit-tow-car.md
@@ -13,7 +13,8 @@ Enters, exits, or requests a tow for the car.
 
 ## Behavior
 
-### Button Press
+### Button Press (Hold)
+- Uses long-press: hold the Stream Deck button until iRacing registers the action
 - Context-dependent action:
   - If in garage: Enter car
   - If in car: Exit car

--- a/packages/actions/src/actions/car-control.test.ts
+++ b/packages/actions/src/actions/car-control.test.ts
@@ -212,10 +212,11 @@ describe("CarControl", () => {
       expect(mockHoldBinding).not.toHaveBeenCalled();
     });
 
-    it("should call tapGlobalBinding on keyDown for enter-exit-tow", async () => {
+    it("should call holdBinding on keyDown for enter-exit-tow", async () => {
       await action.onKeyDown(fakeEvent("action-1", { control: "enter-exit-tow" }) as any);
 
-      expect(mockTapBinding).toHaveBeenCalledWith("carControlEnterExitTow");
+      expect(mockHoldBinding).toHaveBeenCalledWith("action-1", "carControlEnterExitTow");
+      expect(mockTapBinding).not.toHaveBeenCalled();
     });
 
     it("should call tapGlobalBinding on keyDown for pause-sim", async () => {

--- a/packages/actions/src/actions/car-control.ts
+++ b/packages/actions/src/actions/car-control.ts
@@ -66,7 +66,7 @@ const DEFAULT_PIT_SPEED = 80;
 const TELEMETRY_AWARE_CONTROLS = new Set<CarControlType>(["pit-speed-limiter", "push-to-pass", "drs"]);
 
 /** Controls that use hold pattern (press on keyDown, release on keyUp) */
-const HOLD_CONTROLS = new Set<CarControlType>(["starter", "headlight-flash"]);
+const HOLD_CONTROLS = new Set<CarControlType>(["starter", "headlight-flash", "enter-exit-tow"]);
 
 /**
  * @internal Exported for testing
@@ -332,7 +332,7 @@ function renderDynamicIcon(settings: CarControlSettings, iconContent: string, sh
  * Car Control Action
  * Provides core car operation controls (starter, ignition, pit limiter, enter/exit/tow, pause,
  * headlight flash, push to pass, DRS, tear off visor).
- * Starter and headlight flash use long-press (hold while pressed); all others use tap.
+ * Starter, headlight flash, and enter/exit/tow use long-press (hold while pressed); all others use tap.
  */
 export const CAR_CONTROL_UUID = "com.iracedeck.sd.core.car-control" as const;
 


### PR DESCRIPTION
## Related Issue

Fixes #187

## What changed?

- Added `enter-exit-tow` to the `HOLD_CONTROLS` set in `car-control.ts` so it uses `holdBinding`/`releaseBinding` instead of `tapBinding`
- Updated the test to assert hold behavior instead of tap for enter-exit-tow
- Updated action documentation to describe hold behavior
- Updated iracedeck-actions skill to annotate `starter` and `enter-exit-tow` as hold controls

## How to test

1. Add a Car Control action to Stream Deck
2. Set control to "Enter/Exit/Tow Car"
3. In iRacing, be in a state where tow is available
4. Press and hold the Stream Deck button — the key should stay pressed until the button is released

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests updated and passing
- [x] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * The enter-exit-tow action now requires holding the Stream Deck button (long-press) until iRacing registers the action, rather than a simple tap. The functionality remains the same: enter the garage when idle, exit the car when driving, or request a tow when stuck on track.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->