### PR TITLE
fix(pi): show global settings for all fuel service modes (#305)

### DIFF
--- a/packages/stream-deck-plugin/src/pi/fuel-service.ejs
+++ b/packages/stream-deck-plugin/src/pi/fuel-service.ejs
@@ -65,13 +65,13 @@
 			<%- include('global-key-bindings', {
 				keyBindings: require('./data/key-bindings.json').fuelService
 			}) %>
+		</div>
 
 		<%- include('global-title-defaults') %>
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
 		<%- include('global-common-settings') %>
-		</div>
 
 		<script>
 			const FUEL_MACRO_MODES = ["add-fuel", "reduce-fuel", "set-fuel-amount"];


### PR DESCRIPTION
## Related Issue

Fixes #305

## What changed?

Moved the `</div>` closing tag for `key-bindings-section` so it only wraps the `global-key-bindings` partial. Previously, all global settings partials (title defaults, color defaults, border defaults, graphic defaults, common settings) were inside the hidden div, making them invisible for non-keyboard modes like Toggle Fuel Fill.

## How to test

1. Add a Fuel Service action to the Stream Deck
2. Set mode to **Toggle Fuel Fill** (or any non-keyboard mode)
3. Verify the Global Settings section shows title defaults, color defaults, border defaults, graphic defaults, and common settings
4. Switch to a keyboard mode (e.g., Toggle Autofuel) and verify key bindings also appear

## Checklist

- [x] Linked to an approved issue
- [ ] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the HTML structure of settings sections to ensure global settings are properly grouped and contained within their intended containers, improving interface organization and layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->