### PR TITLE
fix(actions): show '--' placeholder on fuel toggle when no telemetry available (#227)

### DIFF
--- a/packages/actions/src/actions/fuel-service.test.ts
+++ b/packages/actions/src/actions/fuel-service.test.ts
@@ -508,12 +508,16 @@ describe("FuelService", () => {
       expect(getFuelAmount({ PitSvFuel: 50.0 } as any)).toBe(50.0);
     });
 
-    it("returns 0 when telemetry is null", () => {
-      expect(getFuelAmount(null)).toBe(0);
+    it("returns 0 when PitSvFuel is 0", () => {
+      expect(getFuelAmount({ PitSvFuel: 0 } as any)).toBe(0);
     });
 
-    it("returns 0 when PitSvFuel is undefined", () => {
-      expect(getFuelAmount({} as any)).toBe(0);
+    it("returns undefined when telemetry is null", () => {
+      expect(getFuelAmount(null)).toBeUndefined();
+    });
+
+    it("returns undefined when PitSvFuel is undefined", () => {
+      expect(getFuelAmount({} as any)).toBeUndefined();
     });
   });
 
@@ -558,6 +562,24 @@ describe("FuelService", () => {
 
         expect(decoded).toContain("status-off");
         expect(decoded).toContain("+0 L");
+      });
+
+      it("should show '--' placeholder when no telemetry is available", () => {
+        const telemetryState: FuelServiceTelemetryState = {};
+        const result = generateFuelServiceSvg({ mode: "toggle-fuel-fill", amount: 1, unit: "l" }, telemetryState);
+        const decoded = decodeURIComponent(result);
+
+        expect(decoded).toContain("--");
+        expect(decoded).not.toContain("+0");
+        expect(decoded).toContain("status-off");
+      });
+
+      it("should show '--' placeholder when fuelAmount is undefined but fuelFillOn is set", () => {
+        const telemetryState: FuelServiceTelemetryState = { fuelFillOn: false };
+        const result = generateFuelServiceSvg({ mode: "toggle-fuel-fill", amount: 1, unit: "l" }, telemetryState);
+        const decoded = decodeURIComponent(result);
+
+        expect(decoded).toContain("--");
       });
 
       it("should show fuel amount in gallons for imperial units", () => {

--- a/packages/actions/src/actions/fuel-service.ts
+++ b/packages/actions/src/actions/fuel-service.ts
@@ -140,10 +140,11 @@ export function isFuelFillOn(telemetry: TelemetryData | null): boolean {
 /**
  * @internal Exported for testing
  *
- * Returns the pit service fuel amount (liters) from telemetry.
+ * Returns the pit service fuel amount (liters) from telemetry,
+ * or undefined when no telemetry is available.
  */
-export function getFuelAmount(telemetry: TelemetryData | null): number {
-  if (!telemetry || telemetry.PitSvFuel === undefined) return 0;
+export function getFuelAmount(telemetry: TelemetryData | null): number | undefined {
+  if (!telemetry || telemetry.PitSvFuel === undefined) return undefined;
 
   return telemetry.PitSvFuel;
 }
@@ -170,7 +171,10 @@ export function formatFuelFillAmount(liters: number, displayUnits: number | unde
  */
 function fuelFillDynamicIcon(telemetryState: FuelServiceTelemetryState, graphic1Color: string): string {
   const statusBar = telemetryState.fuelFillOn ? statusBarOn() : statusBarOff();
-  const fuelText = formatFuelFillAmount(telemetryState.fuelAmount ?? 0, telemetryState.displayUnits);
+  const fuelText =
+    telemetryState.fuelAmount === undefined
+      ? "--"
+      : formatFuelFillAmount(telemetryState.fuelAmount, telemetryState.displayUnits);
 
   return `
     <text x="72" y="24" text-anchor="middle" dominant-baseline="central"
@@ -496,7 +500,7 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
 
   private buildStateKey(settings: FuelServiceSettings, telemetryState: FuelServiceTelemetryState): string {
     if (settings.mode === "toggle-fuel-fill") {
-      return `fuel-fill|${telemetryState.fuelFillOn ?? false}|${telemetryState.fuelAmount ?? 0}|${telemetryState.displayUnits ?? 0}`;
+      return `fuel-fill|${telemetryState.fuelFillOn ?? false}|${telemetryState.fuelAmount ?? "none"}|${telemetryState.displayUnits ?? 0}`;
     }
 
     return settings.mode;


### PR DESCRIPTION
## Related Issue

Fixes #227

## What changed?

- `getFuelAmount()` returns `undefined` instead of `0` when no telemetry is available, distinguishing "no data" from "zero fuel requested"
- `fuelFillDynamicIcon()` displays `"--"` when `fuelAmount` is `undefined`, only calling `formatFuelFillAmount()` with real telemetry data
- `buildStateKey()` uses `"none"` for undefined fuel amount so the icon updates correctly when telemetry connects with an actual `0` value

## How to test

1. Add a Fuel Service action in toggle-fuel-fill mode
2. Before connecting to iRacing, verify the icon shows "--" (not "+0 g")
3. Connect to iRacing and verify the icon updates to show the actual fuel amount
4. Run `pnpm test --filter @iracedeck/actions` — all 76 tests pass

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fuel display now shows "--" when fuel telemetry data is unavailable, instead of defaulting to zero liters, providing clearer indication of missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->