### PR TITLE
fix(actions): fix replay next/prev car track navigation (#216)

### DIFF
--- a/packages/actions/src/actions/replay-control.test.ts
+++ b/packages/actions/src/actions/replay-control.test.ts
@@ -91,11 +91,16 @@ vi.mock("@iracedeck/icons/replay-control/prev-car-number.svg", () => ({
   default: '<svg xmlns="http://www.w3.org/2000/svg">prev-car-number {{mainLabel}} {{subLabel}}</svg>',
 }));
 
-vi.mock("@iracedeck/iracing-sdk", () => ({
-  getCarNumberFromSessionInfo: vi.fn(),
-  getCarNumberRawFromSessionInfo: vi.fn(),
-  getAllCarNumbers: vi.fn(() => []),
-}));
+vi.mock("@iracedeck/iracing-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@iracedeck/iracing-sdk")>();
+
+  return {
+    ...actual,
+    getCarNumberFromSessionInfo: vi.fn(),
+    getCarNumberRawFromSessionInfo: vi.fn(),
+    getAllCarNumbers: vi.fn(() => []),
+  };
+});
 
 vi.mock("@iracedeck/deck-core", () => ({
   CommonSettings: {

--- a/packages/actions/src/actions/replay-control.ts
+++ b/packages/actions/src/actions/replay-control.ts
@@ -41,6 +41,7 @@ import speedDisplayIconSvg from "@iracedeck/icons/replay-control/speed-display.s
 import speedIncreaseIconSvg from "@iracedeck/icons/replay-control/speed-increase.svg";
 import stopIconSvg from "@iracedeck/icons/replay-control/stop.svg";
 import {
+  findNearestCarOnTrack,
   getAllCarNumbers,
   getCarNumberFromSessionInfo,
   getCarNumberRawFromSessionInfo,
@@ -281,55 +282,12 @@ export function generateReplayControlSvg(
  * @internal Exported for testing
  *
  * Find the physically closest car ahead or behind the currently viewed car (CamCarIdx).
- * Uses circular track distance based on CarIdxLapDistPct (0.0–1.0) to find the nearest
- * car in the specified direction, regardless of lap count.
- * Skips inactive cars (lap < 0) but includes all others (even those flagged on pit road).
+ * Delegates to the shared findNearestCarOnTrack from @iracedeck/iracing-sdk.
  */
 export function findAdjacentCarOnTrack(telemetry: TelemetryData | null, direction: "ahead" | "behind"): number | null {
-  if (!telemetry?.CarIdxLapCompleted || !telemetry?.CarIdxLapDistPct) return null;
+  const camCarIdx = (telemetry?.CamCarIdx as number) ?? -1;
 
-  const camCarIdx = (telemetry.CamCarIdx as number) ?? -1;
-
-  if (camCarIdx < 0) return null;
-
-  const lapCompleted = telemetry.CarIdxLapCompleted as number[];
-  const lapDistPct = telemetry.CarIdxLapDistPct as number[];
-
-  const currentDist = lapDistPct[camCarIdx];
-  const hasValidPosition = currentDist !== undefined && currentDist >= 0;
-
-  let bestIdx: number | null = null;
-  let bestDist = Infinity;
-
-  for (let idx = 0; idx < lapCompleted.length; idx++) {
-    if (idx === camCarIdx) continue;
-
-    if (lapCompleted[idx] === undefined || lapCompleted[idx] < 0) continue;
-
-    if (lapDistPct[idx] === undefined || lapDistPct[idx] < 0) continue;
-
-    if (hasValidPosition) {
-      const dist =
-        direction === "ahead"
-          ? (lapDistPct[idx] - currentDist + 1.0) % 1.0
-          : (currentDist - lapDistPct[idx] + 1.0) % 1.0;
-
-      if (dist > 0 && dist < bestDist) {
-        bestDist = dist;
-        bestIdx = idx;
-      }
-    } else {
-      // No reference position — fall back to car closest to start/finish line
-      const distToSF = Math.min(lapDistPct[idx], 1.0 - lapDistPct[idx]);
-
-      if (distToSF < bestDist) {
-        bestDist = distToSF;
-        bestIdx = idx;
-      }
-    }
-  }
-
-  return bestIdx;
+  return findNearestCarOnTrack(telemetry, camCarIdx, direction);
 }
 
 /**

--- a/packages/iracing-sdk/src/index.ts
+++ b/packages/iracing-sdk/src/index.ts
@@ -113,6 +113,9 @@ export {
   type TemplateContext,
 } from "./template-context.js";
 
+// Track utilities
+export { findNearestCarOnTrack, type FindNearestCarOptions } from "./track-utils.js";
+
 // Flag utilities
 export { type FlagInfo, FLAG_DEFINITIONS, resolveActiveFlag, resolveAllActiveFlags } from "./flag-utils.js";
 

--- a/packages/iracing-sdk/src/template-context.test.ts
+++ b/packages/iracing-sdk/src/template-context.test.ts
@@ -117,7 +117,6 @@ describe("findNearestDriverOnTrack", () => {
     const telemetry = makeTelemetry({
       CarIdxLapCompleted: [4, 5, 3],
       CarIdxLapDistPct: [0.5, 0.7, 0.3],
-      CarIdxOnPitRoad: [false, false, false],
     });
 
     const result = findNearestDriverOnTrack(0, drivers, telemetry, "ahead");
@@ -129,7 +128,6 @@ describe("findNearestDriverOnTrack", () => {
     const telemetry = makeTelemetry({
       CarIdxLapCompleted: [4, 5, 3],
       CarIdxLapDistPct: [0.5, 0.7, 0.3],
-      CarIdxOnPitRoad: [false, false, false],
     });
 
     const result = findNearestDriverOnTrack(0, drivers, telemetry, "behind");
@@ -137,40 +135,41 @@ describe("findNearestDriverOnTrack", () => {
     expect(result?.UserName).toBe("Behind Car");
   });
 
-  it("should return null when leading on track", () => {
+  it("should wrap around when leading on track", () => {
     const telemetry = makeTelemetry({
       CarIdxLapCompleted: [10, 5, 3],
       CarIdxLapDistPct: [0.9, 0.7, 0.3],
-      CarIdxOnPitRoad: [false, false, false],
     });
 
+    // Circular: player at 0.9, ahead wraps to Behind Car at 0.3 (gap=0.4)
     const result = findNearestDriverOnTrack(0, drivers, telemetry, "ahead");
 
-    expect(result).toBeNull();
+    expect(result?.UserName).toBe("Behind Car");
   });
 
-  it("should return null when last on track", () => {
+  it("should wrap around when last on track", () => {
     const telemetry = makeTelemetry({
       CarIdxLapCompleted: [1, 5, 3],
       CarIdxLapDistPct: [0.1, 0.7, 0.3],
-      CarIdxOnPitRoad: [false, false, false],
     });
 
+    // Circular: player at 0.1, behind wraps to Ahead Car at 0.7 (gap=0.4)
     const result = findNearestDriverOnTrack(0, drivers, telemetry, "behind");
 
-    expect(result).toBeNull();
+    expect(result?.UserName).toBe("Ahead Car");
   });
 
-  it("should skip cars on pit road", () => {
+  it("should include cars flagged as on pit road", () => {
     const telemetry = makeTelemetry({
       CarIdxLapCompleted: [4, 5, 3],
       CarIdxLapDistPct: [0.5, 0.7, 0.3],
       CarIdxOnPitRoad: [false, true, false],
     });
 
+    // CarIdxOnPitRoad is unreliable; Ahead Car at 0.7 is still closest ahead
     const result = findNearestDriverOnTrack(0, drivers, telemetry, "ahead");
 
-    expect(result).toBeNull();
+    expect(result?.UserName).toBe("Ahead Car");
   });
 
   it("should skip pace car", () => {
@@ -183,12 +182,12 @@ describe("findNearestDriverOnTrack", () => {
     const telemetry = makeTelemetry({
       CarIdxLapCompleted: [4, 5, 3],
       CarIdxLapDistPct: [0.5, 0.7, 0.3],
-      CarIdxOnPitRoad: [false, false, false],
     });
 
+    // Pace car skipped; ahead wraps to Behind Car at 0.3 (gap=0.8)
     const result = findNearestDriverOnTrack(0, driversWithPace, telemetry, "ahead");
 
-    expect(result).toBeNull();
+    expect(result?.UserName).toBe("Behind Car");
   });
 
   it("should skip spectators", () => {
@@ -201,19 +200,19 @@ describe("findNearestDriverOnTrack", () => {
     const telemetry = makeTelemetry({
       CarIdxLapCompleted: [4, 5, 3],
       CarIdxLapDistPct: [0.5, 0.7, 0.3],
-      CarIdxOnPitRoad: [false, false, false],
     });
 
+    // Spectator skipped; ahead wraps to Behind Car at 0.3 (gap=0.8)
     const result = findNearestDriverOnTrack(0, driversWithSpectator, telemetry, "ahead");
 
-    expect(result).toBeNull();
+    expect(result?.UserName).toBe("Behind Car");
   });
 
   it("should return null with no telemetry", () => {
     expect(findNearestDriverOnTrack(0, drivers, null, "ahead")).toBeNull();
   });
 
-  it("should find lapped car directly ahead", () => {
+  it("should find lapped car directly ahead by physical proximity", () => {
     const driversMany = [
       makeDriver({ CarIdx: 0, UserName: "Player" }),
       makeDriver({ CarIdx: 1, UserName: "Leader" }),
@@ -223,12 +222,12 @@ describe("findNearestDriverOnTrack", () => {
     const telemetry = makeTelemetry({
       CarIdxLapCompleted: [10, 12, 8],
       CarIdxLapDistPct: [0.5, 0.9, 0.51],
-      CarIdxOnPitRoad: [false, false, false],
     });
 
+    // Lapped Car at 0.51 is physically closest ahead (gap=0.01) vs Leader at 0.9 (gap=0.4)
     const result = findNearestDriverOnTrack(0, driversMany, telemetry, "ahead");
 
-    expect(result?.UserName).toBe("Leader");
+    expect(result?.UserName).toBe("Lapped Car");
   });
 });
 

--- a/packages/iracing-sdk/src/template-context.ts
+++ b/packages/iracing-sdk/src/template-context.ts
@@ -5,6 +5,7 @@
  * Used by resolveTemplate() to hydrate {{variable}} placeholders.
  */
 import type { SDKController } from "./SDKController.js";
+import { findNearestCarOnTrack } from "./track-utils.js";
 import type { SessionInfo, TelemetryData } from "./types.js";
 
 /**
@@ -247,9 +248,8 @@ export function splitDriverName(userName: string): { firstName: string; lastName
 /**
  * @internal Exported for testing
  *
- * Finds the physically closest car on track in a given direction.
- * Uses laps completed + lap distance percentage for track progress.
- * Excludes cars in the pits, pace car, spectators, and inactive cars.
+ * Finds the physically closest driver on track in a given direction.
+ * Delegates to findNearestCarOnTrack with a filter that excludes pace car and spectators.
  */
 export function findNearestDriverOnTrack(
   playerCarIdx: number,
@@ -257,51 +257,22 @@ export function findNearestDriverOnTrack(
   telemetry: TelemetryData | null,
   direction: "ahead" | "behind",
 ): DriverEntry | null {
-  if (!telemetry?.CarIdxLapCompleted || !telemetry?.CarIdxLapDistPct) return null;
-
-  const lapCompleted = telemetry.CarIdxLapCompleted;
-  const lapDistPct = telemetry.CarIdxLapDistPct;
-  const onPitRoad = telemetry.CarIdxOnPitRoad;
-
-  // Build sorted list of active on-track cars by track progress
-  const activeCars: Array<{ carIdx: number; progress: number }> = [];
+  // Build a set of car indices to skip (pace car, spectators)
+  const skipIndices = new Set<number>();
 
   for (const driver of drivers) {
-    const idx = driver.CarIdx;
-
-    // Skip inactive, pace car, spectators, pit road
-    if (lapCompleted[idx] === undefined || lapCompleted[idx] < 0) continue;
-
-    if (driver.CarIsPaceCar === 1 || driver.IsSpectator === 1) continue;
-
-    if (onPitRoad && onPitRoad[idx]) continue;
-
-    const progress = lapCompleted[idx] + (lapDistPct[idx] ?? 0);
-    activeCars.push({ carIdx: idx, progress });
+    if (driver.CarIsPaceCar === 1 || driver.IsSpectator === 1) {
+      skipIndices.add(driver.CarIdx);
+    }
   }
 
-  // Sort by progress descending (highest first = most laps/distance)
-  activeCars.sort((a, b) => b.progress - a.progress);
+  const carIdx = findNearestCarOnTrack(telemetry, playerCarIdx, direction, {
+    skipIdx: (idx) => skipIndices.has(idx),
+  });
 
-  const playerIndex = activeCars.findIndex((c) => c.carIdx === playerCarIdx);
+  if (carIdx === null) return null;
 
-  if (playerIndex === -1) return null;
-
-  if (direction === "ahead") {
-    // Car ahead = higher progress = lower index in sorted array
-    if (playerIndex === 0) return null;
-
-    const aheadCarIdx = activeCars[playerIndex - 1].carIdx;
-
-    return drivers.find((d) => d.CarIdx === aheadCarIdx) ?? null;
-  } else {
-    // Car behind = lower progress = higher index in sorted array
-    if (playerIndex === activeCars.length - 1) return null;
-
-    const behindCarIdx = activeCars[playerIndex + 1].carIdx;
-
-    return drivers.find((d) => d.CarIdx === behindCarIdx) ?? null;
-  }
+  return drivers.find((d) => d.CarIdx === carIdx) ?? null;
 }
 
 /**

--- a/packages/iracing-sdk/src/track-utils.test.ts
+++ b/packages/iracing-sdk/src/track-utils.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "vitest";
+
+import { findNearestCarOnTrack } from "./track-utils.js";
+
+function makeTelemetry(refCarIdx: number, cars: Array<{ idx: number; laps: number; dist: number }>) {
+  const maxIdx = Math.max(...cars.map((c) => c.idx), refCarIdx, 0);
+  const lapCompleted = new Array(maxIdx + 1).fill(-1);
+  const lapDistPct = new Array(maxIdx + 1).fill(-1);
+
+  for (const car of cars) {
+    lapCompleted[car.idx] = car.laps;
+    lapDistPct[car.idx] = car.dist;
+  }
+
+  return {
+    CarIdxLapCompleted: lapCompleted,
+    CarIdxLapDistPct: lapDistPct,
+  };
+}
+
+describe("findNearestCarOnTrack", () => {
+  it("should find the physically closest car ahead", () => {
+    const telemetry = makeTelemetry(2, [
+      { idx: 1, laps: 5, dist: 0.8 },
+      { idx: 2, laps: 5, dist: 0.5 },
+      { idx: 3, laps: 5, dist: 0.2 },
+    ]);
+
+    expect(findNearestCarOnTrack(telemetry, 2, "ahead")).toBe(1);
+  });
+
+  it("should find the physically closest car behind", () => {
+    const telemetry = makeTelemetry(2, [
+      { idx: 1, laps: 5, dist: 0.8 },
+      { idx: 2, laps: 5, dist: 0.5 },
+      { idx: 3, laps: 5, dist: 0.2 },
+    ]);
+
+    expect(findNearestCarOnTrack(telemetry, 2, "behind")).toBe(3);
+  });
+
+  it("should wrap around at start/finish when looking ahead", () => {
+    const telemetry = makeTelemetry(1, [
+      { idx: 1, laps: 5, dist: 0.95 },
+      { idx: 2, laps: 5, dist: 0.5 },
+      { idx: 3, laps: 5, dist: 0.05 },
+    ]);
+
+    expect(findNearestCarOnTrack(telemetry, 1, "ahead")).toBe(3);
+  });
+
+  it("should wrap around at start/finish when looking behind", () => {
+    const telemetry = makeTelemetry(3, [
+      { idx: 1, laps: 5, dist: 0.95 },
+      { idx: 2, laps: 5, dist: 0.5 },
+      { idx: 3, laps: 5, dist: 0.05 },
+    ]);
+
+    expect(findNearestCarOnTrack(telemetry, 3, "behind")).toBe(1);
+  });
+
+  it("should use physical proximity regardless of lap count", () => {
+    const telemetry = makeTelemetry(2, [
+      { idx: 1, laps: 6, dist: 0.2 },
+      { idx: 2, laps: 5, dist: 0.9 },
+      { idx: 3, laps: 5, dist: 0.1 },
+    ]);
+
+    expect(findNearestCarOnTrack(telemetry, 2, "ahead")).toBe(3);
+    expect(findNearestCarOnTrack(telemetry, 2, "behind")).toBe(1);
+  });
+
+  it("should skip inactive cars", () => {
+    const telemetry = makeTelemetry(3, [
+      { idx: 1, laps: 5, dist: 0.8 },
+      { idx: 2, laps: -1, dist: 0.5 },
+      { idx: 3, laps: 5, dist: 0.2 },
+    ]);
+
+    expect(findNearestCarOnTrack(telemetry, 3, "ahead")).toBe(1);
+  });
+
+  it("should apply skipIdx filter", () => {
+    const telemetry = makeTelemetry(3, [
+      { idx: 1, laps: 5, dist: 0.8 },
+      { idx: 2, laps: 5, dist: 0.3 },
+      { idx: 3, laps: 5, dist: 0.2 },
+    ]);
+
+    // Skip idx 2, so ahead should be idx 1 instead
+    expect(findNearestCarOnTrack(telemetry, 3, "ahead", { skipIdx: (idx) => idx === 2 })).toBe(1);
+  });
+
+  it("should include cars flagged as on pit road", () => {
+    const telemetry = makeTelemetry(3, [
+      { idx: 1, laps: 5, dist: 0.8 },
+      { idx: 2, laps: 5, dist: 0.3 },
+      { idx: 3, laps: 5, dist: 0.2 },
+    ]);
+
+    (telemetry as Record<string, unknown>).CarIdxOnPitRoad = [false, false, true, false];
+    expect(findNearestCarOnTrack(telemetry, 3, "ahead")).toBe(2);
+  });
+
+  it("should return null when telemetry is null", () => {
+    expect(findNearestCarOnTrack(null, 0, "ahead")).toBeNull();
+  });
+
+  it("should return null when referenceCarIdx is negative", () => {
+    const telemetry = makeTelemetry(0, [{ idx: 0, laps: 5, dist: 0.5 }]);
+
+    expect(findNearestCarOnTrack(telemetry, -1, "ahead")).toBeNull();
+  });
+
+  it("should return null when no candidates exist", () => {
+    const telemetry = makeTelemetry(1, [{ idx: 1, laps: 5, dist: 0.5 }]);
+
+    expect(findNearestCarOnTrack(telemetry, 1, "ahead")).toBeNull();
+    expect(findNearestCarOnTrack(telemetry, 1, "behind")).toBeNull();
+  });
+
+  it("should return the only candidate for both directions", () => {
+    const telemetry = makeTelemetry(1, [
+      { idx: 1, laps: 5, dist: 0.5 },
+      { idx: 2, laps: 5, dist: 0.8 },
+    ]);
+
+    expect(findNearestCarOnTrack(telemetry, 1, "ahead")).toBe(2);
+    expect(findNearestCarOnTrack(telemetry, 1, "behind")).toBe(2);
+  });
+
+  it("should navigate from inactive reference car using its track position", () => {
+    const telemetry = makeTelemetry(5, [
+      { idx: 1, laps: 5, dist: 0.8 },
+      { idx: 2, laps: 5, dist: 0.5 },
+      { idx: 5, laps: -1, dist: 0.6 },
+    ]);
+
+    expect(findNearestCarOnTrack(telemetry, 5, "ahead")).toBe(1);
+    expect(findNearestCarOnTrack(telemetry, 5, "behind")).toBe(2);
+  });
+
+  it("should fall back to car closest to S/F when reference has no position", () => {
+    const telemetry = makeTelemetry(5, [
+      { idx: 1, laps: 5, dist: 0.1 },
+      { idx: 2, laps: 5, dist: 0.5 },
+      { idx: 3, laps: 5, dist: 0.95 },
+    ]);
+
+    expect(findNearestCarOnTrack(telemetry, 5, "ahead")).toBe(3);
+    expect(findNearestCarOnTrack(telemetry, 5, "behind")).toBe(3);
+  });
+
+  it("should fall back when reference car has no lap data", () => {
+    const telemetry = makeTelemetry(99, [
+      { idx: 1, laps: 5, dist: 0.8 },
+      { idx: 2, laps: 5, dist: 0.5 },
+    ]);
+
+    expect(findNearestCarOnTrack(telemetry, 99, "ahead")).toBe(1);
+    expect(findNearestCarOnTrack(telemetry, 99, "behind")).toBe(1);
+  });
+
+  // Real telemetry data from telemetry-snapshot-20260328-211129.json
+  const snapshot211129 = [
+    { idx: 2, laps: 11, dist: 0.38954538106918335 },
+    { idx: 3, laps: 12, dist: 0.5192081332206726 },
+    { idx: 5, laps: 9, dist: 0.48601317405700684 },
+    { idx: 6, laps: 12, dist: 0.43214255571365356 },
+    { idx: 8, laps: 12, dist: 0.14112484455108643 },
+    { idx: 9, laps: 12, dist: 0.5137969255447388 },
+    { idx: 11, laps: 12, dist: 0.44958096742630005 },
+    { idx: 12, laps: 12, dist: 0.2255899459123611 },
+    { idx: 13, laps: 12, dist: 0.2612520456314087 },
+    { idx: 14, laps: 12, dist: 0.36889901757240295 },
+    { idx: 15, laps: 12, dist: 0.265424907207489 },
+    { idx: 16, laps: 4, dist: 0.04441389814019203 },
+    { idx: 17, laps: 12, dist: 0.26450181007385254 },
+    { idx: 18, laps: 12, dist: 0.45216333866119385 },
+    { idx: 19, laps: 12, dist: 0.3390771448612213 },
+    { idx: 20, laps: 12, dist: 0.39654332399368286 },
+    { idx: 22, laps: 12, dist: 0.25014644861221313 },
+    { idx: 23, laps: 5, dist: 0.05720538645982742 },
+    { idx: 24, laps: 12, dist: 0.5042067170143127 },
+  ];
+
+  it("should match real telemetry — camera on #15 Niklas", () => {
+    const telemetry = makeTelemetry(15, snapshot211129);
+
+    expect(findNearestCarOnTrack(telemetry, 15, "ahead")).toBe(19);
+    expect(findNearestCarOnTrack(telemetry, 15, "behind")).toBe(17);
+  });
+
+  it("should match real telemetry — camera on #16 near start/finish", () => {
+    const telemetry = makeTelemetry(16, snapshot211129);
+
+    expect(findNearestCarOnTrack(telemetry, 16, "ahead")).toBe(23);
+    expect(findNearestCarOnTrack(telemetry, 16, "behind")).toBe(3);
+  });
+
+  it("should match real telemetry — disconnected #10 falls back to closest to S/F", () => {
+    const telemetry = makeTelemetry(10, [
+      { idx: 3, laps: 2, dist: 0.9950405955314636 },
+      { idx: 11, laps: 1, dist: 0.08401884138584137 },
+      { idx: 12, laps: 0, dist: 0.9472545981407166 },
+      { idx: 14, laps: 2, dist: 0.15486976504325867 },
+      { idx: 16, laps: 1, dist: 0.08401890844106674 },
+    ]);
+
+    expect(findNearestCarOnTrack(telemetry, 10, "ahead")).toBe(3);
+    expect(findNearestCarOnTrack(telemetry, 10, "behind")).toBe(3);
+  });
+});

--- a/packages/iracing-sdk/src/track-utils.ts
+++ b/packages/iracing-sdk/src/track-utils.ts
@@ -1,0 +1,72 @@
+import type { TelemetryData } from "./types.js";
+
+export interface FindNearestCarOptions {
+  /** Predicate to skip specific car indices (e.g., pace car, spectators) */
+  skipIdx?: (idx: number) => boolean;
+}
+
+/**
+ * Find the physically closest car on track ahead or behind a reference car.
+ * Uses circular track distance based on CarIdxLapDistPct (0.0–1.0), regardless of lap count.
+ *
+ * When the reference car has no valid track position (e.g., disconnected), falls back to
+ * the car closest to the start/finish line for both directions.
+ *
+ * @param telemetry - Current telemetry data
+ * @param referenceCarIdx - The car index to measure from (e.g., CamCarIdx or PlayerCarIdx)
+ * @param direction - "ahead" or "behind" on the physical track
+ * @param options - Optional filters (e.g., skip pace car)
+ * @returns The carIdx of the nearest car, or null if no candidates
+ */
+export function findNearestCarOnTrack(
+  telemetry: TelemetryData | null,
+  referenceCarIdx: number,
+  direction: "ahead" | "behind",
+  options?: FindNearestCarOptions,
+): number | null {
+  if (!telemetry?.CarIdxLapCompleted || !telemetry?.CarIdxLapDistPct) return null;
+
+  if (referenceCarIdx < 0) return null;
+
+  const lapCompleted = telemetry.CarIdxLapCompleted as number[];
+  const lapDistPct = telemetry.CarIdxLapDistPct as number[];
+  const skipIdx = options?.skipIdx;
+
+  const currentDist = lapDistPct[referenceCarIdx];
+  const hasValidPosition = currentDist !== undefined && currentDist >= 0;
+
+  let bestIdx: number | null = null;
+  let bestDist = Infinity;
+
+  for (let idx = 0; idx < lapCompleted.length; idx++) {
+    if (idx === referenceCarIdx) continue;
+
+    if (lapCompleted[idx] === undefined || lapCompleted[idx] < 0) continue;
+
+    if (lapDistPct[idx] === undefined || lapDistPct[idx] < 0) continue;
+
+    if (skipIdx?.(idx)) continue;
+
+    if (hasValidPosition) {
+      const dist =
+        direction === "ahead"
+          ? (lapDistPct[idx] - currentDist + 1.0) % 1.0
+          : (currentDist - lapDistPct[idx] + 1.0) % 1.0;
+
+      if (dist > 0 && dist < bestDist) {
+        bestDist = dist;
+        bestIdx = idx;
+      }
+    } else {
+      // No reference position — fall back to car closest to start/finish line
+      const distToSF = Math.min(lapDistPct[idx], 1.0 - lapDistPct[idx]);
+
+      if (distToSF < bestDist) {
+        bestDist = distToSF;
+        bestIdx = idx;
+      }
+    }
+  }
+
+  return bestIdx;
+}


### PR DESCRIPTION
## Related Issue

Fixes #215

## What changed?

- **Circular track distance**: Replaced race-progress sorting (`laps + distPct`) with circular distance math using only `CarIdxLapDistPct`. Next/prev car now selects the physically closest car on the track surface, regardless of lap count.
- **Removed `CarIdxOnPitRoad` filter**: This telemetry flag is unreliable — 7 cars showed `OnPitRoad=true` while actually on track (`TrackSurface=3`). All cars with valid positions are now valid navigation targets.
- **Fallback for inactive camera car**: When the camera is on a disconnected car (`dist=-1`), falls back to the car closest to the start/finish line instead of doing nothing.
- **Extracted shared `findNearestCarOnTrack`** into `@iracedeck/iracing-sdk/track-utils`. Both `findAdjacentCarOnTrack` (replay camera) and `findNearestDriverOnTrack` (template context `track_ahead`/`track_behind`) now delegate to it, eliminating duplicate code and duplicate bugs. Template context still filters pace car and spectators via `skipIdx`.
- **Real telemetry regression tests**: Tests use full float64 precision data from captured telemetry snapshots.

## How to test

- Enter replay mode with multiple cars on different laps
- Use Next Car / Previous Car — should select the physically closest car ahead/behind
- Focus a disconnected car, press Next/Prev — should jump to a car near the start/finish line
- Verify `track_ahead`/`track_behind` template variables still exclude pace car and spectators

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved car tracking logic to better identify nearby vehicles on track in various scenarios, including when the camera car lacks position data.
  * Consolidated adjacent-car selection to use shared track utilities, ensuring consistent behavior across the application.

* **Tests**
  * Enhanced test coverage for car proximity detection, including edge cases like inactive cars and pit-road scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->