### PR TITLE
fix(actions): simplify replay play/pause toggle and fix disconnect reset (#237)

### DIFF
--- a/packages/actions/src/actions/replay-control.test.ts
+++ b/packages/actions/src/actions/replay-control.test.ts
@@ -350,33 +350,29 @@ describe("ReplayControl", () => {
     });
 
     // Transport labels
-    it("should include PLAY label for play-pause mode", () => {
+    it("should include PLAY / PAUSE label for play-pause mode", () => {
       const result = generateReplayControlSvg({ mode: "play-pause" });
 
-      expect(decodeURIComponent(result)).toContain("PLAY");
+      expect(decodeURIComponent(result)).toContain("PLAY / PAUSE");
     });
 
-    it("should include PLAY and BACKWARD labels for play-backward mode", () => {
+    it("should include PLAY BACKW label for play-backward mode", () => {
       const decoded = decodeURIComponent(generateReplayControlSvg({ mode: "play-backward" }));
 
-      expect(decoded).toContain("PLAY");
-      expect(decoded).toContain("BACKWARD");
+      expect(decoded).toContain("PLAY BACKW");
     });
 
-    it("should show PAUSE label and pause icon for play-backward when isPlaying is true", () => {
+    it("should show PLAY BACKW label and pause icon for play-backward when isPlaying is true", () => {
       const decoded = decodeURIComponent(generateReplayControlSvg({ mode: "play-backward" }, true));
 
-      expect(decoded).toContain("PAUSE");
+      expect(decoded).toContain("PLAY BACKW");
       expect(decoded).toContain("pause-icon");
-      expect(decoded).not.toContain("BACKWARD");
     });
 
-    it("should show PLAY label for play-backward when isPlaying is false", () => {
+    it("should show PLAY BACKW label for play-backward when isPlaying is false", () => {
       const decoded = decodeURIComponent(generateReplayControlSvg({ mode: "play-backward" }, false));
 
-      expect(decoded).toContain("PLAY");
-      expect(decoded).toContain("BACKWARD");
-      expect(decoded).not.toContain("PAUSE");
+      expect(decoded).toContain("PLAY BACKW");
     });
 
     it("should include STOP label for stop mode", () => {
@@ -553,26 +549,24 @@ describe("ReplayControl", () => {
     });
 
     // Play/pause telemetry-aware label toggle
-    it("should show PLAY label when isPlaying is false", () => {
+    it("should show PLAY / PAUSE label and play icon when not playing", () => {
       const decoded = decodeURIComponent(generateReplayControlSvg({ mode: "play-pause" }, false));
 
-      expect(decoded).toContain("PLAY");
-      expect(decoded).not.toContain("PAUSE");
+      expect(decoded).toContain("PLAY / PAUSE");
+      expect(decoded).toContain("play-pause");
     });
 
-    it("should show PAUSE label and pause icon when isPlaying is true", () => {
+    it("should show PLAY / PAUSE label and pause icon when playing", () => {
       const decoded = decodeURIComponent(generateReplayControlSvg({ mode: "play-pause" }, true));
 
-      expect(decoded).toContain("PAUSE");
+      expect(decoded).toContain("PLAY / PAUSE");
       expect(decoded).toContain("pause-icon");
-      expect(decoded).not.toContain("FORWARD");
     });
 
-    it("should show PLAY label when isPlaying is undefined", () => {
+    it("should show PLAY / PAUSE label when isPlaying is undefined", () => {
       const decoded = decodeURIComponent(generateReplayControlSvg({ mode: "play-pause" }));
 
-      expect(decoded).toContain("PLAY");
-      expect(decoded).not.toContain("PAUSE");
+      expect(decoded).toContain("PLAY / PAUSE");
     });
 
     it("should not affect non-play-pause mode labels when isPlaying is true", () => {
@@ -893,6 +887,170 @@ describe("ReplayControl", () => {
       vi.mocked(getCarNumberFromSessionInfo).mockReturnValue("7");
 
       expect(findAdjacentCarByNumber({}, 0, "next")).toBe(3042);
+    });
+  });
+
+  describe("play/pause behavior", () => {
+    function fakeEvent(actionId: string, settings: Record<string, unknown> = {}) {
+      return {
+        action: { id: actionId, setTitle: vi.fn(), setImage: vi.fn() },
+        payload: { settings },
+      };
+    }
+
+    const mockReplay = {
+      play: vi.fn(() => true),
+      pause: vi.fn(() => true),
+      setPlaySpeed: vi.fn(() => true),
+    };
+
+    let action: ReplayControl;
+
+    beforeEach(async () => {
+      vi.clearAllMocks();
+      const { getCommands } = await import("@iracedeck/deck-core");
+      vi.mocked(getCommands).mockReturnValue({ replay: mockReplay, camera: { switchNum: vi.fn() } } as any);
+      action = new ReplayControl();
+    });
+
+    describe("play-pause toggle", () => {
+      beforeEach(async () => {
+        await action.onWillAppear(fakeEvent("ctx-1", { mode: "play-pause" }) as any);
+      });
+
+      it("should pause when playing forward", async () => {
+        (action as any).replaySpeed.set("ctx-1", 1);
+
+        await action.onKeyDown(fakeEvent("ctx-1", { mode: "play-pause" }) as any);
+
+        expect(mockReplay.pause).toHaveBeenCalled();
+        expect((action as any).replaySpeed.get("ctx-1")).toBe(0);
+      });
+
+      it("should play at 1x when paused", async () => {
+        (action as any).replaySpeed.set("ctx-1", 0);
+
+        await action.onKeyDown(fakeEvent("ctx-1", { mode: "play-pause" }) as any);
+
+        expect(mockReplay.play).toHaveBeenCalled();
+        expect((action as any).replaySpeed.get("ctx-1")).toBe(1);
+      });
+
+      it("should pause when playing backward (not mirror)", async () => {
+        (action as any).replaySpeed.set("ctx-1", -4);
+
+        await action.onKeyDown(fakeEvent("ctx-1", { mode: "play-pause" }) as any);
+
+        expect(mockReplay.pause).toHaveBeenCalled();
+        expect(mockReplay.play).not.toHaveBeenCalled();
+        expect(mockReplay.setPlaySpeed).not.toHaveBeenCalled();
+        expect((action as any).replaySpeed.get("ctx-1")).toBe(0);
+      });
+
+      it("should pause when in slow-motion (not mirror)", async () => {
+        (action as any).replaySpeed.set("ctx-1", 2);
+        (action as any).replaySlowMotion.set("ctx-1", true);
+
+        await action.onKeyDown(fakeEvent("ctx-1", { mode: "play-pause" }) as any);
+
+        expect(mockReplay.pause).toHaveBeenCalled();
+        expect(mockReplay.setPlaySpeed).not.toHaveBeenCalled();
+        expect((action as any).replaySpeed.get("ctx-1")).toBe(0);
+      });
+
+      it("should always play at 1x, never restore previous speed", async () => {
+        // Play at 8x, pause, then play again — should be 1x, not 8x
+        (action as any).replaySpeed.set("ctx-1", 8);
+        await action.onKeyDown(fakeEvent("ctx-1", { mode: "play-pause" }) as any);
+        expect(mockReplay.pause).toHaveBeenCalled();
+
+        vi.clearAllMocks();
+        await action.onKeyDown(fakeEvent("ctx-1", { mode: "play-pause" }) as any);
+        expect(mockReplay.play).toHaveBeenCalled();
+        expect((action as any).replaySpeed.get("ctx-1")).toBe(1);
+      });
+    });
+
+    describe("play-backward toggle", () => {
+      beforeEach(async () => {
+        await action.onWillAppear(fakeEvent("ctx-1", { mode: "play-backward" }) as any);
+      });
+
+      it("should pause when playing backward", async () => {
+        (action as any).replaySpeed.set("ctx-1", -1);
+
+        await action.onKeyDown(fakeEvent("ctx-1", { mode: "play-backward" }) as any);
+
+        expect(mockReplay.pause).toHaveBeenCalled();
+        expect((action as any).replaySpeed.get("ctx-1")).toBe(0);
+      });
+
+      it("should play backward at -1x when paused", async () => {
+        (action as any).replaySpeed.set("ctx-1", 0);
+
+        await action.onKeyDown(fakeEvent("ctx-1", { mode: "play-backward" }) as any);
+
+        expect(mockReplay.setPlaySpeed).toHaveBeenCalledWith(-1);
+        expect((action as any).replaySpeed.get("ctx-1")).toBe(-1);
+      });
+
+      it("should pause when playing forward (not switch to backward)", async () => {
+        (action as any).replaySpeed.set("ctx-1", 4);
+
+        await action.onKeyDown(fakeEvent("ctx-1", { mode: "play-backward" }) as any);
+
+        expect(mockReplay.pause).toHaveBeenCalled();
+        expect(mockReplay.setPlaySpeed).not.toHaveBeenCalled();
+        expect((action as any).replaySpeed.get("ctx-1")).toBe(0);
+      });
+    });
+
+    describe("cross-button display sync", () => {
+      it("should update play-pause display when play-backward is pressed", async () => {
+        // Both buttons visible on the same action instance
+        await action.onWillAppear(fakeEvent("pp-ctx", { mode: "play-pause" }) as any);
+        await action.onWillAppear(fakeEvent("pb-ctx", { mode: "play-backward" }) as any);
+
+        // Playing forward — both should show pause state
+        (action as any).replaySpeed.set("pp-ctx", 1);
+        (action as any).replaySpeed.set("pb-ctx", 1);
+
+        // Press play-backward → pauses
+        await action.onKeyDown(fakeEvent("pb-ctx", { mode: "play-backward" }) as any);
+
+        // Both contexts should have speed 0 (paused)
+        expect((action as any).replaySpeed.get("pp-ctx")).toBe(0);
+        expect((action as any).replaySpeed.get("pb-ctx")).toBe(0);
+
+        // Both displays should have been re-rendered
+        expect(action.updateKeyImage).toHaveBeenCalled();
+      });
+    });
+
+    describe("disconnect handling", () => {
+      it("should reset speed to 0 when telemetry becomes null", async () => {
+        await action.onWillAppear(fakeEvent("ctx-1", { mode: "play-pause" }) as any);
+
+        (action as any).replaySpeed.set("ctx-1", 4);
+        (action as any).replaySlowMotion.set("ctx-1", false);
+
+        (action as any).updateTelemetryState("ctx-1", null);
+
+        expect((action as any).replaySpeed.get("ctx-1")).toBe(0);
+        expect((action as any).replaySlowMotion.get("ctx-1")).toBe(false);
+      });
+
+      it("should reset slow-motion flag on disconnect", async () => {
+        await action.onWillAppear(fakeEvent("ctx-1", { mode: "play-pause" }) as any);
+
+        (action as any).replaySpeed.set("ctx-1", 2);
+        (action as any).replaySlowMotion.set("ctx-1", true);
+
+        (action as any).updateTelemetryState("ctx-1", null);
+
+        expect((action as any).replaySpeed.get("ctx-1")).toBe(0);
+        expect((action as any).replaySlowMotion.get("ctx-1")).toBe(false);
+      });
     });
   });
 

--- a/packages/actions/src/actions/replay-control.ts
+++ b/packages/actions/src/actions/replay-control.ts
@@ -122,8 +122,8 @@ const REPLAY_CONTROL_ICONS: Record<ReplayControlMode, string> = {
 };
 
 const REPLAY_CONTROL_TITLES: Record<ReplayControlMode, string> = {
-  "play-pause": "FORWARD\nPLAY",
-  "play-backward": "BACKWARD\nPLAY",
+  "play-pause": "PLAY / PAUSE",
+  "play-backward": "PLAY BACKW",
   stop: "STOP",
   "fast-forward": "FAST\nFORWARD",
   rewind: "REWIND",
@@ -348,11 +348,16 @@ export function generateReplayControlSvg(
     return svgToDataUri(svg);
   }
 
-  // play-pause / play-backward: icon and title switch based on playing state
+  // play-pause / play-backward: icon switches to pause when playing
   if ((mode === "play-pause" || mode === "play-backward") && isPlaying) {
     iconSvg = pauseIconSvg;
     const pauseColors = resolveIconColors(iconSvg, getGlobalColors(), settings.colorOverrides);
-    const title = resolveTitleSettings(iconSvg, getGlobalTitleSettings(), settings.titleOverrides, "PAUSE");
+    const title = resolveTitleSettings(
+      iconSvg,
+      getGlobalTitleSettings(),
+      settings.titleOverrides,
+      REPLAY_CONTROL_TITLES[mode],
+    );
 
     const border = resolveBorderSettings(iconSvg, getGlobalBorderSettings(), settings.borderOverrides);
 
@@ -432,8 +437,8 @@ type ReplayControlSettings = z.infer<typeof ReplayControlSettings>;
 /**
  * Replay Control
  * Unified replay action combining transport, speed, and navigation controls.
- * Provides progressive speed control for fast-forward, rewind, and slow-motion,
- * with speed memory across pause/resume and telemetry-driven display.
+ * Provides progressive speed control for fast-forward, rewind, and slow-motion
+ * with telemetry-driven display.
  */
 export const REPLAY_CONTROL_UUID = "com.iracedeck.sd.core.replay-control" as const;
 
@@ -443,9 +448,6 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
 
   /** Current slow-motion state from telemetry, keyed by action context ID */
   private replaySlowMotion = new Map<string, boolean>();
-
-  /** Speed stored when pausing, restored on play (global, not per-context) */
-  private pausedSpeed: { speed: number; slowMotion: boolean } | null = null;
 
   /** Active long-press repeat timers, keyed by action context ID */
   private repeatTimers = new Map<
@@ -592,7 +594,12 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
   }
 
   private updateTelemetryState(contextId: string, telemetry: TelemetryData | null): void {
-    if (!telemetry) return;
+    if (!telemetry) {
+      this.replaySpeed.set(contextId, 0);
+      this.replaySlowMotion.set(contextId, false);
+
+      return;
+    }
 
     if (telemetry.ReplayPlaySpeed !== undefined) {
       this.replaySpeed.set(contextId, telemetry.ReplayPlaySpeed as number);
@@ -613,17 +620,11 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
   }
 
   /**
-   * Determines if the play-pause/play-backward icon should show PAUSE.
-   * Play-pause shows PAUSE when playing forward; play-backward shows PAUSE when playing backward.
+   * Determines if the play-pause/play-backward icon should show the PAUSE icon.
+   * Shows PAUSE when playing in any direction (forward or backward).
    */
-  private shouldShowPause(contextId: string, mode: ReplayControlMode): boolean {
-    const speed = this.replaySpeed.get(contextId) ?? 0;
-
-    if (mode === "play-pause") return speed > 0;
-
-    if (mode === "play-backward") return speed < 0;
-
-    return speed !== 0;
+  private shouldShowPause(contextId: string): boolean {
+    return (this.replaySpeed.get(contextId) ?? 0) !== 0;
   }
 
   private buildTelemetryStateKey(contextId: string): string {
@@ -676,47 +677,18 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
       case "play-pause": {
         const current = this.getCurrentSpeed();
 
-        if (current.speed > 0) {
-          // Playing forward (any speed) → pause, remember slow-mo speeds
-          if (current.slowMotion) {
-            this.pausedSpeed = current;
-          }
-
+        if (current.speed !== 0) {
+          // Any non-zero speed → pause
           const success = replay.pause();
           this.setLocalSpeed(0, false);
           this.logger.info("Pause executed");
-          this.logger.debug(`Result: ${success}, stored speed: ${current.speed}`);
-        } else if (current.speed === 0) {
-          // Paused → play forward, restore slow-motion speed or 1x
-          const stored = this.pausedSpeed;
-          let success: boolean;
-
-          if (stored) {
-            success = replay.setPlaySpeed(stored.speed, stored.slowMotion);
-            this.setLocalSpeed(stored.speed, stored.slowMotion);
-            this.logger.info("Play executed with restored speed");
-            this.logger.debug(`Result: ${success}, speed: ${stored.speed}, slowMotion: ${stored.slowMotion}`);
-          } else {
-            success = replay.play();
-            this.setLocalSpeed(1, false);
-            this.logger.info("Play executed");
-            this.logger.debug(`Result: ${success}`);
-          }
-
-          this.pausedSpeed = null;
-        } else if (current.slowMotion) {
-          // Slow-mo backward → mirror to forward slow-mo
-          const mirroredSpeed = Math.abs(current.speed);
-          const success = replay.setPlaySpeed(mirroredSpeed, true);
-          this.setLocalSpeed(mirroredSpeed, true);
-          this.logger.info("Play executed (mirrored slow-mo)");
-          this.logger.debug(`Result: ${success}, speed: ${mirroredSpeed}`);
+          this.logger.debug(`Result: ${success}, was speed: ${current.speed}`);
         } else {
-          // Rewind/backward at non-slow-mo → reset to 1x
+          // Paused → play forward at 1x
           const success = replay.play();
           this.setLocalSpeed(1, false);
-          this.logger.info("Play executed (reset to 1x)");
-          this.logger.debug(`Result: ${success}, was speed: ${current.speed}`);
+          this.logger.info("Play executed");
+          this.logger.debug(`Result: ${success}`);
         }
 
         break;
@@ -724,47 +696,18 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
       case "play-backward": {
         const current = this.getCurrentSpeed();
 
-        if (current.speed < 0) {
-          // Playing backward (any speed) → pause, remember slow-mo speeds
-          if (current.slowMotion) {
-            this.pausedSpeed = current;
-          }
-
+        if (current.speed !== 0) {
+          // Any non-zero speed → pause
           const success = replay.pause();
           this.setLocalSpeed(0, false);
           this.logger.info("Pause backward executed");
-          this.logger.debug(`Result: ${success}, stored speed: ${current.speed}`);
-        } else if (current.speed === 0) {
-          // Paused → play backward, restore slow-motion reverse speed or -1x
-          const stored = this.pausedSpeed;
-          let success: boolean;
-
-          if (stored) {
-            success = replay.setPlaySpeed(stored.speed, stored.slowMotion);
-            this.setLocalSpeed(stored.speed, stored.slowMotion);
-            this.logger.info("Play backward executed with restored speed");
-            this.logger.debug(`Result: ${success}, speed: ${stored.speed}, slowMotion: ${stored.slowMotion}`);
-          } else {
-            success = replay.setPlaySpeed(-1);
-            this.setLocalSpeed(-1, false);
-            this.logger.info("Play backward executed");
-            this.logger.debug(`Result: ${success}`);
-          }
-
-          this.pausedSpeed = null;
-        } else if (current.slowMotion) {
-          // Slow-mo forward → mirror to backward slow-mo
-          const mirroredSpeed = -Math.abs(current.speed);
-          const success = replay.setPlaySpeed(mirroredSpeed, true);
-          this.setLocalSpeed(mirroredSpeed, true);
-          this.logger.info("Play backward executed (mirrored slow-mo)");
-          this.logger.debug(`Result: ${success}, speed: ${mirroredSpeed}`);
+          this.logger.debug(`Result: ${success}, was speed: ${current.speed}`);
         } else {
-          // FF/forward at non-slow-mo → reset to -1x
+          // Paused → play backward at -1x
           const success = replay.setPlaySpeed(-1);
           this.setLocalSpeed(-1, false);
-          this.logger.info("Play backward executed (reset to -1x)");
-          this.logger.debug(`Result: ${success}, was speed: ${current.speed}`);
+          this.logger.info("Play backward executed");
+          this.logger.debug(`Result: ${success}`);
         }
 
         break;
@@ -772,7 +715,6 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
       case "stop": {
         const success = replay.pause();
         this.setLocalSpeed(0, false);
-        this.pausedSpeed = null;
         this.logger.info("Stop executed");
         this.logger.debug(`Result: ${success}`);
         break;
@@ -1047,6 +989,10 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
         break;
       }
     }
+
+    // Re-render all telemetry-driven buttons (play-pause, play-backward, speed-display)
+    // so cross-button state stays in sync (e.g., pressing play-backward updates the play-pause icon)
+    this.updateAllTelemetryDisplays();
   }
 
   private executeDialDown(contextId: string, settings: ReplayControlSettings): void {
@@ -1056,8 +1002,10 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
     if (mode === "speed-increase" || mode === "speed-decrease") {
       // Speed modes: encoder push resets to normal speed
       const success = replay.play();
+      this.setLocalSpeed(1, false);
       this.logger.info("Speed reset to normal");
       this.logger.debug(`Result: ${success}`);
+      this.updateAllTelemetryDisplays();
     } else if (mode === "play-pause" || mode === "play-backward") {
       this.executeMode(contextId, settings);
     } else if (mode === "set-speed") {
@@ -1073,8 +1021,10 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
     } else {
       // Transport modes: encoder push plays
       const success = replay.play();
+      this.setLocalSpeed(1, false);
       this.logger.info("Play executed (dial)");
       this.logger.debug(`Result: ${success}`);
+      this.updateAllTelemetryDisplays();
     }
   }
 
@@ -1131,7 +1081,7 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
     ev: IDeckWillAppearEvent<ReplayControlSettings> | IDeckDidReceiveSettingsEvent<ReplayControlSettings>,
     settings: ReplayControlSettings,
   ): Promise<void> {
-    const isPlaying = this.shouldShowPause(ev.action.id, settings.mode);
+    const isPlaying = this.shouldShowPause(ev.action.id);
     const speed = this.replaySpeed.get(ev.action.id);
     const slowMo = this.replaySlowMotion.get(ev.action.id);
     const svgDataUri = generateReplayControlSvg(settings, isPlaying, speed, slowMo);
@@ -1140,10 +1090,18 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
     this.setRegenerateCallback(ev.action.id, () => generateReplayControlSvg(settings, isPlaying, speed, slowMo));
   }
 
+  private updateAllTelemetryDisplays(): void {
+    for (const [contextId, settings] of this.activeContexts) {
+      if (TELEMETRY_DISPLAY_MODES.has(settings.mode)) {
+        this.updateDisplayFromTelemetry(contextId, settings);
+      }
+    }
+  }
+
   private async updateDisplayFromTelemetry(contextId: string, settings: ReplayControlSettings): Promise<void> {
     if (!TELEMETRY_DISPLAY_MODES.has(settings.mode)) return;
 
-    const isPlaying = this.shouldShowPause(contextId, settings.mode);
+    const isPlaying = this.shouldShowPause(contextId);
     const speed = this.replaySpeed.get(contextId) ?? 0;
     const slowMo = this.replaySlowMotion.get(contextId) ?? false;
     const bo = settings.borderOverrides;


### PR DESCRIPTION
## Related Issue

Fixes #237

## What changed?

- Removed speed memory (`pausedSpeed`) — play always starts at 1x, no restored speeds
- Simplified play-pause and play-backward to two-branch logic: any non-zero speed pauses, paused state plays at 1x/-1x
- Fixed disconnect handling: `updateTelemetryState` resets speed to 0 when telemetry is null, so the icon shows Play state
- Added `updateAllTelemetryDisplays()` so all play/pause buttons re-render after any speed change (cross-button sync)
- Simplified `shouldShowPause` — both modes show Pause when playing in any direction
- Updated titles: play-pause → "PLAY / PAUSE", play-backward → "PLAY BACKW"
- Fixed `executeDialDown` to call `setLocalSpeed` and update displays for dial-push speed changes

## How to test

1. Place both Play/Pause and Play Backward buttons on the Stream Deck
2. Press Play — both should show Pause icon
3. Press Play Backward — should pause, both icons return to Play state
4. Press Play Backward again — should play backward, both show Pause icon
5. Disconnect from iRacing — icons should reset to Play state
6. Verify fast-forward/rewind progressive speed still works as before

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [N/A] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed replay control button synchronization to keep displays consistent across multiple contexts.

* **Changes**
  * Updated replay control button labels for improved readability.
  * Simplified pause/play speed behavior for more straightforward control interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->