### PR TITLE
fix(icons): replace hardcoded background color in replay-control car icons (#218)

### DIFF
--- a/packages/icons/replay-control/jump-to-my-car.svg
+++ b/packages/icons/replay-control/jump-to-my-car.svg
@@ -12,7 +12,7 @@
     </g>
 
     <!-- Heart cutout (background color = hole effect) -->
-    <path d="M 72,62 C 67,57 60,53 60,48 C 60,44 63,42 67,42 C 69,42 71,43 72,45 C 73,43 75,42 77,42 C 81,42 84,44 84,48 C 84,53 77,57 72,62 Z" fill="#2a3a4a"/>
+    <path d="M 72,62 C 67,57 60,53 60,48 C 60,44 63,42 67,42 C 69,42 71,43 72,45 C 73,43 75,42 77,42 C 81,42 84,44 84,48 C 84,53 77,57 72,62 Z" fill="{{backgroundColor}}"/>
 
     <!-- Two-line label -->
     <text x="72" y="116" text-anchor="middle" dominant-baseline="central"

--- a/packages/icons/replay-control/next-car-number.svg
+++ b/packages/icons/replay-control/next-car-number.svg
@@ -13,11 +13,11 @@
 
     <!-- Number sequence on car body -->
     <text x="58" y="60" text-anchor="middle" dominant-baseline="central"
-          fill="#2a3a4a" font-family="Arial, sans-serif" font-size="14" font-weight="bold">1</text>
+          fill="{{backgroundColor}}" font-family="Arial, sans-serif" font-size="14" font-weight="bold">1</text>
     <text x="72" y="60" text-anchor="middle" dominant-baseline="central"
-          fill="#2a3a4a" font-family="Arial, sans-serif" font-size="14" font-weight="bold">2</text>
+          fill="{{backgroundColor}}" font-family="Arial, sans-serif" font-size="14" font-weight="bold">2</text>
     <text x="86" y="60" text-anchor="middle" dominant-baseline="central"
-          fill="#2a3a4a" font-family="Arial, sans-serif" font-size="14" font-weight="bold">3</text>
+          fill="{{backgroundColor}}" font-family="Arial, sans-serif" font-size="14" font-weight="bold">3</text>
 
     <!-- Two-line label -->
     <text x="72" y="116" text-anchor="middle" dominant-baseline="central"

--- a/packages/icons/replay-control/next-car.svg
+++ b/packages/icons/replay-control/next-car.svg
@@ -12,7 +12,7 @@
     </g>
 
     <!-- Right arrow cutout (same as next-lap arrow, background color) -->
-    <polygon points="66,43 82,51 66,59" fill="#2a3a4a"/>
+    <polygon points="66,43 82,51 66,59" fill="{{backgroundColor}}"/>
 
     <!-- Two-line label -->
     <text x="72" y="116" text-anchor="middle" dominant-baseline="central"

--- a/packages/icons/replay-control/prev-car-number.svg
+++ b/packages/icons/replay-control/prev-car-number.svg
@@ -13,11 +13,11 @@
 
     <!-- Number sequence on car body -->
     <text x="58" y="60" text-anchor="middle" dominant-baseline="central"
-          fill="#2a3a4a" font-family="Arial, sans-serif" font-size="14" font-weight="bold">3</text>
+          fill="{{backgroundColor}}" font-family="Arial, sans-serif" font-size="14" font-weight="bold">3</text>
     <text x="72" y="60" text-anchor="middle" dominant-baseline="central"
-          fill="#2a3a4a" font-family="Arial, sans-serif" font-size="14" font-weight="bold">2</text>
+          fill="{{backgroundColor}}" font-family="Arial, sans-serif" font-size="14" font-weight="bold">2</text>
     <text x="86" y="60" text-anchor="middle" dominant-baseline="central"
-          fill="#2a3a4a" font-family="Arial, sans-serif" font-size="14" font-weight="bold">1</text>
+          fill="{{backgroundColor}}" font-family="Arial, sans-serif" font-size="14" font-weight="bold">1</text>
 
     <!-- Two-line label -->
     <text x="72" y="116" text-anchor="middle" dominant-baseline="central"

--- a/packages/icons/replay-control/prev-car.svg
+++ b/packages/icons/replay-control/prev-car.svg
@@ -12,7 +12,7 @@
     </g>
 
     <!-- Left arrow cutout (same as prev-lap arrow, background color) -->
-    <polygon points="78,43 62,51 78,59" fill="#2a3a4a"/>
+    <polygon points="78,43 62,51 78,59" fill="{{backgroundColor}}"/>
 
     <!-- Two-line label -->
     <text x="72" y="116" text-anchor="middle" dominant-baseline="central"


### PR DESCRIPTION
## Related Issue

Fixes #218

## What changed?

Replaced hardcoded `#2a3a4a` fill with `{{backgroundColor}}` Mustache placeholder in 5 replay-control car icons so color overrides apply correctly:

- `next-car.svg` — arrow cutout polygon
- `prev-car.svg` — arrow cutout polygon
- `next-car-number.svg` — number sequence text (1 2 3)
- `prev-car-number.svg` — number sequence text (3 2 1)
- `jump-to-my-car.svg` — heart cutout path

## How to test

- Apply a non-default background color override to any of the 5 affected replay-control actions
- Verify the cutout/text elements match the new background color instead of staying `#2a3a4a`

## Checklist

- [x] Linked to an approved issue
- [ ] New code has unit tests — N/A (SVG-only change, icon preview freshness test passes)
- [ ] Changes registered in all applicable plugins (Stream Deck, Mirabox) — N/A
- [x] No unrelated changes included