### PR TITLE
chore(ci): remove redundant versioned/latest release assets (#195)

### DIFF
--- a/.github/workflows/release-pack-dock.yml
+++ b/.github/workflows/release-pack-dock.yml
@@ -32,20 +32,18 @@ jobs:
 
       - name: Pack Mirabox plugin
         run: |
-          $version = if ("${{ github.ref_name }}".StartsWith("v")) { "${{ github.ref_name }}".TrimStart("v") } else { "dev" }
           npx @elgato/cli@latest pack packages/mirabox-plugin/com.iracedeck.sd.core.sdPlugin --force --ignore-validation
-          Rename-Item "com.iracedeck.sd.core.streamDeckPlugin" "com.iracedeck.sd.core.v${version}.sdPlugin"
-          Copy-Item "com.iracedeck.sd.core.v${version}.sdPlugin" "com.iracedeck.sd.core.sdPlugin"
+          Rename-Item "com.iracedeck.sd.core.streamDeckPlugin" "com.iracedeck.sd.core.sdPlugin"
         shell: pwsh
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: mirabox-plugin
-          path: com.iracedeck.sd.core*.sdPlugin
+          path: com.iracedeck.sd.core.sdPlugin
 
       - name: Attach plugin to GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: com.iracedeck.sd.core*.sdPlugin
+          files: com.iracedeck.sd.core.sdPlugin

--- a/.github/workflows/release-pack.yml
+++ b/.github/workflows/release-pack.yml
@@ -31,21 +31,16 @@ jobs:
         run: pnpm install --prod --no-frozen-lockfile
 
       - name: Pack Stream Deck plugin
-        run: |
-          $version = if ("${{ github.ref_name }}".StartsWith("v")) { "${{ github.ref_name }}".TrimStart("v") } else { "dev" }
-          npx @elgato/cli@latest pack packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin
-          Rename-Item "com.iracedeck.sd.core.streamDeckPlugin" "iracedeck-streamdeck-v${version}.streamDeckPlugin"
-          Copy-Item "iracedeck-streamdeck-v${version}.streamDeckPlugin" "iracedeck-streamdeck-latest.streamDeckPlugin"
-        shell: pwsh
+        run: npx @elgato/cli@latest pack packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: streamdeck-plugin
-          path: iracedeck-streamdeck-*.streamDeckPlugin
+          path: com.iracedeck.sd.core.streamDeckPlugin
 
       - name: Attach plugin to GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: iracedeck-streamdeck-*.streamDeckPlugin
+          files: com.iracedeck.sd.core.streamDeckPlugin

--- a/packages/website/src/content/docs/docs/getting-started/installation.md
+++ b/packages/website/src/content/docs/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ The easiest way to install iRaceDeck:
 GitHub Releases may have a newer version available before it appears on the Elgato Marketplace. Use this option if you want the latest version or if the Marketplace install doesn't work:
 
 1. Go to the [GitHub Releases page](https://github.com/niklam/iracedeck/releases/)
-2. Find the latest release and download the file named **`iracedeck-vX.X.X.streamDeckPlugin`** (e.g., `iracedeck-v1.0.0.streamDeckPlugin`)
+2. Find the latest release and download **`com.iracedeck.sd.core.streamDeckPlugin`**
 3. Double-click the downloaded `.streamDeckPlugin` file
 4. The Stream Deck software will open and install the plugin automatically
 5. Look for the **iRaceDeck** category in the Stream Deck action list


### PR DESCRIPTION
## Related Issue

Fixes #195

## What changed?

- **`release-pack.yml`** — removed versioned rename and "latest" copy; the `@elgato/cli pack` output (`com.iracedeck.sd.core.streamDeckPlugin`) is used directly as the release asset
- **`release-pack-dock.yml`** — removed versioned rename and copy; renamed the pack output to `com.iracedeck.sd.core.sdPlugin` directly
- **`installation.md`** — updated GitHub Releases download instructions to reference the new stable filename

### Desired release output (per release)
| Plugin | Filename |
|--------|----------|
| Stream Deck | `com.iracedeck.sd.core.streamDeckPlugin` |
| Mirabox | `com.iracedeck.sd.core.sdPlugin` |

## How to test

1. Trigger `release-pack.yml` and `release-pack-dock.yml` via `workflow_dispatch`
2. Verify each workflow produces exactly one artifact with the expected stable filename
3. Verify the installation docs render correctly on the website

## Checklist

- [x] Linked to an approved issue
- [ ] New code has unit tests — N/A (CI config only)
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the release and packaging process for the Stream Deck plugin.

* **Documentation**
  * Updated installation instructions to reflect the new plugin filename convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->