### PR TITLE
fix(pi): prevent font size reset when Property Inspector opens (#281)

### DIFF
--- a/packages/stream-deck-plugin/src/pi-templates/partials/head-common.ejs
+++ b/packages/stream-deck-plugin/src/pi-templates/partials/head-common.ejs
@@ -312,8 +312,8 @@
   })();
 
   // Font Size checkbox gate: sdpi-checkbox (persists via setting attribute) + ird-range-input.
-  // When unchecked: hide range, clear fontSize setting.
-  // When checked: show range, sdpi persists fontSize normally.
+  // Visibility only during init/polling — the ird-range-input default attribute handles display.
+  // Value clearing only on explicit user uncheck (change listener).
   (function() {
     async function initFontSizeToggle() {
       await customElements.whenDefined('sdpi-checkbox');
@@ -326,26 +326,26 @@
         return toggle.checked === true || toggle.value === true || toggle.value === 'true';
       }
 
-      function showControls(show) {
+      function setVisibility(show) {
         if (show) {
           item.classList.remove('hidden');
-          if (!range.value || range.value === '') {
-            range.value = '9';
-            range.dispatchEvent(new Event('change', { bubbles: true }));
-          }
         } else {
           item.classList.add('hidden');
-          range.value = '';
-          range.dispatchEvent(new Event('change', { bubbles: true }));
         }
       }
 
+      // User interaction: clear fontSize on uncheck so it falls back to defaults
       toggle.addEventListener('change', function() {
-        showControls(isChecked());
+        var checked = isChecked();
+        setVisibility(checked);
+        if (!checked) {
+          range.value = '';
+          range.dispatchEvent(new Event('change', { bubbles: true }));
+        }
       });
 
-      // Initial state check
-      showControls(isChecked());
+      // Initial state — visibility only, no value manipulation
+      setVisibility(isChecked());
 
       // Polling fallback for checkbox state (sdpi-checkbox loads asynchronously)
       var lastChecked = isChecked();
@@ -353,7 +353,7 @@
         var cur = isChecked();
         if (cur !== lastChecked) {
           lastChecked = cur;
-          showControls(cur);
+          setVisibility(cur);
         }
       }, 100);
     }

--- a/packages/stream-deck-plugin/src/pi-templates/partials/title-overrides.ejs
+++ b/packages/stream-deck-plugin/src/pi-templates/partials/title-overrides.ejs
@@ -39,7 +39,7 @@
       '<sdpi-checkbox id="title-override-fontSize-toggle" setting="titleOverrides.fontSizeEnabled" label="Override font size"></sdpi-checkbox>' +
     '</sdpi-item>' +
     '<sdpi-item id="title-fontSize-item" class="hidden" label="Font Size">' +
-      '<ird-range-input id="title-override-fontSize" setting="titleOverrides.fontSize" min="5" max="100" showlabels></ird-range-input>' +
+      '<ird-range-input id="title-override-fontSize" setting="titleOverrides.fontSize" min="5" max="100" default="9" showlabels></ird-range-input>' +
     '</sdpi-item>' +
 
     '<div class="ird-section-subtitle">Position</div>' +


### PR DESCRIPTION
## Summary

- Separated the font size gate script into visibility-only (init/polling) and value-clearing (user interaction only) paths to prevent the race condition where the saved font size was overwritten on PI open
- Added `default="9"` attribute to the font size range input so `updateDisplay()` shows the visual default without persisting

## Test plan

- [ ] Set font size override to a non-default value (e.g., 16), close and reopen the PI — value should persist
- [ ] Uncheck "Override font size", reopen PI, check it again — should show default 9
- [ ] Verify newly added keys also respect saved font size on PI reopen

Closes #281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved font size toggle behavior to only clear values when explicitly unchecked, preventing unintended automatic changes.

* **Chores**
  * Added default font size value to the font size input for consistent initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->