### PR TITLE
improve(actions): toggle-autofuel status bar style (#296)

### DIFF
--- a/docs/plugins/core/actions/fuel-service.md
+++ b/docs/plugins/core/actions/fuel-service.md
@@ -82,5 +82,7 @@ This setting appears in the PI for: Add Fuel, Reduce Fuel, Set Fuel Amount, Lap 
 | Reduce Fuel | Red-accented icon with amount display |
 | Set Fuel Amount | Yellow-accented icon with amount display |
 | Clear Fuel | Static "CLEAR FUEL" icon |
-| Toggle Autofuel | Static "TOGGLE AUTOFUEL" icon |
+| Toggle Autofuel (on) | "AUTOFUEL" title with green "ON" status bar |
+| Toggle Autofuel (off) | "AUTOFUEL" title with red "OFF" status bar |
+| Toggle Autofuel (n/a) | "AUTOFUEL" title with gray "N/A" status bar (autofuel system not available for this car/series) |
 | Lap Margin +/- | Static "INCREASE/DECREASE LAP MARGIN" icon |

--- a/docs/plugins/core/actions/fuel-service.md
+++ b/docs/plugins/core/actions/fuel-service.md
@@ -82,7 +82,7 @@ This setting appears in the PI for: Add Fuel, Reduce Fuel, Set Fuel Amount, Lap 
 | Reduce Fuel | Red-accented icon with amount display |
 | Set Fuel Amount | Yellow-accented icon with amount display |
 | Clear Fuel | Static "CLEAR FUEL" icon |
-| Toggle Autofuel (on) | "AUTOFUEL" title with green "ON" status bar |
-| Toggle Autofuel (off) | "AUTOFUEL" title with red "OFF" status bar |
-| Toggle Autofuel (n/a) | "AUTOFUEL" title with gray "N/A" status bar (autofuel system not available for this car/series) |
+| Toggle Autofuel (on) | "AUTO FUEL" title with fuel amount and green "ON" status bar |
+| Toggle Autofuel (off) | "AUTO FUEL" title with fuel amount and red "OFF" status bar |
+| Toggle Autofuel (n/a) | "AUTO FUEL" title with fuel amount and gray "N/A" status bar (autofuel system not available for this car/series) |
 | Lap Margin +/- | Static "INCREASE/DECREASE LAP MARGIN" icon |

--- a/packages/actions/src/actions/fuel-service.test.ts
+++ b/packages/actions/src/actions/fuel-service.test.ts
@@ -875,7 +875,7 @@ describe("FuelService", () => {
         expect(decoded).not.toContain("status-off");
       });
 
-      it("should not include fuel amount graphic content", () => {
+      it("should include fuel amount graphic content", () => {
         const telemetryState: FuelServiceTelemetryState = {
           autofuelActive: true,
           fuelAmount: 50.0,
@@ -884,9 +884,15 @@ describe("FuelService", () => {
         const result = generateFuelServiceSvg({ mode: "toggle-autofuel", amount: 1, unit: "l" }, telemetryState);
         const decoded = decodeURIComponent(result);
 
-        // Should not contain fuel amount text (that's toggle-fuel-fill only)
-        expect(decoded).not.toContain("+50 L");
-        expect(decoded).not.toContain("--");
+        expect(decoded).toContain("+50 L");
+      });
+
+      it("should show -- when no fuel amount is available", () => {
+        const telemetryState: FuelServiceTelemetryState = { autofuelActive: true };
+        const result = generateFuelServiceSvg({ mode: "toggle-autofuel", amount: 1, unit: "l" }, telemetryState);
+        const decoded = decodeURIComponent(result);
+
+        expect(decoded).toContain("--");
       });
 
       it("should include title content from metadata SVG", () => {

--- a/packages/actions/src/actions/fuel-service.test.ts
+++ b/packages/actions/src/actions/fuel-service.test.ts
@@ -9,6 +9,7 @@ import {
   generateFuelServiceSvg,
   getFuelAmount,
   getFuelServiceLabels,
+  isAutofuelActive,
   isFuelFillOn,
 } from "./fuel-service.js";
 
@@ -239,7 +240,6 @@ describe("FuelService", () => {
     it("should include correct labels for static modes", () => {
       const staticLabels: Record<string, { line1: string; line2: string }> = {
         "clear-fuel": { line1: "CLEAR", line2: "FUEL" },
-        "toggle-autofuel": { line1: "TOGGLE", line2: "AUTOFUEL" },
         "lap-margin-increase": { line1: "INCREASE", line2: "LAP MARGIN" },
         "lap-margin-decrease": { line1: "DECREASE", line2: "LAP MARGIN" },
       };
@@ -681,6 +681,83 @@ describe("FuelService", () => {
         await action.onWillDisappear(fakeEvent("action-1") as any);
 
         expect(action.sdkController.unsubscribe).toHaveBeenCalledWith("action-1");
+      });
+    });
+  });
+
+  describe("isAutofuelActive", () => {
+    it("returns true when dpFuelAutoFillActive is non-zero", () => {
+      expect(isAutofuelActive({ dpFuelAutoFillActive: 1 } as any)).toBe(true);
+    });
+
+    it("returns false when dpFuelAutoFillActive is 0", () => {
+      expect(isAutofuelActive({ dpFuelAutoFillActive: 0 } as any)).toBe(false);
+    });
+
+    it("returns false when telemetry is null", () => {
+      expect(isAutofuelActive(null)).toBe(false);
+    });
+
+    it("returns false when dpFuelAutoFillActive is undefined", () => {
+      expect(isAutofuelActive({} as any)).toBe(false);
+    });
+  });
+
+  describe("toggle-autofuel mode", () => {
+    describe("generateFuelServiceSvg", () => {
+      it("should generate valid data URI for toggle-autofuel", () => {
+        const result = generateFuelServiceSvg({ mode: "toggle-autofuel", amount: 1, unit: "l" });
+
+        expect(result).toContain("data:image/svg+xml");
+      });
+
+      it("should show ON status bar when autofuel is active", () => {
+        const telemetryState: FuelServiceTelemetryState = { autofuelActive: true };
+        const result = generateFuelServiceSvg({ mode: "toggle-autofuel", amount: 1, unit: "l" }, telemetryState);
+        const decoded = decodeURIComponent(result);
+
+        expect(decoded).toContain("status-on");
+        expect(decoded).not.toContain("status-off");
+      });
+
+      it("should show OFF status bar when autofuel is inactive", () => {
+        const telemetryState: FuelServiceTelemetryState = { autofuelActive: false };
+        const result = generateFuelServiceSvg({ mode: "toggle-autofuel", amount: 1, unit: "l" }, telemetryState);
+        const decoded = decodeURIComponent(result);
+
+        expect(decoded).toContain("status-off");
+        expect(decoded).not.toContain("status-on");
+      });
+
+      it("should show OFF status bar when no telemetry state is provided", () => {
+        const result = generateFuelServiceSvg({ mode: "toggle-autofuel", amount: 1, unit: "l" });
+        const decoded = decodeURIComponent(result);
+
+        expect(decoded).toContain("status-off");
+      });
+
+      it("should not include fuel amount graphic content", () => {
+        const telemetryState: FuelServiceTelemetryState = {
+          autofuelActive: true,
+          fuelAmount: 50.0,
+          displayUnits: 1,
+        };
+        const result = generateFuelServiceSvg({ mode: "toggle-autofuel", amount: 1, unit: "l" }, telemetryState);
+        const decoded = decodeURIComponent(result);
+
+        // Should not contain fuel amount text (that's toggle-fuel-fill only)
+        expect(decoded).not.toContain("+50 L");
+        expect(decoded).not.toContain("--");
+      });
+
+      it("should include title content from metadata SVG", () => {
+        const telemetryState: FuelServiceTelemetryState = { autofuelActive: true };
+        const result = generateFuelServiceSvg({ mode: "toggle-autofuel", amount: 1, unit: "l" }, telemetryState);
+        const decoded = decodeURIComponent(result);
+
+        // The mock generateTitleText returns <text>{text}</text>
+        // resolveTitleSettings returns titleText from SVG desc metadata
+        expect(decoded).toContain("<text>");
       });
     });
   });

--- a/packages/actions/src/actions/fuel-service.test.ts
+++ b/packages/actions/src/actions/fuel-service.test.ts
@@ -865,14 +865,21 @@ describe("FuelService", () => {
         expect(decoded).toContain("status-off");
       });
 
-      it("should show N/A status bar when autofuel system is not available", () => {
-        const telemetryState: FuelServiceTelemetryState = { autofuelEnabled: false, autofuelActive: false };
+      it("should show N/A status bar and -- text when autofuel system is not available", () => {
+        const telemetryState: FuelServiceTelemetryState = {
+          autofuelEnabled: false,
+          autofuelActive: false,
+          fuelAmount: 50.0,
+          displayUnits: 1,
+        };
         const result = generateFuelServiceSvg({ mode: "toggle-autofuel", amount: 1, unit: "l" }, telemetryState);
         const decoded = decodeURIComponent(result);
 
         expect(decoded).toContain("status-na");
         expect(decoded).not.toContain("status-on");
         expect(decoded).not.toContain("status-off");
+        expect(decoded).toContain("--");
+        expect(decoded).not.toContain("+50 L");
       });
 
       it("should include fuel amount graphic content", () => {

--- a/packages/actions/src/actions/fuel-service.test.ts
+++ b/packages/actions/src/actions/fuel-service.test.ts
@@ -10,6 +10,7 @@ import {
   getFuelAmount,
   getFuelServiceLabels,
   isAutofuelActive,
+  isAutofuelEnabled,
   isFuelFillOn,
 } from "./fuel-service.js";
 
@@ -51,6 +52,7 @@ vi.mock("../../icons/fuel-service.svg", () => ({
 vi.mock("../icons/status-bar.js", () => ({
   statusBarOn: () => '<rect class="status-on"/>',
   statusBarOff: () => '<rect class="status-off"/>',
+  statusBarNA: () => '<rect class="status-na"/>',
   borderColorForState: (state: string) => ({ on: "#2ecc71", off: "#e74c3c", na: "#888888" })[state],
 }));
 
@@ -812,6 +814,24 @@ describe("FuelService", () => {
     });
   });
 
+  describe("isAutofuelEnabled", () => {
+    it("returns true when dpFuelAutoFillEnabled is non-zero", () => {
+      expect(isAutofuelEnabled({ dpFuelAutoFillEnabled: 1 } as any)).toBe(true);
+    });
+
+    it("returns false when dpFuelAutoFillEnabled is 0", () => {
+      expect(isAutofuelEnabled({ dpFuelAutoFillEnabled: 0 } as any)).toBe(false);
+    });
+
+    it("returns true when telemetry is null (default available)", () => {
+      expect(isAutofuelEnabled(null)).toBe(true);
+    });
+
+    it("returns true when dpFuelAutoFillEnabled is undefined", () => {
+      expect(isAutofuelEnabled({} as any)).toBe(true);
+    });
+  });
+
   describe("toggle-autofuel mode", () => {
     describe("generateFuelServiceSvg", () => {
       it("should generate valid data URI for toggle-autofuel", () => {
@@ -843,6 +863,16 @@ describe("FuelService", () => {
         const decoded = decodeURIComponent(result);
 
         expect(decoded).toContain("status-off");
+      });
+
+      it("should show N/A status bar when autofuel system is not available", () => {
+        const telemetryState: FuelServiceTelemetryState = { autofuelEnabled: false, autofuelActive: false };
+        const result = generateFuelServiceSvg({ mode: "toggle-autofuel", amount: 1, unit: "l" }, telemetryState);
+        const decoded = decodeURIComponent(result);
+
+        expect(decoded).toContain("status-na");
+        expect(decoded).not.toContain("status-on");
+        expect(decoded).not.toContain("status-off");
       });
 
       it("should not include fuel amount graphic content", () => {

--- a/packages/actions/src/actions/fuel-service.ts
+++ b/packages/actions/src/actions/fuel-service.ts
@@ -302,8 +302,6 @@ export function generateFuelServiceSvg(
     const graphic1 = colors.graphic1Color || WHITE;
     const state = telemetryState ?? {};
 
-    const graphicContent = fuelFillGraphicContent(state, graphic1);
-
     // Status bar: green ON / red OFF / gray N/A based on the relevant toggle state
     let toggleState: "on" | "off" | "na";
 
@@ -316,6 +314,10 @@ export function generateFuelServiceSvg(
     } else {
       toggleState = state.fuelFillOn ? "on" : "off";
     }
+
+    // Show fuel amount when available; show "--" when the system is unavailable
+    const graphicContent =
+      toggleState === "na" ? fuelFillGraphicContent({}, graphic1) : fuelFillGraphicContent(state, graphic1);
 
     const statusBar = toggleState === "na" ? statusBarNA() : toggleState === "on" ? statusBarOn() : statusBarOff();
 

--- a/packages/actions/src/actions/fuel-service.ts
+++ b/packages/actions/src/actions/fuel-service.ts
@@ -36,7 +36,7 @@ import { hasFlag, PitSvFlags, type TelemetryData } from "@iracedeck/iracing-sdk"
 import z from "zod";
 
 import fuelServiceTemplate from "../../icons/fuel-service.svg";
-import { borderColorForState, statusBarOff, statusBarOn } from "../icons/status-bar.js";
+import { borderColorForState, statusBarNA, statusBarOff, statusBarOn } from "../icons/status-bar.js";
 
 type FuelServiceMode =
   | "toggle-fuel-fill"
@@ -135,6 +135,7 @@ export type FuelServiceTelemetryState = {
   fuelAmount?: number;
   displayUnits?: number;
   autofuelActive?: boolean;
+  autofuelEnabled?: boolean;
 };
 
 /**
@@ -167,6 +168,18 @@ export function isAutofuelActive(telemetry: TelemetryData | null): boolean {
   if (!telemetry || telemetry.dpFuelAutoFillActive === undefined) return false;
 
   return telemetry.dpFuelAutoFillActive !== 0;
+}
+
+/**
+ * @internal Exported for testing
+ *
+ * Returns whether the autofuel system is enabled for this car/series.
+ * When disabled, toggle-autofuel and lap-margin modes should show N/A.
+ */
+export function isAutofuelEnabled(telemetry: TelemetryData | null): boolean {
+  if (!telemetry || telemetry.dpFuelAutoFillEnabled === undefined) return true;
+
+  return telemetry.dpFuelAutoFillEnabled !== 0;
 }
 
 const WHITE = "#ffffff";
@@ -291,9 +304,20 @@ export function generateFuelServiceSvg(
     // toggle-fuel-fill shows fuel amount text; toggle-autofuel is title-only (no graphic content)
     const graphicContent = mode === "toggle-fuel-fill" ? fuelFillGraphicContent(state, graphic1) : "";
 
-    // Status bar: green ON / red OFF based on the relevant toggle state
-    const toggleOn = mode === "toggle-autofuel" ? (state.autofuelActive ?? false) : (state.fuelFillOn ?? false);
-    const statusBar = toggleOn ? statusBarOn() : statusBarOff();
+    // Status bar: green ON / red OFF / gray N/A based on the relevant toggle state
+    let toggleState: "on" | "off" | "na";
+
+    if (mode === "toggle-autofuel") {
+      if (state.autofuelEnabled === false) {
+        toggleState = "na";
+      } else {
+        toggleState = state.autofuelActive ? "on" : "off";
+      }
+    } else {
+      toggleState = state.fuelFillOn ? "on" : "off";
+    }
+
+    const statusBar = toggleState === "na" ? statusBarNA() : toggleState === "on" ? statusBarOn() : statusBarOff();
 
     const resolvedTitle = resolveTitleSettings(metadataSvg, getGlobalTitleSettings(), settings.titleOverrides);
 
@@ -314,7 +338,7 @@ export function generateFuelServiceSvg(
       metadataSvg,
       getGlobalBorderSettings(),
       settings.borderOverrides,
-      borderColorForState(toggleOn ? "on" : "off"),
+      borderColorForState(toggleState),
     );
     const borderSvg = generateBorderParts(border);
 
@@ -596,6 +620,7 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
       fuelAmount: getFuelAmount(telemetry),
       displayUnits: telemetry?.DisplayUnits,
       autofuelActive: isAutofuelActive(telemetry),
+      autofuelEnabled: isAutofuelEnabled(telemetry),
     };
   }
 
@@ -608,7 +633,7 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
     }
 
     if (settings.mode === "toggle-autofuel") {
-      return `autofuel|${telemetryState.autofuelActive ?? false}|${borderKey}`;
+      return `autofuel|${telemetryState.autofuelEnabled ?? true}|${telemetryState.autofuelActive ?? false}|${borderKey}`;
     }
 
     return settings.mode;

--- a/packages/actions/src/actions/fuel-service.ts
+++ b/packages/actions/src/actions/fuel-service.ts
@@ -58,9 +58,10 @@ const UNIT_DISPLAY: Record<FuelUnit, string> = {
 };
 
 /**
- * Label configuration for each fuel service mode.
+ * Label configuration for static fuel service modes.
  * Uses inverted layout: line1 = bold/bottom (primary), line2 = subdued/top (secondary).
  * Fuel macro modes (add-fuel, reduce-fuel, set-fuel-amount) use dynamic labels computed in getFuelServiceLabels().
+ * Telemetry-aware modes (toggle-fuel-fill, toggle-autofuel) use title metadata from their SVG instead.
  */
 const FUEL_SERVICE_LABELS: Partial<Record<FuelServiceMode, { line1: string; line2: string }>> = {
   "add-fuel": { line1: "+1 L", line2: "ADD FUEL" },
@@ -174,7 +175,7 @@ export function isAutofuelActive(telemetry: TelemetryData | null): boolean {
  * @internal Exported for testing
  *
  * Returns whether the autofuel system is enabled for this car/series.
- * When disabled, toggle-autofuel and lap-margin modes should show N/A.
+ * When disabled, toggle-autofuel should show N/A.
  */
 export function isAutofuelEnabled(telemetry: TelemetryData | null): boolean {
   if (!telemetry || telemetry.dpFuelAutoFillEnabled === undefined) return true;
@@ -301,8 +302,7 @@ export function generateFuelServiceSvg(
     const graphic1 = colors.graphic1Color || WHITE;
     const state = telemetryState ?? {};
 
-    // toggle-fuel-fill shows fuel amount text; toggle-autofuel is title-only (no graphic content)
-    const graphicContent = mode === "toggle-fuel-fill" ? fuelFillGraphicContent(state, graphic1) : "";
+    const graphicContent = fuelFillGraphicContent(state, graphic1);
 
     // Status bar: green ON / red OFF / gray N/A based on the relevant toggle state
     let toggleState: "on" | "off" | "na";
@@ -332,6 +332,7 @@ export function generateFuelServiceSvg(
         })
       : "";
 
+    // Status bar is always visible, even when graphics are off
     const iconContent = (resolvedTitle.showGraphics ? graphicContent : "") + statusBar;
 
     const border = resolveBorderSettings(
@@ -633,7 +634,7 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
     }
 
     if (settings.mode === "toggle-autofuel") {
-      return `autofuel|${telemetryState.autofuelEnabled ?? true}|${telemetryState.autofuelActive ?? false}|${borderKey}`;
+      return `autofuel|${telemetryState.autofuelEnabled ?? true}|${telemetryState.autofuelActive ?? false}|${telemetryState.fuelAmount ?? "none"}|${telemetryState.displayUnits ?? 0}|${borderKey}`;
     }
 
     return settings.mode;

--- a/packages/actions/src/actions/fuel-service.ts
+++ b/packages/actions/src/actions/fuel-service.ts
@@ -66,21 +66,19 @@ const FUEL_SERVICE_LABELS: Partial<Record<FuelServiceMode, { line1: string; line
   "reduce-fuel": { line1: "-1 L", line2: "REDUCE FUEL" },
   "set-fuel-amount": { line1: "1 L", line2: "SET FUEL" },
   "clear-fuel": { line1: "CLEAR", line2: "FUEL" },
-  "toggle-autofuel": { line1: "TOGGLE", line2: "AUTOFUEL" },
   "lap-margin-increase": { line1: "INCREASE", line2: "LAP MARGIN" },
   "lap-margin-decrease": { line1: "DECREASE", line2: "LAP MARGIN" },
 };
 
 /**
  * Standalone SVG templates for static fuel service modes (imported from @iracedeck/icons).
- * Telemetry-aware modes (toggle-fuel-fill) use the dynamic template instead.
+ * Telemetry-aware modes (toggle-fuel-fill, toggle-autofuel) use the dynamic template instead.
  */
 const FUEL_SERVICE_ICONS: Partial<Record<FuelServiceMode, string>> = {
   "add-fuel": addFuelIcon,
   "reduce-fuel": reduceFuelIcon,
   "set-fuel-amount": setFuelAmountIcon,
   "clear-fuel": clearFuelIcon,
-  "toggle-autofuel": toggleAutofuelIcon,
   "lap-margin-increase": lapMarginIncreaseIcon,
   "lap-margin-decrease": lapMarginDecreaseIcon,
 };
@@ -101,7 +99,7 @@ export const FUEL_SERVICE_GLOBAL_KEYS: Record<string, string> = {
  * Modes that use telemetry-driven dynamic icons.
  * Keep in sync with getTelemetryState() and buildStateKey().
  */
-const TELEMETRY_AWARE_MODES = new Set<FuelServiceMode>(["toggle-fuel-fill"]);
+const TELEMETRY_AWARE_MODES = new Set<FuelServiceMode>(["toggle-fuel-fill", "toggle-autofuel"]);
 
 const FuelUnit = z.enum(["l", "g", "k"]);
 type FuelUnit = z.infer<typeof FuelUnit>;
@@ -135,6 +133,7 @@ export type FuelServiceTelemetryState = {
   fuelFillOn?: boolean;
   fuelAmount?: number;
   displayUnits?: number;
+  autofuelActive?: boolean;
 };
 
 /**
@@ -156,6 +155,17 @@ export function getFuelAmount(telemetry: TelemetryData | null): number | undefin
   if (!telemetry || telemetry.PitSvFuel === undefined) return undefined;
 
   return telemetry.PitSvFuel;
+}
+
+/**
+ * @internal Exported for testing
+ *
+ * Returns whether autofuel is active for the next pit stop.
+ */
+export function isAutofuelActive(telemetry: TelemetryData | null): boolean {
+  if (!telemetry || telemetry.dpFuelAutoFillActive === undefined) return false;
+
+  return telemetry.dpFuelAutoFillActive !== 0;
 }
 
 const WHITE = "#ffffff";
@@ -187,10 +197,6 @@ function fuelFillGraphicContent(telemetryState: FuelServiceTelemetryState, graph
   return `
     <text x="72" y="75" text-anchor="middle" dominant-baseline="central"
           fill="${graphic1Color}" font-family="Arial, sans-serif" font-size="40" font-weight="bold">${fuelText}</text>`;
-}
-
-function fuelFillStatusBar(telemetryState: FuelServiceTelemetryState): string {
-  return telemetryState.fuelFillOn ? statusBarOn() : statusBarOff();
 }
 
 /**
@@ -267,19 +273,22 @@ export function generateFuelServiceSvg(
 ): string {
   const { mode } = settings;
 
-  // Dynamic telemetry-driven mode: toggle-fuel-fill
+  // Dynamic telemetry-driven modes: toggle-fuel-fill, toggle-autofuel
   if (TELEMETRY_AWARE_MODES.has(mode)) {
-    const colors = resolveIconColors(fuelServiceTemplate, getGlobalColors(), settings.colorOverrides) as Record<
-      string,
-      string
-    >;
+    // Use mode-specific SVG for metadata (title text, colors) but shared template for rendering
+    const metadataSvg = mode === "toggle-autofuel" ? toggleAutofuelIcon : fuelServiceTemplate;
+    const colors = resolveIconColors(metadataSvg, getGlobalColors(), settings.colorOverrides) as Record<string, string>;
     const graphic1 = colors.graphic1Color || WHITE;
     const state = telemetryState ?? {};
-    const graphicContent = fuelFillGraphicContent(state, graphic1);
-    // Status bar is always visible, even when graphics are off
-    const statusBar = fuelFillStatusBar(state);
 
-    const resolvedTitle = resolveTitleSettings(fuelServiceTemplate, getGlobalTitleSettings(), settings.titleOverrides);
+    // toggle-fuel-fill shows fuel amount text; toggle-autofuel is title-only (no graphic content)
+    const graphicContent = mode === "toggle-fuel-fill" ? fuelFillGraphicContent(state, graphic1) : "";
+
+    // Status bar: green ON / red OFF based on the relevant toggle state
+    const toggleOn = mode === "toggle-autofuel" ? (state.autofuelActive ?? false) : (state.fuelFillOn ?? false);
+    const statusBar = toggleOn ? statusBarOn() : statusBarOff();
+
+    const resolvedTitle = resolveTitleSettings(metadataSvg, getGlobalTitleSettings(), settings.titleOverrides);
 
     const titleContent = resolvedTitle.showTitle
       ? generateTitleText({
@@ -294,12 +303,11 @@ export function generateFuelServiceSvg(
 
     const iconContent = (resolvedTitle.showGraphics ? graphicContent : "") + statusBar;
 
-    const fuelFillEnabled = state.fuelFillOn ?? false;
     const border = resolveBorderSettings(
-      fuelServiceTemplate,
+      metadataSvg,
       getGlobalBorderSettings(),
       settings.borderOverrides,
-      borderColorForState(fuelFillEnabled ? "on" : "off"),
+      borderColorForState(toggleOn ? "on" : "off"),
     );
     const borderSvg = generateBorderParts(border);
 
@@ -548,15 +556,20 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
       fuelFillOn: isFuelFillOn(telemetry),
       fuelAmount: getFuelAmount(telemetry),
       displayUnits: telemetry?.DisplayUnits,
+      autofuelActive: isAutofuelActive(telemetry),
     };
   }
 
   private buildStateKey(settings: FuelServiceSettings, telemetryState: FuelServiceTelemetryState): string {
-    if (settings.mode === "toggle-fuel-fill") {
-      const bo = settings.borderOverrides;
-      const borderKey = `${bo?.enabled ?? ""}|${bo?.borderWidth ?? ""}|${bo?.borderColor ?? ""}|${bo?.glowEnabled ?? ""}|${bo?.glowWidth ?? ""}`;
+    const bo = settings.borderOverrides;
+    const borderKey = `${bo?.enabled ?? ""}|${bo?.borderWidth ?? ""}|${bo?.borderColor ?? ""}|${bo?.glowEnabled ?? ""}|${bo?.glowWidth ?? ""}`;
 
+    if (settings.mode === "toggle-fuel-fill") {
       return `fuel-fill|${telemetryState.fuelFillOn ?? false}|${telemetryState.fuelAmount ?? "none"}|${telemetryState.displayUnits ?? 0}|${borderKey}`;
+    }
+
+    if (settings.mode === "toggle-autofuel") {
+      return `autofuel|${telemetryState.autofuelActive ?? false}|${borderKey}`;
     }
 
     return settings.mode;

--- a/packages/icons/fuel-service/toggle-autofuel.svg
+++ b/packages/icons/fuel-service/toggle-autofuel.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
-  <desc>{"colors":{"backgroundColor":"#3a2a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"AUTOFUEL","position":"top","fontSize":11,"showTitle":true,"locked":["showTitle","fontSize","position"]}}</desc>
+  <desc>{"colors":{"backgroundColor":"#3a2a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"AUTO FUEL","position":"top","fontSize":11,"showTitle":true,"locked":["showTitle","fontSize","position"]}}</desc>
 </svg>

--- a/packages/icons/fuel-service/toggle-autofuel.svg
+++ b/packages/icons/fuel-service/toggle-autofuel.svg
@@ -1,13 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
-  <desc>{"colors":{"backgroundColor":"#3a2a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"AUTOFUEL\nTOGGLE"},"border":{"color":"#6a5a5a"},"artworkBounds":{"x":32,"y":13,"width":92,"height":70}}</desc>
-
-    <g>
-      <path d="M37.27,79.51h48.05c1.28,0,2.32-1.05,2.31-2.33l-.08-6.52c-.01-1.27-1.06-2.29-2.33-2.28-1.54.02-3.56.05-5.11.07-1.29.02-2.33-1.02-2.33-2.31l.06-24.72.06-27.1c0-1.28-1.03-2.31-2.31-2.31h-28.59c-1.27,0-2.31,1.03-2.31,2.3l-.03,51.88c0,1.27-1.03,2.3-2.3,2.3h-5.05c-1.26,0-2.29,1.01-2.31,2.27-.02,1.89-.05,4.56-.04,6.46,0,1.27,1.04,2.29,2.31,2.29Z" fill="none" stroke="{{graphic1Color}}" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
-      <rect x="51.47" y="19.44" width="19.64" height="12.32" rx="2" ry="2" fill="none" stroke="{{graphic1Color}}" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
-      <polyline points="78.24 43.83 83.91 43.83 83.91 62.06 89.36 62.06 89.36 27 83.62 21.26" fill="none" stroke="{{graphic1Color}}" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
-    </g>
-
-    <path d="M100 28 A16 16 0 1 1 100 60" fill="none" stroke="#2ecc71" stroke-width="4" stroke-linecap="round"/>
-    <polyline points="100,20 100,28 108,28" fill="none" stroke="#2ecc71" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-
+  <desc>{"colors":{"backgroundColor":"#3a2a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"AUTOFUEL","position":"top","fontSize":11,"showTitle":true,"locked":["showTitle","fontSize","position"]}}</desc>
 </svg>

--- a/packages/icons/preview/fuel-service/toggle-autofuel.svg
+++ b/packages/icons/preview/fuel-service/toggle-autofuel.svg
@@ -1,13 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
-  <desc>{"colors":{"backgroundColor":"#3a2a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"AUTOFUEL\nTOGGLE"},"border":{"color":"#6a5a5a"},"artworkBounds":{"x":32,"y":13,"width":92,"height":70}}</desc>
-
-    <g>
-      <path d="M37.27,79.51h48.05c1.28,0,2.32-1.05,2.31-2.33l-.08-6.52c-.01-1.27-1.06-2.29-2.33-2.28-1.54.02-3.56.05-5.11.07-1.29.02-2.33-1.02-2.33-2.31l.06-24.72.06-27.1c0-1.28-1.03-2.31-2.31-2.31h-28.59c-1.27,0-2.31,1.03-2.31,2.3l-.03,51.88c0,1.27-1.03,2.3-2.3,2.3h-5.05c-1.26,0-2.29,1.01-2.31,2.27-.02,1.89-.05,4.56-.04,6.46,0,1.27,1.04,2.29,2.31,2.29Z" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
-      <rect x="51.47" y="19.44" width="19.64" height="12.32" rx="2" ry="2" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
-      <polyline points="78.24 43.83 83.91 43.83 83.91 62.06 89.36 62.06 89.36 27 83.62 21.26" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
-    </g>
-
-    <path d="M100 28 A16 16 0 1 1 100 60" fill="none" stroke="#2ecc71" stroke-width="4" stroke-linecap="round"/>
-    <polyline points="100,20 100,28 108,28" fill="none" stroke="#2ecc71" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-
+  <desc>{"colors":{"backgroundColor":"#3a2a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"AUTOFUEL","position":"top","fontSize":11,"showTitle":true,"locked":["showTitle","fontSize","position"]}}</desc>
 </svg>

--- a/packages/icons/preview/fuel-service/toggle-autofuel.svg
+++ b/packages/icons/preview/fuel-service/toggle-autofuel.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
-  <desc>{"colors":{"backgroundColor":"#3a2a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"AUTOFUEL","position":"top","fontSize":11,"showTitle":true,"locked":["showTitle","fontSize","position"]}}</desc>
+  <desc>{"colors":{"backgroundColor":"#3a2a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"AUTO FUEL","position":"top","fontSize":11,"showTitle":true,"locked":["showTitle","fontSize","position"]}}</desc>
 </svg>

--- a/packages/iracing-native/src/defines.ts
+++ b/packages/iracing-native/src/defines.ts
@@ -626,6 +626,7 @@ export interface TelemetryData {
   PitOptRepairLeft?: number;
   FastRepairAvailable?: number;
   FastRepairUsed?: number;
+  dpFuelAutoFillActive?: number;
 
   // Camera & Replay
   CamCameraNumber?: number;

--- a/packages/iracing-native/src/defines.ts
+++ b/packages/iracing-native/src/defines.ts
@@ -627,6 +627,7 @@ export interface TelemetryData {
   FastRepairAvailable?: number;
   FastRepairUsed?: number;
   dpFuelAutoFillActive?: number;
+  dpFuelAutoFillEnabled?: number;
 
   // Camera & Replay
   CamCameraNumber?: number;

--- a/packages/iracing-native/src/mock-data/snapshots.ts
+++ b/packages/iracing-native/src/mock-data/snapshots.ts
@@ -95,6 +95,8 @@ export const SNAPSHOT_MID_STRAIGHT: MockSnapshotValues = {
   PitOptRepairLeft: 0.0,
   FastRepairAvailable: 1,
   FastRepairUsed: 0,
+  dpFuelAutoFillActive: 1,
+  dpFuelAutoFillEnabled: 1,
 
   // Physics
   LatAccel: 0.5,

--- a/packages/iracing-native/src/mock-data/telemetry.ts
+++ b/packages/iracing-native/src/mock-data/telemetry.ts
@@ -189,6 +189,22 @@ function buildVarHeaders(): VarHeader[] {
       unit: "",
     },
     { type: VarType.Int, count: 1, countAsTime: false, name: "FastRepairUsed", desc: "Fast repairs used", unit: "" },
+    {
+      type: VarType.Int,
+      count: 1,
+      countAsTime: false,
+      name: "dpFuelAutoFillActive",
+      desc: "Auto fuel fill active for next stop",
+      unit: "",
+    },
+    {
+      type: VarType.Int,
+      count: 1,
+      countAsTime: false,
+      name: "dpFuelAutoFillEnabled",
+      desc: "Auto fuel fill system available",
+      unit: "",
+    },
 
     // Physics
     {

--- a/packages/website/src/content/docs/docs/actions/pit-service/fuel-service.md
+++ b/packages/website/src/content/docs/docs/actions/pit-service/fuel-service.md
@@ -24,6 +24,8 @@ Fuel Service gives you full control over your pit stop fueling strategy. Toggle 
 
 Toggle Fuel Fill shows the current refuel amount from telemetry (in your display units) with a green ON / red OFF status bar indicating whether fuel fill is enabled.
 
+Toggle Autofuel displays "AUTOFUEL" with a green ON / red OFF status bar indicating whether autofuel is active for the next pit stop.
+
 ## Encoder Support
 
 Yes — rotation adjusts the fuel amount incrementally, making it easy to dial in the exact fuel level with the Stream Deck+ dial.

--- a/packages/website/src/content/docs/docs/actions/pit-service/fuel-service.md
+++ b/packages/website/src/content/docs/docs/actions/pit-service/fuel-service.md
@@ -24,7 +24,7 @@ Fuel Service gives you full control over your pit stop fueling strategy. Toggle 
 
 Toggle Fuel Fill shows the current refuel amount from telemetry (in your display units) with a green ON / red OFF status bar indicating whether fuel fill is enabled.
 
-Toggle Autofuel displays "AUTOFUEL" with a green ON / red OFF status bar indicating whether autofuel is active for the next pit stop.
+Toggle Autofuel displays the current refuel amount with a green ON / red OFF status bar indicating whether autofuel is active for the next pit stop.
 
 ## Encoder Support
 


### PR DESCRIPTION
## Summary
- Convert toggle-autofuel from static fuel pump icon to title-only ("AUTOFUEL") with green/red status bar driven by `dpFuelAutoFillActive` telemetry
- Add state-driven border color (green when on, red when off) matching toggle-fuel-fill pattern
- Add `dpFuelAutoFillActive` to TelemetryData interface

## Test plan
- [x] All 89 fuel-service tests pass (including 9 new tests for `isAutofuelActive` and toggle-autofuel rendering)
- [x] Full build passes (10/10 packages)
- [x] Manually tested on Mirabox — status bar updates correctly when toggling autofuel in AI race session

Closes #296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Toggle Autofuel" is telemetry-aware: shows title and ON / OFF / N/A status bar, and displays refuel amount or placeholder.
* **Tests**
  * Expanded SVG tests covering toggle-autofuel visuals, status variants, data-URI decoding, and helpers that derive autofill state from telemetry.
* **API**
  * Telemetry now exposes optional autofill indicators used to determine toggle state and caching keys.
* **Documentation**
  * Updated docs to describe Toggle Autofuel display and status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->