### PR TITLE
feat(actions): add addedWithVersion to CommonSettings for version-dependent defaults (#315)

### DIFF
--- a/packages/deck-core/src/base-action.ts
+++ b/packages/deck-core/src/base-action.ts
@@ -302,9 +302,13 @@ export abstract class BaseAction<T = Record<string, unknown>> implements IDeckAc
     // Note: setSettings triggers onDidReceiveSettings — benign since it only re-reads
     // the same settings that were just written.
     if (!settings.addedWithVersion && isPluginConfigInitialized()) {
-      const version = getPluginVersion();
-      this.logger.debug(`Persisting addedWithVersion=${version} for context ${ev.action.id}`);
-      await ev.action.setSettings({ ...settings, addedWithVersion: version });
+      try {
+        const version = getPluginVersion();
+        this.logger.debug(`Persisting addedWithVersion=${version} for context ${ev.action.id}`);
+        await ev.action.setSettings({ ...settings, addedWithVersion: version });
+      } catch (err) {
+        this.logger.warn(`Failed to persist addedWithVersion for context ${ev.action.id}: ${err}`);
+      }
     }
 
     if (settings.flagsOverlay === true || settings.flagsOverlay === "true") {

--- a/packages/deck-core/src/base-action.ts
+++ b/packages/deck-core/src/base-action.ts
@@ -11,6 +11,7 @@ import { type ILogger, silentLogger } from "@iracedeck/logger";
 
 import { getGlobalSettings, onGlobalSettingsChange } from "./global-settings.js";
 import { applyInactiveOverlay, svgToDataUri } from "./overlay-utils.js";
+import { getPluginVersion, isPluginConfigInitialized } from "./plugin-config.js";
 import { getController } from "./sdk-singleton.js";
 import type {
   IDeckActionContext,
@@ -290,12 +291,21 @@ export abstract class BaseAction<T = Record<string, unknown>> implements IDeckAc
 
   /**
    * Called when the action appears on the device.
-   * Tracks flag overlay opt-in from settings.
+   * Persists addedWithVersion on first appearance and tracks flag overlay opt-in.
    *
    * Subclasses should call `super.onWillAppear(ev)` if they override this.
    */
   async onWillAppear(ev: IDeckWillAppearEvent<T>): Promise<void> {
     const settings = ev.payload.settings as Record<string, unknown>;
+
+    // Persist addedWithVersion on first appearance (missing = pre-existing instance).
+    // Note: setSettings triggers onDidReceiveSettings — benign since it only re-reads
+    // the same settings that were just written.
+    if (!settings.addedWithVersion && isPluginConfigInitialized()) {
+      const version = getPluginVersion();
+      this.logger.debug(`Persisting addedWithVersion=${version} for context ${ev.action.id}`);
+      await ev.action.setSettings({ ...settings, addedWithVersion: version });
+    }
 
     if (settings.flagsOverlay === true || settings.flagsOverlay === "true") {
       this.flagOverlayContexts.add(ev.action.id);

--- a/packages/deck-core/src/common-settings.ts
+++ b/packages/deck-core/src/common-settings.ts
@@ -153,6 +153,7 @@ export const GraphicOverridesSchema = z
 export type GraphicOverrides = z.infer<typeof GraphicOverridesSchema>;
 
 export const CommonSettings = z.object({
+  addedWithVersion: z.string().default("0.0.0"),
   flagsOverlay: z
     .union([z.boolean(), z.string()])
     .transform((val) => val === true || val === "true")

--- a/packages/stream-deck-plugin/src/shared/base-action.test.ts
+++ b/packages/stream-deck-plugin/src/shared/base-action.test.ts
@@ -1,4 +1,10 @@
-import { applyInactiveOverlay, BaseAction, overlayConfig } from "@iracedeck/deck-core";
+import {
+  _resetPluginConfig,
+  applyInactiveOverlay,
+  BaseAction,
+  initPluginConfig,
+  overlayConfig,
+} from "@iracedeck/deck-core";
 import type { FlagInfo } from "@iracedeck/iracing-sdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -8,6 +14,7 @@ function createMockKeyAction(id: string) {
     id,
     isKey: vi.fn().mockReturnValue(true),
     setImage: vi.fn().mockResolvedValue(undefined),
+    setSettings: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -424,6 +431,39 @@ describe("BaseAction", () => {
 
       await testAction.onDidReceiveSettings(ev2);
       expect(testAction.isFlagOverlayEnabled("context-1")).toBe(true);
+    });
+  });
+
+  describe("addedWithVersion persistence", () => {
+    afterEach(() => {
+      _resetPluginConfig();
+    });
+
+    it("should persist addedWithVersion on first appear when missing", async () => {
+      initPluginConfig({ version: "1.13.0", platform: "stream-deck" });
+      const ev = createMockEvent("context-1", {}) as any;
+
+      await testAction.onWillAppear(ev);
+
+      expect(ev.action.setSettings).toHaveBeenCalledOnce();
+      expect(ev.action.setSettings).toHaveBeenCalledWith(expect.objectContaining({ addedWithVersion: "1.13.0" }));
+    });
+
+    it("should not overwrite existing addedWithVersion", async () => {
+      initPluginConfig({ version: "1.14.0", platform: "stream-deck" });
+      const ev = createMockEvent("context-1", { addedWithVersion: "1.12.0" }) as any;
+
+      await testAction.onWillAppear(ev);
+
+      expect(ev.action.setSettings).not.toHaveBeenCalled();
+    });
+
+    it("should not persist when plugin config is not initialized", async () => {
+      const ev = createMockEvent("context-1", {}) as any;
+
+      await testAction.onWillAppear(ev);
+
+      expect(ev.action.setSettings).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Related Issue

Fixes #315

## What changed?

- Added `addedWithVersion` field to `CommonSettings` (Zod default `"0.0.0"` for pre-existing instances)
- `BaseAction.onWillAppear()` persists the current plugin version (from `config.json` via `getPluginVersion()`) on first appearance when the field is missing
- Existing instances get `"0.0.0"`, new instances get the current plugin version (e.g., `"1.13.0"`)
- This enables version-dependent setting defaults: `semver.lt(settings.addedWithVersion, "1.13.0") ? oldDefault : newDefault`

## How to test

1. Run `pnpm test` — all tests pass including 3 new tests for version persistence
2. Verify behavior: action with no `addedWithVersion` in settings → persisted on first `onWillAppear`
3. Verify behavior: action with existing `addedWithVersion` → not overwritten
4. Verify behavior: plugin config not initialized → no persistence attempted

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Actions automatically capture and persist the plugin version when first added to a device, improving version tracking and visibility across different plugin deployments.

* **Tests**
  * Added test coverage for the automatic version tracking functionality, including verification of initialization behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->