### PR TITLE
feat(build): generate build-time config.json with version and platform (#314)

### DIFF
--- a/packages/deck-core/src/index.ts
+++ b/packages/deck-core/src/index.ts
@@ -194,3 +194,14 @@ export {
 
 // Key binding utilities
 export { formatKeyBinding, parseKeyBinding, parseBinding } from "./key-binding-utils.js";
+
+// Plugin config singleton
+export {
+  initPluginConfig,
+  getPluginVersion,
+  getPluginPlatform,
+  isPluginConfigInitialized,
+  _resetPluginConfig,
+  type PluginConfig,
+  type PluginPlatform,
+} from "./plugin-config.js";

--- a/packages/deck-core/src/index.ts
+++ b/packages/deck-core/src/index.ts
@@ -203,5 +203,4 @@ export {
   isPluginConfigInitialized,
   _resetPluginConfig,
   type PluginConfig,
-  type PluginPlatform,
 } from "./plugin-config.js";

--- a/packages/deck-core/src/plugin-config.test.ts
+++ b/packages/deck-core/src/plugin-config.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  _resetPluginConfig,
+  getPluginPlatform,
+  getPluginVersion,
+  initPluginConfig,
+  isPluginConfigInitialized,
+} from "./plugin-config.js";
+
+describe("plugin-config", () => {
+  afterEach(() => {
+    _resetPluginConfig();
+  });
+
+  describe("initPluginConfig", () => {
+    it("should initialize with the provided config", () => {
+      initPluginConfig({ version: "1.13.0", platform: "stream-deck" });
+
+      expect(getPluginVersion()).toBe("1.13.0");
+      expect(getPluginPlatform()).toBe("stream-deck");
+    });
+
+    it("should throw if called twice", () => {
+      initPluginConfig({ version: "1.13.0", platform: "stream-deck" });
+
+      expect(() => initPluginConfig({ version: "1.14.0", platform: "mirabox" })).toThrow("already initialized");
+    });
+  });
+
+  describe("getPluginVersion", () => {
+    it("should throw if not initialized", () => {
+      expect(() => getPluginVersion()).toThrow("not initialized");
+    });
+
+    it("should return the version string", () => {
+      initPluginConfig({ version: "2.0.0", platform: "stream-deck" });
+
+      expect(getPluginVersion()).toBe("2.0.0");
+    });
+  });
+
+  describe("getPluginPlatform", () => {
+    it("should throw if not initialized", () => {
+      expect(() => getPluginPlatform()).toThrow("not initialized");
+    });
+
+    it("should return stream-deck platform", () => {
+      initPluginConfig({ version: "1.0.0", platform: "stream-deck" });
+
+      expect(getPluginPlatform()).toBe("stream-deck");
+    });
+
+    it("should return mirabox platform", () => {
+      initPluginConfig({ version: "1.0.0", platform: "mirabox" });
+
+      expect(getPluginPlatform()).toBe("mirabox");
+    });
+  });
+
+  describe("isPluginConfigInitialized", () => {
+    it("should return false before initialization", () => {
+      expect(isPluginConfigInitialized()).toBe(false);
+    });
+
+    it("should return true after initialization", () => {
+      initPluginConfig({ version: "1.0.0", platform: "stream-deck" });
+
+      expect(isPluginConfigInitialized()).toBe(true);
+    });
+  });
+
+  describe("_resetPluginConfig", () => {
+    it("should allow re-initialization after reset", () => {
+      initPluginConfig({ version: "1.0.0", platform: "stream-deck" });
+      _resetPluginConfig();
+
+      initPluginConfig({ version: "2.0.0", platform: "mirabox" });
+
+      expect(getPluginVersion()).toBe("2.0.0");
+      expect(getPluginPlatform()).toBe("mirabox");
+    });
+  });
+});

--- a/packages/deck-core/src/plugin-config.ts
+++ b/packages/deck-core/src/plugin-config.ts
@@ -9,11 +9,9 @@
  * 2. Import getPluginVersion() wherever the version is needed
  */
 
-export type PluginPlatform = "stream-deck" | "mirabox";
-
 export interface PluginConfig {
   version: string;
-  platform: PluginPlatform;
+  platform: string;
 }
 
 let config: PluginConfig | null = null;
@@ -47,11 +45,11 @@ export function getPluginVersion(): string {
 }
 
 /**
- * Get the plugin platform ("stream-deck" or "mirabox").
+ * Get the plugin platform identifier (e.g., "stream-deck", "mirabox").
  *
  * @throws Error if initPluginConfig() has not been called
  */
-export function getPluginPlatform(): PluginPlatform {
+export function getPluginPlatform(): string {
   if (!config) {
     throw new Error("Plugin config not initialized. Call initPluginConfig() first.");
   }

--- a/packages/deck-core/src/plugin-config.ts
+++ b/packages/deck-core/src/plugin-config.ts
@@ -1,0 +1,74 @@
+/**
+ * Plugin Config Singleton
+ *
+ * Stores build-time plugin configuration (version, future feature flags).
+ * Each plugin process has its own instance.
+ *
+ * Usage:
+ * 1. Call initPluginConfig() once at plugin startup with config read from config.json
+ * 2. Import getPluginVersion() wherever the version is needed
+ */
+
+export type PluginPlatform = "stream-deck" | "mirabox";
+
+export interface PluginConfig {
+  version: string;
+  platform: PluginPlatform;
+}
+
+let config: PluginConfig | null = null;
+
+/**
+ * Initialize the plugin config singleton.
+ * Should be called once at plugin startup.
+ *
+ * @param pluginConfig - Config object read from config.json
+ * @throws Error if called more than once
+ */
+export function initPluginConfig(pluginConfig: PluginConfig): void {
+  if (config) {
+    throw new Error("Plugin config already initialized. initPluginConfig() should only be called once.");
+  }
+
+  config = pluginConfig;
+}
+
+/**
+ * Get the plugin version string (e.g., "1.13.0").
+ *
+ * @throws Error if initPluginConfig() has not been called
+ */
+export function getPluginVersion(): string {
+  if (!config) {
+    throw new Error("Plugin config not initialized. Call initPluginConfig() first.");
+  }
+
+  return config.version;
+}
+
+/**
+ * Get the plugin platform ("stream-deck" or "mirabox").
+ *
+ * @throws Error if initPluginConfig() has not been called
+ */
+export function getPluginPlatform(): PluginPlatform {
+  if (!config) {
+    throw new Error("Plugin config not initialized. Call initPluginConfig() first.");
+  }
+
+  return config.platform;
+}
+
+/**
+ * Check if plugin config has been initialized.
+ */
+export function isPluginConfigInitialized(): boolean {
+  return config !== null;
+}
+
+/**
+ * Reset the plugin config singleton (for testing only).
+ */
+export function _resetPluginConfig(): void {
+  config = null;
+}

--- a/packages/mirabox-plugin/rollup.config.mjs
+++ b/packages/mirabox-plugin/rollup.config.mjs
@@ -9,6 +9,7 @@ import { copyFileSync, cpSync, existsSync, mkdirSync, readFileSync, readdirSync,
 import { piTemplatePlugin } from "../stream-deck-plugin/src/build/pi-template-plugin.mjs";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const rootPackageJson = JSON.parse(readFileSync(path.resolve(__dirname, "../../package.json"), "utf-8"));
 const iconsPackagePath = path.resolve(__dirname, "../icons");
 const elgatoPluginPath = path.resolve(__dirname, "../stream-deck-plugin");
 
@@ -138,7 +139,7 @@ const config = {
 			templatesDir: path.join(elgatoPluginPath, "src/pi"),
 			outputDir: `${sdPlugin}/ui`,
 			partialsDir: path.join(elgatoPluginPath, "src/pi-templates/partials"),
-			manifestPath: `${sdPlugin}/manifest.json`,
+			version: rootPackageJson.version,
 		}),
 		// Copy static assets (imgs/, JS files) from the Elgato plugin
 		copyAssetsPlugin(sdPlugin),
@@ -197,6 +198,16 @@ const config = {
 					}
 				};
 				this.emitFile({ fileName: "package.json", source: JSON.stringify(pkg, null, 2), type: "asset" });
+			},
+		},
+		{
+			name: "emit-plugin-config",
+			generateBundle() {
+				const config = {
+					version: rootPackageJson.version,
+					platform: "mirabox",
+				};
+				this.emitFile({ fileName: "config.json", source: JSON.stringify(config, null, 2), type: "asset" });
 			},
 		},
 	],

--- a/packages/mirabox-plugin/src/plugin.ts
+++ b/packages/mirabox-plugin/src/plugin.ts
@@ -82,10 +82,20 @@ import {
   initializeKeyboard,
   initializeSDK,
   initializeSimHub,
+  initPluginConfig,
+  type PluginConfig,
 } from "@iracedeck/deck-core";
 import { IRacingNative } from "@iracedeck/iracing-native";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { focusIRacingIfEnabled, initWindowFocus } from "./shared/window-focus.js";
+
+// Load build-time config (version, platform)
+const __binDir = dirname(fileURLToPath(import.meta.url));
+const pluginConfig: PluginConfig = JSON.parse(readFileSync(join(__binDir, "config.json"), "utf-8"));
+initPluginConfig(pluginConfig);
 
 // Create the VSDinside platform adapter
 const adapter = new VSDPlatformAdapter();

--- a/packages/stream-deck-plugin/.gitignore
+++ b/packages/stream-deck-plugin/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 
 # Generated PI HTML (built from src/pi/*.ejs templates)
 *.sdPlugin/ui/*.html
+

--- a/packages/stream-deck-plugin/rollup.config.mjs
+++ b/packages/stream-deck-plugin/rollup.config.mjs
@@ -9,6 +9,7 @@ import { readFileSync, readdirSync } from "node:fs";
 import { piTemplatePlugin } from "./src/build/pi-template-plugin.mjs";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const rootPackageJson = JSON.parse(readFileSync(path.resolve(__dirname, "../../package.json"), "utf-8"));
 const iconsPackagePath = path.resolve(__dirname, "../icons");
 const actionsPackagePath = path.resolve(__dirname, "../actions/src");
 
@@ -80,7 +81,7 @@ const config = {
 			templatesDir: "src/pi",
 			outputDir: `${sdPlugin}/ui`,
 			partialsDir: "src/pi-templates/partials",
-			manifestPath: `${sdPlugin}/manifest.json`,
+			version: rootPackageJson.version,
 		}),
 		{
 			name: "watch-externals",
@@ -134,6 +135,16 @@ const config = {
 					}
 				};
 				this.emitFile({ fileName: "package.json", source: JSON.stringify(pkg, null, 2), type: "asset" });
+			},
+		},
+		{
+			name: "emit-plugin-config",
+			generateBundle() {
+				const config = {
+					version: rootPackageJson.version,
+					platform: "stream-deck",
+				};
+				this.emitFile({ fileName: "config.json", source: JSON.stringify(config, null, 2), type: "asset" });
 			},
 		},
 	],

--- a/packages/stream-deck-plugin/src/build/pi-template-plugin.mjs
+++ b/packages/stream-deck-plugin/src/build/pi-template-plugin.mjs
@@ -95,21 +95,8 @@ function createTemplateRequire(templateDir) {
 /**
  * Rollup plugin for compiling EJS Property Inspector templates
  */
-/**
- * Read the plugin version from manifest.json and trim to semver (first 3 segments).
- * Stream Deck manifests use 4-segment versions (e.g., "1.8.0.0") — display as "1.8.0".
- */
-function readManifestVersion(manifestPath) {
-  if (!manifestPath || !existsSync(manifestPath)) return undefined;
-  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
-  const raw = manifest.Version;
-  if (!raw) return undefined;
-  return raw.split(".").slice(0, 3).join(".");
-}
-
 export function piTemplatePlugin(options) {
-  const { templatesDir, outputDir, partialsDir, additionalPartialsDirs = [], manifestPath } = options;
-  const version = readManifestVersion(manifestPath);
+  const { templatesDir, outputDir, partialsDir, additionalPartialsDirs = [], version } = options;
 
   // Build list of partial search directories
   const partialSearchDirs = [partialsDir, ...additionalPartialsDirs].filter((d) => existsSync(d));
@@ -184,7 +171,7 @@ export function piTemplatePlugin(options) {
           const html = ejs.render(templateContent, {
             // Make data files available as 'data' object
             data: dataFiles,
-            // Plugin version from manifest.json (trimmed)
+            // Plugin version from package.json
             version: version || "unknown",
             // Documentation URL for this action (empty string if not mapped)
             docsUrl,

--- a/packages/stream-deck-plugin/src/build/pi-template-plugin.mjs
+++ b/packages/stream-deck-plugin/src/build/pi-template-plugin.mjs
@@ -98,6 +98,10 @@ function createTemplateRequire(templateDir) {
 export function piTemplatePlugin(options) {
   const { templatesDir, outputDir, partialsDir, additionalPartialsDirs = [], version } = options;
 
+  if (!version) {
+    throw new Error("piTemplatePlugin: version option is required");
+  }
+
   // Build list of partial search directories
   const partialSearchDirs = [partialsDir, ...additionalPartialsDirs].filter((d) => existsSync(d));
 
@@ -172,7 +176,7 @@ export function piTemplatePlugin(options) {
             // Make data files available as 'data' object
             data: dataFiles,
             // Plugin version from package.json
-            version: version || "unknown",
+            version: version,
             // Documentation URL for this action (empty string if not mapped)
             docsUrl,
             // Also expose a require function for inline requires
@@ -180,7 +184,7 @@ export function piTemplatePlugin(options) {
             // Expose locals for checking if variables are defined
             locals: {
               data: dataFiles,
-              version: version || "unknown",
+              version: version,
               docsUrl,
             },
           }, {

--- a/packages/stream-deck-plugin/src/build/pi-template-plugin.test.ts
+++ b/packages/stream-deck-plugin/src/build/pi-template-plugin.test.ts
@@ -39,6 +39,7 @@ describe("piTemplatePlugin", () => {
       templatesDir,
       outputDir,
       partialsDir,
+      version: "1.0.0",
     });
 
     // Mock rollup context
@@ -81,6 +82,7 @@ describe("piTemplatePlugin", () => {
       templatesDir,
       outputDir,
       partialsDir,
+      version: "1.0.0",
     });
 
     const context = {
@@ -118,6 +120,7 @@ describe("piTemplatePlugin", () => {
       templatesDir,
       outputDir,
       partialsDir,
+      version: "1.0.0",
     });
 
     const context = {
@@ -150,6 +153,7 @@ describe("piTemplatePlugin", () => {
       templatesDir,
       outputDir,
       partialsDir,
+      version: "1.0.0",
     });
 
     const context = {
@@ -182,6 +186,7 @@ describe("piTemplatePlugin", () => {
       templatesDir,
       outputDir,
       partialsDir,
+      version: "1.0.0",
     });
 
     const context = {
@@ -207,6 +212,7 @@ describe("piTemplatePlugin", () => {
       templatesDir: path.join(testDir, "nonexistent"),
       outputDir,
       partialsDir,
+      version: "1.0.0",
     });
 
     const context = {
@@ -240,6 +246,7 @@ describe("piTemplatePlugin", () => {
       templatesDir,
       outputDir,
       partialsDir,
+      version: "1.0.0",
     });
 
     const context = {

--- a/packages/stream-deck-plugin/src/plugin.ts
+++ b/packages/stream-deck-plugin/src/plugin.ts
@@ -75,10 +75,20 @@ import {
   initializeKeyboard,
   initializeSDK,
   initializeSimHub,
+  initPluginConfig,
+  type PluginConfig,
 } from "@iracedeck/deck-core";
 import { IRacingNative } from "@iracedeck/iracing-native";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { focusIRacingIfEnabled, initWindowFocus } from "./shared/index.js";
+
+// Load build-time config (version, platform)
+const __binDir = dirname(fileURLToPath(import.meta.url));
+const pluginConfig: PluginConfig = JSON.parse(readFileSync(join(__binDir, "config.json"), "utf-8"));
+initPluginConfig(pluginConfig);
 
 // Create the Elgato platform adapter
 const adapter = new ElgatoPlatformAdapter(streamDeck);


### PR DESCRIPTION
## Related Issue

Fixes #314

## What changed?

- Added `plugin-config.ts` singleton to `@iracedeck/deck-core` with `initPluginConfig()`, `getPluginVersion()`, and `getPluginPlatform()`
- Both plugin Rollup configs now emit `config.json` to `bin/` with `{ version, platform }` read from root `package.json`
- Both `plugin.ts` files read `config.json` at startup and call `initPluginConfig()`
- PI version display now reads version directly from `package.json` instead of `manifest.json`

## How to test

1. Run `pnpm build` — verify `config.json` is generated in both `sdPlugin/bin/` directories
2. Check contents: stream-deck-plugin has `"platform": "stream-deck"`, mirabox-plugin has `"platform": "mirabox"`
3. Both should have `"version": "1.12.0"`
4. Run `pnpm test` — all tests pass including new `plugin-config.test.ts`
5. Verify PI version footer still displays correctly in Stream Deck

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed plugin configuration API to read version and platform at runtime.
  * Build updated to emit platform-specific config assets and to load them during plugin startup.

* **Tests**
  * Added test suite validating plugin configuration initialization, state handling, and accessors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->