### PR TITLE
docs(website): convert action pages to per-mode format (#319)

### DIFF
--- a/.claude/rules/website-action-docs.md
+++ b/.claude/rules/website-action-docs.md
@@ -32,6 +32,10 @@ Description of what this mode does.
 
 **Encoder:** Describe rotation behavior, or "No rotation support."
 
+**Keyboard:** Default keyboard binding: `Key`. | No default key binding. | No keyboard support.
+
+**SDK support:** Yes. | No.
+
 **Settings:** No additional settings.
 
 ---
@@ -41,6 +45,10 @@ Description of what this mode does.
 Description of what this mode does.
 
 **Encoder:** Describe rotation behavior, or "No rotation support."
+
+**Keyboard:** Default keyboard binding: `Key`. | No default key binding. | No keyboard support.
+
+**SDK support:** Yes. | No.
 
 ##### Setting: Setting Name
 
@@ -60,13 +68,19 @@ Description including default value.
 - Each mode is self-contained — all its settings, encoder behavior, and explanation are within the mode section
 - Repetition across modes is acceptable; clarity over brevity
 
-### Encoder and Settings lines
+### Per-mode lines
 
-- **Encoder** comes before **Settings** within each mode
-- Both use bold labels: `**Encoder:**` and `**Settings:**`
-- Separate them with a blank line so they render on different lines
-- For modes without settings: `**Settings:** No additional settings.`
-- For modes with settings: omit the **Settings** line and use `##### Setting:` subheaders instead
+Each mode section must include the following bold-label lines, in this order, separated by blank lines:
+
+1. `**Encoder:**` — rotation behavior, or `No rotation support.`
+2. `**Keyboard:**` — one of:
+   - `Default keyboard binding: \`Key\`.` (action ships with a default — e.g., `F1`, `Ctrl+Shift+R`)
+   - `No default key binding.` (action uses a configurable keyboard shortcut but ships without a default; user must set both the iRacing binding and the action binding)
+   - `No keyboard support.` (mode does not use the keyboard at all — typically SDK-only)
+3. `**SDK support:**` — `Yes.` or `No.` Reflects whether this specific mode uses an iRacing SDK command (`getCommands().*`) versus a keyboard fallback.
+4. `**Settings:**` — `No additional settings.` when there are none. When the mode has settings, omit this line and use `##### Setting: <name>` subheaders instead.
+
+`**Keyboard:**` and `**SDK support:**` are mode-specific: within a single action, different modes may use SDK for some behaviors and keyboard for others. Document each mode as it actually behaves in code — `packages/actions/src/actions/<action>.ts` (look for `getCommands()` vs `tapBinding`/`holdBinding`) is the source of truth for SDK usage; `packages/stream-deck-plugin/src/pi/<action>.ejs` (the `default` attribute on `ird-key-binding`) and `packages/stream-deck-plugin/src/pi/data/key-bindings.json` are the source of truth for default keys.
 
 ### Setting subheaders
 

--- a/.claude/rules/website-action-docs.md
+++ b/.claude/rules/website-action-docs.md
@@ -30,13 +30,13 @@ Select the mode from the **Action** dropdown in the Property Inspector.
 
 Description of what this mode does.
 
-##### Details
+#### Details
 
 - **Dial:** Describe rotation behavior, or `No rotation support`
 - **Default binding:** `` `Key` ``, or `No default key binding`, or `No keyboard binding`
 - **Telemetry-aware icon:** `Yes` (with a brief note on what updates), or `No`
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -46,17 +46,17 @@ Description of what this mode does.
 
 Description of what this mode does.
 
-##### Details
+#### Details
 
 - **Dial:** Describe rotation behavior, or `No rotation support`
 - **Default binding:** `` `Key` ``, or `No default key binding`, or `No keyboard binding`
 - **Telemetry-aware icon:** `Yes` (with a brief note on what updates), or `No`
 
-##### Setting: Setting Name
+#### Setting: Setting Name
 
 Description including default value. Options as bullet list if applicable.
 
-##### Setting: Another Setting
+#### Setting: Another Setting
 
 Description including default value.
 ```
@@ -72,7 +72,7 @@ Description including default value.
 
 ### Per-mode Details block
 
-Each mode section must include a `##### Details` subheader containing a bullet list with the following items, in order:
+Each mode section must include a `#### Details` subheader containing a bullet list with the following items, in order:
 
 1. **Dial:** rotation behavior, or `No rotation support`
 2. **Default binding:** one of:
@@ -87,12 +87,12 @@ The Details block is mode-specific: within a single action, different modes may 
 
 ### Settings block
 
-- For modes without settings, add `##### Settings` followed by a single bullet: `- No additional settings`
-- For modes with settings, omit the `##### Settings` wrapper and use `##### Setting: <name>` subheaders directly under the Details block.
+- For modes without settings, add `#### Settings` followed by a single bullet: `- No additional settings`
+- For modes with settings, omit the `#### Settings` wrapper and use `#### Setting: <name>` subheaders directly under the Details block.
 
 ### Setting subheaders
 
-- Use `#####` (h5) with prefix: `##### Setting: Setting Name`
+- Use `####` (h4) with prefix: `#### Setting: Setting Name`
 - Include the default value in the description text (not in a table)
 - List options as bullet points with bold option names: `- **Option** — description`
 - Use `:::tip` blocks for recommendations

--- a/.claude/rules/website-action-docs.md
+++ b/.claude/rules/website-action-docs.md
@@ -30,13 +30,15 @@ Select the mode from the **Action** dropdown in the Property Inspector.
 
 Description of what this mode does.
 
-**Encoder:** Describe rotation behavior, or "No rotation support."
+##### Details
 
-**Keyboard:** Default keyboard binding: `Key`. | No default key binding. | No keyboard support.
+- **Dial:** Describe rotation behavior, or `No rotation support`
+- **Default binding:** `` `Key` ``, or `No default key binding`, or `No keyboard binding`
+- **Telemetry-aware icon:** `Yes` (with a brief note on what updates), or `No`
 
-**SDK support:** Yes. | No.
+##### Settings
 
-**Settings:** No additional settings.
+- No additional settings
 
 ---
 
@@ -44,11 +46,11 @@ Description of what this mode does.
 
 Description of what this mode does.
 
-**Encoder:** Describe rotation behavior, or "No rotation support."
+##### Details
 
-**Keyboard:** Default keyboard binding: `Key`. | No default key binding. | No keyboard support.
-
-**SDK support:** Yes. | No.
+- **Dial:** Describe rotation behavior, or `No rotation support`
+- **Default binding:** `` `Key` ``, or `No default key binding`, or `No keyboard binding`
+- **Telemetry-aware icon:** `Yes` (with a brief note on what updates), or `No`
 
 ##### Setting: Setting Name
 
@@ -65,22 +67,28 @@ Description including default value.
 
 - Each mode gets its own `###` subheader under `## Modes`
 - Modes are separated by horizontal rules (`---`), no trailing rule after the last mode
-- Each mode is self-contained — all its settings, encoder behavior, and explanation are within the mode section
+- Each mode is self-contained — all its settings, dial behavior, and explanation are within the mode section
 - Repetition across modes is acceptable; clarity over brevity
 
-### Per-mode lines
+### Per-mode Details block
 
-Each mode section must include the following bold-label lines, in this order, separated by blank lines:
+Each mode section must include a `##### Details` subheader containing a bullet list with the following items, in order:
 
-1. `**Encoder:**` — rotation behavior, or `No rotation support.`
-2. `**Keyboard:**` — one of:
-   - `Default keyboard binding: \`Key\`.` (action ships with a default — e.g., `F1`, `Ctrl+Shift+R`)
-   - `No default key binding.` (action uses a configurable keyboard shortcut but ships without a default; user must set both the iRacing binding and the action binding)
-   - `No keyboard support.` (mode does not use the keyboard at all — typically SDK-only)
-3. `**SDK support:**` — `Yes.` or `No.` Reflects whether this specific mode uses an iRacing SDK command (`getCommands().*`) versus a keyboard fallback.
-4. `**Settings:**` — `No additional settings.` when there are none. When the mode has settings, omit this line and use `##### Setting: <name>` subheaders instead.
+1. **Dial:** rotation behavior, or `No rotation support`
+2. **Default binding:** one of:
+   - `` `Key` `` — action ships with a default keyboard binding (e.g., `` `F1` ``, `` `Ctrl+Shift+R` ``)
+   - `No default key binding` — action uses a configurable keyboard shortcut but ships without a default; user must set both the iRacing binding and the action binding
+   - `No keyboard binding` — mode does not use the keyboard at all (typically SDK-only)
+3. **Telemetry-aware icon:** `Yes` (followed by a short note on what the icon reflects — e.g., "shows the currently selected pit service compound") or `No`. A mode is telemetry-aware when its icon re-renders in response to live `TelemetryData` updates; a mode that only renders a static icon on settings change is `No`.
 
-`**Keyboard:**` and `**SDK support:**` are mode-specific: within a single action, different modes may use SDK for some behaviors and keyboard for others. Document each mode as it actually behaves in code — `packages/actions/src/actions/<action>.ts` (look for `getCommands()` vs `tapBinding`/`holdBinding`) is the source of truth for SDK usage; `packages/stream-deck-plugin/src/pi/<action>.ejs` (the `default` attribute on `ird-key-binding`) and `packages/stream-deck-plugin/src/pi/data/key-bindings.json` are the source of truth for default keys.
+Trailing periods are omitted from each Details bullet value (the bullet list is terse metadata, not prose).
+
+The Details block is mode-specific: within a single action, different modes may use SDK for some behaviors and keyboard for others, and different modes may or may not react to telemetry. Document each mode as it actually behaves in code — `packages/actions/src/actions/<action>.ts` (look for `getCommands()` vs `tapBinding`/`holdBinding`, and whether the mode's icon-generation path subscribes to `sdkController` / reads `TelemetryData`) is the source of truth for how a mode is triggered and whether it is telemetry-aware; `packages/stream-deck-plugin/src/pi/<action>.ejs` (the `default` attribute on `ird-key-binding`) and `packages/stream-deck-plugin/src/pi/data/key-bindings.json` are the source of truth for default keys.
+
+### Settings block
+
+- For modes without settings, add `##### Settings` followed by a single bullet: `- No additional settings`
+- For modes with settings, omit the `##### Settings` wrapper and use `##### Setting: <name>` subheaders directly under the Details block.
 
 ### Setting subheaders
 
@@ -92,5 +100,5 @@ Each mode section must include the following bold-label lines, in this order, se
 ### What NOT to include
 
 - No settings summary tables (Type/Default columns add no value)
-- No separate "Encoder Support" top-level section (documented per mode)
+- No separate "Dial Support" / "Encoder Support" top-level section (documented per mode)
 - No "Properties" table (Action ID, SDK support, etc. — that belongs in internal docs)

--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -7,7 +7,7 @@ description: Use when looking up Stream Deck actions, sub-actions, modes, catego
 
 ## Data File
 
-Complete action definitions (33 actions, 362 controls): `docs/reference/actions.json`
+Complete action definitions (30 documented actions, 254 modes): `docs/reference/actions.json`
 
 Each action entry:
 ```json
@@ -33,87 +33,90 @@ When asked about actions or controls:
 
 ## Category Overview
 
-| Category | Actions | Controls | Description |
-|----------|---------|----------|-------------|
+| Category | Actions | Modes | Description |
+|----------|---------|-------|-------------|
 | Display & Session | 2 | 7 | Live session data: incidents, laps, position, fuel, flags |
-| Driving Controls | 5 | 41 | AI spotter, audio, black boxes, look direction, car control |
-| Cockpit & Interface | 5 | 41 | Wipers, force feedback, splits & reference, telemetry, UI toggles |
-| View & Camera | 8 | 124 | FOV, replay, camera controls, broadcast tools |
+| Driving Controls | 5 | 27 | AI spotter, audio, black boxes, look direction, car control |
+| Cockpit & Interface | 5 | 33 | Wipers, force feedback, splits & reference, telemetry, UI toggles |
+| View & Camera | 5 | 87 | FOV, replay, camera controls, broadcast tools |
 | Media | 1 | 7 | Video recording, screenshots, texture management |
 | Pit Service | 3 | 15 | Fuel, tires, compounds, tearoff, fast repair |
-| Car Setup | 7 | 79 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control |
-| Chat | 2 | 48 | Chat, macros (15), whisper, reply, race admin commands |
-| **Total** | **33** | **362** | |
+| Car Setup | 7 | 44 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control |
+| Communication | 2 | 34 | Chat, macros (15), whisper, reply, race admin commands |
+| **Total** | **30** | **254** | |
+
+Mode counts reflect the PI Mode/Setting dropdown choices documented in each action page. Directional variants (Increase/Decrease) are treated as a single mode with a Direction sub-setting, matching the per-mode website format. Legacy replay actions (Replay Transport, Replay Speed, Replay Navigation) and Camera Cycle (Legacy) still exist in the plugin manifest for backward compatibility but are not counted as documented actions.
 
 ## Actions by Category
 
 ### Display & Session
 
-| Action | Controls | Modes |
-|--------|----------|-------|
+| Action | Modes | Mode values |
+|--------|-------|-------------|
 | Session Info | 6 | incidents, time-remaining, laps, position, fuel, flags |
+| Telemetry Display | 1 | template (Mustache-driven display, no Mode dropdown) |
 
 ### Driving Controls
 
-| Action | Controls | Modes |
-|--------|----------|-------|
+| Action | Modes | Mode values |
+|--------|-------|-------------|
 | AI Spotter Controls | 7 | damage-report, weather-report, toggle-report-laps, announce-leader, louder, quieter, silence |
-| Audio Controls | 6 | 2 categories (voice-chat, master) x 3 actions (volume-up, volume-down, mute) |
-| Black Box Selector | 13 | 11 direct selections + next/previous cycle |
-| Look Direction | 4 | look-left, look-right, look-up, look-down (hold pattern) |
-| Car Control | 10 | starter (hold), ignition, pit-speed-limiter (telemetry-aware), enter-exit-tow (hold), pause-sim, headlight-flash (hold), push-to-pass (telemetry-aware), drs (telemetry-aware), tear-off-visor, escape (hold, direct keyboard, auto-hold option) |
+| Audio Controls | 3 | push-to-talk (hold), voice-chat (with volume-up/down/mute action), master (with volume-up/down action) |
+| Black Box Selector | 3 | direct (with 11 Black Box options), next, previous |
+| Look Direction | 4 | look-left, look-right, look-up, look-down (all hold pattern) |
+| Car Control | 10 | pit-speed-limiter (telemetry-aware), push-to-pass (telemetry-aware), drs (telemetry-aware), headlight-flash (hold), tear-off-visor, ignition, starter (hold), enter-exit-tow (hold, telemetry-aware), escape (hardcoded ESC, auto-hold option), pause-sim |
 
 ### Cockpit & Interface
 
-| Action | Controls | Modes |
-|--------|----------|-------|
-| Cockpit Misc | 10 | toggle/trigger wipers, FFB +/-, latency, dash pages +/-, in-lap mode |
-| Splits & Reference | 7 | cycle (next/previous), toggle-ref-car, custom-sector-start, custom-sector-end, active-reset-set, active-reset-run |
-| Telemetry Control | 5 | toggle-logging, mark-event, start/stop/restart recording |
-| Force Feedback | 11 | auto-compute FFB force, FFB force +/-, wheel LFE +/-, bass shaker LFE +/-, wheel LFE intensity +/-, haptic LFE intensity +/- |
-| Toggle UI Elements | 8 | dash-box, speed/gear, radio, FPS, weather, mirror, edit mode, replay UI |
+| Action | Modes | Mode values |
+|--------|-------|-------------|
+| Cockpit Misc | 7 | toggle-wipers, trigger-wipers, ffb-max-force (+/-), report-latency, dash-page-1 (+/-), dash-page-2 (+/-), in-lap-mode |
+| Splits & Reference | 6 | cycle (+/- direction), toggle-ref-car, custom-sector-start, custom-sector-end, active-reset-set, active-reset-run |
+| Telemetry Control | 5 | toggle-logging, mark-event, start/stop/restart recording (SDK) |
+| Force Feedback | 6 | auto-compute-ffb-force, ffb-force (+/-), wheel-lfe (+/-), bass-shaker-lfe (+/-), wheel-lfe-intensity (+/-), haptic-lfe-intensity (+/-) |
+| Toggle UI Elements | 9 | dash-box, speed/gear/pedals, radio, FPS/network, weather, virtual mirror, UI edit, display-ref-car (deprecated), replay-ui (SDK) |
 
 ### View & Camera
 
-| Action | Controls | Modes |
-|--------|----------|-------|
-| View Adjustment | 9 | FOV +/-, horizon +/-, driver height +/-, recenter VR, UI size +/- |
-| Replay Control | 25 | play/pause, play-backward, stop, FF, rewind, slow-mo, frame +/-, speed +/-, set speed, speed display, session next/prev, lap next/prev, incident next/prev, jump to beginning, jump to live, jump to my car, next/prev car, next/prev-car-number |
-| Camera Controls | 12 | Cycle: camera (with group subset selection), sub-camera, car, driving; Focus: your car, leader, incident, exiting, by position, by car number, camera state; Change: direct camera group select |
-| Camera Editor Adjustments | 29 | 14 parameters +/- plus auto-set mic gain |
-| Camera Editor Controls | 28 | Camera tool, origins, locks, states, undo/redo, grid, bookmarks |
+| Action | Modes | Mode values |
+|--------|-------|-------------|
+| View Adjustment | 5 | fov (+/-), horizon (+/-), driver-height (+/-), recenter-vr, ui-size (+/-) |
+| Replay Control | 25 | play/pause, play-backward, stop, FF, rewind, slow-mo, frame +/-, speed +/-, set-speed, speed-display, session next/prev, lap next/prev, incident next/prev, jump to beginning/live/my car, next/prev car, next/prev car number |
+| Camera Controls | 12 | change-camera, cycle (camera / sub-camera / car / driving), focus (your car / leader / incident / exiting), switch (by position / car number), set-camera-state |
+| Camera Editor Adjustments | 15 | latitude, longitude, altitude, yaw, pitch, fov-zoom, key-step, vanish-x, vanish-y, blimp-radius, blimp-velocity, mic-gain (all +/-), auto-set-mic-gain, f-number (+/-), focus-depth (+/-) |
+| Camera Editor Controls | 30 | Open Camera Tool, 14 toggles (key accel/10x, parabolic mic, temp edits, dampening, zoom, beyond fence, in cockpit, mouse nav, pitch/roll gyro, limit shot range, show camera, shot selection, manual focus), cycle position/aim type, acquire start/end, camera CRUD (insert/remove/copy/paste), group CRUD (copy/paste), track/car save/load |
 
 ### Media
 
-| Action | Controls | Modes |
-|--------|----------|-------|
-| Media Capture | 7 | start/stop video, timer, toggle capture, screenshot, giant screenshot, reload textures |
+| Action | Modes | Mode values |
+|--------|-------|-------------|
+| Media Capture | 7 | start-stop-video, video-timer, toggle-video-capture, take-screenshot, take-giant-screenshot (keyboard), reload-all-textures, reload-car-textures |
 
 ### Pit Service
 
-| Action | Controls | Modes |
-|--------|----------|-------|
-| Pit Quick Actions | 3 | clear all, tearoff (telemetry-aware), fast repair (telemetry-aware) |
-| Fuel Service | 8 | toggle fuel fill (telemetry-aware), add/reduce/set/clear fuel, toggle autofuel, lap margin +/- |
-| Tire Service | 4 | change all tires, clear, toggle tires (per-wheel), change compound (telemetry-aware) |
+| Action | Modes | Mode values |
+|--------|-------|-------------|
+| Pit Quick Actions | 3 | clear-all-checkboxes, windshield-tearoff (telemetry-aware), request-fast-repair (telemetry-aware) |
+| Fuel Service | 8 | toggle-fuel-fill (telemetry-aware), add-fuel, reduce-fuel, set-fuel-amount, clear-fuel, toggle-autofuel (telemetry-aware), lap-margin-increase, lap-margin-decrease |
+| Tire Service | 4 | change-all-tires, clear-tires, toggle-tires (telemetry-aware per-wheel), change-compound (telemetry-aware) |
 
 ### Car Setup
 
-| Action | Controls | Modes |
-|--------|----------|-------|
-| Setup Brakes | 13 | ABS toggle/adjust, brake bias +/-, fine +/-, peak +/-, misc +/-, engine braking +/- |
-| Setup Chassis | 26 | Front/rear ARB, spring rate, ride height, bump, rebound, tire pressure +/-, power steering +/- |
-| Setup Aero | 7 | Front/rear wing +/-, qualifying tape +/-, RF brake attached toggle |
-| Setup Engine | 8 | Engine power, throttle shaping, boost, launch RPM +/- |
-| Setup Fuel | 7 | Fuel mixture +/-, fuel cut position +/-, disable fuel cut, low fuel accept, FCY mode |
-| Setup Hybrid | 9 | MGU-K regen/deploy/fixed +/-, HYS boost (hold), HYS regen (hold), HYS no boost |
-| Setup Traction | 9 | TC toggle, TC slots 1-4 +/- |
+| Action | Modes | Mode values |
+|--------|-------|-------------|
+| Setup Aero | 4 | front-wing (+/-), rear-wing (+/-), qualifying-tape (+/-), rf-brake-attached |
+| Setup Brakes | 7 | abs-toggle, abs-adjust (+/-), brake-bias (+/-), brake-bias-fine (+/-), peak-brake-bias (+/-), brake-misc (+/-), engine-braking (+/-) |
+| Setup Chassis | 13 | differential-preload/entry/middle/exit, front/rear ARB, left/right spring, LF/RF/LR/RR shock, power-steering (all +/-) |
+| Setup Engine | 4 | engine-power (+/-), throttle-shaping (+/-), boost-level (+/-), launch-rpm (+/-) |
+| Setup Fuel | 5 | fuel-mixture (+/-), fuel-cut-position (+/-), disable-fuel-cut, low-fuel-accept, fcy-mode-toggle |
+| Setup Hybrid | 6 | mguk-regen-gain (+/-), mguk-deploy-mode (+/-), mguk-fixed-deploy (+/-), hys-boost (hold), hys-regen (hold), hys-no-boost |
+| Setup Traction | 5 | tc-toggle, tc-slot-1/2/3/4 (all +/-) |
 
-### Chat
+### Communication
 
-| Action | Controls | Modes |
-|--------|----------|-------|
-| Chat | 21 | open, reply, whisper, respond PM, cancel, send message, 15 macros |
+| Action | Modes | Mode values |
+|--------|-------|-------------|
+| Chat | 7 | send-message, macro (1-15), reply, respond-pm, whisper (keyboard), open-chat, cancel |
 | Race Admin | 27 | yellow, black-flag, dq-driver, show-dqs-field, show-dqs-driver, clear-penalties, clear-all, wave-around, eol, pit-close, pit-open, pace-laps, single/double-file-restart, advance-session, grid-set, grid-start, track-state, grant/revoke-admin, remove-driver, enable/disable-chat (all/driver), message-all, rc-message |
 
 ## Control Patterns

--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -7,7 +7,9 @@ description: Use when looking up Stream Deck actions, sub-actions, modes, catego
 
 ## Data File
 
-Complete action definitions (30 documented actions, 254 modes): `docs/reference/actions.json`
+Complete action definitions: `docs/reference/actions.json`
+
+The website currently documents **30 actions with 254 modes** (the totals used in this file and in user-facing docs). `docs/reference/actions.json` has not yet been re-synced to the new per-mode counting convention; use this skill file or the website as the source of truth for action and mode counts, and treat `actions.json` as a detailed inventory of individual mode values that is occasionally out of date.
 
 Each action entry:
 ```json

--- a/.claude/skills/website/SKILL.md
+++ b/.claude/skills/website/SKILL.md
@@ -54,12 +54,12 @@ src/content/docs/
     │   ├── overview.md
     │   ├── display-session/         # 2 actions
     │   ├── driving/                 # 5 actions
-    │   ├── cockpit/                 # 4 actions
-    │   ├── view-camera/             # 6 actions
+    │   ├── cockpit/                 # 5 actions
+    │   ├── view-camera/             # 5 actions
     │   ├── media/                   # 1 action
     │   ├── pit-service/             # 3 actions
     │   ├── car-setup/               # 7 actions
-    │   └── communication/           # 1 action
+    │   └── communication/           # 2 actions
     └── reference/
         ├── action-types.md
         └── keyboard-shortcuts.md
@@ -78,6 +78,8 @@ Defined in `astro.config.mjs` under `starlight.sidebar`. Uses `{ slug: "..." }` 
 
 ## Action Doc Template
 
+See the canonical example at `packages/website/src/content/docs/docs/actions/pit-service/tire-service.md` and the full rule at `.claude/rules/website-action-docs.md`. The short version:
+
 ```md
 ---
 title: {Action Name}
@@ -92,14 +94,24 @@ sidebar:
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| {label} | {description} |
+Select the mode from the **{Dropdown Label}** dropdown in the Property Inspector.
 
-## Encoder Support
+### {Mode Name}
 
-{Yes/No — what rotation does}
+{Mode description}
+
+##### Details
+
+- **Dial:** {rotation behavior, or `No rotation support`}
+- **Default binding:** {`Key`, `No default key binding`, or `No keyboard binding`}
+- **Telemetry-aware icon:** {`Yes` (with note on what updates) or `No`}
+
+##### Settings
+
+- No additional settings
 ```
+
+For modes with settings, replace the `##### Settings` block with one or more `##### Setting: {Name}` subheaders documenting defaults and options inline.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@
 
 ## Features
 
-**32 actions** with **349 controls** across 8 categories, all with Stream Deck+ encoder support:
+**30 actions** with **254 modes** across 8 categories, with Stream Deck+ dial rotation support on most modes:
 
-| Category | Actions | Controls | Examples |
-|----------|---------|----------|---------|
+| Category | Actions | Modes | Examples |
+|----------|---------|-------|---------|
 | **Display & Session** | 2 | 7 | Incidents, laps, position, fuel, flags |
-| **Driving Controls** | 5 | 39 | AI spotter, audio, black box cycling, look direction, car control |
-| **Cockpit & Interface** | 4 | 30 | Wipers, FFB, splits & reference, telemetry, UI toggles |
-| **View & Camera** | 8 | 124 | FOV, replay transport, camera focus, broadcast tools |
+| **Driving Controls** | 5 | 27 | AI spotter, audio, black box cycling, look direction, car control |
+| **Cockpit & Interface** | 5 | 33 | Wipers, FFB, splits & reference, telemetry, UI toggles |
+| **View & Camera** | 5 | 87 | FOV, replay, camera controls, broadcast tools |
 | **Media** | 1 | 7 | Video recording, screenshots |
 | **Pit Service** | 3 | 15 | Fuel, tires, compounds, tearoff, fast repair |
-| **Car Setup** | 7 | 79 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control |
-| **Chat** | 2 | 48 | Chat, macros, whisper, reply, race admin commands |
+| **Car Setup** | 7 | 44 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control |
+| **Communication** | 2 | 34 | Chat, macros, whisper, reply, race admin commands |
 
 **Key highlights:**
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-aero.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-aero.md
@@ -17,13 +17,13 @@ Select the mode from the **Setting** dropdown in the Property Inspector. Directi
 
 Adjust the front wing angle. The **Direction** setting picks whether pressing the button increases or decreases the angle.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts the front wing (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Front Wing + and Front Wing - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button increases the front wing angle
 - **Decrease** — Pressing the button decreases the front wing angle
@@ -34,13 +34,13 @@ Adjust the front wing angle. The **Direction** setting picks whether pressing th
 
 Adjust the rear wing angle. The **Direction** setting picks whether pressing the button increases or decreases the angle.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts the rear wing (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Rear Wing + and Rear Wing - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button increases the rear wing angle
 - **Decrease** — Pressing the button decreases the rear wing angle
@@ -51,13 +51,13 @@ Adjust the rear wing angle. The **Direction** setting picks whether pressing the
 
 Adjust the amount of qualifying tape covering the radiators. The **Direction** setting picks whether pressing the button adds or removes tape.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts qualifying tape (clockwise = more tape, counter-clockwise = less tape), regardless of the Direction setting
 - **Default binding:** No default key binding — both Qualifying Tape + and Qualifying Tape - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button adds more tape
 - **Decrease** — Pressing the button removes tape
@@ -68,12 +68,12 @@ Adjust the amount of qualifying tape covering the radiators. The **Direction** s
 
 Toggle the right-front brake attachment.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-aero.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-aero.md
@@ -3,24 +3,77 @@ title: Setup Aero
 description: Adjust aerodynamic settings like front wing, rear wing, and qualifying tape during a session.
 sidebar:
   badge:
-    text: "7 modes"
+    text: "4 modes"
     variant: tip
 ---
 
-Adjust aerodynamic settings on your car during a session. Includes front and rear wing angles, qualifying tape, and brake attachment controls.
+Adjust aerodynamic setup options from the cockpit — front and rear wing angles, qualifying tape, and the right-front brake attachment.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| Front Wing More | Increase front wing angle |
-| Front Wing Less | Decrease front wing angle |
-| Rear Wing More | Increase rear wing angle |
-| Rear Wing Less | Decrease rear wing angle |
-| Qualifying Tape More | Add more qualifying tape |
-| Qualifying Tape Less | Remove qualifying tape |
-| RF Brake Attached Toggle | Toggle right-front brake attachment |
+Select the mode from the **Setting** dropdown in the Property Inspector. Directional modes also expose a **Direction** setting for Increase / Decrease.
 
-## Encoder Support
+### Front Wing
 
-Yes — rotate the dial to increase or decrease the selected aerodynamic setting.
+Adjust the front wing angle. The **Direction** setting picks whether pressing the button increases or decreases the angle.
+
+##### Details
+
+- **Dial:** Rotation adjusts the front wing (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both Front Wing + and Front Wing - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button increases the front wing angle
+- **Decrease** — Pressing the button decreases the front wing angle
+
+---
+
+### Rear Wing
+
+Adjust the rear wing angle. The **Direction** setting picks whether pressing the button increases or decreases the angle.
+
+##### Details
+
+- **Dial:** Rotation adjusts the rear wing (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both Rear Wing + and Rear Wing - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button increases the rear wing angle
+- **Decrease** — Pressing the button decreases the rear wing angle
+
+---
+
+### Qualifying Tape
+
+Adjust the amount of qualifying tape covering the radiators. The **Direction** setting picks whether pressing the button adds or removes tape.
+
+##### Details
+
+- **Dial:** Rotation adjusts qualifying tape (clockwise = more tape, counter-clockwise = less tape), regardless of the Direction setting
+- **Default binding:** No default key binding — both Qualifying Tape + and Qualifying Tape - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button adds more tape
+- **Decrease** — Pressing the button removes tape
+
+---
+
+### RF Brake Attached
+
+Toggle the right-front brake attachment.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-brakes.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-brakes.md
@@ -1,32 +1,130 @@
 ---
 title: Setup Brakes
-description: Adjust brake settings including ABS, brake bias, peak brake bias, and engine braking during a session.
+description: Adjust brake settings including ABS, brake bias, peak brake bias, engine braking, and more.
 sidebar:
   badge:
-    text: "13 modes"
+    text: "7 modes"
     variant: tip
 ---
 
-Adjust brake-related settings on your car during a session. Includes ABS control, brake bias adjustments at multiple granularities, peak brake bias, miscellaneous brake settings, and engine braking.
+Adjust brake-related setup options from the cockpit — ABS level, brake bias (coarse and fine), peak brake bias, miscellaneous brake settings, and engine braking.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| ABS Toggle | Toggle ABS on or off |
-| ABS Increase | Increase ABS level |
-| ABS Decrease | Decrease ABS level |
-| Brake Bias Forward | Shift brake bias toward the front |
-| Brake Bias Rearward | Shift brake bias toward the rear |
-| Brake Bias Fine Forward | Fine-adjust brake bias toward the front |
-| Brake Bias Fine Rearward | Fine-adjust brake bias toward the rear |
-| Peak Brake Bias Increase | Increase peak brake bias |
-| Peak Brake Bias Decrease | Decrease peak brake bias |
-| Brake Misc Increase | Increase miscellaneous brake setting |
-| Brake Misc Decrease | Decrease miscellaneous brake setting |
-| Engine Braking Increase | Increase engine braking level |
-| Engine Braking Decrease | Decrease engine braking level |
+Select the mode from the **Setting** dropdown in the Property Inspector. Directional modes also expose a **Direction** setting for Increase / Decrease.
 
-## Encoder Support
+### ABS Toggle
 
-Yes — rotate the dial to increase or decrease the selected brake setting.
+Toggle ABS on or off.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### ABS Adjust
+
+Step the ABS level up or down. The **Direction** setting picks whether pressing the button raises or lowers the level.
+
+##### Details
+
+- **Dial:** Rotation adjusts the ABS level (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both ABS Adjust + and ABS Adjust - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the ABS level
+- **Decrease** — Pressing the button lowers the ABS level
+
+---
+
+### Brake Bias
+
+Shift the brake bias forward or rearward. The **Direction** setting picks whether pressing the button moves bias forward (increase) or rearward (decrease).
+
+##### Details
+
+- **Dial:** Rotation adjusts brake bias (clockwise = forward, counter-clockwise = rearward), regardless of the Direction setting
+- **Default binding:** `=` (increase) and `-` (decrease) — matches iRacing's default brake bias keys
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button shifts bias forward
+- **Decrease** — Pressing the button shifts bias rearward
+
+---
+
+### Brake Bias Fine
+
+Fine-adjust the brake bias in smaller increments than the main Brake Bias mode.
+
+##### Details
+
+- **Dial:** Rotation adjusts brake bias fine (clockwise = forward, counter-clockwise = rearward), regardless of the Direction setting
+- **Default binding:** No default key binding — both Brake Bias Fine + and Brake Bias Fine - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button shifts bias fine forward
+- **Decrease** — Pressing the button shifts bias fine rearward
+
+---
+
+### Peak Brake Bias
+
+Adjust the peak brake bias setting.
+
+##### Details
+
+- **Dial:** Rotation adjusts peak brake bias (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both Peak Brake Bias + and Peak Brake Bias - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises peak brake bias
+- **Decrease** — Pressing the button lowers peak brake bias
+
+---
+
+### Brake Misc
+
+Adjust iRacing's "brake misc" catch-all setting. The exact effect depends on the car.
+
+##### Details
+
+- **Dial:** Rotation adjusts brake misc (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both Brake Misc + and Brake Misc - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the value
+- **Decrease** — Pressing the button lowers the value
+
+---
+
+### Engine Braking
+
+Adjust the engine braking level.
+
+##### Details
+
+- **Dial:** Rotation adjusts engine braking (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both Engine Braking + and Engine Braking - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises engine braking
+- **Decrease** — Pressing the button lowers engine braking

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-brakes.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-brakes.md
@@ -17,13 +17,13 @@ Select the mode from the **Setting** dropdown in the Property Inspector. Directi
 
 Toggle ABS on or off.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -33,13 +33,13 @@ Toggle ABS on or off.
 
 Step the ABS level up or down. The **Direction** setting picks whether pressing the button raises or lowers the level.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts the ABS level (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both ABS Adjust + and ABS Adjust - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the ABS level
 - **Decrease** — Pressing the button lowers the ABS level
@@ -50,13 +50,13 @@ Step the ABS level up or down. The **Direction** setting picks whether pressing 
 
 Shift the brake bias forward or rearward. The **Direction** setting picks whether pressing the button moves bias forward (increase) or rearward (decrease).
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts brake bias (clockwise = forward, counter-clockwise = rearward), regardless of the Direction setting
 - **Default binding:** `=` (increase) and `-` (decrease) — matches iRacing's default brake bias keys
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button shifts bias forward
 - **Decrease** — Pressing the button shifts bias rearward
@@ -67,13 +67,13 @@ Shift the brake bias forward or rearward. The **Direction** setting picks whethe
 
 Fine-adjust the brake bias in smaller increments than the main Brake Bias mode.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts brake bias fine (clockwise = forward, counter-clockwise = rearward), regardless of the Direction setting
 - **Default binding:** No default key binding — both Brake Bias Fine + and Brake Bias Fine - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button shifts bias fine forward
 - **Decrease** — Pressing the button shifts bias fine rearward
@@ -84,13 +84,13 @@ Fine-adjust the brake bias in smaller increments than the main Brake Bias mode.
 
 Adjust the peak brake bias setting.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts peak brake bias (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Peak Brake Bias + and Peak Brake Bias - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises peak brake bias
 - **Decrease** — Pressing the button lowers peak brake bias
@@ -101,13 +101,13 @@ Adjust the peak brake bias setting.
 
 Adjust iRacing's "brake misc" catch-all setting. The exact effect depends on the car.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts brake misc (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Brake Misc + and Brake Misc - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the value
 - **Decrease** — Pressing the button lowers the value
@@ -118,13 +118,13 @@ Adjust iRacing's "brake misc" catch-all setting. The exact effect depends on the
 
 Adjust the engine braking level.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts engine braking (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Engine Braking + and Engine Braking - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises engine braking
 - **Decrease** — Pressing the button lowers engine braking

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-chassis.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-chassis.md
@@ -17,13 +17,13 @@ Select the mode from the **Setting** dropdown in the Property Inspector. Every c
 
 Adjust the differential preload value.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts differential preload (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Diff Preload + and Diff Preload - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the value
 - **Decrease** — Pressing the button lowers the value
@@ -34,13 +34,13 @@ Adjust the differential preload value.
 
 Adjust the differential entry (on-throttle) setting.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts differential entry (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Diff Entry + and Diff Entry - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the value
 - **Decrease** — Pressing the button lowers the value
@@ -51,13 +51,13 @@ Adjust the differential entry (on-throttle) setting.
 
 Adjust the differential middle (coasting) setting.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts differential middle (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Diff Middle + and Diff Middle - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the value
 - **Decrease** — Pressing the button lowers the value
@@ -68,13 +68,13 @@ Adjust the differential middle (coasting) setting.
 
 Adjust the differential exit setting.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts differential exit (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Diff Exit + and Diff Exit - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the value
 - **Decrease** — Pressing the button lowers the value
@@ -85,13 +85,13 @@ Adjust the differential exit setting.
 
 Adjust the front anti-roll bar stiffness.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts the front ARB (clockwise = stiffer, counter-clockwise = softer), regardless of the Direction setting
 - **Default binding:** No default key binding — both Front ARB + and Front ARB - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button stiffens the ARB
 - **Decrease** — Pressing the button softens the ARB
@@ -102,13 +102,13 @@ Adjust the front anti-roll bar stiffness.
 
 Adjust the rear anti-roll bar stiffness.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts the rear ARB (clockwise = stiffer, counter-clockwise = softer), regardless of the Direction setting
 - **Default binding:** No default key binding — both Rear ARB + and Rear ARB - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button stiffens the ARB
 - **Decrease** — Pressing the button softens the ARB
@@ -119,13 +119,13 @@ Adjust the rear anti-roll bar stiffness.
 
 Adjust the left-side spring preload.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts the left spring (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Left Spring + and Left Spring - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the value
 - **Decrease** — Pressing the button lowers the value
@@ -136,13 +136,13 @@ Adjust the left-side spring preload.
 
 Adjust the right-side spring preload.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts the right spring (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Right Spring + and Right Spring - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the value
 - **Decrease** — Pressing the button lowers the value
@@ -153,13 +153,13 @@ Adjust the right-side spring preload.
 
 Adjust the left-front shock setting.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts the left-front shock (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both LF Shock + and LF Shock - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the value
 - **Decrease** — Pressing the button lowers the value
@@ -170,13 +170,13 @@ Adjust the left-front shock setting.
 
 Adjust the right-front shock setting.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts the right-front shock (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both RF Shock + and RF Shock - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the value
 - **Decrease** — Pressing the button lowers the value
@@ -187,13 +187,13 @@ Adjust the right-front shock setting.
 
 Adjust the left-rear shock setting.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts the left-rear shock (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both LR Shock + and LR Shock - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the value
 - **Decrease** — Pressing the button lowers the value
@@ -204,13 +204,13 @@ Adjust the left-rear shock setting.
 
 Adjust the right-rear shock setting.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts the right-rear shock (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both RR Shock + and RR Shock - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the value
 - **Decrease** — Pressing the button lowers the value
@@ -221,13 +221,13 @@ Adjust the right-rear shock setting.
 
 Adjust the power steering assist level.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts power steering (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Power Steering + and Power Steering - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the assist level
 - **Decrease** — Pressing the button lowers the assist level

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-chassis.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-chassis.md
@@ -1,45 +1,233 @@
 ---
 title: Setup Chassis
-description: Adjust chassis settings including anti-roll bars, springs, ride height, dampers, tire pressure, and power steering during a session.
+description: Adjust chassis setup options — differential, anti-roll bars, springs, shocks, and power steering — during a session.
 sidebar:
   badge:
-    text: "26 modes"
+    text: "13 modes"
     variant: tip
 ---
 
-Adjust chassis and suspension settings on your car during a session. Covers anti-roll bars, spring rates, ride height, bump and rebound damping, tire pressures, and power steering.
+Adjust chassis setup options from the cockpit: differential curves, anti-roll bars, spring preloads, shock absorbers, and power steering.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| Front ARB Stiffer | Stiffen front anti-roll bar |
-| Front ARB Softer | Soften front anti-roll bar |
-| Rear ARB Stiffer | Stiffen rear anti-roll bar |
-| Rear ARB Softer | Soften rear anti-roll bar |
-| Front Spring Rate Stiffer | Stiffen front spring rate |
-| Front Spring Rate Softer | Soften front spring rate |
-| Rear Spring Rate Stiffer | Stiffen rear spring rate |
-| Rear Spring Rate Softer | Soften rear spring rate |
-| Front Ride Height Up | Raise front ride height |
-| Front Ride Height Down | Lower front ride height |
-| Rear Ride Height Up | Raise rear ride height |
-| Rear Ride Height Down | Lower rear ride height |
-| Front Bump Stiffer | Stiffen front bump damping |
-| Front Bump Softer | Soften front bump damping |
-| Rear Bump Stiffer | Stiffen rear bump damping |
-| Rear Bump Softer | Soften rear bump damping |
-| Front Rebound Stiffer | Stiffen front rebound damping |
-| Front Rebound Softer | Soften front rebound damping |
-| Rear Rebound Stiffer | Stiffen rear rebound damping |
-| Rear Rebound Softer | Soften rear rebound damping |
-| Front Tire Pressure Up | Increase front tire pressure |
-| Front Tire Pressure Down | Decrease front tire pressure |
-| Rear Tire Pressure Up | Increase rear tire pressure |
-| Rear Tire Pressure Down | Decrease rear tire pressure |
-| Power Steering Increase | Increase power steering assist |
-| Power Steering Decrease | Decrease power steering assist |
+Select the mode from the **Setting** dropdown in the Property Inspector. Every chassis mode is directional — pick **Increase** or **Decrease** in the **Direction** setting to control what a button press does.
 
-## Encoder Support
+### Differential Preload
 
-Yes — rotate the dial to increase or decrease the selected chassis setting.
+Adjust the differential preload value.
+
+##### Details
+
+- **Dial:** Rotation adjusts differential preload (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both Diff Preload + and Diff Preload - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the value
+- **Decrease** — Pressing the button lowers the value
+
+---
+
+### Differential Entry
+
+Adjust the differential entry (on-throttle) setting.
+
+##### Details
+
+- **Dial:** Rotation adjusts differential entry (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both Diff Entry + and Diff Entry - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the value
+- **Decrease** — Pressing the button lowers the value
+
+---
+
+### Differential Middle
+
+Adjust the differential middle (coasting) setting.
+
+##### Details
+
+- **Dial:** Rotation adjusts differential middle (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both Diff Middle + and Diff Middle - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the value
+- **Decrease** — Pressing the button lowers the value
+
+---
+
+### Differential Exit
+
+Adjust the differential exit setting.
+
+##### Details
+
+- **Dial:** Rotation adjusts differential exit (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both Diff Exit + and Diff Exit - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the value
+- **Decrease** — Pressing the button lowers the value
+
+---
+
+### Front ARB
+
+Adjust the front anti-roll bar stiffness.
+
+##### Details
+
+- **Dial:** Rotation adjusts the front ARB (clockwise = stiffer, counter-clockwise = softer), regardless of the Direction setting
+- **Default binding:** No default key binding — both Front ARB + and Front ARB - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button stiffens the ARB
+- **Decrease** — Pressing the button softens the ARB
+
+---
+
+### Rear ARB
+
+Adjust the rear anti-roll bar stiffness.
+
+##### Details
+
+- **Dial:** Rotation adjusts the rear ARB (clockwise = stiffer, counter-clockwise = softer), regardless of the Direction setting
+- **Default binding:** No default key binding — both Rear ARB + and Rear ARB - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button stiffens the ARB
+- **Decrease** — Pressing the button softens the ARB
+
+---
+
+### Left Spring
+
+Adjust the left-side spring preload.
+
+##### Details
+
+- **Dial:** Rotation adjusts the left spring (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both Left Spring + and Left Spring - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the value
+- **Decrease** — Pressing the button lowers the value
+
+---
+
+### Right Spring
+
+Adjust the right-side spring preload.
+
+##### Details
+
+- **Dial:** Rotation adjusts the right spring (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both Right Spring + and Right Spring - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the value
+- **Decrease** — Pressing the button lowers the value
+
+---
+
+### LF Shock
+
+Adjust the left-front shock setting.
+
+##### Details
+
+- **Dial:** Rotation adjusts the left-front shock (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both LF Shock + and LF Shock - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the value
+- **Decrease** — Pressing the button lowers the value
+
+---
+
+### RF Shock
+
+Adjust the right-front shock setting.
+
+##### Details
+
+- **Dial:** Rotation adjusts the right-front shock (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both RF Shock + and RF Shock - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the value
+- **Decrease** — Pressing the button lowers the value
+
+---
+
+### LR Shock
+
+Adjust the left-rear shock setting.
+
+##### Details
+
+- **Dial:** Rotation adjusts the left-rear shock (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both LR Shock + and LR Shock - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the value
+- **Decrease** — Pressing the button lowers the value
+
+---
+
+### RR Shock
+
+Adjust the right-rear shock setting.
+
+##### Details
+
+- **Dial:** Rotation adjusts the right-rear shock (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both RR Shock + and RR Shock - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the value
+- **Decrease** — Pressing the button lowers the value
+
+---
+
+### Power Steering
+
+Adjust the power steering assist level.
+
+##### Details
+
+- **Dial:** Rotation adjusts power steering (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both Power Steering + and Power Steering - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the assist level
+- **Decrease** — Pressing the button lowers the assist level

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-engine.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-engine.md
@@ -17,13 +17,13 @@ Select the mode from the **Setting** dropdown in the Property Inspector. Every e
 
 Adjust the engine power setting.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts engine power (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Engine Power + and Engine Power - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises engine power
 - **Decrease** — Pressing the button lowers engine power
@@ -34,13 +34,13 @@ Adjust the engine power setting.
 
 Adjust the throttle shape (linear / progressive curve).
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts throttle shaping (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Throttle Shape + and Throttle Shape - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the value
 - **Decrease** — Pressing the button lowers the value
@@ -51,13 +51,13 @@ Adjust the throttle shape (linear / progressive curve).
 
 Adjust the engine boost level.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts boost (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Boost + and Boost - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises boost
 - **Decrease** — Pressing the button lowers boost
@@ -68,13 +68,13 @@ Adjust the engine boost level.
 
 Adjust the launch control RPM target.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts launch RPM (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Launch RPM + and Launch RPM - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the RPM target
 - **Decrease** — Pressing the button lowers the RPM target

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-engine.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-engine.md
@@ -3,25 +3,78 @@ title: Setup Engine
 description: Adjust engine settings including power, throttle shaping, boost level, and launch RPM during a session.
 sidebar:
   badge:
-    text: "8 modes"
+    text: "4 modes"
     variant: tip
 ---
 
-Adjust engine-related settings on your car during a session. Includes engine power, throttle shaping, boost level, and launch RPM controls.
+Adjust engine-related setup options from the cockpit: engine power, throttle shaping, boost level, and launch RPM.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| Engine Power Increase | Increase engine power output |
-| Engine Power Decrease | Decrease engine power output |
-| Throttle Shaping Increase | Increase throttle shaping |
-| Throttle Shaping Decrease | Decrease throttle shaping |
-| Boost Level Increase | Increase boost level |
-| Boost Level Decrease | Decrease boost level |
-| Launch RPM Increase | Increase launch control RPM |
-| Launch RPM Decrease | Decrease launch control RPM |
+Select the mode from the **Setting** dropdown in the Property Inspector. Every engine mode is directional — pick **Increase** or **Decrease** in the **Direction** setting to control what a button press does.
 
-## Encoder Support
+### Engine Power
 
-Yes — rotate the dial to increase or decrease the selected engine setting.
+Adjust the engine power setting.
+
+##### Details
+
+- **Dial:** Rotation adjusts engine power (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both Engine Power + and Engine Power - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises engine power
+- **Decrease** — Pressing the button lowers engine power
+
+---
+
+### Throttle Shaping
+
+Adjust the throttle shape (linear / progressive curve).
+
+##### Details
+
+- **Dial:** Rotation adjusts throttle shaping (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both Throttle Shape + and Throttle Shape - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the value
+- **Decrease** — Pressing the button lowers the value
+
+---
+
+### Boost Level
+
+Adjust the engine boost level.
+
+##### Details
+
+- **Dial:** Rotation adjusts boost (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both Boost + and Boost - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises boost
+- **Decrease** — Pressing the button lowers boost
+
+---
+
+### Launch RPM
+
+Adjust the launch control RPM target.
+
+##### Details
+
+- **Dial:** Rotation adjusts launch RPM (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both Launch RPM + and Launch RPM - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the RPM target
+- **Decrease** — Pressing the button lowers the RPM target

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-fuel.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-fuel.md
@@ -3,24 +3,92 @@ title: Setup Fuel
 description: Adjust in-car fuel settings including mixture, fuel cut position, and FCY mode during a session.
 sidebar:
   badge:
-    text: "7 modes"
+    text: "5 modes"
     variant: tip
 ---
 
-Adjust in-car fuel settings during a session. This controls fuel mixture, fuel cut behavior, and full course yellow mode. These are live car adjustments, not pit service fuel requests.
+Adjust in-car fuel settings from the cockpit: fuel mixture, fuel cut position, disable fuel cut, low fuel accept, and full-course yellow mode. These are live car adjustments, not pit service fuel requests.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| Fuel Mixture Richer | Enrich the fuel mixture |
-| Fuel Mixture Leaner | Lean out the fuel mixture |
-| Fuel Cut Position Increase | Increase fuel cut position |
-| Fuel Cut Position Decrease | Decrease fuel cut position |
-| Disable Fuel Cut Toggle | Toggle fuel cut on or off |
-| Low Fuel Accept Toggle | Toggle acceptance of low fuel warning |
-| FCY Mode Toggle | Toggle full course yellow fuel saving mode |
+Select the mode from the **Setting** dropdown in the Property Inspector. Directional modes (Fuel Mixture, Fuel Cut Position) also expose a **Direction** setting for Increase / Decrease.
 
-## Encoder Support
+### Fuel Mixture
 
-Yes — rotate the dial to increase or decrease the selected fuel setting.
+Adjust the fuel / air mixture setting.
+
+##### Details
+
+- **Dial:** Rotation adjusts fuel mixture (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both Fuel Mixture + and Fuel Mixture - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the mixture
+- **Decrease** — Pressing the button lowers the mixture
+
+---
+
+### Fuel Cut Position
+
+Adjust the fuel cut position setting.
+
+##### Details
+
+- **Dial:** Rotation adjusts fuel cut position (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both Fuel Cut Position + and Fuel Cut Position - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the value
+- **Decrease** — Pressing the button lowers the value
+
+---
+
+### Disable Fuel Cut
+
+Toggle the fuel cut disable setting.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Low Fuel Accept
+
+Accept the low fuel warning dialog that appears in some series.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### FCY Mode Toggle
+
+Toggle full-course yellow mode on or off.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-fuel.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-fuel.md
@@ -17,13 +17,13 @@ Select the mode from the **Setting** dropdown in the Property Inspector. Directi
 
 Adjust the fuel / air mixture setting.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts fuel mixture (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Fuel Mixture + and Fuel Mixture - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the mixture
 - **Decrease** — Pressing the button lowers the mixture
@@ -34,13 +34,13 @@ Adjust the fuel / air mixture setting.
 
 Adjust the fuel cut position setting.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts fuel cut position (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Fuel Cut Position + and Fuel Cut Position - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the value
 - **Decrease** — Pressing the button lowers the value
@@ -51,13 +51,13 @@ Adjust the fuel cut position setting.
 
 Toggle the fuel cut disable setting.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -67,13 +67,13 @@ Toggle the fuel cut disable setting.
 
 Accept the low fuel warning dialog that appears in some series.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -83,12 +83,12 @@ Accept the low fuel warning dialog that appears in some series.
 
 Toggle full-course yellow mode on or off.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-hybrid.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-hybrid.md
@@ -3,30 +3,109 @@ title: Setup Hybrid
 description: Control hybrid system settings including MGU-K regen, deploy modes, and HYS boost/regen during a session.
 sidebar:
   badge:
-    text: "9 modes"
+    text: "6 modes"
     variant: tip
 ---
 
-Control hybrid energy recovery and deployment settings during a session. Includes MGU-K regeneration gain, deploy modes, fixed deployment levels, and HYS (Hybrid System) boost and regen controls.
+Control hybrid energy recovery and deployment settings from the cockpit: MGU-K regeneration gain, deploy mode, fixed deploy level, HYS (Hybrid System) boost, HYS regen, and the HYS no-boost toggle.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| MGU-K Regen Gain Increase | Increase MGU-K regeneration gain |
-| MGU-K Regen Gain Decrease | Decrease MGU-K regeneration gain |
-| MGU-K Deploy Mode Up | Switch to a higher MGU-K deploy mode |
-| MGU-K Deploy Mode Down | Switch to a lower MGU-K deploy mode |
-| MGU-K Fixed Deploy Increase | Increase MGU-K fixed deployment level |
-| MGU-K Fixed Deploy Decrease | Decrease MGU-K fixed deployment level |
-| HYS Boost | Activate HYS boost (held while button is pressed) |
-| HYS Regen | Activate HYS regen (held while button is pressed) |
-| HYS No Boost Toggle | Toggle HYS no-boost mode |
+Select the mode from the **Setting** dropdown in the Property Inspector. Directional modes (MGU-K Re-Gen Gain, MGU-K Deploy Mode, MGU-K Fixed Deploy) also expose a **Direction** setting for Increase / Decrease. HYS Boost and HYS Regen use a hold pattern — the key is held while the button is pressed and released when you release it.
 
-:::note
-HYS Boost and HYS Regen use the hold pattern -- the key is held down while the Stream Deck button is pressed and released when the button is released.
-:::
+### MGU-K Re-Gen Gain
 
-## Encoder Support
+Adjust the MGU-K regeneration gain.
 
-Yes — rotate the dial to increase or decrease the selected hybrid setting.
+##### Details
+
+- **Dial:** Rotation adjusts MGU-K regen gain (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both MGU-K Re-Gen Gain + and MGU-K Re-Gen Gain - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the regen gain
+- **Decrease** — Pressing the button lowers the regen gain
+
+---
+
+### MGU-K Deploy Mode
+
+Step through the MGU-K deploy modes.
+
+##### Details
+
+- **Dial:** Rotation steps through MGU-K deploy modes (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both MGU-K Deploy Mode + and MGU-K Deploy Mode - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button advances to the next deploy mode
+- **Decrease** — Pressing the button goes back to the previous deploy mode
+
+---
+
+### MGU-K Fixed Deploy
+
+Adjust the fixed MGU-K deployment level.
+
+##### Details
+
+- **Dial:** Rotation adjusts the fixed deploy level (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both MGU-K Fixed Deploy + and MGU-K Fixed Deploy - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the deploy level
+- **Decrease** — Pressing the button lowers the deploy level
+
+---
+
+### HYS Boost
+
+Hold the HYS boost key for as long as the button is pressed. Release the button to stop boosting.
+
+##### Details
+
+- **Dial:** No rotation support; press and hold the dial to boost, release to stop
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### HYS Regen
+
+Hold the HYS regen key for as long as the button is pressed. Release the button to stop regenerating.
+
+##### Details
+
+- **Dial:** No rotation support; press and hold the dial to regenerate, release to stop
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### HYS No Boost
+
+Toggle the "no boost" mode on or off.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-hybrid.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-hybrid.md
@@ -17,13 +17,13 @@ Select the mode from the **Setting** dropdown in the Property Inspector. Directi
 
 Adjust the MGU-K regeneration gain.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts MGU-K regen gain (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both MGU-K Re-Gen Gain + and MGU-K Re-Gen Gain - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the regen gain
 - **Decrease** — Pressing the button lowers the regen gain
@@ -34,13 +34,13 @@ Adjust the MGU-K regeneration gain.
 
 Step through the MGU-K deploy modes.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation steps through MGU-K deploy modes (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both MGU-K Deploy Mode + and MGU-K Deploy Mode - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button advances to the next deploy mode
 - **Decrease** — Pressing the button goes back to the previous deploy mode
@@ -51,13 +51,13 @@ Step through the MGU-K deploy modes.
 
 Adjust the fixed MGU-K deployment level.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts the fixed deploy level (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both MGU-K Fixed Deploy + and MGU-K Fixed Deploy - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the deploy level
 - **Decrease** — Pressing the button lowers the deploy level
@@ -68,13 +68,13 @@ Adjust the fixed MGU-K deployment level.
 
 Hold the HYS boost key for as long as the button is pressed. Release the button to stop boosting.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support; press and hold the dial to boost, release to stop
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -84,13 +84,13 @@ Hold the HYS boost key for as long as the button is pressed. Release the button 
 
 Hold the HYS regen key for as long as the button is pressed. Release the button to stop regenerating.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support; press and hold the dial to regenerate, release to stop
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -100,12 +100,12 @@ Hold the HYS regen key for as long as the button is pressed. Release the button 
 
 Toggle the "no boost" mode on or off.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-traction.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-traction.md
@@ -17,13 +17,13 @@ Select the mode from the **Setting** dropdown in the Property Inspector. TC Slot
 
 Toggle traction control on or off.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -33,13 +33,13 @@ Toggle traction control on or off.
 
 Adjust TC slot 1.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts TC slot 1 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both TC Slot 1 + and TC Slot 1 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the value
 - **Decrease** — Pressing the button lowers the value
@@ -50,13 +50,13 @@ Adjust TC slot 1.
 
 Adjust TC slot 2.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts TC slot 2 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both TC Slot 2 + and TC Slot 2 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the value
 - **Decrease** — Pressing the button lowers the value
@@ -67,13 +67,13 @@ Adjust TC slot 2.
 
 Adjust TC slot 3.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts TC slot 3 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both TC Slot 3 + and TC Slot 3 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the value
 - **Decrease** — Pressing the button lowers the value
@@ -84,13 +84,13 @@ Adjust TC slot 3.
 
 Adjust TC slot 4.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts TC slot 4 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both TC Slot 4 + and TC Slot 4 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the value
 - **Decrease** — Pressing the button lowers the value

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-traction.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-traction.md
@@ -3,26 +3,94 @@ title: Setup Traction
 description: Adjust traction control settings across multiple TC slots during a session.
 sidebar:
   badge:
-    text: "9 modes"
+    text: "5 modes"
     variant: tip
 ---
 
-Adjust traction control settings on your car during a session. Supports toggling traction control on or off, and adjusting levels across four independent TC slots.
+Adjust traction control from the cockpit: toggle TC on or off, and step the four independent TC slot levels.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| TC Toggle | Toggle traction control on or off |
-| TC Slot 1 Increase | Increase traction control level in slot 1 |
-| TC Slot 1 Decrease | Decrease traction control level in slot 1 |
-| TC Slot 2 Increase | Increase traction control level in slot 2 |
-| TC Slot 2 Decrease | Decrease traction control level in slot 2 |
-| TC Slot 3 Increase | Increase traction control level in slot 3 |
-| TC Slot 3 Decrease | Decrease traction control level in slot 3 |
-| TC Slot 4 Increase | Increase traction control level in slot 4 |
-| TC Slot 4 Decrease | Decrease traction control level in slot 4 |
+Select the mode from the **Setting** dropdown in the Property Inspector. TC Slot modes expose a **Direction** setting for Increase / Decrease; TC Toggle does not.
 
-## Encoder Support
+### TC Toggle
 
-Yes — rotate the dial to increase or decrease the selected traction control setting.
+Toggle traction control on or off.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### TC Slot 1
+
+Adjust TC slot 1.
+
+##### Details
+
+- **Dial:** Rotation adjusts TC slot 1 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both TC Slot 1 + and TC Slot 1 - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the value
+- **Decrease** — Pressing the button lowers the value
+
+---
+
+### TC Slot 2
+
+Adjust TC slot 2.
+
+##### Details
+
+- **Dial:** Rotation adjusts TC slot 2 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both TC Slot 2 + and TC Slot 2 - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the value
+- **Decrease** — Pressing the button lowers the value
+
+---
+
+### TC Slot 3
+
+Adjust TC slot 3.
+
+##### Details
+
+- **Dial:** Rotation adjusts TC slot 3 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both TC Slot 3 + and TC Slot 3 - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the value
+- **Decrease** — Pressing the button lowers the value
+
+---
+
+### TC Slot 4
+
+Adjust TC slot 4.
+
+##### Details
+
+- **Dial:** Rotation adjusts TC slot 4 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both TC Slot 4 + and TC Slot 4 - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the value
+- **Decrease** — Pressing the button lowers the value

--- a/packages/website/src/content/docs/docs/actions/cockpit/cockpit-misc.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/cockpit-misc.md
@@ -1,29 +1,127 @@
 ---
 title: Cockpit Misc
-description: Miscellaneous cockpit controls including wipers, FFB, latency, and dash pages
+description: Miscellaneous cockpit controls — wipers, FFB max force, latency, dash pages, and in-lap mode.
 sidebar:
   badge:
-    text: "10 modes"
+    text: "7 modes"
     variant: tip
 ---
 
-The Cockpit Misc action groups together various cockpit controls that don't fit neatly into other categories. Manage wipers, force feedback, latency reporting, dashboard pages, and in-lap mode.
+Cockpit Misc groups together various cockpit controls that don't fit neatly into other categories. Manage wipers, force feedback maximum force, latency reporting, dashboard pages, and in-lap mode.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| Toggle Wipers | Toggles the windshield wipers on or off. |
-| Trigger Wipers | Triggers a single wiper sweep. |
-| FFB Max Force Up | Increases the force feedback maximum force. |
-| FFB Max Force Down | Decreases the force feedback maximum force. |
-| Report Latency | Reports the current network latency. |
-| Dash Page 1 Next | Cycles to the next page on dashboard display 1. |
-| Dash Page 1 Previous | Cycles to the previous page on dashboard display 1. |
-| Dash Page 2 Next | Cycles to the next page on dashboard display 2. |
-| Dash Page 2 Previous | Cycles to the previous page on dashboard display 2. |
-| In-Lap Mode | Toggles in-lap mode. |
+Select the mode from the **Control** dropdown in the Property Inspector. Directional modes (FFB Max Force, Dash Page 1, Dash Page 2) also expose a **Direction** setting for Increase / Decrease.
 
-## Encoder Support
+### Toggle Wipers
 
-Yes.
+Toggle the windshield wipers on or off.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Shift+W`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Trigger Wipers
+
+Trigger a single wiper sweep.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+Alt+W`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### FFB Max Force
+
+Adjust the force feedback maximum force. The **Direction** setting picks whether pressing the button increases or decreases the force.
+
+##### Details
+
+- **Dial:** Rotation adjusts FFB max force (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both FFB Force Increase and FFB Force Decrease must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the max force
+- **Decrease** — Pressing the button lowers the max force
+
+---
+
+### Report Latency
+
+Report the current network latency in chat.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `L`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Dash Page 1
+
+Cycle through the pages on dashboard display 1. The **Direction** setting picks whether pressing the button advances to the next page or goes back to the previous one.
+
+##### Details
+
+- **Dial:** Rotation cycles dash page 1 (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
+- **Default binding:** No default key binding — both Dash Page 1 + and Dash Page 1 - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button advances to the next page
+- **Decrease** — Pressing the button goes back to the previous page
+
+---
+
+### Dash Page 2
+
+Cycle through the pages on dashboard display 2. The **Direction** setting picks whether pressing the button advances to the next page or goes back to the previous one.
+
+##### Details
+
+- **Dial:** Rotation cycles dash page 2 (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
+- **Default binding:** No default key binding — both Dash Page 2 + and Dash Page 2 - must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button advances to the next page
+- **Decrease** — Pressing the button goes back to the previous page
+
+---
+
+### In-Lap Mode
+
+Toggle in-lap mode (used for practice and qualifying to mark the return to pit).
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Shift+Alt+L`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings

--- a/packages/website/src/content/docs/docs/actions/cockpit/cockpit-misc.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/cockpit-misc.md
@@ -17,13 +17,13 @@ Select the mode from the **Control** dropdown in the Property Inspector. Directi
 
 Toggle the windshield wipers on or off.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Shift+W`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -33,13 +33,13 @@ Toggle the windshield wipers on or off.
 
 Trigger a single wiper sweep.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+Alt+W`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -49,13 +49,13 @@ Trigger a single wiper sweep.
 
 Adjust the force feedback maximum force. The **Direction** setting picks whether pressing the button increases or decreases the force.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts FFB max force (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both FFB Force Increase and FFB Force Decrease must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the max force
 - **Decrease** — Pressing the button lowers the max force
@@ -66,13 +66,13 @@ Adjust the force feedback maximum force. The **Direction** setting picks whether
 
 Report the current network latency in chat.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `L`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -82,13 +82,13 @@ Report the current network latency in chat.
 
 Cycle through the pages on dashboard display 1. The **Direction** setting picks whether pressing the button advances to the next page or goes back to the previous one.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles dash page 1 (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
 - **Default binding:** No default key binding — both Dash Page 1 + and Dash Page 1 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button advances to the next page
 - **Decrease** — Pressing the button goes back to the previous page
@@ -99,13 +99,13 @@ Cycle through the pages on dashboard display 1. The **Direction** setting picks 
 
 Cycle through the pages on dashboard display 2. The **Direction** setting picks whether pressing the button advances to the next page or goes back to the previous one.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles dash page 2 (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
 - **Default binding:** No default key binding — both Dash Page 2 + and Dash Page 2 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button advances to the next page
 - **Decrease** — Pressing the button goes back to the previous page
@@ -116,12 +116,12 @@ Cycle through the pages on dashboard display 2. The **Direction** setting picks 
 
 Toggle in-lap mode (used for practice and qualifying to mark the return to pit).
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Alt+L`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings

--- a/packages/website/src/content/docs/docs/actions/cockpit/force-feedback.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/force-feedback.md
@@ -1,67 +1,113 @@
 ---
 title: Force Feedback
-description: Force feedback and haptic controls
+description: Force feedback and haptic controls for wheel, bass shaker, and LFE intensity.
 sidebar:
   badge:
-    text: "11 modes"
+    text: "6 modes"
     variant: tip
 ---
 
-Force Feedback provides control over all force feedback and haptic settings from iRacing's Audio & Force Feedback page.
-
-## Properties
-
-| Property | Value |
-|----------|-------|
-| Action ID | `com.iracedeck.sd.core.force-feedback` |
-| Type | Toggle / +/- |
-| SDK Support | No |
-| Encoder Support | Yes |
+Control force feedback and haptic settings from iRacing's Audio & Force Feedback page: auto-compute FFB, overall FFB force, wheel LFE loudness and intensity, bass shaker LFE loudness, and haptic LFE intensity.
 
 ## Modes
 
-### Force Feedback
+Select the mode from the **Mode** dropdown in the Property Inspector. Directional modes also expose a **Direction** setting.
 
-| Mode | Type | Direction | Default Key | iRacing Setting |
-|------|------|-----------|-------------|-----------------|
-| Auto Compute FFB Force | Toggle | — | `Ctrl+A` | Auto Compute FFB Force |
-| FFB Force | +/- | Increase / Decrease | *(none)* | Increase FFB Force / Decrease FFB Force |
-| Wheel LFE | +/- | Louder / Quieter | *(none)* | Wheel LFE Louder / Wheel LFE Quieter |
+### Auto Compute FFB Force
 
-### Bass Shaker
+Toggle iRacing's auto-compute FFB force calibration. This is a disruptive toggle — the dial **press** is intentionally a no-op on Stream Deck+ so you can't flip it by accident while rotating a dial nearby.
 
-| Mode | Type | Direction | Default Key | iRacing Setting |
-|------|------|-----------|-------------|-----------------|
-| BassShaker LFE | +/- | Louder / Quieter | *(none)* | BassShaker LFE Louder / BassShaker LFE Quieter |
+##### Details
 
-### Wheel LFE Controls
+- **Dial:** No rotation support; dial press is also disabled to prevent accidental toggling
+- **Default binding:** `Ctrl+A`
+- **Telemetry-aware icon:** No
 
-| Mode | Type | Direction | Default Key | iRacing Setting |
-|------|------|-----------|-------------|-----------------|
-| Wheel LFE Intensity | +/- | More Intense / Less Intense | *(none)* | Wheel LFE More Intense / Wheel LFE Less Intense |
+##### Settings
 
-### Haptic LFE Controls
+- No additional settings
 
-| Mode | Type | Direction | Default Key | iRacing Setting |
-|------|------|-----------|-------------|-----------------|
-| Haptic LFE Intensity | +/- | More Intense / Less Intense | *(none)* | Haptic LFE More Intense / Haptic LFE Less Intense |
+---
 
-## Encoder Support
+### FFB Force
 
-All directional modes support Stream Deck+ encoder rotation:
-- **Clockwise** = increase / louder / more intense
-- **Counter-clockwise** = decrease / quieter / less intense
+Adjust the overall force feedback force. Shares the same global key binding as Cockpit Misc's FFB Max Force mode — configuring one updates the other.
 
-Auto Compute FFB Force does **not** support encoder — it is a keypad-only toggle. The dial press is a no-op to prevent accidental toggling.
+##### Details
 
-## Settings
+- **Dial:** Rotation adjusts FFB force (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** No default key binding — both FFB Force Increase and FFB Force Decrease must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| Mode | Dropdown | Auto Compute FFB Force | Force feedback control to activate |
-| Direction | Dropdown | Increase | Direction for +/- modes (hidden for toggle modes) |
+##### Setting: Direction
 
-## Notes
+- **Increase** (default) — Pressing the button raises the force
+- **Decrease** — Pressing the button lowers the force
 
-- FFB Force increase/decrease shares global key bindings with the Cockpit Misc action for backward compatibility.
-- All key bindings default to no key — users must configure them to match their iRacing settings, except Auto Compute FFB Force which defaults to `Ctrl+A`.
+---
+
+### Wheel LFE
+
+Adjust the wheel LFE (low-frequency effects) loudness.
+
+##### Details
+
+- **Dial:** Rotation adjusts wheel LFE loudness (clockwise = louder, counter-clockwise = quieter), regardless of the Direction setting
+- **Default binding:** No default key binding — both Wheel LFE Louder and Wheel LFE Quieter must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button makes it louder
+- **Decrease** — Pressing the button makes it quieter
+
+---
+
+### Bass Shaker LFE
+
+Adjust the bass shaker LFE loudness.
+
+##### Details
+
+- **Dial:** Rotation adjusts bass shaker LFE loudness (clockwise = louder, counter-clockwise = quieter), regardless of the Direction setting
+- **Default binding:** No default key binding — both Bass Shaker LFE Louder and Bass Shaker LFE Quieter must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button makes it louder
+- **Decrease** — Pressing the button makes it quieter
+
+---
+
+### Wheel LFE Intensity
+
+Adjust the wheel LFE intensity curve.
+
+##### Details
+
+- **Dial:** Rotation adjusts wheel LFE intensity (clockwise = more intense, counter-clockwise = less intense), regardless of the Direction setting
+- **Default binding:** No default key binding — both Wheel LFE More Intense and Wheel LFE Less Intense must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button makes it more intense
+- **Decrease** — Pressing the button makes it less intense
+
+---
+
+### Haptic LFE Intensity
+
+Adjust the haptic LFE intensity curve.
+
+##### Details
+
+- **Dial:** Rotation adjusts haptic LFE intensity (clockwise = more intense, counter-clockwise = less intense), regardless of the Direction setting
+- **Default binding:** No default key binding — both Haptic LFE More Intense and Haptic LFE Less Intense must be configured in iRacing and in the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button makes it more intense
+- **Decrease** — Pressing the button makes it less intense

--- a/packages/website/src/content/docs/docs/actions/cockpit/force-feedback.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/force-feedback.md
@@ -17,13 +17,13 @@ Select the mode from the **Mode** dropdown in the Property Inspector. Directiona
 
 Toggle iRacing's auto-compute FFB force calibration. This is a disruptive toggle — the dial **press** is intentionally a no-op on Stream Deck+ so you can't flip it by accident while rotating a dial nearby.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support; dial press is also disabled to prevent accidental toggling
 - **Default binding:** `Ctrl+A`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -33,13 +33,13 @@ Toggle iRacing's auto-compute FFB force calibration. This is a disruptive toggle
 
 Adjust the overall force feedback force. Shares the same global key binding as Cockpit Misc's FFB Max Force mode — configuring one updates the other.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts FFB force (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both FFB Force Increase and FFB Force Decrease must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the force
 - **Decrease** — Pressing the button lowers the force
@@ -50,13 +50,13 @@ Adjust the overall force feedback force. Shares the same global key binding as C
 
 Adjust the wheel LFE (low-frequency effects) loudness.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts wheel LFE loudness (clockwise = louder, counter-clockwise = quieter), regardless of the Direction setting
 - **Default binding:** No default key binding — both Wheel LFE Louder and Wheel LFE Quieter must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button makes it louder
 - **Decrease** — Pressing the button makes it quieter
@@ -67,13 +67,13 @@ Adjust the wheel LFE (low-frequency effects) loudness.
 
 Adjust the bass shaker LFE loudness.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts bass shaker LFE loudness (clockwise = louder, counter-clockwise = quieter), regardless of the Direction setting
 - **Default binding:** No default key binding — both Bass Shaker LFE Louder and Bass Shaker LFE Quieter must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button makes it louder
 - **Decrease** — Pressing the button makes it quieter
@@ -84,13 +84,13 @@ Adjust the bass shaker LFE loudness.
 
 Adjust the wheel LFE intensity curve.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts wheel LFE intensity (clockwise = more intense, counter-clockwise = less intense), regardless of the Direction setting
 - **Default binding:** No default key binding — both Wheel LFE More Intense and Wheel LFE Less Intense must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button makes it more intense
 - **Decrease** — Pressing the button makes it less intense
@@ -101,13 +101,13 @@ Adjust the wheel LFE intensity curve.
 
 Adjust the haptic LFE intensity curve.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts haptic LFE intensity (clockwise = more intense, counter-clockwise = less intense), regardless of the Direction setting
 - **Default binding:** No default key binding — both Haptic LFE More Intense and Haptic LFE Less Intense must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button makes it more intense
 - **Decrease** — Pressing the button makes it less intense

--- a/packages/website/src/content/docs/docs/actions/cockpit/splits-delta-cycle.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/splits-delta-cycle.md
@@ -17,13 +17,13 @@ Select the mode from the **Mode** dropdown in the Property Inspector.
 
 Cycle through iRacing's splits delta display modes. When placed on a key, pressing the button sends the direction chosen in the **Direction** setting. When placed on a dial, rotating the dial cycles next / previous regardless of the Direction setting.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles splits delta modes (clockwise = next, counter-clockwise = previous); pressing the dial does nothing in this mode
 - **Default binding:** Depends on the selected direction — see the **Direction** setting below
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 Which splits delta hotkey the button press sends. Both directions are globally configurable.
 
@@ -36,13 +36,13 @@ Which splits delta hotkey the button press sends. Both directions are globally c
 
 Toggle the reference car overlay on or off. Replaces the old "Display Reference Car" option from the Toggle UI Elements action.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+C`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -52,13 +52,13 @@ Toggle the reference car overlay on or off. Replaces the old "Display Reference 
 
 Mark the start point for a custom sector on the current lap.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -68,13 +68,13 @@ Mark the start point for a custom sector on the current lap.
 
 Mark the end point for a custom sector on the current lap. Together with **Custom Sector Start**, this defines a user-chosen section you can compare against.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -84,13 +84,13 @@ Mark the end point for a custom sector on the current lap. Together with **Custo
 
 Save the current car state — position, speed, temperatures — as a reset snapshot. Solo practice sessions only.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -100,12 +100,12 @@ Save the current car state — position, speed, temperatures — as a reset snap
 
 Teleport the car back to the saved active reset snapshot. Solo practice sessions only.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings

--- a/packages/website/src/content/docs/docs/actions/cockpit/splits-delta-cycle.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/splits-delta-cycle.md
@@ -1,31 +1,111 @@
 ---
 title: Splits & Reference
-description: Cycle splits delta modes, toggle reference car, mark custom sectors, and use active reset
+description: Cycle splits delta modes, toggle reference car, mark custom sectors, and use active reset.
 sidebar:
   badge:
     text: "6 modes"
     variant: tip
 ---
 
-The Splits & Reference action lets you switch between iRacing's different splits delta display modes, toggle the reference car display, mark custom sector start and end points, and use active reset to practice specific track sections.
+Switch between iRacing's split-time delta display modes, toggle the reference car display, mark custom sector start and end points, or use active reset to practice specific track sections without leaving the cockpit.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| Cycle Delta Mode | Cycles through splits delta display modes (next or previous, configured via direction setting). |
-| Toggle Reference Car | Toggles the reference car display on or off. |
-| Custom Sector Start | Marks the start point for a custom sector. |
-| Custom Sector End | Marks the end point for a custom sector. |
-| Set Active Reset Point | Saves the current car state as a reset snapshot (solo practice only). |
-| Reset to Start Point | Teleports the car back to the saved active reset snapshot (solo practice only). |
+Select the mode from the **Mode** dropdown in the Property Inspector.
 
-## Encoder Support
+### Cycle Splits Delta
 
-Yes — in Cycle mode, rotation cycles through delta modes (clockwise for next, counter-clockwise for previous). In all other modes, pressing the encoder triggers the configured action.
+Cycle through iRacing's splits delta display modes. When placed on a key, pressing the button sends the direction chosen in the **Direction** setting. When placed on a dial, rotating the dial cycles next / previous regardless of the Direction setting.
 
-## Notes
+##### Details
 
-- The "Toggle Reference Car" mode replaces the former "Display Reference Car" option in the Toggle UI Elements action.
-- Active Reset only works in solo practice sessions. The car's full state (position, speed, temperatures) is captured when setting the point.
-- Custom Sector and Active Reset key bindings have no defaults in iRacing — users must configure keys in both iRacing settings and the Stream Deck Property Inspector.
+- **Dial:** Rotation cycles splits delta modes (clockwise = next, counter-clockwise = previous); pressing the dial does nothing in this mode
+- **Default binding:** Depends on the selected direction — see the **Direction** setting below
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+Which splits delta hotkey the button press sends. Both directions are globally configurable.
+
+- **Next** (default `Tab`) — Advance to the next splits delta mode
+- **Previous** (default `Shift+Tab`) — Go back to the previous splits delta mode
+
+---
+
+### Toggle Reference Car
+
+Toggle the reference car overlay on or off. Replaces the old "Display Reference Car" option from the Toggle UI Elements action.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+C`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Custom Sector Start
+
+Mark the start point for a custom sector on the current lap.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Custom Sector End
+
+Mark the end point for a custom sector on the current lap. Together with **Custom Sector Start**, this defines a user-chosen section you can compare against.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Set Active Reset Point
+
+Save the current car state — position, speed, temperatures — as a reset snapshot. Solo practice sessions only.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Reset to Start Point
+
+Teleport the car back to the saved active reset snapshot. Solo practice sessions only.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings

--- a/packages/website/src/content/docs/docs/actions/cockpit/telemetry-control.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/telemetry-control.md
@@ -1,24 +1,92 @@
 ---
 title: Telemetry Control
-description: Control telemetry logging and recording in iRacing
+description: Control telemetry logging and recording in iRacing.
 sidebar:
   badge:
     text: "5 modes"
     variant: tip
 ---
 
-The Telemetry Control action manages iRacing's telemetry logging and recording features. Toggle logging, mark events of interest, and control recording sessions.
+Manage iRacing's telemetry logging and recording features. Toggle logging, mark events of interest for later review, and start / stop / restart recording sessions.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| Toggle Logging | Toggles telemetry logging on or off. |
-| Mark Event | Marks the current moment in the telemetry log for later review. |
-| Start Recording | Starts a telemetry recording session. |
-| Stop Recording | Stops the current telemetry recording session. |
-| Restart Recording | Stops and immediately restarts telemetry recording. |
+Select the mode from the **Action** dropdown in the Property Inspector.
 
-## Encoder Support
+### Toggle Logging
 
-Yes.
+Toggle iRacing's telemetry log file on or off.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Alt+L`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Mark Event
+
+Mark the current moment in the telemetry log for later review.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `M`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Start Recording
+
+Start a telemetry recording session via the iRacing SDK.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Stop Recording
+
+Stop the current telemetry recording session via the iRacing SDK.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Restart Recording
+
+Stop and immediately restart telemetry recording via the iRacing SDK.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings

--- a/packages/website/src/content/docs/docs/actions/cockpit/telemetry-control.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/telemetry-control.md
@@ -17,13 +17,13 @@ Select the mode from the **Action** dropdown in the Property Inspector.
 
 Toggle iRacing's telemetry log file on or off.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Alt+L`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -33,13 +33,13 @@ Toggle iRacing's telemetry log file on or off.
 
 Mark the current moment in the telemetry log for later review.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `M`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -49,13 +49,13 @@ Mark the current moment in the telemetry log for later review.
 
 Start a telemetry recording session via the iRacing SDK.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -65,13 +65,13 @@ Start a telemetry recording session via the iRacing SDK.
 
 Stop the current telemetry recording session via the iRacing SDK.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -81,12 +81,12 @@ Stop the current telemetry recording session via the iRacing SDK.
 
 Stop and immediately restart telemetry recording via the iRacing SDK.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings

--- a/packages/website/src/content/docs/docs/actions/cockpit/toggle-ui-elements.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/toggle-ui-elements.md
@@ -1,28 +1,160 @@
 ---
 title: Toggle UI Elements
-description: Show or hide iRacing's on-screen UI elements
+description: Show or hide iRacing's on-screen UI elements.
 sidebar:
   badge:
-    text: "8 modes"
+    text: "9 modes"
     variant: tip
 ---
 
-The Toggle UI Elements action lets you quickly show or hide various iRacing on-screen overlays and displays. Clean up your view or bring back the information you need with a single button press.
+Show or hide iRacing's on-screen overlays and displays. Clean up your view or bring back the information you need with a single button press.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| Dash Box | Toggles the dashboard information box. |
-| Speed/Gear/Pedals | Toggles the speed, gear, and pedal inputs display. |
-| Radio Display | Toggles the radio communication display. |
-| FPS/Network Display | Toggles the FPS and network statistics display. |
-| Weather Radar | Toggles the weather radar overlay. |
-| Virtual Mirror | Toggles the virtual mirror. |
-| UI Edit Mode | Enters or exits UI edit mode for repositioning overlays. |
-| Display Reference Car | Toggles the reference car display. *(Deprecated — use the [Splits & Reference](/docs/actions/cockpit/splits-delta-cycle/) action instead.)* |
-| Replay UI | Toggles the replay user interface controls. |
+Select the mode from the **Element** dropdown in the Property Inspector.
 
-## Encoder Support
+### Dash Box
 
-Yes — rotation cycles through the available UI elements.
+Toggle the dashboard information box.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `D`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Speed / Gear / Pedals
+
+Toggle the speed, gear, and pedal inputs display.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `P`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Radio Display
+
+Toggle the radio communication display.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `O`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### FPS / Network Display
+
+Toggle the FPS and network statistics display.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `F`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Weather Radar
+
+Toggle the weather radar overlay.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Shift+Alt+R`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Virtual Mirror
+
+Toggle the virtual mirror.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Alt+M`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### UI Edit Mode
+
+Enter or exit UI edit mode for repositioning overlays.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Alt+K`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Display Reference Car
+
+Toggle the reference car display.
+
+:::caution
+**Deprecated** — use the [Splits & Reference](/docs/actions/cockpit/splits-delta-cycle/) action's **Toggle Reference Car** mode instead. Both modes share the same global key binding, so switching actions will not change your hotkey.
+:::
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+C`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Replay UI
+
+Toggle the replay user interface controls. This mode uses the iRacing SDK camera commands and reads the current `CamCameraState` flag from telemetry to decide whether to show or hide the UI.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings

--- a/packages/website/src/content/docs/docs/actions/cockpit/toggle-ui-elements.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/toggle-ui-elements.md
@@ -17,13 +17,13 @@ Select the mode from the **Element** dropdown in the Property Inspector.
 
 Toggle the dashboard information box.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `D`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -33,13 +33,13 @@ Toggle the dashboard information box.
 
 Toggle the speed, gear, and pedal inputs display.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `P`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -49,13 +49,13 @@ Toggle the speed, gear, and pedal inputs display.
 
 Toggle the radio communication display.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `O`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -65,13 +65,13 @@ Toggle the radio communication display.
 
 Toggle the FPS and network statistics display.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `F`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -81,13 +81,13 @@ Toggle the FPS and network statistics display.
 
 Toggle the weather radar overlay.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Alt+R`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -97,13 +97,13 @@ Toggle the weather radar overlay.
 
 Toggle the virtual mirror.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Alt+M`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -113,13 +113,13 @@ Toggle the virtual mirror.
 
 Enter or exit UI edit mode for repositioning overlays.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Alt+K`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -133,13 +133,13 @@ Toggle the reference car display.
 **Deprecated** — use the [Splits & Reference](/docs/actions/cockpit/splits-delta-cycle/) action's **Toggle Reference Car** mode instead. Both modes share the same global key binding, so switching actions will not change your hotkey.
 :::
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+C`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -149,12 +149,12 @@ Toggle the reference car display.
 
 Toggle the replay user interface controls. This mode uses the iRacing SDK camera commands and reads the current `CamCameraState` flag from telemetry to decide whether to show or hide the UI.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings

--- a/packages/website/src/content/docs/docs/actions/communication/chat.md
+++ b/packages/website/src/content/docs/docs/actions/communication/chat.md
@@ -21,17 +21,17 @@ Select the mode from the **Mode** dropdown in the Property Inspector.
 
 Send a user-defined chat message. Supports [template variables](/docs/features/template-variables/) — for example, `Going {{Speed}} mph` resolves the current speed at send time. Multiline input is supported in the Property Inspector for easier editing, but newlines collapse into spaces when the message is sent (iRacing chat is single-line).
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — when the button text or message template references live variables (e.g., `{{Speed}}`), the button re-renders whenever those variables change
 
-##### Setting: Message Text
+#### Setting: Message Text
 
 The text to send. Accepts template variables. Defaults to empty — configure before using this mode.
 
-##### Setting: Font Size
+#### Setting: Font Size
 
 Font size (5–36 px) used to render Message Text on the button. Defaults to `11`. Only affects the on-button rendering, not the sent message length.
 
@@ -41,17 +41,17 @@ Font size (5–36 px) used to render Message Text on the button. Defaults to `11
 
 Send one of iRacing's 15 built-in chat macros.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Macro Number
+#### Setting: Macro Number
 
 Which macro slot to fire (1–15). Defaults to `1`. The macro's text is defined inside iRacing, not in the Property Inspector.
 
-##### Setting: Font Size
+#### Setting: Font Size
 
 Font size (5–36 px) used on the button. Defaults to `11`. For macro mode, this only applies when a custom **Key Text** is set — the default "Macro + number" layout uses fixed font sizes.
 
@@ -61,13 +61,13 @@ Font size (5–36 px) used on the button. Defaults to `11`. For macro mode, this
 
 Reply to the most recent chat message using iRacing's reply command.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -77,13 +77,13 @@ Reply to the most recent chat message using iRacing's reply command.
 
 Respond to the most recent private message received.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -93,13 +93,13 @@ Respond to the most recent private message received.
 
 Send a private whisper to a specific driver. Whisper has no SDK command in iRacing, so this mode falls back to a keyboard binding.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding — Whisper has no default iRacing hotkey, so you must configure it in both iRacing and the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -109,13 +109,13 @@ Send a private whisper to a specific driver. Whisper has no SDK command in iRaci
 
 Open the chat input window without sending anything.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -125,13 +125,13 @@ Open the chat input window without sending anything.
 
 Cancel or close the chat window.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -139,10 +139,10 @@ Cancel or close the chat window.
 
 In addition to the mode-specific settings above, two Property Inspector settings apply to every Chat mode.
 
-##### Setting: Icon Color
+#### Setting: Icon Color
 
 The background color used for the chat button icon. Defaults to `#4a90d9` (blue).
 
-##### Setting: Key Text
+#### Setting: Key Text
 
 Custom text displayed on the Stream Deck button, replacing the default icon labels. Supports two lines (use a line break to split) and [template variables](/docs/features/template-variables/) for live-updating button text.

--- a/packages/website/src/content/docs/docs/actions/communication/chat.md
+++ b/packages/website/src/content/docs/docs/actions/communication/chat.md
@@ -1,57 +1,148 @@
 ---
 title: Chat
-description: Send chat messages, macros, replies, whispers, and manage the chat window in iRacing.
+description: Send chat messages, macros, replies, whispers, and manage the chat window.
 sidebar:
   badge:
     text: "7 modes"
     variant: tip
 ---
 
-Send chat messages and interact with the iRacing chat system. Includes sending custom messages, triggering built-in chat macros, replying to messages, whispering to drivers, and managing the chat window.
+Send chat messages and interact with iRacing's chat system. Includes sending custom messages, triggering built-in chat macros, replying to messages, whispering a specific driver, and managing the chat window.
+
+:::note
+Chat macros correspond to iRacing's built-in macro slots 1 through 15. Configure the macro text inside iRacing's chat macro settings.
+:::
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| Send Custom Message | Send a user-defined chat message (supports [template variables](/docs/features/template-variables/)) |
-| Chat Macro | Send one of iRacing's 15 built-in chat macros (select slot 1–15) |
-| Reply | Reply to the last chat message |
-| Respond to Last PM | Respond to the last private message |
-| Whisper | Send a private message to a specific driver |
-| Open Chat | Open the chat window |
-| Cancel | Cancel or close the chat window |
+Select the mode from the **Mode** dropdown in the Property Inspector.
 
-:::note
-Chat macros correspond to iRacing's built-in macro slots 1 through 15. Configure the macro text within iRacing's chat macro settings.
-:::
+### Send Custom Message
 
-## Settings
+Send a user-defined chat message. Supports [template variables](/docs/features/template-variables/) — for example, `Going {{Speed}} mph` resolves the current speed at send time. Multiline input is supported in the Property Inspector for easier editing, but newlines collapse into spaces when the message is sent (iRacing chat is single-line).
 
-| Setting | Type | Default | Applies to |
-|---------|------|---------|------------|
-| Mode | Dropdown | Send Message | All |
-| Message Text | Text area | *(empty)* | Send Message |
-| Macro Number | Dropdown (1–15) | 1 | Macro |
-| Icon Color | Color picker | `#4a90d9` | All |
-| Key Text | Text area | *(empty, uses default labels)* | All |
-| Font Size | Number (5–36) | 11 | Send Message, Macro |
+##### Details
 
-### Message Text
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — when the button text or message template references live variables (e.g., `{{Speed}}`), the button re-renders whenever those variables change
 
-The message to send when using **Send Message** mode. Supports [template variables](/docs/features/template-variables/) — for example, `Going {{Speed}} mph` will resolve the current speed at send time. Multiline input is supported for easier editing, but newlines are collapsed into spaces when the message is sent (iRacing chat is single-line).
+##### Setting: Message Text
 
-### Key Text
+The text to send. Accepts template variables. Defaults to empty — configure before using this mode.
 
-Custom text displayed on the Stream Deck button. When set, it replaces the default icon labels. Supports [template variables](/docs/features/template-variables/) for live-updating button text. Supports two lines — use a line break to split.
+##### Setting: Font Size
 
-### Font Size
+Font size (5–36 px) used to render Message Text on the button. Defaults to `11`. Only affects the on-button rendering, not the sent message length.
 
-Controls the text size (5–36px) rendered on the button for **Send Message** and **Macro** modes. For **Macro** mode, the font size only applies when custom Key Text is set; the default "Macro + number" layout uses fixed font sizes.
+---
 
-## Encoder Support
+### Chat Macro
 
-Yes — press the dial to trigger the configured chat action. Dial rotation is not used.
+Send one of iRacing's 15 built-in chat macros.
 
-## Keyboard Bindings
+##### Details
 
-The **Whisper** mode uses a configurable keyboard shortcut (global setting shared across all Chat action instances). All other modes use iRacing SDK commands and do not require keyboard bindings.
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Macro Number
+
+Which macro slot to fire (1–15). Defaults to `1`. The macro's text is defined inside iRacing, not in the Property Inspector.
+
+##### Setting: Font Size
+
+Font size (5–36 px) used on the button. Defaults to `11`. For macro mode, this only applies when a custom **Key Text** is set — the default "Macro + number" layout uses fixed font sizes.
+
+---
+
+### Reply
+
+Reply to the most recent chat message using iRacing's reply command.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Respond to Last PM
+
+Respond to the most recent private message received.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Whisper
+
+Send a private whisper to a specific driver. Whisper has no SDK command in iRacing, so this mode falls back to a keyboard binding.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding — Whisper has no default iRacing hotkey, so you must configure it in both iRacing and the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Open Chat
+
+Open the chat input window without sending anything.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Cancel
+
+Cancel or close the chat window.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+## Shared settings
+
+In addition to the mode-specific settings above, two Property Inspector settings apply to every Chat mode.
+
+##### Setting: Icon Color
+
+The background color used for the chat button icon. Defaults to `#4a90d9` (blue).
+
+##### Setting: Key Text
+
+Custom text displayed on the Stream Deck button, replacing the default icon labels. Supports two lines (use a line break to split) and [template variables](/docs/features/template-variables/) for live-updating button text.

--- a/packages/website/src/content/docs/docs/actions/communication/chat.md
+++ b/packages/website/src/content/docs/docs/actions/communication/chat.md
@@ -139,10 +139,10 @@ Cancel or close the chat window.
 
 In addition to the mode-specific settings above, two Property Inspector settings apply to every Chat mode.
 
-#### Setting: Icon Color
+### Setting: Icon Color
 
 The background color used for the chat button icon. Defaults to `#4a90d9` (blue).
 
-#### Setting: Key Text
+### Setting: Key Text
 
 Custom text displayed on the Stream Deck button, replacing the default icon labels. Supports two lines (use a line break to split) and [template variables](/docs/features/template-variables/) for live-updating button text.

--- a/packages/website/src/content/docs/docs/actions/communication/race-admin.md
+++ b/packages/website/src/content/docs/docs/actions/communication/race-admin.md
@@ -7,67 +7,500 @@ sidebar:
     variant: tip
 ---
 
-Quick access to iRacing session admin chat commands from your Stream Deck. Designed for league race directors and hosted session admins who need to issue commands like `!yellow`, `!black`, `!pitclose`, and more without typing them manually.
+Quick access to iRacing session admin chat commands from your Stream Deck. Designed for league race directors and hosted session admins who need to issue commands like `!yellow`, `!black`, `!pitclose`, and more without typing them manually. Every mode sends its command through the iRacing SDK chat API — no keyboard bindings, no telemetry awareness.
 
-All commands are sent as chat messages via the iRacing SDK. Commands that accept a `<driver>` parameter support automatic targeting of the currently viewed car or a pre-defined car number.
+Every command that accepts an optional `[message]` parameter supports [template variables](/docs/features/template-variables/), so you can include live data like lap number, session time, or track name in the messages you send.
 
-## Race Control
+:::note
+Commands that accept a `<driver>` parameter share a **Driver Target** setting that decides how the car number is picked at send time. Rather than repeating the full setting on every such mode, it is documented once in the **Shared settings** section at the bottom of this page.
+:::
 
-| Mode | Command | Description |
-|------|---------|-------------|
-| Throw Yellow Flag | `!yellow [message]` | Throw a caution flag |
-| Black Flag Driver | `!black <driver> [time/laps/D]` | Issue a penalty — time (seconds), laps, or drive-through |
-| Disqualify Driver | `!dq <driver> [message]` | Disqualify a driver without removing them |
-| Show Disqualifications (Field) | `!showdqs` | Display disqualifications for the entire field |
-| Show Disqualifications (Driver) | `!showdqs <driver>` | Display disqualifications for a specific driver |
-| Clear Driver Penalties | `!clear <driver> [message]` | Clear all penalties for a driver |
-| Clear All Penalties | `!clearall` | Clear all penalties for the entire field |
-| Wave Driver Around | `!waveby <driver> [message]` | Move car to next lap and end of pace line |
-| End of Line Penalty | `!eol <driver> [message]` | Move driver to end of pace line |
-| Close Pit Entrance | `!pitclose` | Close pit entrances during green flag |
-| Open Pit Entrance | `!pitopen` | Open pit entrances during green flag |
-| Adjust Pace Laps | `!pacelaps <+n\|-n\|n>` | Add, subtract, or set pace laps until green |
-| Single-File Restart | `!restart single` | Switch to single-file restart rules |
-| Double-File Restart | `!restart double` | Switch to double-file restart rules |
+## Modes
 
-## Session Management
+Select the mode from the **Mode** dropdown in the Property Inspector. The dropdown is grouped by **Race Control**, **Session Management**, and **Driver & Chat Management**.
 
-| Mode | Command | Description |
-|------|---------|-------------|
-| Advance Session | `!advance [message]` | Advance to the next session (e.g., qualify to grid) |
-| Delay Race Start | `!gridset [minutes]` | Disable auto-race start (max 10 minutes) |
-| Start Race | `!gridstart` | Initiate the pace car or standing start sequence |
-| Track State (Rubber) | `!trackstate [percent]` | Set track usage % for next session (0-100, or -1 to carry over) |
+### Throw Yellow Flag
 
-## Driver & Chat Management
+Throw a caution flag — sends `!yellow [message]`.
 
-| Mode | Command | Description |
-|------|---------|-------------|
-| Grant Admin | `!admin <driver> [message]` | Grant admin privileges to a driver |
-| Revoke Admin | `!nadmin <driver> [message]` | Revoke admin privileges from a driver |
-| Remove Driver | `!remove <driver> [message]` | Permanently remove a driver from the session |
-| Enable Chat (All) | `!chat` | Re-enable chat for all drivers |
-| Enable Chat (Driver) | `!chat <driver>` | Re-enable chat for a specific driver |
-| Disable Chat (All) | `!nchat` | Disable chat for all non-admin drivers |
-| Mute Driver | `!nchat <driver>` | Mute a specific driver |
-| Message All Participants | `/all <message>` | Send a message to all participants (bypasses chat disable) |
-| Race Control Message | `/rc <message>` | Send a message visible only to administrators |
+##### Details
 
-## Driver Targeting
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
 
-Commands that accept a `<driver>` parameter have two targeting methods:
+##### Setting: Message
 
-### Currently Viewed Car (default)
+Optional caution message (supports template variables).
 
-When the **"Use Viewed Car"** checkbox is checked (the default), the action automatically reads the car number of the car currently being followed in the replay/broadcast view. Simply view a car and press the button — the command targets that car.
+---
 
-### Pre-defined Car Number
+### Black Flag Driver
 
-When the checkbox is unchecked, a number input appears where you enter a car number. This car number is used every time the action fires, regardless of which car is being viewed. The car number is also displayed on the button icon.
+Issue a penalty — sends `!black <driver> [time/laps/D]`. Black Flag supports three penalty types.
 
-## Message Templates
+##### Details
 
-Commands that accept an optional `[message]` parameter support [template variables](/docs/features/template-variables/). This lets you include dynamic data in your messages:
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Driver Target
+
+See **Shared settings** below — this mode needs a driver.
+
+##### Setting: Penalty Type
+
+- **Time** (default) — Penalty duration in seconds (e.g., `30`)
+- **Laps** — Number of laps to serve (e.g., `2`)
+- **Drive-Through** — Drive-through penalty (`D`)
+
+---
+
+### Disqualify Driver
+
+Disqualify a driver without removing them — sends `!dq <driver> [message]`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Driver Target
+
+See **Shared settings** below — this mode needs a driver.
+
+##### Setting: Message
+
+Optional disqualification message (supports template variables).
+
+---
+
+### Show Disqualifications (Field)
+
+Display disqualifications for the entire field — sends `!showdqs`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Show Disqualifications (Driver)
+
+Display disqualifications for a specific driver — sends `!showdqs <driver>`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Driver Target
+
+See **Shared settings** below — this mode needs a driver.
+
+---
+
+### Clear Driver Penalties
+
+Clear all penalties for a driver — sends `!clear <driver> [message]`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Driver Target
+
+See **Shared settings** below — this mode needs a driver.
+
+##### Setting: Message
+
+Optional explanation (supports template variables).
+
+---
+
+### Clear All Penalties
+
+Clear all penalties for the entire field — sends `!clearall`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Wave Driver Around
+
+Wave a car to the next lap and the end of the pace line — sends `!waveby <driver> [message]`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Driver Target
+
+See **Shared settings** below — this mode needs a driver.
+
+##### Setting: Message
+
+Optional explanation (supports template variables).
+
+---
+
+### End of Line Penalty
+
+Move a driver to the end of the pace line — sends `!eol <driver> [message]`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Driver Target
+
+See **Shared settings** below — this mode needs a driver.
+
+##### Setting: Message
+
+Optional explanation (supports template variables).
+
+---
+
+### Close Pit Entrance
+
+Close pit entrances during green flag running — sends `!pitclose`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Open Pit Entrance
+
+Open pit entrances during green flag running — sends `!pitopen`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Adjust Pace Laps
+
+Add, subtract, or set pace laps until green — sends `!pacelaps <+n|-n|n>`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Pace Laps Operation
+
+- **+** (default) — Add the given number of pace laps
+- **−** — Subtract the given number of pace laps
+- **=** — Set the absolute pace lap count
+
+##### Setting: Pace Laps Value
+
+The number of laps passed with the operation.
+
+---
+
+### Single-File Restart
+
+Switch to single-file restart rules — sends `!restart single`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Double-File Restart
+
+Switch to double-file restart rules — sends `!restart double`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Advance Session
+
+Advance to the next session (e.g., qualify to grid) — sends `!advance [message]`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Message
+
+Optional message to broadcast with the session change (supports template variables).
+
+---
+
+### Delay Race Start
+
+Disable auto-race start for a number of minutes — sends `!gridset [minutes]` (max 10 minutes).
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Minutes
+
+Number of minutes to delay. iRacing caps this at 10.
+
+---
+
+### Start Race
+
+Initiate the pace car or standing start sequence — sends `!gridstart`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Track State (Rubber)
+
+Set the track usage percentage for the next session — sends `!trackstate [percent]`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Percent
+
+Track usage percent from `0` to `100`, or `-1` to carry the current state forward.
+
+---
+
+### Grant Admin
+
+Grant admin privileges to a driver — sends `!admin <driver> [message]`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Driver Target
+
+See **Shared settings** below — this mode needs a driver.
+
+##### Setting: Message
+
+Optional message (supports template variables).
+
+---
+
+### Revoke Admin
+
+Revoke admin privileges from a driver — sends `!nadmin <driver> [message]`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Driver Target
+
+See **Shared settings** below — this mode needs a driver.
+
+##### Setting: Message
+
+Optional message (supports template variables).
+
+---
+
+### Remove Driver
+
+Permanently remove a driver from the session — sends `!remove <driver> [message]`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Driver Target
+
+See **Shared settings** below — this mode needs a driver.
+
+##### Setting: Message
+
+Optional removal message (supports template variables).
+
+---
+
+### Enable Chat (All)
+
+Re-enable chat for all drivers — sends `!chat`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Enable Chat (Driver)
+
+Re-enable chat for a specific driver — sends `!chat <driver>`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Driver Target
+
+See **Shared settings** below — this mode needs a driver.
+
+---
+
+### Disable Chat (All)
+
+Disable chat for all non-admin drivers — sends `!nchat`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Mute Driver
+
+Mute a specific driver — sends `!nchat <driver>`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Driver Target
+
+See **Shared settings** below — this mode needs a driver.
+
+---
+
+### Message All Participants
+
+Send a message to every participant, bypassing chat disables — sends `/all <message>`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Message
+
+Required. Supports template variables.
+
+---
+
+### Race Control Message
+
+Send a message visible only to administrators — sends `/rc <message>`.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Message
+
+Required. Supports template variables.
+
+## Shared settings
+
+### Driver Target
+
+Every mode that accepts a `<driver>` parameter shares a single targeting setting with two options:
+
+- **Use Viewed Car** (default) — The action reads the car number of the car currently being followed in the replay / broadcast view at send time. View a car and press the button; the command targets that car.
+- **Pre-defined Car Number** — Unchecking **Use Viewed Car** reveals a number input. The same car number is used on every press, regardless of which car is being viewed, and is also rendered on the button icon so you can tell which car the button targets.
+
+### Message templates
+
+Every `[message]` parameter supports [template variables](/docs/features/template-variables/), so you can include live telemetry or session data in the messages you send. Examples:
 
 ```text
 !advance Race starting in {{session.time_remaining}}
@@ -75,30 +508,21 @@ Commands that accept an optional `[message]` parameter support [template variabl
 /all Welcome to {{track.short_name}}!
 ```
 
-## Black Flag Penalty Types
-
-The Black Flag mode supports three penalty types:
-
-- **Time** — Penalty duration in seconds (e.g., 30)
-- **Laps** — Number of laps to serve (e.g., 2)
-- **Drive-Through** — Drive-through penalty
-
-## Encoder Support
-
-Yes — press the dial to execute the currently selected command.
-
-## Common Workflows
+## Common workflows
 
 **Issue a black flag:**
-1. Set the mode to "Black Flag Driver" with your desired penalty type
-2. View the offending car in the replay/broadcast
+
+1. Set the mode to **Black Flag Driver** with your desired penalty type
+2. View the offending car in the replay / broadcast
 3. Press the button — the command targets the viewed car automatically
 
 **Throw a yellow with a message:**
-1. Set the mode to "Throw Yellow Flag"
-2. Enter a message like "Caution for debris"
-3. Press the button at any time
+
+1. Set the mode to **Throw Yellow Flag**
+2. Enter a message like `Caution for debris`
+3. Press the button when you need the caution
 
 **Quick pit control:**
-1. Set up two buttons: one for "Close Pit Entrance", one for "Open Pit Entrance"
+
+1. Set up two buttons: one for **Close Pit Entrance**, one for **Open Pit Entrance**
 2. Press to toggle pit status during green flag racing

--- a/packages/website/src/content/docs/docs/actions/communication/race-admin.md
+++ b/packages/website/src/content/docs/docs/actions/communication/race-admin.md
@@ -23,13 +23,13 @@ Select the mode from the **Mode** dropdown in the Property Inspector. The dropdo
 
 Throw a caution flag — sends `!yellow [message]`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Message
+#### Setting: Message
 
 Optional caution message (supports template variables).
 
@@ -39,17 +39,17 @@ Optional caution message (supports template variables).
 
 Issue a penalty — sends `!black <driver> [time/laps/D]`. Black Flag supports three penalty types.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Driver Target
+#### Setting: Driver Target
 
 See **Shared settings** below — this mode needs a driver.
 
-##### Setting: Penalty Type
+#### Setting: Penalty Type
 
 - **Time** (default) — Penalty duration in seconds (e.g., `30`)
 - **Laps** — Number of laps to serve (e.g., `2`)
@@ -61,17 +61,17 @@ See **Shared settings** below — this mode needs a driver.
 
 Disqualify a driver without removing them — sends `!dq <driver> [message]`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Driver Target
+#### Setting: Driver Target
 
 See **Shared settings** below — this mode needs a driver.
 
-##### Setting: Message
+#### Setting: Message
 
 Optional disqualification message (supports template variables).
 
@@ -81,13 +81,13 @@ Optional disqualification message (supports template variables).
 
 Display disqualifications for the entire field — sends `!showdqs`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -97,13 +97,13 @@ Display disqualifications for the entire field — sends `!showdqs`.
 
 Display disqualifications for a specific driver — sends `!showdqs <driver>`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Driver Target
+#### Setting: Driver Target
 
 See **Shared settings** below — this mode needs a driver.
 
@@ -113,17 +113,17 @@ See **Shared settings** below — this mode needs a driver.
 
 Clear all penalties for a driver — sends `!clear <driver> [message]`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Driver Target
+#### Setting: Driver Target
 
 See **Shared settings** below — this mode needs a driver.
 
-##### Setting: Message
+#### Setting: Message
 
 Optional explanation (supports template variables).
 
@@ -133,13 +133,13 @@ Optional explanation (supports template variables).
 
 Clear all penalties for the entire field — sends `!clearall`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -149,17 +149,17 @@ Clear all penalties for the entire field — sends `!clearall`.
 
 Wave a car to the next lap and the end of the pace line — sends `!waveby <driver> [message]`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Driver Target
+#### Setting: Driver Target
 
 See **Shared settings** below — this mode needs a driver.
 
-##### Setting: Message
+#### Setting: Message
 
 Optional explanation (supports template variables).
 
@@ -169,17 +169,17 @@ Optional explanation (supports template variables).
 
 Move a driver to the end of the pace line — sends `!eol <driver> [message]`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Driver Target
+#### Setting: Driver Target
 
 See **Shared settings** below — this mode needs a driver.
 
-##### Setting: Message
+#### Setting: Message
 
 Optional explanation (supports template variables).
 
@@ -189,13 +189,13 @@ Optional explanation (supports template variables).
 
 Close pit entrances during green flag running — sends `!pitclose`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -205,13 +205,13 @@ Close pit entrances during green flag running — sends `!pitclose`.
 
 Open pit entrances during green flag running — sends `!pitopen`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -221,19 +221,19 @@ Open pit entrances during green flag running — sends `!pitopen`.
 
 Add, subtract, or set pace laps until green — sends `!pacelaps <+n|-n|n>`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Pace Laps Operation
+#### Setting: Pace Laps Operation
 
 - **+** (default) — Add the given number of pace laps
 - **−** — Subtract the given number of pace laps
 - **=** — Set the absolute pace lap count
 
-##### Setting: Pace Laps Value
+#### Setting: Pace Laps Value
 
 The number of laps passed with the operation.
 
@@ -243,13 +243,13 @@ The number of laps passed with the operation.
 
 Switch to single-file restart rules — sends `!restart single`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -259,13 +259,13 @@ Switch to single-file restart rules — sends `!restart single`.
 
 Switch to double-file restart rules — sends `!restart double`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -275,13 +275,13 @@ Switch to double-file restart rules — sends `!restart double`.
 
 Advance to the next session (e.g., qualify to grid) — sends `!advance [message]`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Message
+#### Setting: Message
 
 Optional message to broadcast with the session change (supports template variables).
 
@@ -291,13 +291,13 @@ Optional message to broadcast with the session change (supports template variabl
 
 Disable auto-race start for a number of minutes — sends `!gridset [minutes]` (max 10 minutes).
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Minutes
+#### Setting: Minutes
 
 Number of minutes to delay. iRacing caps this at 10.
 
@@ -307,13 +307,13 @@ Number of minutes to delay. iRacing caps this at 10.
 
 Initiate the pace car or standing start sequence — sends `!gridstart`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -323,13 +323,13 @@ Initiate the pace car or standing start sequence — sends `!gridstart`.
 
 Set the track usage percentage for the next session — sends `!trackstate [percent]`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Percent
+#### Setting: Percent
 
 Track usage percent from `0` to `100`, or `-1` to carry the current state forward.
 
@@ -339,17 +339,17 @@ Track usage percent from `0` to `100`, or `-1` to carry the current state forwar
 
 Grant admin privileges to a driver — sends `!admin <driver> [message]`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Driver Target
+#### Setting: Driver Target
 
 See **Shared settings** below — this mode needs a driver.
 
-##### Setting: Message
+#### Setting: Message
 
 Optional message (supports template variables).
 
@@ -359,17 +359,17 @@ Optional message (supports template variables).
 
 Revoke admin privileges from a driver — sends `!nadmin <driver> [message]`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Driver Target
+#### Setting: Driver Target
 
 See **Shared settings** below — this mode needs a driver.
 
-##### Setting: Message
+#### Setting: Message
 
 Optional message (supports template variables).
 
@@ -379,17 +379,17 @@ Optional message (supports template variables).
 
 Permanently remove a driver from the session — sends `!remove <driver> [message]`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Driver Target
+#### Setting: Driver Target
 
 See **Shared settings** below — this mode needs a driver.
 
-##### Setting: Message
+#### Setting: Message
 
 Optional removal message (supports template variables).
 
@@ -399,13 +399,13 @@ Optional removal message (supports template variables).
 
 Re-enable chat for all drivers — sends `!chat`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -415,13 +415,13 @@ Re-enable chat for all drivers — sends `!chat`.
 
 Re-enable chat for a specific driver — sends `!chat <driver>`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Driver Target
+#### Setting: Driver Target
 
 See **Shared settings** below — this mode needs a driver.
 
@@ -431,13 +431,13 @@ See **Shared settings** below — this mode needs a driver.
 
 Disable chat for all non-admin drivers — sends `!nchat`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -447,13 +447,13 @@ Disable chat for all non-admin drivers — sends `!nchat`.
 
 Mute a specific driver — sends `!nchat <driver>`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Driver Target
+#### Setting: Driver Target
 
 See **Shared settings** below — this mode needs a driver.
 
@@ -463,13 +463,13 @@ See **Shared settings** below — this mode needs a driver.
 
 Send a message to every participant, bypassing chat disables — sends `/all <message>`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Message
+#### Setting: Message
 
 Required. Supports template variables.
 
@@ -479,13 +479,13 @@ Required. Supports template variables.
 
 Send a message visible only to administrators — sends `/rc <message>`.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Message
+#### Setting: Message
 
 Required. Supports template variables.
 

--- a/packages/website/src/content/docs/docs/actions/display-session/session-info.md
+++ b/packages/website/src/content/docs/docs/actions/display-session/session-info.md
@@ -1,29 +1,110 @@
 ---
 title: Session Info
-description: Display live session information including incidents, time, laps, position, fuel, and flags
+description: Display live session information — incidents, time, laps, position, fuel, and flags.
 sidebar:
   badge:
     text: "6 modes"
     variant: tip
 ---
 
-The Session Info action displays real-time session data on your Stream Deck button. Each mode shows different telemetry information with live-updating icons that respond to in-session events.
+Display real-time session data on your Stream Deck button. Each mode shows different telemetry with a live-updating icon. Session Info is purely a display action — pressing the button does nothing.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| Incidents | Shows live incident count. Flashes the icon when a new incident is received. |
-| Time Remaining | Displays session time remaining. Flashes when under 5 minutes remain. |
-| Laps | Shows the current lap number. |
-| Position | Displays current race position. Optionally shows total cars (e.g., "3/24"). |
-| Fuel | Shows fuel amount or fuel percentage remaining. |
-| Flags | Displays currently active flags with corresponding colors and a pulsing animation. |
+Select the mode from the **Mode** dropdown in the Property Inspector.
 
-## Encoder Support
+### Incidents
 
-Yes — rotation cycles through the available display modes.
+Show the live incident count. The icon flashes red when a new incident is received so you notice it even if you weren't looking.
 
-:::note
-This action is telemetry-aware. Icons update in real time with live session data from iRacing.
-:::
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — the incident count updates live and the icon flashes when a new incident is added
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Time Remaining
+
+Display the session time remaining. The icon flashes when less than 5 minutes remain so you can spot the cutoff at a glance.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — the countdown updates every second and the icon flashes when under 5 minutes remain
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Laps
+
+Show the current lap number.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — the lap number updates as you cross the start/finish line
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Position
+
+Display the current race position. Optionally shows total cars (e.g., `3/24`) by enabling the **Show Total** setting.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — the position updates live as drivers pass or are overtaken
+
+##### Setting: Show Total
+
+- **Off** (default) — Show just your position (e.g., `3`)
+- **On** — Show position out of field size (e.g., `3/24`)
+
+---
+
+### Fuel
+
+Show fuel amount or fuel percentage remaining.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — the fuel reading updates live
+
+##### Setting: Fuel Format
+
+- **Amount** (default) — Show the absolute fuel amount, respecting your iRacing display units (liters or gallons)
+- **Percentage** — Show fuel as a percentage of tank capacity
+
+---
+
+### Flags
+
+Display currently active flags with the corresponding colors and a pulsing animation when flags change.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — the icon updates to reflect the active flag (green, yellow, white, checkered, etc.) and pulses when a new flag is raised
+
+##### Settings
+
+- No additional settings

--- a/packages/website/src/content/docs/docs/actions/display-session/session-info.md
+++ b/packages/website/src/content/docs/docs/actions/display-session/session-info.md
@@ -17,13 +17,13 @@ Select the mode from the **Mode** dropdown in the Property Inspector.
 
 Show the live incident count. The icon flashes red when a new incident is received so you notice it even if you weren't looking.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the incident count updates live and the icon flashes when a new incident is added
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -33,13 +33,13 @@ Show the live incident count. The icon flashes red when a new incident is receiv
 
 Display the session time remaining. The icon flashes when less than 5 minutes remain so you can spot the cutoff at a glance.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the countdown updates every second and the icon flashes when under 5 minutes remain
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -49,13 +49,13 @@ Display the session time remaining. The icon flashes when less than 5 minutes re
 
 Show the current lap number.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the lap number updates as you cross the start/finish line
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -65,13 +65,13 @@ Show the current lap number.
 
 Display the current race position. Optionally shows total cars (e.g., `3/24`) by enabling the **Show Total** setting.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the position updates live as drivers pass or are overtaken
 
-##### Setting: Show Total
+#### Setting: Show Total
 
 - **Off** (default) — Show just your position (e.g., `3`)
 - **On** — Show position out of field size (e.g., `3/24`)
@@ -82,13 +82,13 @@ Display the current race position. Optionally shows total cars (e.g., `3/24`) by
 
 Show fuel amount or fuel percentage remaining.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the fuel reading updates live
 
-##### Setting: Fuel Format
+#### Setting: Fuel Format
 
 - **Amount** (default) — Show the absolute fuel amount, respecting your iRacing display units (liters or gallons)
 - **Percentage** — Show fuel as a percentage of tank capacity
@@ -99,12 +99,12 @@ Show fuel amount or fuel percentage remaining.
 
 Display currently active flags with the corresponding colors and a pulsing animation when flags change.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the icon updates to reflect the active flag (green, yellow, white, checkered, etc.) and pulses when a new flag is raised
 
-##### Settings
+#### Settings
 
 - No additional settings

--- a/packages/website/src/content/docs/docs/actions/display-session/telemetry-display.md
+++ b/packages/website/src/content/docs/docs/actions/display-session/telemetry-display.md
@@ -3,7 +3,7 @@ title: Telemetry Display
 description: Display any telemetry or session variable using a custom Mustache template.
 sidebar:
   badge:
-    text: "custom"
+    text: "1 mode"
     variant: tip
 ---
 
@@ -19,22 +19,22 @@ This action has a single mode — there is no Mode dropdown in the Property Insp
 
 Render a Mustache template using live iRacing telemetry and session data. The button re-renders whenever the referenced variables change.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the rendered value updates whenever any telemetry or session variable referenced in the template changes
 
-##### Setting: Title
+#### Setting: Title
 
 The title text shown above the rendered value. Supports Mustache templating, so you can drive it from telemetry too. Defaults to `I AM`.
 
-##### Setting: Template
+#### Setting: Template
 
 The Mustache template used to render the value. Defaults to `#{{self.car_number}}\n{{self.first_name}}` — this renders your car number and first name, e.g., `#42` / `John`.
 
 Multi-line output is supported — newlines in the rendered output stack vertically on the button.
 
-##### Setting: Font Size
+#### Setting: Font Size
 
 The font size for the rendered value. Defaults to `15`. Adjust to fit more text on the button or to make small values easier to read at a glance.

--- a/packages/website/src/content/docs/docs/actions/display-session/telemetry-display.md
+++ b/packages/website/src/content/docs/docs/actions/display-session/telemetry-display.md
@@ -1,20 +1,40 @@
 ---
 title: Telemetry Display
-description: Display any telemetry or session variable using custom Mustache templates
+description: Display any telemetry or session variable using a custom Mustache template.
 sidebar:
   badge:
     text: "custom"
     variant: tip
 ---
 
-The Telemetry Display action provides a flexible way to show any iRacing telemetry or session variable on your Stream Deck button. It uses custom Mustache templates, allowing you to define exactly what data is shown and how it is formatted.
+Telemetry Display is a flexible, template-driven button that can show any iRacing telemetry or session variable. Instead of a fixed mode enum, you write a Mustache template in the Property Inspector and the button renders whatever the template resolves to. Telemetry Display is purely a display action — pressing the button does nothing.
+
+See the [Template Variables](/docs/features/template-variables/) reference for the full list of available variables.
 
 ## Modes
 
-This action does not use predefined modes. Instead, you configure a custom Mustache template in the Property Inspector to display any available telemetry or session variable.
+This action has a single mode — there is no Mode dropdown in the Property Inspector.
 
-## Encoder Support
+### Template Display
 
-No.
+Render a Mustache template using live iRacing telemetry and session data. The button re-renders whenever the referenced variables change.
 
-See the [Template Variables](/docs/features/template-variables/) reference for a full list of available variables.
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — the rendered value updates whenever any telemetry or session variable referenced in the template changes
+
+##### Setting: Title
+
+The title text shown above the rendered value. Supports Mustache templating, so you can drive it from telemetry too. Defaults to `I AM`.
+
+##### Setting: Template
+
+The Mustache template used to render the value. Defaults to `#{{self.car_number}}\n{{self.first_name}}` — this renders your car number and first name, e.g., `#42` / `John`.
+
+Multi-line output is supported — newlines in the rendered output stack vertically on the button.
+
+##### Setting: Font Size
+
+The font size for the rendered value. Defaults to `15`. Adjust to fit more text on the button or to make small values easier to read at a glance.

--- a/packages/website/src/content/docs/docs/actions/driving/ai-spotter-controls.md
+++ b/packages/website/src/content/docs/docs/actions/driving/ai-spotter-controls.md
@@ -17,13 +17,13 @@ Select the mode from the **Control** dropdown in the Property Inspector.
 
 Ask the spotter to read the current damage status.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -33,13 +33,13 @@ Ask the spotter to read the current damage status.
 
 Ask the spotter to read the current weather conditions.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -49,13 +49,13 @@ Ask the spotter to read the current weather conditions.
 
 Toggle whether the spotter reports lap information.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -65,13 +65,13 @@ Toggle whether the spotter reports lap information.
 
 Toggle the announcement of the leader crossing the start/finish line.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -81,13 +81,13 @@ Toggle the announcement of the leader crossing the start/finish line.
 
 Raise the spotter volume.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -97,13 +97,13 @@ Raise the spotter volume.
 
 Lower the spotter volume.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -113,12 +113,12 @@ Lower the spotter volume.
 
 Silence the spotter entirely.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings

--- a/packages/website/src/content/docs/docs/actions/driving/ai-spotter-controls.md
+++ b/packages/website/src/content/docs/docs/actions/driving/ai-spotter-controls.md
@@ -1,26 +1,124 @@
 ---
 title: AI Spotter Controls
-description: Control iRacing's AI spotter including damage reports, weather, and volume
+description: Control iRacing's AI spotter — damage and weather reports, lap announcements, and volume.
 sidebar:
   badge:
     text: "7 modes"
     variant: tip
 ---
 
-The AI Spotter Controls action lets you manage iRacing's AI spotter directly from your Stream Deck. Trigger reports, toggle announcements, or adjust spotter volume without leaving the track.
+Manage iRacing's AI spotter directly from your Stream Deck. Trigger reports, toggle announcements, or adjust spotter volume without leaving the track.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| Damage Report | Requests a damage report from the spotter. |
-| Weather Report | Requests a weather report from the spotter. |
-| Toggle Report Laps | Toggles whether the spotter reports lap information. |
-| Announce Leader at S/F Line | Toggles the announcement of the leader crossing the start/finish line. |
-| Spotter Louder | Increases the spotter volume. |
-| Spotter Quieter | Decreases the spotter volume. |
-| Spotter Silence | Silences the spotter entirely. |
+Select the mode from the **Control** dropdown in the Property Inspector.
 
-## Encoder Support
+### Damage Report
 
-No.
+Ask the spotter to read the current damage status.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Weather Report
+
+Ask the spotter to read the current weather conditions.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Toggle Report Laps
+
+Toggle whether the spotter reports lap information.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Announce Leader at S/F Line
+
+Toggle the announcement of the leader crossing the start/finish line.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Spotter Louder
+
+Raise the spotter volume.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Spotter Quieter
+
+Lower the spotter volume.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Spotter Silence
+
+Silence the spotter entirely.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings

--- a/packages/website/src/content/docs/docs/actions/driving/audio-controls.md
+++ b/packages/website/src/content/docs/docs/actions/driving/audio-controls.md
@@ -1,32 +1,63 @@
 ---
 title: Audio Controls
-description: Adjust voice chat and master volume in iRacing
+description: Adjust voice chat and master volume in iRacing, and hold push-to-talk.
 sidebar:
   badge:
-    text: "6 modes"
+    text: "3 modes"
     variant: tip
 ---
 
-The Audio Controls action provides quick access to iRacing's audio settings. Adjust voice chat or master volume levels and mute/unmute without navigating menus.
+Quick access to iRacing's audio settings: hold push-to-talk, or raise / lower / mute voice chat and master volume without navigating menus.
 
 ## Modes
 
+Select the mode from the **Mode** dropdown in the Property Inspector. Voice Chat and Master modes also expose an **Action** setting for Volume Up / Volume Down (and Mute for Voice Chat).
+
+### Push to Talk
+
+Hold voice chat push-to-talk for as long as the button is pressed. Release the button to stop transmitting. Works the same on a key and on a dial — pressing the dial holds, releasing the dial stops transmitting.
+
+##### Details
+
+- **Dial:** No rotation support; press and hold the dial to transmit, release to stop
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
 ### Voice Chat
 
-| Mode | Description |
-|------|-------------|
-| Voice Chat Volume Up | Increases the voice chat volume. |
-| Voice Chat Volume Down | Decreases the voice chat volume. |
-| Voice Chat Mute | Toggles voice chat mute. |
+Control voice chat volume and mute.
 
-### Master Volume
+##### Details
 
-| Mode | Description |
-|------|-------------|
-| Master Volume Up | Increases the master volume. |
-| Master Volume Down | Decreases the master volume. |
-| Master Volume Mute | Toggles master volume mute. |
+- **Dial:** Rotation adjusts voice chat volume (clockwise = up, counter-clockwise = down) regardless of the Action setting; pressing the dial **always** toggles mute, even if the Action setting is Volume Up or Volume Down
+- **Default binding:** Depends on the selected action — see the **Action** setting below
+- **Telemetry-aware icon:** No
 
-## Encoder Support
+##### Setting: Action
 
-Yes — rotation adjusts the volume up or down depending on the selected category.
+- **Volume Up** (default, default key `Shift+Ctrl+Alt+numpad_add`) — Pressing the button raises voice chat volume
+- **Volume Down** (default key `Shift+Ctrl+Alt+numpad_subtract`) — Pressing the button lowers voice chat volume
+- **Mute** (default key `Shift+Ctrl+Alt+M`) — Pressing the button toggles voice chat mute
+
+---
+
+### Master
+
+Control the iRacing master volume. The Master mode has no mute option — the Action dropdown only exposes Volume Up and Volume Down.
+
+##### Details
+
+- **Dial:** Rotation adjusts master volume (clockwise = up, counter-clockwise = down) regardless of the Action setting; pressing the dial triggers the configured action
+- **Default binding:** Depends on the selected action — see the **Action** setting below
+- **Telemetry-aware icon:** No
+
+##### Setting: Action
+
+- **Volume Up** (default, default key `Shift+Alt+numpad_add`) — Pressing the button raises master volume
+- **Volume Down** (default key `Shift+Alt+numpad_subtract`) — Pressing the button lowers master volume

--- a/packages/website/src/content/docs/docs/actions/driving/audio-controls.md
+++ b/packages/website/src/content/docs/docs/actions/driving/audio-controls.md
@@ -7,7 +7,7 @@ sidebar:
     variant: tip
 ---
 
-Quick access to iRacing's audio settings: hold push-to-talk, or raise / lower / mute voice chat and master volume without navigating menus.
+Quick access to iRacing's audio settings: hold push-to-talk, raise / lower / mute voice chat volume, or raise / lower the master volume — all without navigating menus.
 
 ## Modes
 
@@ -17,13 +17,13 @@ Select the mode from the **Mode** dropdown in the Property Inspector. Voice Chat
 
 Hold voice chat push-to-talk for as long as the button is pressed. Release the button to stop transmitting. Works the same on a key and on a dial — pressing the dial holds, releasing the dial stops transmitting.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support; press and hold the dial to transmit, release to stop
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -33,13 +33,13 @@ Hold voice chat push-to-talk for as long as the button is pressed. Release the b
 
 Control voice chat volume and mute.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts voice chat volume (clockwise = up, counter-clockwise = down) regardless of the Action setting; pressing the dial **always** toggles mute, even if the Action setting is Volume Up or Volume Down
 - **Default binding:** Depends on the selected action — see the **Action** setting below
 - **Telemetry-aware icon:** No
 
-##### Setting: Action
+#### Setting: Action
 
 - **Volume Up** (default, default key `Shift+Ctrl+Alt+numpad_add`) — Pressing the button raises voice chat volume
 - **Volume Down** (default key `Shift+Ctrl+Alt+numpad_subtract`) — Pressing the button lowers voice chat volume
@@ -51,13 +51,13 @@ Control voice chat volume and mute.
 
 Control the iRacing master volume. The Master mode has no mute option — the Action dropdown only exposes Volume Up and Volume Down.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts master volume (clockwise = up, counter-clockwise = down) regardless of the Action setting; pressing the dial triggers the configured action
 - **Default binding:** Depends on the selected action — see the **Action** setting below
 - **Telemetry-aware icon:** No
 
-##### Setting: Action
+#### Setting: Action
 
 - **Volume Up** (default, default key `Shift+Alt+numpad_add`) — Pressing the button raises master volume
 - **Volume Down** (default key `Shift+Alt+numpad_subtract`) — Pressing the button lowers master volume

--- a/packages/website/src/content/docs/docs/actions/driving/black-box-selector.md
+++ b/packages/website/src/content/docs/docs/actions/driving/black-box-selector.md
@@ -1,43 +1,72 @@
 ---
 title: Black Box Selector
-description: Navigate iRacing's black box overlays with direct selection or cycling
+description: Navigate iRacing's black box overlays with direct selection or cycling.
 sidebar:
   badge:
-    text: "13 modes"
+    text: "3 modes"
     variant: tip
 ---
 
-The Black Box Selector action lets you jump directly to any of iRacing's black box overlays or cycle through them sequentially. Each direct selection mode acts as a toggle — pressing it opens the black box, and pressing it again while that black box is already selected closes it. Key bindings are shared globally across all instances of this action.
+Open any of iRacing's black box overlays directly, or cycle through them sequentially. Direct-selection acts as a toggle — pressing a button opens the black box, and pressing it again while that black box is already selected closes it.
 
 ## Modes
 
-### Direct Selection
+Select the mode from the **Mode** dropdown in the Property Inspector. In **Direct** mode, also pick which overlay the button opens from the **Black Box** dropdown.
 
-| Mode | Description |
-|------|-------------|
-| Lap Timing | Toggle the Lap Timing black box |
-| Standings | Toggle the Standings black box |
-| Relative | Toggle the Relative black box |
-| Fuel | Toggle the Fuel black box |
-| Tires | Toggle the Tires black box |
-| Tire Info | Toggle the Tire Info black box |
-| Pit Stop | Toggle the Pit Stop black box |
-| In-Car | Toggle the In-Car black box |
-| Mirror/Graphics | Toggle the Mirror/Graphics black box |
-| Radio | Toggle the Radio black box |
-| Weather | Toggle the Weather black box |
+### Direct
 
-### Cycle
+Open a specific black box overlay. Pressing the button toggles the overlay — press once to open, press again to close. The **Black Box** setting picks which overlay the button controls.
 
-| Mode | Description |
-|------|-------------|
-| Next | Cycles to the next black box. |
-| Previous | Cycles to the previous black box. |
+##### Details
 
-## Encoder Support
+- **Dial:** Rotation cycles through black boxes (clockwise = next, counter-clockwise = previous), using the **Cycle Next** / **Cycle Previous** bindings regardless of which black box is selected
+- **Default binding:** Depends on the selected black box — see the **Black Box** setting below
+- **Telemetry-aware icon:** No
 
-Yes — rotation cycles through the black boxes (clockwise for next, counter-clockwise for previous).
+##### Setting: Black Box
 
-:::note
-This action uses global key bindings shared across all instances. Configuring a key binding on one instance updates it for all Black Box Selector actions.
-:::
+The overlay this button opens. Each option has its own key binding with the defaults shown below; all bindings can be reconfigured.
+
+- **Lap Timing** (default `F1`) — Lap Timing black box
+- **Standings** (default `F2`) — Standings black box
+- **Relative** (default `F3`) — Relative black box
+- **Fuel** (default `F4`) — Fuel black box
+- **Tires** (default `F5`) — Tires black box
+- **Tire Info** (default `F6`) — Tire Info black box
+- **Pit-Stop Adjustments** (default `F7`) — Pit stop adjustments black box
+- **In-Car Adjustments** (default `F8`) — In-car adjustments black box
+- **Mirror Adjustments** (default `F9`) — Mirror adjustments black box
+- **Radio Adjustments** (default `F10`) — Radio adjustments black box
+- **Weather** (default `F11`) — Weather black box
+
+---
+
+### Next
+
+Cycle to the next black box.
+
+##### Details
+
+- **Dial:** Rotation cycles through black boxes (clockwise = next, counter-clockwise = previous)
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Previous
+
+Cycle to the previous black box.
+
+##### Details
+
+- **Dial:** Rotation cycles through black boxes (clockwise = next, counter-clockwise = previous)
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings

--- a/packages/website/src/content/docs/docs/actions/driving/black-box-selector.md
+++ b/packages/website/src/content/docs/docs/actions/driving/black-box-selector.md
@@ -17,13 +17,13 @@ Select the mode from the **Mode** dropdown in the Property Inspector. In **Direc
 
 Open a specific black box overlay. Pressing the button toggles the overlay — press once to open, press again to close. The **Black Box** setting picks which overlay the button controls.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles through black boxes (clockwise = next, counter-clockwise = previous), using the **Cycle Next** / **Cycle Previous** bindings regardless of which black box is selected
 - **Default binding:** Depends on the selected black box — see the **Black Box** setting below
 - **Telemetry-aware icon:** No
 
-##### Setting: Black Box
+#### Setting: Black Box
 
 The overlay this button opens. Each option has its own key binding with the defaults shown below; all bindings can be reconfigured.
 
@@ -45,13 +45,13 @@ The overlay this button opens. Each option has its own key binding with the defa
 
 Cycle to the next black box.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles through black boxes (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -61,12 +61,12 @@ Cycle to the next black box.
 
 Cycle to the previous black box.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles through black boxes (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings

--- a/packages/website/src/content/docs/docs/actions/driving/car-control.md
+++ b/packages/website/src/content/docs/docs/actions/driving/car-control.md
@@ -17,13 +17,13 @@ Select the mode from the **Control** dropdown in the Property Inspector.
 
 Toggle the pit speed limiter.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `A`
 - **Telemetry-aware icon:** Yes — the icon reflects the current pit limiter state from iRacing telemetry in real time
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -33,13 +33,13 @@ Toggle the pit speed limiter.
 
 Activate Push To Pass / Overtake for IndyCar, Super Formula, LMDh, and other cars with OTP.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding — Push To Pass has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
 - **Telemetry-aware icon:** Yes — the icon reads `P2P_Status` (not the momentary button press) so it shows whether overtake power is currently active, not just whether you pressed the button
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -49,13 +49,13 @@ Activate Push To Pass / Overtake for IndyCar, Super Formula, LMDh, and other car
 
 Toggle DRS on Formula cars.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding — DRS has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
 - **Telemetry-aware icon:** Yes — the icon reads `DRS_Status` to show whether DRS is currently open
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -65,13 +65,13 @@ Toggle DRS on Formula cars.
 
 Flash the headlights while the button is held. Useful for multi-class racing communication.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support; press and hold the dial to flash, release to stop
 - **Default binding:** No default key binding — Headlight Flash has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -81,13 +81,13 @@ Flash the headlights while the button is held. Useful for multi-class racing com
 
 Tear off a layer of visor film in open-wheel cars, clearing the view.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding — Tear Off Visor has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -97,13 +97,13 @@ Tear off a layer of visor film in open-wheel cars, clearing the view.
 
 Toggle the ignition on or off.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `I`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -113,13 +113,13 @@ Toggle the ignition on or off.
 
 Engage the car starter. Hold the button to crank.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support; press and hold the dial to crank, release to stop
 - **Default binding:** `S`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -129,13 +129,13 @@ Engage the car starter. Hold the button to crank.
 
 Context-aware car entry, exit, pit reset, or tow. The icon updates dynamically based on your current iRacing state, and the button uses a hold pattern — press and hold to confirm the action.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support; press and hold the dial to confirm, release to cancel
 - **Default binding:** `Shift+R`
 - **Telemetry-aware icon:** Yes — the icon switches between Enter Car, Exit Car, Reset to Pits, and Tow based on whether you are out of the car, in the pits, on track in a non-race session, or on track in a race
 
-##### Setting: State icons
+#### Setting: State icons
 
 Enter/Exit/Tow automatically picks one of four display states based on live telemetry. There is no setting to override this — it is shown here only to document the mapping:
 
@@ -150,13 +150,13 @@ Enter/Exit/Tow automatically picks one of four display states based on live tele
 
 Send the `Escape` key to exit the car or dismiss dialogs. The `Escape` key is hardcoded and is not affected by any Property Inspector key binding.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support; manual hold holds `Escape` while the button is pressed, auto-hold releases after 1.5 seconds or when you press again
 - **Default binding:** `Escape` (hardcoded — iRacing always uses `Escape` for this action, so the binding is not user-configurable)
 - **Telemetry-aware icon:** No
 
-##### Setting: Auto Hold
+#### Setting: Auto Hold
 
 - **Off** (default) — Hold the button to hold `Escape`; release the button to release `Escape`
 - **On** — A single tap holds `Escape` for 1.5 seconds automatically; tap again during those 1.5 seconds to cancel early
@@ -167,12 +167,12 @@ Send the `Escape` key to exit the car or dismiss dialogs. The `Escape` key is ha
 
 Pause the simulation.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Shift+P`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings

--- a/packages/website/src/content/docs/docs/actions/driving/car-control.md
+++ b/packages/website/src/content/docs/docs/actions/driving/car-control.md
@@ -1,48 +1,178 @@
 ---
 title: Car Control
-description: Control car functions including starter, ignition, pit limiter, headlights, DRS, escape, and more
+description: Control car functions — starter, ignition, pit limiter, headlights, DRS, Push To Pass, escape, and more.
 sidebar:
   badge:
     text: "10 modes"
     variant: tip
 ---
 
-The Car Control action provides quick access to essential car functions. Toggle the pit speed limiter, headlights, Push To Pass, DRS, starter, ignition, or tear off your visor — plus exit the car with Escape — all from a single button.
+Quick access to essential car functions: toggle the pit speed limiter, headlights, Push To Pass, DRS, starter, ignition, or tear off your visor — plus exit the car with Escape or pause the sim — all from a single button.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| Pit Speed Limiter | Toggles the pit speed limiter. Icon updates based on telemetry to reflect current state. |
-| Push To Pass | Activates Push To Pass / Overtake (IndyCar, Super Formula, LMDh, and other cars with OTP). Icon shows ON/OFF status from telemetry (`P2P_Status`). |
-| DRS | Toggles DRS (Formula cars). Icon shows ON/OFF status from telemetry (`DRS_Status`). |
-| Headlight Flash | Flashes headlights while held. Useful for multi-class racing communication. |
-| Tear Off Visor | Tears off visor film in open-wheel cars, clearing the view. |
-| Ignition | Toggles the ignition on or off. |
-| Starter | Engages the car starter. Hold button to crank. |
-| Enter/Exit/Tow | Context-aware car entry, exit, pit reset, or tow. Icon updates dynamically based on telemetry. Hold button to confirm. |
-| Escape | Sends the ESC key to exit the car or dismiss dialogs. Supports manual hold or auto-hold (1.5s timed hold with tap-to-cancel). |
-| Pause Sim | Pauses the simulation. |
+Select the mode from the **Control** dropdown in the Property Inspector.
 
-## Encoder Support
+### Pit Speed Limiter
 
-Yes.
+Toggle the pit speed limiter.
 
-### Enter/Exit/Tow States
+##### Details
 
-The Enter/Exit/Tow mode dynamically changes its icon based on your current state in iRacing:
+- **Dial:** No rotation support
+- **Default binding:** `A`
+- **Telemetry-aware icon:** Yes — the icon reflects the current pit limiter state from iRacing telemetry in real time
 
-| State | Condition | Icon |
-|-------|-----------|------|
-| Enter Car | Out of car (replay/spectator) | Car with inward arrow |
-| Exit Car | In the pits | Car with outward arrow |
-| Reset to Pits | On track, non-race session | Car with reset arrow |
-| Tow | On track, race session | Tow hook |
+##### Settings
 
-:::note
-Pit Speed Limiter, Push To Pass, DRS, and Enter/Exit/Tow modes feature telemetry-aware icons that reflect the current state in real time. Push To Pass reads the `P2P_Status` variable (not the momentary button press), so it accurately shows whether overtake power is currently active. Enter/Exit/Tow, Headlight Flash, and Starter use a hold pattern — the action is active while the button is pressed. Escape also uses a hold pattern by default, with an optional auto-hold mode that holds ESC for 1.5 seconds on a single tap (press again to cancel early).
-:::
+- No additional settings
 
-:::caution
-Headlight Flash, Push To Pass, DRS, and Tear Off Visor have no default iRacing key binding. You must configure both the iRacing binding and the action key binding for these modes to work.
-:::
+---
+
+### Push To Pass
+
+Activate Push To Pass / Overtake for IndyCar, Super Formula, LMDh, and other cars with OTP.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding — Push To Pass has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
+- **Telemetry-aware icon:** Yes — the icon reads `P2P_Status` (not the momentary button press) so it shows whether overtake power is currently active, not just whether you pressed the button
+
+##### Settings
+
+- No additional settings
+
+---
+
+### DRS
+
+Toggle DRS on Formula cars.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding — DRS has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
+- **Telemetry-aware icon:** Yes — the icon reads `DRS_Status` to show whether DRS is currently open
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Headlight Flash
+
+Flash the headlights while the button is held. Useful for multi-class racing communication.
+
+##### Details
+
+- **Dial:** No rotation support; press and hold the dial to flash, release to stop
+- **Default binding:** No default key binding — Headlight Flash has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Tear Off Visor
+
+Tear off a layer of visor film in open-wheel cars, clearing the view.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding — Tear Off Visor has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Ignition
+
+Toggle the ignition on or off.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `I`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Starter
+
+Engage the car starter. Hold the button to crank.
+
+##### Details
+
+- **Dial:** No rotation support; press and hold the dial to crank, release to stop
+- **Default binding:** `S`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Enter/Exit/Tow
+
+Context-aware car entry, exit, pit reset, or tow. The icon updates dynamically based on your current iRacing state, and the button uses a hold pattern — press and hold to confirm the action.
+
+##### Details
+
+- **Dial:** No rotation support; press and hold the dial to confirm, release to cancel
+- **Default binding:** `Shift+R`
+- **Telemetry-aware icon:** Yes — the icon switches between Enter Car, Exit Car, Reset to Pits, and Tow based on whether you are out of the car, in the pits, on track in a non-race session, or on track in a race
+
+##### Setting: State icons
+
+Enter/Exit/Tow automatically picks one of four display states based on live telemetry. There is no setting to override this — it is shown here only to document the mapping:
+
+- **Enter Car** — Out of car (replay or spectator); the icon shows a car with an inward arrow
+- **Exit Car** — In the pits; the icon shows a car with an outward arrow
+- **Reset to Pits** — On track in a non-race session; the icon shows a car with a reset arrow
+- **Tow** — On track in a race session; the icon shows a tow hook
+
+---
+
+### Escape
+
+Send the `Escape` key to exit the car or dismiss dialogs. The `Escape` key is hardcoded and is not affected by any Property Inspector key binding.
+
+##### Details
+
+- **Dial:** No rotation support; manual hold holds `Escape` while the button is pressed, auto-hold releases after 1.5 seconds or when you press again
+- **Default binding:** `Escape` (hardcoded — iRacing always uses `Escape` for this action, so the binding is not user-configurable)
+- **Telemetry-aware icon:** No
+
+##### Setting: Auto Hold
+
+- **Off** (default) — Hold the button to hold `Escape`; release the button to release `Escape`
+- **On** — A single tap holds `Escape` for 1.5 seconds automatically; tap again during those 1.5 seconds to cancel early
+
+---
+
+### Pause Sim
+
+Pause the simulation.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Shift+P`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings

--- a/packages/website/src/content/docs/docs/actions/driving/look-direction.md
+++ b/packages/website/src/content/docs/docs/actions/driving/look-direction.md
@@ -1,27 +1,76 @@
 ---
 title: Look Direction
-description: Hold a direction key to look left, right, up, or down while driving
+description: Hold a direction key to look left, right, up, or down while driving.
 sidebar:
   badge:
     text: "4 modes"
     variant: tip
 ---
 
-The Look Direction action simulates holding a look direction key for as long as the Stream Deck button is pressed. Release the button to return to your default view.
+Look Direction simulates holding a look-direction key for as long as the button is held. Press the button (or dial) to start looking, release it to return to the default view. Unlike most actions that send a single key tap, this one holds the key down until you release the button.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| Look Left | Holds the look-left key while the button is pressed. |
-| Look Right | Holds the look-right key while the button is pressed. |
-| Look Up | Holds the look-up key while the button is pressed. |
-| Look Down | Holds the look-down key while the button is pressed. |
+Select the mode from the **Direction** dropdown in the Property Inspector.
 
-## Encoder Support
+### Look Left
 
-No.
+Hold the look-left key while the button is pressed.
 
-:::note
-This action uses a hold pattern. The key is pressed when you press the button and released when you release the button, unlike most actions which send a single key tap.
-:::
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Z`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Look Right
+
+Hold the look-right key while the button is pressed.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `X`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Look Up
+
+Hold the look-up key while the button is pressed.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Look Down
+
+Hold the look-down key while the button is pressed.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings

--- a/packages/website/src/content/docs/docs/actions/driving/look-direction.md
+++ b/packages/website/src/content/docs/docs/actions/driving/look-direction.md
@@ -17,13 +17,13 @@ Select the mode from the **Direction** dropdown in the Property Inspector.
 
 Hold the look-left key while the button is pressed.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Z`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -33,13 +33,13 @@ Hold the look-left key while the button is pressed.
 
 Hold the look-right key while the button is pressed.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `X`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -49,13 +49,13 @@ Hold the look-right key while the button is pressed.
 
 Hold the look-up key while the button is pressed.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -65,12 +65,12 @@ Hold the look-up key while the button is pressed.
 
 Hold the look-down key while the button is pressed.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings

--- a/packages/website/src/content/docs/docs/actions/media/media-capture.md
+++ b/packages/website/src/content/docs/docs/actions/media/media-capture.md
@@ -17,13 +17,13 @@ Select the mode from the **Action** dropdown in the Property Inspector.
 
 Toggle video recording on or off via the iRacing SDK.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -33,13 +33,13 @@ Toggle video recording on or off via the iRacing SDK.
 
 Show the video recording timer overlay via the iRacing SDK.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -49,13 +49,13 @@ Show the video recording timer overlay via the iRacing SDK.
 
 Enable or disable the video capture subsystem via the iRacing SDK.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -65,13 +65,13 @@ Enable or disable the video capture subsystem via the iRacing SDK.
 
 Capture a standard screenshot via the iRacing SDK.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -81,13 +81,13 @@ Capture a standard screenshot via the iRacing SDK.
 
 Capture a high-resolution giant screenshot. This mode uses a keyboard binding because iRacing does not expose a giant screenshot SDK command.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+Shift+PrintScreen`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -97,13 +97,13 @@ Capture a high-resolution giant screenshot. This mode uses a keyboard binding be
 
 Reload all in-sim textures via the iRacing SDK.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -113,12 +113,12 @@ Reload all in-sim textures via the iRacing SDK.
 
 Reload only the player's car textures via the iRacing SDK.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings

--- a/packages/website/src/content/docs/docs/actions/media/media-capture.md
+++ b/packages/website/src/content/docs/docs/actions/media/media-capture.md
@@ -7,20 +7,118 @@ sidebar:
     variant: tip
 ---
 
-Media Capture puts iRacing's recording and screenshot functions at your fingertips. Quickly start or stop video capture, grab screenshots, or reload textures without leaving the cockpit.
+One-tap access to iRacing's recording, screenshot, and texture-reload functions. Start or stop video capture, grab screenshots, or reload textures without leaving the cockpit.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| Start/Stop Video | Start or stop a video recording session |
-| Video Timer | Display the current video recording timer |
-| Toggle Video Capture | Enable or disable the video capture subsystem |
-| Take Screenshot | Capture a standard screenshot |
-| Take Giant Screenshot | Capture a high-resolution giant screenshot |
-| Reload All Textures | Reload all in-sim textures |
-| Reload Car Textures | Reload car textures only |
+Select the mode from the **Action** dropdown in the Property Inspector.
 
-## Encoder Support
+### Start/Stop Video
 
-Yes — rotation provides additional control depending on the selected mode.
+Toggle video recording on or off via the iRacing SDK.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Video Timer
+
+Show the video recording timer overlay via the iRacing SDK.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Toggle Video Capture
+
+Enable or disable the video capture subsystem via the iRacing SDK.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Take Screenshot
+
+Capture a standard screenshot via the iRacing SDK.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Take Giant Screenshot
+
+Capture a high-resolution giant screenshot. This mode uses a keyboard binding because iRacing does not expose a giant screenshot SDK command.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+Shift+PrintScreen`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Reload All Textures
+
+Reload all in-sim textures via the iRacing SDK.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Reload Car Textures
+
+Reload only the player's car textures via the iRacing SDK.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings

--- a/packages/website/src/content/docs/docs/actions/overview.md
+++ b/packages/website/src/content/docs/docs/actions/overview.md
@@ -3,25 +3,25 @@ title: Actions Overview
 description: All iRaceDeck actions organized by category
 ---
 
-iRaceDeck provides 33 actions with 362 controls for iRacing, organized into 8 categories.
+iRaceDeck provides 30 actions with 254 modes for iRacing, organized into 8 categories.
 
 ## Categories
 
-| Category | Actions | Controls | Description |
-|----------|---------|----------|-------------|
+| Category | Actions | Modes | Description |
+|----------|---------|-------|-------------|
 | [Display & Session](/docs/actions/display-session/session-info/) | 2 | 7 | Live session data: incidents, laps, position, fuel, flags |
-| [Driving Controls](/docs/actions/driving/ai-spotter-controls/) | 5 | 41 | AI spotter, audio, black boxes, look direction, car control |
-| [Cockpit & Interface](/docs/actions/cockpit/cockpit-misc/) | 5 | 41 | Wipers, force feedback, splits & reference, telemetry, UI toggles |
-| [View & Camera](/docs/actions/view-camera/view-adjustment/) | 8 | 124 | FOV, replay, camera controls, broadcast tools |
+| [Driving Controls](/docs/actions/driving/ai-spotter-controls/) | 5 | 27 | AI spotter, audio, black boxes, look direction, car control |
+| [Cockpit & Interface](/docs/actions/cockpit/cockpit-misc/) | 5 | 33 | Wipers, force feedback, splits & reference, telemetry, UI toggles |
+| [View & Camera](/docs/actions/view-camera/view-adjustment/) | 5 | 87 | FOV, replay, camera controls, broadcast tools |
 | [Media](/docs/actions/media/media-capture/) | 1 | 7 | Video recording, screenshots, texture management |
 | [Pit Service](/docs/actions/pit-service/pit-quick-actions/) | 3 | 15 | Fuel, tires, compounds, tearoff, fast repair |
-| [Car Setup](/docs/actions/car-setup/setup-aero/) | 7 | 79 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction |
-| [Communication](/docs/actions/communication/chat/) | 2 | 48 | Chat, macros, whisper, reply, race admin commands |
+| [Car Setup](/docs/actions/car-setup/setup-aero/) | 7 | 44 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction |
+| [Communication](/docs/actions/communication/chat/) | 2 | 34 | Chat, macros, whisper, reply, race admin commands |
 
 ## How Actions Work
 
 Most actions support multiple **modes** selectable via the Property Inspector. For example, the Session Info action can display incidents, time remaining, lap count, position, fuel level, or active flags — all from a single action type.
 
-Actions that support the **encoder** can also be used with the Stream Deck+ dial for rotation-based input (e.g., cycling through black boxes or adjusting volume).
+Actions that support dial rotation can also be used with the Stream Deck+ dial for rotation-based input (e.g., cycling through black boxes or adjusting volume).
 
 All keyboard shortcuts used by actions are **user-configurable** through the Property Inspector to match your iRacing key bindings.

--- a/packages/website/src/content/docs/docs/actions/pit-service/fuel-service.md
+++ b/packages/website/src/content/docs/docs/actions/pit-service/fuel-service.md
@@ -17,13 +17,13 @@ Select the mode from the **Mode** dropdown in the Property Inspector.
 
 Toggle the fuel fill checkbox on or off via the iRacing SDK. The icon shows the current refuel amount from telemetry (in your iRacing display units) with a green ON / red OFF status bar and a matching border color reflecting whether fuel fill is enabled.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — shows the current refuel amount and an on/off indicator driven by `PitSvFlags.FuelFill`
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -31,19 +31,19 @@ Toggle the fuel fill checkbox on or off via the iRacing SDK. The icon shows the 
 
 ### Add Fuel
 
-Queue an "add fuel" chat macro. Pressing the button sends `#+fuel <amount>` to increase the pending fuel for the next pit stop. Dial rotation is bidirectional — clockwise adds, counter-clockwise reduces (using the Reduce Fuel macro) so you can fine-tune with a single dial.
+Queue an "add fuel" chat macro. Pressing the button sends `#fuel +<amount><unit>$` (e.g., `#fuel +2l$`) to increase the pending fuel for the next pit stop. Dial rotation is bidirectional — clockwise adds, counter-clockwise reduces (using the Reduce Fuel macro) so you can fine-tune with a single dial.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts fuel (clockwise = add, counter-clockwise = reduce)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Amount
+#### Setting: Amount
 
 The increment to add. Numeric — supports comma or period decimal separators (e.g., `1`, `2.5`, `0,5`). Defaults to `1`.
 
-##### Setting: Unit
+#### Setting: Unit
 
 - **L** (default) — Liters
 - **GAL** — Gallons
@@ -53,19 +53,19 @@ The increment to add. Numeric — supports comma or period decimal separators (e
 
 ### Reduce Fuel
 
-Queue a "reduce fuel" chat macro. Pressing the button sends `#-fuel <amount>` to decrease the pending fuel for the next pit stop. Dial rotation is bidirectional — clockwise reduces, counter-clockwise adds (using the Add Fuel macro).
+Queue a "reduce fuel" chat macro. Pressing the button sends `#fuel -<amount><unit>$` (e.g., `#fuel -2l$`) to decrease the pending fuel for the next pit stop. Dial rotation is bidirectional — clockwise reduces, counter-clockwise adds (using the Add Fuel macro).
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts fuel (clockwise = reduce, counter-clockwise = add)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Amount
+#### Setting: Amount
 
 The decrement to subtract. Numeric — supports comma or period decimal separators. Defaults to `1`.
 
-##### Setting: Unit
+#### Setting: Unit
 
 - **L** (default) — Liters
 - **GAL** — Gallons
@@ -75,19 +75,23 @@ The decrement to subtract. Numeric — supports comma or period decimal separato
 
 ### Set Fuel Amount
 
-Queue a "set fuel" chat macro. Pressing the button sends `#fuel <amount>` to set the pending fuel to an absolute value.
+Queue a "set fuel" chat macro. Pressing the button sends `#fuel <amount><unit>$` (e.g., `#fuel 30l$`) to set the pending fuel to an absolute value.
 
-##### Details
+:::note
+When iRacing's autofuel "enable fueling on change" setting is off and your fuel fill checkbox is currently off, the macro uses the `#-fuel` prefix instead of `#fuel` so your fuel fill stays off after the command. You don't need to do anything for this — it happens automatically based on your live pit service state.
+:::
+
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Amount
+#### Setting: Amount
 
 The target fuel amount. Numeric — supports comma or period decimal separators. Defaults to `1`.
 
-##### Setting: Unit
+#### Setting: Unit
 
 - **L** (default) — Liters
 - **GAL** — Gallons
@@ -99,13 +103,13 @@ The target fuel amount. Numeric — supports comma or period decimal separators.
 
 Clear the pending fuel request via the iRacing SDK. Removes the fuel line from the pit service.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -115,13 +119,13 @@ Clear the pending fuel request via the iRacing SDK. Removes the fuel line from t
 
 Toggle iRacing's autofuel checkbox on or off. The icon shows the current refuel amount and a green ON / red OFF status bar plus matching border color reflecting whether autofuel is active.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Ctrl+A`
 - **Telemetry-aware icon:** Yes — shows the current refuel amount and an on/off indicator driven by `PitSvFlags.FuelAutofill`
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -131,13 +135,13 @@ Toggle iRacing's autofuel checkbox on or off. The icon shows the current refuel 
 
 Raise the autofuel lap margin by one. Pressing the button taps the iRacing "Lap Margin Increase" hotkey. Dial rotation is bidirectional — clockwise increases, counter-clockwise decreases.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts lap margin (clockwise = increase, counter-clockwise = decrease)
 - **Default binding:** `Shift+Alt+X`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -147,12 +151,12 @@ Raise the autofuel lap margin by one. Pressing the button taps the iRacing "Lap 
 
 Lower the autofuel lap margin by one. Pressing the button taps the iRacing "Lap Margin Decrease" hotkey. Dial rotation is bidirectional — clockwise decreases, counter-clockwise increases.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts lap margin (clockwise = decrease, counter-clockwise = increase)
 - **Default binding:** `Shift+Alt+S`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings

--- a/packages/website/src/content/docs/docs/actions/pit-service/fuel-service.md
+++ b/packages/website/src/content/docs/docs/actions/pit-service/fuel-service.md
@@ -7,25 +7,152 @@ sidebar:
     variant: tip
 ---
 
-Fuel Service gives you full control over your pit stop fueling strategy. Toggle fuel fill with live telemetry feedback, adjust fuel amounts, toggle autofuel, and fine-tune lap margins without opening the pit menu.
+Full control over your pit stop fueling strategy. Toggle fuel fill with live telemetry feedback, adjust the fuel amount with a fixed macro, toggle autofuel, or fine-tune the lap margin — all without opening the pit menu.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| Toggle Fuel Fill | Toggle the fuel fill checkbox on/off with live refuel amount display |
-| Add Fuel | Increase the fuel amount for the next pit stop |
-| Reduce Fuel | Decrease the fuel amount for the next pit stop |
-| Set Fuel Amount | Set the fuel to a specific amount |
-| Clear Fuel | Clear all fuel from the pit request |
-| Toggle Autofuel | Toggle the autofuel setting on or off |
-| Lap Margin Increase | Increase the fuel lap margin |
-| Lap Margin Decrease | Decrease the fuel lap margin |
+Select the mode from the **Mode** dropdown in the Property Inspector.
 
-Toggle Fuel Fill shows the current refuel amount from telemetry (in your display units) with a green ON / red OFF status bar indicating whether fuel fill is enabled.
+### Toggle Fuel Fill
 
-Toggle Autofuel displays the current refuel amount with a green ON / red OFF status bar indicating whether autofuel is active for the next pit stop.
+Toggle the fuel fill checkbox on or off via the iRacing SDK. The icon shows the current refuel amount from telemetry (in your iRacing display units) with a green ON / red OFF status bar and a matching border color reflecting whether fuel fill is enabled.
 
-## Encoder Support
+##### Details
 
-Yes — rotation adjusts the fuel amount incrementally, making it easy to dial in the exact fuel level with the Stream Deck+ dial.
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — shows the current refuel amount and an on/off indicator driven by `PitSvFlags.FuelFill`
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Add Fuel
+
+Queue an "add fuel" chat macro. Pressing the button sends `#+fuel <amount>` to increase the pending fuel for the next pit stop. Dial rotation is bidirectional — clockwise adds, counter-clockwise reduces (using the Reduce Fuel macro) so you can fine-tune with a single dial.
+
+##### Details
+
+- **Dial:** Rotation adjusts fuel (clockwise = add, counter-clockwise = reduce)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Amount
+
+The increment to add. Numeric — supports comma or period decimal separators (e.g., `1`, `2.5`, `0,5`). Defaults to `1`.
+
+##### Setting: Unit
+
+- **L** (default) — Liters
+- **GAL** — Gallons
+- **KG** — Kilograms
+
+---
+
+### Reduce Fuel
+
+Queue a "reduce fuel" chat macro. Pressing the button sends `#-fuel <amount>` to decrease the pending fuel for the next pit stop. Dial rotation is bidirectional — clockwise reduces, counter-clockwise adds (using the Add Fuel macro).
+
+##### Details
+
+- **Dial:** Rotation adjusts fuel (clockwise = reduce, counter-clockwise = add)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Amount
+
+The decrement to subtract. Numeric — supports comma or period decimal separators. Defaults to `1`.
+
+##### Setting: Unit
+
+- **L** (default) — Liters
+- **GAL** — Gallons
+- **KG** — Kilograms
+
+---
+
+### Set Fuel Amount
+
+Queue a "set fuel" chat macro. Pressing the button sends `#fuel <amount>` to set the pending fuel to an absolute value.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Amount
+
+The target fuel amount. Numeric — supports comma or period decimal separators. Defaults to `1`.
+
+##### Setting: Unit
+
+- **L** (default) — Liters
+- **GAL** — Gallons
+- **KG** — Kilograms
+
+---
+
+### Clear Fuel
+
+Clear the pending fuel request via the iRacing SDK. Removes the fuel line from the pit service.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Toggle Autofuel
+
+Toggle iRacing's autofuel checkbox on or off. The icon shows the current refuel amount and a green ON / red OFF status bar plus matching border color reflecting whether autofuel is active.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Shift+Ctrl+A`
+- **Telemetry-aware icon:** Yes — shows the current refuel amount and an on/off indicator driven by `PitSvFlags.FuelAutofill`
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Lap Margin Increase
+
+Raise the autofuel lap margin by one. Pressing the button taps the iRacing "Lap Margin Increase" hotkey. Dial rotation is bidirectional — clockwise increases, counter-clockwise decreases.
+
+##### Details
+
+- **Dial:** Rotation adjusts lap margin (clockwise = increase, counter-clockwise = decrease)
+- **Default binding:** `Shift+Alt+X`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Lap Margin Decrease
+
+Lower the autofuel lap margin by one. Pressing the button taps the iRacing "Lap Margin Decrease" hotkey. Dial rotation is bidirectional — clockwise decreases, counter-clockwise increases.
+
+##### Details
+
+- **Dial:** Rotation adjusts lap margin (clockwise = decrease, counter-clockwise = increase)
+- **Default binding:** `Shift+Alt+S`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings

--- a/packages/website/src/content/docs/docs/actions/pit-service/pit-quick-actions.md
+++ b/packages/website/src/content/docs/docs/actions/pit-service/pit-quick-actions.md
@@ -7,18 +7,54 @@ sidebar:
     variant: tip
 ---
 
-Pit Quick Actions provides one-tap access to the most common pit service shortcuts so you can manage your pit stop strategy without navigating menus.
+Pit Quick Actions gives you one-tap access to the most common pit service shortcuts so you can manage your pit stop strategy without navigating iRacing's menus.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| Clear All Checkboxes | Uncheck all pit service options |
-| Windshield Tearoff | Toggle windshield tearoff with live ON/OFF status |
-| Request Fast Repair | Toggle fast repair with live ON/OFF/N/A status |
+Select the mode from the **Action** dropdown in the Property Inspector.
 
-Windshield Tearoff and Request Fast Repair show telemetry-driven status bars: green ON when enabled, red OFF when disabled. Fast Repair shows a gray N/A bar when no fast repairs are available.
+### Clear All Checkboxes
 
-## Encoder Support
+Clear every pit service checkbox in a single press — tires, fuel, windshield, fast repair, and any other options iRacing exposes.
 
-Yes — rotation cycles through the available quick actions.
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Windshield Tearoff
+
+Toggle the windshield tearoff request. Press once to queue a tearoff, press again to cancel.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — status bar shows green when a tearoff is requested and red when it is not, and the border color tracks the same on / off state
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Request Fast Repair
+
+Toggle a fast repair request. Press once to queue a fast repair, press again to cancel. When no fast repairs are available, the button falls back to a grey N/A state and does not send the command.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — status bar shows green when a fast repair is queued, red when it is not, and grey N/A when the session has no fast repairs left; the border color tracks the same on / off / n/a state
+
+##### Settings
+
+- No additional settings

--- a/packages/website/src/content/docs/docs/actions/pit-service/pit-quick-actions.md
+++ b/packages/website/src/content/docs/docs/actions/pit-service/pit-quick-actions.md
@@ -17,13 +17,13 @@ Select the mode from the **Action** dropdown in the Property Inspector.
 
 Clear every pit service checkbox in a single press — tires, fuel, windshield, fast repair, and any other options iRacing exposes.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -33,13 +33,13 @@ Clear every pit service checkbox in a single press — tires, fuel, windshield, 
 
 Toggle the windshield tearoff request. Press once to queue a tearoff, press again to cancel.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — status bar shows green when a tearoff is requested and red when it is not, and the border color tracks the same on / off state
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -49,12 +49,12 @@ Toggle the windshield tearoff request. Press once to queue a tearoff, press agai
 
 Toggle a fast repair request. Press once to queue a fast repair, press again to cancel. When no fast repairs are available, the button falls back to a grey N/A state and does not send the command.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — status bar shows green when a fast repair is queued, red when it is not, and grey N/A when the session has no fast repairs left; the border color tracks the same on / off / n/a state
 
-##### Settings
+#### Settings
 
 - No additional settings

--- a/packages/website/src/content/docs/docs/actions/pit-service/tire-service.md
+++ b/packages/website/src/content/docs/docs/actions/pit-service/tire-service.md
@@ -9,10 +9,6 @@ sidebar:
 
 Tire Service handles everything tire-related for your pit stops. Change all tires at once, toggle individual wheels, clear tire selections, or switch between dry and wet compounds.
 
-:::note
-Tire Service is telemetry-aware — the icon updates with live data from the sim so you always see the current tire state.
-:::
-
 ## Modes
 
 Select the mode from the **Action** dropdown in the Property Inspector.
@@ -21,9 +17,15 @@ Select the mode from the **Action** dropdown in the Property Inspector.
 
 Request new tires on all four corners. Uses iRacing's `#t` pit chat macro.
 
-**Encoder:** No rotation support.
+##### Details
 
-**Settings:** No additional settings.
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
 
 ---
 
@@ -31,9 +33,15 @@ Request new tires on all four corners. Uses iRacing's `#t` pit chat macro.
 
 Clear all tire change requests — removes all tires from the pit service.
 
-**Encoder:** No rotation support.
+##### Details
 
-**Settings:** No additional settings.
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
 
 ---
 
@@ -41,7 +49,11 @@ Clear all tire change requests — removes all tires from the pit service.
 
 Toggle tire changes per wheel. You choose which tires (LF, RF, LR, RR) the button controls, and how the button behaves when pressed.
 
-**Encoder:** No rotation support.
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — tire colors reflect the current iRacing pit service state
 
 ##### Setting: Operation
 
@@ -57,6 +69,7 @@ Toggle tire changes per wheel. You choose which tires (LF, RF, LR, RR) the butto
 All four tires are selected by default. Choose which tires the button controls: Left Front, Right Front, Left Rear, Right Rear.
 
 Common configurations:
+
 - **All four** — toggle all tires on/off
 - **Left side** (LF + LR) — toggle left side only
 - **Right side** (RF + RR) — toggle right side only
@@ -71,6 +84,12 @@ Cycle through available tire compounds. Each press advances to the next compound
 
 The available compounds depend on the car — most cars have DRY and WET, while some have additional options like Soft, Medium, and Hard.
 
-**Encoder:** No rotation support.
+##### Details
 
-**Settings:** No additional settings.
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — shows the currently selected pit service compound
+
+##### Settings
+
+- No additional settings

--- a/packages/website/src/content/docs/docs/actions/pit-service/tire-service.md
+++ b/packages/website/src/content/docs/docs/actions/pit-service/tire-service.md
@@ -17,13 +17,13 @@ Select the mode from the **Action** dropdown in the Property Inspector.
 
 Request new tires on all four corners. Uses iRacing's `#t` pit chat macro.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -33,13 +33,13 @@ Request new tires on all four corners. Uses iRacing's `#t` pit chat macro.
 
 Clear all tire change requests — removes all tires from the pit service.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -49,13 +49,13 @@ Clear all tire change requests — removes all tires from the pit service.
 
 Toggle tire changes per wheel. You choose which tires (LF, RF, LR, RR) the button controls, and how the button behaves when pressed.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — tire colors reflect the current iRacing pit service state
 
-##### Setting: Operation
+#### Setting: Operation
 
 - **Select configured tires** (default for new actions) — Clears all tires first, then selects exactly the configured set. Pressing "right side" always results in only the right side tires being selected, regardless of what was selected before. If the configured tires are already the only ones selected, pressing the button clears them.
 - **Toggle configured tires** (default for actions created before v1.13.0) — Flips each configured tire without clearing first. The result depends on which tires are currently selected — pressing "right side" when all four tires are selected will turn right side *off*, leaving left side selected.
@@ -64,7 +64,7 @@ Toggle tire changes per wheel. You choose which tires (LF, RF, LR, RR) the butto
 **Select configured tires** is recommended for most setups. It lets you switch between tire configurations (e.g., "all four" → "right side only") with a single button press — useful when pit strategy changes quickly during a caution.
 :::
 
-##### Setting: Tires
+#### Setting: Tires
 
 All four tires are selected by default. Choose which tires the button controls: Left Front, Right Front, Left Rear, Right Rear.
 
@@ -84,12 +84,12 @@ Cycle through available tire compounds. Each press advances to the next compound
 
 The available compounds depend on the car — most cars have DRY and WET, while some have additional options like Soft, Medium, and Hard.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — shows the currently selected pit service compound
 
-##### Settings
+#### Settings
 
 - No additional settings

--- a/packages/website/src/content/docs/docs/actions/view-camera/camera-editor-adjustments.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/camera-editor-adjustments.md
@@ -17,13 +17,13 @@ Select the mode from the **Adjustment** dropdown in the Property Inspector. Ever
 
 Move the camera along the latitude axis.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts latitude (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** `D` (increase) and `A` (decrease)
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button increases latitude
 - **Decrease** — Pressing the button decreases latitude
@@ -34,13 +34,13 @@ Move the camera along the latitude axis.
 
 Move the camera along the longitude axis.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts longitude (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** `S` (increase) and `W` (decrease)
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button increases longitude
 - **Decrease** — Pressing the button decreases longitude
@@ -51,13 +51,13 @@ Move the camera along the longitude axis.
 
 Move the camera along the altitude axis.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts altitude (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** `Alt+S` (increase) and `Alt+W` (decrease)
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button increases altitude
 - **Decrease** — Pressing the button decreases altitude
@@ -68,13 +68,13 @@ Move the camera along the altitude axis.
 
 Rotate the camera on the yaw axis.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts yaw (clockwise = positive, counter-clockwise = negative), regardless of the Direction setting
 - **Default binding:** `Ctrl+D` (increase) and `Ctrl+A` (decrease)
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button rotates yaw clockwise
 - **Decrease** — Pressing the button rotates yaw counter-clockwise
@@ -85,13 +85,13 @@ Rotate the camera on the yaw axis.
 
 Tilt the camera on the pitch axis.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts pitch (clockwise = up, counter-clockwise = down), regardless of the Direction setting
 - **Default binding:** `Ctrl+W` (increase) and `Ctrl+S` (decrease)
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button tilts pitch upward
 - **Decrease** — Pressing the button tilts pitch downward
@@ -102,13 +102,13 @@ Tilt the camera on the pitch axis.
 
 Adjust the camera field of view.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts FOV zoom (clockwise = zoom in, counter-clockwise = zoom out), regardless of the Direction setting
 - **Default binding:** `[` (increase/zoom in) and `]` (decrease/zoom out)
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button zooms in (narrower FOV)
 - **Decrease** — Pressing the button zooms out (wider FOV)
@@ -119,13 +119,13 @@ Adjust the camera field of view.
 
 Adjust the camera editor key step size.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts key step size (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** `-` (increase) and `=` (decrease)
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the step size
 - **Decrease** — Pressing the button lowers the step size
@@ -136,13 +136,13 @@ Adjust the camera editor key step size.
 
 Shift the vanishing point along the X axis.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts the vanishing point X (clockwise = right, counter-clockwise = left), regardless of the Direction setting
 - **Default binding:** `Alt+X` (increase/right) and `Ctrl+X` (decrease/left)
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button shifts the vanishing point right
 - **Decrease** — Pressing the button shifts the vanishing point left
@@ -153,13 +153,13 @@ Shift the vanishing point along the X axis.
 
 Shift the vanishing point along the Y axis.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts the vanishing point Y (clockwise = up, counter-clockwise = down), regardless of the Direction setting
 - **Default binding:** `Alt+Y` (increase/up) and `Ctrl+Y` (decrease/down)
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button shifts the vanishing point up
 - **Decrease** — Pressing the button shifts the vanishing point down
@@ -170,13 +170,13 @@ Shift the vanishing point along the Y axis.
 
 Adjust the blimp camera orbit radius.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts blimp radius (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** `Ctrl+H` (increase) and `Ctrl+G` (decrease)
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button increases the radius
 - **Decrease** — Pressing the button decreases the radius
@@ -187,13 +187,13 @@ Adjust the blimp camera orbit radius.
 
 Adjust the blimp camera orbit velocity.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts blimp velocity (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** `Alt+H` (increase) and `Alt+G` (decrease)
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button increases the velocity
 - **Decrease** — Pressing the button decreases the velocity
@@ -204,13 +204,13 @@ Adjust the blimp camera orbit velocity.
 
 Adjust the camera microphone gain.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts mic gain (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** `Alt+Up` (increase) and `Alt+Down` (decrease)
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the mic gain
 - **Decrease** — Pressing the button lowers the mic gain
@@ -221,13 +221,13 @@ Adjust the camera microphone gain.
 
 Automatically set the microphone gain for the current camera. Non-directional toggle.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+Alt+Down`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -237,13 +237,13 @@ Automatically set the microphone gain for the current camera. Non-directional to
 
 Adjust the camera aperture (depth of field strength).
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts the F-number (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** `Alt+U` (increase) and `Alt+I` (decrease)
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the F-number
 - **Decrease** — Pressing the button lowers the F-number
@@ -254,13 +254,13 @@ Adjust the camera aperture (depth of field strength).
 
 Adjust the focus depth.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts focus depth (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** `Ctrl+U` (increase) and `Ctrl+I` (decrease)
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button increases focus depth
 - **Decrease** — Pressing the button decreases focus depth

--- a/packages/website/src/content/docs/docs/actions/view-camera/camera-editor-adjustments.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/camera-editor-adjustments.md
@@ -3,50 +3,264 @@ title: Camera Editor Adjustments
 description: Fine-tune camera position, orientation, FOV, vanishing point, and audio settings in the iRacing camera editor.
 sidebar:
   badge:
-    text: "29 modes"
+    text: "15 modes"
     variant: tip
 ---
 
-Camera Editor Adjustments provides precise control over every adjustable camera parameter in iRacing's camera editor. Each mode targets a specific axis or property with increase/decrease controls.
-
-:::note
-This action is for fine-tuning camera positions in the iRacing camera editor. Use it alongside Camera Editor Controls for a complete editing workflow.
-:::
+Precise control over every adjustable camera parameter in iRacing's camera editor. Each mode targets a specific axis or property. Use this action alongside [Camera Editor Controls](/docs/actions/view-camera/camera-editor-controls/) for a complete editing workflow.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| Latitude + | Increase camera latitude |
-| Latitude - | Decrease camera latitude |
-| Longitude + | Increase camera longitude |
-| Longitude - | Decrease camera longitude |
-| Altitude + | Increase camera altitude |
-| Altitude - | Decrease camera altitude |
-| Yaw + | Rotate camera yaw clockwise |
-| Yaw - | Rotate camera yaw counter-clockwise |
-| Pitch + | Tilt camera pitch upward |
-| Pitch - | Tilt camera pitch downward |
-| FOV Zoom + | Zoom in (decrease field of view) |
-| FOV Zoom - | Zoom out (increase field of view) |
-| Key Step + | Increase key step size |
-| Key Step - | Decrease key step size |
-| Vanish X + | Shift vanishing point right |
-| Vanish X - | Shift vanishing point left |
-| Vanish Y + | Shift vanishing point up |
-| Vanish Y - | Shift vanishing point down |
-| Blimp Radius + | Increase blimp camera radius |
-| Blimp Radius - | Decrease blimp camera radius |
-| Blimp Velocity + | Increase blimp camera velocity |
-| Blimp Velocity - | Decrease blimp camera velocity |
-| Mic Gain + | Increase microphone gain |
-| Mic Gain - | Decrease microphone gain |
-| Auto Set Mic Gain | Automatically set microphone gain |
-| F-Number + | Increase camera f-number (depth of field) |
-| F-Number - | Decrease camera f-number (depth of field) |
-| Focus Depth + | Increase focus depth |
-| Focus Depth - | Decrease focus depth |
+Select the mode from the **Adjustment** dropdown in the Property Inspector. Every adjustment except Auto Set Mic Gain exposes a **Direction** setting for Increase / Decrease.
 
-## Encoder Support
+### Latitude
 
-Yes — rotation adjusts the selected parameter incrementally, providing precise control with the Stream Deck+ dial.
+Move the camera along the latitude axis.
+
+##### Details
+
+- **Dial:** Rotation adjusts latitude (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** `D` (increase) and `A` (decrease)
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button increases latitude
+- **Decrease** — Pressing the button decreases latitude
+
+---
+
+### Longitude
+
+Move the camera along the longitude axis.
+
+##### Details
+
+- **Dial:** Rotation adjusts longitude (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** `S` (increase) and `W` (decrease)
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button increases longitude
+- **Decrease** — Pressing the button decreases longitude
+
+---
+
+### Altitude
+
+Move the camera along the altitude axis.
+
+##### Details
+
+- **Dial:** Rotation adjusts altitude (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** `Alt+S` (increase) and `Alt+W` (decrease)
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button increases altitude
+- **Decrease** — Pressing the button decreases altitude
+
+---
+
+### Yaw
+
+Rotate the camera on the yaw axis.
+
+##### Details
+
+- **Dial:** Rotation adjusts yaw (clockwise = positive, counter-clockwise = negative), regardless of the Direction setting
+- **Default binding:** `Ctrl+D` (increase) and `Ctrl+A` (decrease)
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button rotates yaw clockwise
+- **Decrease** — Pressing the button rotates yaw counter-clockwise
+
+---
+
+### Pitch
+
+Tilt the camera on the pitch axis.
+
+##### Details
+
+- **Dial:** Rotation adjusts pitch (clockwise = up, counter-clockwise = down), regardless of the Direction setting
+- **Default binding:** `Ctrl+W` (increase) and `Ctrl+S` (decrease)
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button tilts pitch upward
+- **Decrease** — Pressing the button tilts pitch downward
+
+---
+
+### FOV Zoom
+
+Adjust the camera field of view.
+
+##### Details
+
+- **Dial:** Rotation adjusts FOV zoom (clockwise = zoom in, counter-clockwise = zoom out), regardless of the Direction setting
+- **Default binding:** `[` (increase/zoom in) and `]` (decrease/zoom out)
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button zooms in (narrower FOV)
+- **Decrease** — Pressing the button zooms out (wider FOV)
+
+---
+
+### Key Step
+
+Adjust the camera editor key step size.
+
+##### Details
+
+- **Dial:** Rotation adjusts key step size (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** `-` (increase) and `=` (decrease)
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the step size
+- **Decrease** — Pressing the button lowers the step size
+
+---
+
+### Vanish X
+
+Shift the vanishing point along the X axis.
+
+##### Details
+
+- **Dial:** Rotation adjusts the vanishing point X (clockwise = right, counter-clockwise = left), regardless of the Direction setting
+- **Default binding:** `Alt+X` (increase/right) and `Ctrl+X` (decrease/left)
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button shifts the vanishing point right
+- **Decrease** — Pressing the button shifts the vanishing point left
+
+---
+
+### Vanish Y
+
+Shift the vanishing point along the Y axis.
+
+##### Details
+
+- **Dial:** Rotation adjusts the vanishing point Y (clockwise = up, counter-clockwise = down), regardless of the Direction setting
+- **Default binding:** `Alt+Y` (increase/up) and `Ctrl+Y` (decrease/down)
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button shifts the vanishing point up
+- **Decrease** — Pressing the button shifts the vanishing point down
+
+---
+
+### Blimp Radius
+
+Adjust the blimp camera orbit radius.
+
+##### Details
+
+- **Dial:** Rotation adjusts blimp radius (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** `Ctrl+H` (increase) and `Ctrl+G` (decrease)
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button increases the radius
+- **Decrease** — Pressing the button decreases the radius
+
+---
+
+### Blimp Velocity
+
+Adjust the blimp camera orbit velocity.
+
+##### Details
+
+- **Dial:** Rotation adjusts blimp velocity (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** `Alt+H` (increase) and `Alt+G` (decrease)
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button increases the velocity
+- **Decrease** — Pressing the button decreases the velocity
+
+---
+
+### Mic Gain
+
+Adjust the camera microphone gain.
+
+##### Details
+
+- **Dial:** Rotation adjusts mic gain (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** `Alt+Up` (increase) and `Alt+Down` (decrease)
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the mic gain
+- **Decrease** — Pressing the button lowers the mic gain
+
+---
+
+### Auto Set Mic Gain
+
+Automatically set the microphone gain for the current camera. Non-directional toggle.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+Alt+Down`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### F-number
+
+Adjust the camera aperture (depth of field strength).
+
+##### Details
+
+- **Dial:** Rotation adjusts the F-number (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** `Alt+U` (increase) and `Alt+I` (decrease)
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the F-number
+- **Decrease** — Pressing the button lowers the F-number
+
+---
+
+### Focus Depth
+
+Adjust the focus depth.
+
+##### Details
+
+- **Dial:** Rotation adjusts focus depth (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Default binding:** `Ctrl+U` (increase) and `Ctrl+I` (decrease)
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button increases focus depth
+- **Decrease** — Pressing the button decreases focus depth

--- a/packages/website/src/content/docs/docs/actions/view-camera/camera-editor-controls.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/camera-editor-controls.md
@@ -1,51 +1,492 @@
 ---
 title: Camera Editor Controls
-description: Full control of iRacing's camera editor — origin, locking, state management, bookmarks, and more.
+description: Full keyboard-driven control of iRacing's camera editor — tool, toggles, camera CRUD, and save/load.
 sidebar:
   badge:
-    text: "27 modes"
+    text: "30 modes"
     variant: tip
 ---
 
-Camera Editor Controls provides comprehensive access to iRacing's built-in camera editor. Designed for broadcasters and content creators, this action surfaces every major editor function as a selectable mode.
-
-:::note
-This action is designed for broadcasters and content creators who work with iRacing's camera editor to create custom camera angles and replay sequences.
-:::
+Comprehensive access to iRacing's built-in camera editor. Designed for broadcasters and content creators, this action surfaces every major editor function as a selectable mode. Every mode is a single keyboard binding tap — no SDK, no telemetry awareness, no dial rotation.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| Open Camera Tool | Open the camera editor tool |
-| Key Acceleration Toggle | Toggle key acceleration on/off |
-| Set Origin to Player Car | Set the camera origin to the player's car |
-| Set Origin to Incident Point | Set the camera origin to the incident point |
-| Lock Camera to Player | Lock the camera to the player car |
-| Lock Camera to Object | Lock the camera to a tracked object |
-| Park Camera | Park the camera at its current position |
-| Set Camera State (Saved) | Save the current camera state to a persistent slot |
-| Load Camera State (Saved) | Load a previously saved camera state |
-| Delete Camera State (Saved) | Delete a saved camera state |
-| Set Camera State (Unsaved) | Set a temporary camera state |
-| Load Camera State (Unsaved) | Load a temporary camera state |
-| Revert to Saved | Revert the current camera to its last saved state |
-| Export Camera State | Export camera state to a file |
-| Import Camera State | Import camera state from a file |
-| Undo | Undo the last camera editor change |
-| Redo | Redo a previously undone change |
-| Reset Adjustment to Default | Reset the current adjustment to its default value |
-| Clear All Adjustments | Clear all camera adjustments |
-| Show Grid | Toggle the alignment grid overlay |
-| Show Grid Numbers | Toggle grid number labels |
-| Toggle Replay Timescale | Toggle the replay timescale display |
-| Toggle Slow Motion | Toggle slow motion in the editor |
-| Toggle Frame Stepping | Toggle frame-by-frame stepping mode |
-| Use Playhead Time | Use the playhead time for camera operations |
-| Use Current Time | Use the current time for camera operations |
-| Bookmark Editor Action | Bookmark the current editor action |
-| Go to Bookmarked Action | Jump to a previously bookmarked editor action |
+Select the mode from the **Control** dropdown in the Property Inspector. Each mode's Details bullet lists the default iRacing key for that function; every key can be reconfigured as a global setting shared across all Camera Editor Controls instances.
 
-## Encoder Support
+### Open Camera Tool
 
-Yes — rotation steps through modes or adjusts the active parameter with the Stream Deck+ dial.
+Open the iRacing camera editor tool.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+F12`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Key Acceleration Toggle
+
+Toggle the camera editor's key acceleration mode.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+P`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Key 10x Toggle
+
+Toggle the key 10x multiplier mode.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Alt+P`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Parabolic Mic Toggle
+
+Toggle the parabolic microphone mode.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+O`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Cycle Position Type
+
+Step through the available position types.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Alt+N`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Cycle Aim Type
+
+Step through the available aim types.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Alt+M`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Acquire Start
+
+Mark the start of an acquire sequence.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+Q`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Acquire End
+
+Mark the end of an acquire sequence.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Shift+Q`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Temporary Edits Toggle
+
+Toggle temporary edits mode.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+L`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Dampening Toggle
+
+Toggle the camera dampening setting.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+N`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Zoom Toggle
+
+Toggle the zoom mode.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+M`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Beyond Fence Toggle
+
+Toggle the beyond-fence camera mode.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+B`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### In Cockpit Toggle
+
+Toggle the in-cockpit camera mode.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Alt+B`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Mouse Navigation Toggle
+
+Toggle mouse navigation mode.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+Z`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Pitch Gyro Toggle
+
+Toggle the pitch gyro mode.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+J`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Roll Gyro Toggle
+
+Toggle the roll gyro mode.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Alt+J`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Limit Shot Range Toggle
+
+Toggle the limit-shot-range mode.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Alt+O`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Show Camera Toggle
+
+Toggle the show camera overlay.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Alt+Q`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Shot Selection Toggle
+
+Toggle shot selection mode.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+T`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Manual Focus Toggle
+
+Toggle manual focus mode.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+F`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Insert Camera
+
+Insert a new camera at the current position.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Shift+Ctrl+Insert`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Remove Camera
+
+Remove the current camera.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Shift+Ctrl+Delete`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Copy Camera
+
+Copy the current camera to the clipboard.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Shift+Ctrl+C`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Paste Camera
+
+Paste the clipboard camera over the current one.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Shift+Ctrl+V`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Copy Group
+
+Copy the current camera group to the clipboard.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+Alt+C`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Paste Group
+
+Paste the clipboard camera group.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+Alt+V`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Save Track Camera
+
+Save the current camera configuration to the track.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+F11`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Load Track Camera
+
+Load a previously saved track camera.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Shift+Ctrl+F11`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Save Car Camera
+
+Save the current camera configuration to the car.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Alt+F11`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Load Car Camera
+
+Load a previously saved car camera.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Shift+Alt+F11`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings

--- a/packages/website/src/content/docs/docs/actions/view-camera/camera-editor-controls.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/camera-editor-controls.md
@@ -17,13 +17,13 @@ Select the mode from the **Control** dropdown in the Property Inspector. Each mo
 
 Open the iRacing camera editor tool.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+F12`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -33,13 +33,13 @@ Open the iRacing camera editor tool.
 
 Toggle the camera editor's key acceleration mode.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+P`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -49,13 +49,13 @@ Toggle the camera editor's key acceleration mode.
 
 Toggle the key 10x multiplier mode.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Alt+P`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -65,13 +65,13 @@ Toggle the key 10x multiplier mode.
 
 Toggle the parabolic microphone mode.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+O`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -81,13 +81,13 @@ Toggle the parabolic microphone mode.
 
 Step through the available position types.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Alt+N`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -97,13 +97,13 @@ Step through the available position types.
 
 Step through the available aim types.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Alt+M`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -113,13 +113,13 @@ Step through the available aim types.
 
 Mark the start of an acquire sequence.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+Q`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -129,13 +129,13 @@ Mark the start of an acquire sequence.
 
 Mark the end of an acquire sequence.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Q`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -145,13 +145,13 @@ Mark the end of an acquire sequence.
 
 Toggle temporary edits mode.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+L`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -161,13 +161,13 @@ Toggle temporary edits mode.
 
 Toggle the camera dampening setting.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+N`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -177,13 +177,13 @@ Toggle the camera dampening setting.
 
 Toggle the zoom mode.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+M`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -193,13 +193,13 @@ Toggle the zoom mode.
 
 Toggle the beyond-fence camera mode.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+B`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -209,13 +209,13 @@ Toggle the beyond-fence camera mode.
 
 Toggle the in-cockpit camera mode.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Alt+B`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -225,13 +225,13 @@ Toggle the in-cockpit camera mode.
 
 Toggle mouse navigation mode.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+Z`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -241,13 +241,13 @@ Toggle mouse navigation mode.
 
 Toggle the pitch gyro mode.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+J`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -257,13 +257,13 @@ Toggle the pitch gyro mode.
 
 Toggle the roll gyro mode.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Alt+J`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -273,13 +273,13 @@ Toggle the roll gyro mode.
 
 Toggle the limit-shot-range mode.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Alt+O`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -289,13 +289,13 @@ Toggle the limit-shot-range mode.
 
 Toggle the show camera overlay.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Alt+Q`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -305,13 +305,13 @@ Toggle the show camera overlay.
 
 Toggle shot selection mode.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+T`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -321,13 +321,13 @@ Toggle shot selection mode.
 
 Toggle manual focus mode.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+F`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -337,13 +337,13 @@ Toggle manual focus mode.
 
 Insert a new camera at the current position.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Ctrl+Insert`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -353,13 +353,13 @@ Insert a new camera at the current position.
 
 Remove the current camera.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Ctrl+Delete`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -369,13 +369,13 @@ Remove the current camera.
 
 Copy the current camera to the clipboard.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Ctrl+C`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -385,13 +385,13 @@ Copy the current camera to the clipboard.
 
 Paste the clipboard camera over the current one.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Ctrl+V`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -401,13 +401,13 @@ Paste the clipboard camera over the current one.
 
 Copy the current camera group to the clipboard.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+Alt+C`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -417,13 +417,13 @@ Copy the current camera group to the clipboard.
 
 Paste the clipboard camera group.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+Alt+V`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -433,13 +433,13 @@ Paste the clipboard camera group.
 
 Save the current camera configuration to the track.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+F11`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -449,13 +449,13 @@ Save the current camera configuration to the track.
 
 Load a previously saved track camera.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Ctrl+F11`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -465,13 +465,13 @@ Load a previously saved track camera.
 
 Save the current camera configuration to the car.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Alt+F11`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -481,12 +481,12 @@ Save the current camera configuration to the car.
 
 Load a previously saved car camera.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Alt+F11`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings

--- a/packages/website/src/content/docs/docs/actions/view-camera/camera-focus.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/camera-focus.md
@@ -17,13 +17,13 @@ Select the mode from the **Target** dropdown in the Property Inspector.
 
 Switch the active camera group to a specific numeric group (1–20). Useful when you want a single button to always jump to the same camera.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Camera Group
+#### Setting: Camera Group
 
 The numeric camera group to select (1–20). Defaults to `9`. The mapping from number to group (Nose, Cockpit, TV1, etc.) depends on the car and track combination — hover over the group dropdown in the Property Inspector for the list of available groups.
 
@@ -33,18 +33,18 @@ The numeric camera group to select (1–20). Defaults to `9`. The mapping from n
 
 Cycle through camera groups. The **Direction** setting picks whether pressing the button advances to the next group or goes back. When a subset is configured, only the selected groups are cycled.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles camera groups (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the button shows a preview icon for the currently active camera group (Nose, Cockpit, TV1, etc.)
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Next** (default) — Pressing the button advances to the next camera group
 - **Previous** — Pressing the button goes back to the previous camera group
 
-##### Setting: Camera Group Subset
+#### Setting: Camera Group Subset
 
 A checkbox grid in the Property Inspector lets you pick exactly which groups should participate in the cycle. By default Nose, Cockpit, Chase, TV1, TV2, and TV3 are enabled. Use **Select All** / **Clear Selection** to manage the list quickly.
 
@@ -56,13 +56,13 @@ The subset is stored as a global setting shared across every Camera Controls ins
 
 Cycle sub-cameras within the currently active camera group (e.g., left / right / front nose variants).
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles sub-cameras (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Next** (default) — Pressing the button advances to the next sub-camera
 - **Previous** — Pressing the button goes back to the previous sub-camera
@@ -73,13 +73,13 @@ Cycle sub-cameras within the currently active camera group (e.g., left / right /
 
 Switch camera focus to the next / previous car in the field.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles cars (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Next** (default) — Pressing the button focuses the next car
 - **Previous** — Pressing the button focuses the previous car
@@ -90,13 +90,13 @@ Switch camera focus to the next / previous car in the field.
 
 Cycle through the driving-style cameras (cockpit, bumper, nose, chase, etc.).
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles driving cameras (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Next** (default) — Pressing the button advances to the next driving camera
 - **Previous** — Pressing the button goes back to the previous driving camera
@@ -107,13 +107,13 @@ Cycle through the driving-style cameras (cockpit, bumper, nose, chase, etc.).
 
 Center the camera on your own car.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -123,13 +123,13 @@ Center the camera on your own car.
 
 Focus the camera on the current race leader.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -139,13 +139,13 @@ Focus the camera on the current race leader.
 
 Focus the camera on the latest incident reported by iRacing.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -155,13 +155,13 @@ Focus the camera on the latest incident reported by iRacing.
 
 Focus the camera on a car that is currently exiting pit lane.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -171,13 +171,13 @@ Focus the camera on a car that is currently exiting pit lane.
 
 Switch camera focus to the car currently running in a specific race position.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Position
+#### Setting: Position
 
 The race position to focus. Integer from `1` up. Defaults to `1` (race leader).
 
@@ -187,13 +187,13 @@ The race position to focus. Integer from `1` up. Defaults to `1` (race leader).
 
 Switch camera focus to a car by its car number.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Car Number
+#### Setting: Car Number
 
 The car number to focus. Integer. Defaults to `0`.
 
@@ -203,12 +203,12 @@ The car number to focus. Integer. Defaults to `0`.
 
 Apply a predefined iRacing camera state bit flag. Useful for scripting camera setups during replays.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Camera State
+#### Setting: Camera State
 
 The numeric camera state value passed to the iRacing SDK. Integer. Defaults to `0`.

--- a/packages/website/src/content/docs/docs/actions/view-camera/camera-focus.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/camera-focus.md
@@ -1,45 +1,214 @@
 ---
 title: Camera Controls
-description: Cycle through cameras and focus on specific targets with a single button or dial.
+description: Cycle cameras, change camera groups, and focus on specific targets with a single button or dial.
 sidebar:
   badge:
-    text: "11 modes"
+    text: "12 modes"
     variant: tip
 ---
 
-Camera Controls combines camera cycling and focus targeting into one action, giving you full camera control during broadcasts and replay reviews.
+Camera Controls combines camera group selection, camera cycling, and focus targeting into one action. Everything is driven by the iRacing SDK camera commands — no keyboard shortcuts and no configurable bindings.
 
-## Cycle Modes
+## Modes
 
-| Mode | Description |
-|------|-------------|
-| Cycle Camera | Cycle through camera groups (with subset selection) |
-| Cycle Sub-Camera | Cycle sub-cameras within the current group |
-| Cycle Car | Switch focus to the next/previous car |
-| Cycle Driving Camera | Cycle through driving-style cameras |
+Select the mode from the **Target** dropdown in the Property Inspector.
 
-Each cycle mode has a Direction setting (Next / Previous).
+### Change Camera
 
-### Camera Group Selection
+Switch the active camera group to a specific numeric group (1–20). Useful when you want a single button to always jump to the same camera.
 
-When using Cycle Camera mode, you can select which camera groups to cycle through. By default, Nose, Cockpit, Chase, TV1, TV2, and TV3 are enabled.
+##### Details
 
-The Property Inspector shows a checkbox grid with all available camera groups. Use **Select All** and **Clear Selection** to quickly manage the selection.
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
 
-Camera group selection is a global setting shared across all Camera Controls instances.
+##### Setting: Camera Group
 
-## Focus Modes
+The numeric camera group to select (1–20). Defaults to `9`. The mapping from number to group (Nose, Cockpit, TV1, etc.) depends on the car and track combination — hover over the group dropdown in the Property Inspector for the list of available groups.
 
-| Mode | Description |
-|------|-------------|
-| Focus Your Car | Center the camera on your own car |
-| Focus on Leader | Focus the camera on the race leader |
-| Focus on Incident | Focus the camera on the latest incident |
-| Focus on Exiting | Focus the camera on a car exiting pit lane |
-| Switch by Position | Switch camera focus to a car by race position |
-| Switch by Car Number | Switch camera focus to a specific car number |
-| Set Camera State | Set a predefined camera state |
+---
 
-## Encoder Support
+### Cycle Camera
 
-Yes — rotation cycles through cameras in cycle modes (no-op for focus modes). Press activates the selected target.
+Cycle through camera groups. The **Direction** setting picks whether pressing the button advances to the next group or goes back. When a subset is configured, only the selected groups are cycled.
+
+##### Details
+
+- **Dial:** Rotation cycles camera groups (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — the button shows a preview icon for the currently active camera group (Nose, Cockpit, TV1, etc.)
+
+##### Setting: Direction
+
+- **Next** (default) — Pressing the button advances to the next camera group
+- **Previous** — Pressing the button goes back to the previous camera group
+
+##### Setting: Camera Group Subset
+
+A checkbox grid in the Property Inspector lets you pick exactly which groups should participate in the cycle. By default Nose, Cockpit, Chase, TV1, TV2, and TV3 are enabled. Use **Select All** / **Clear Selection** to manage the list quickly.
+
+The subset is stored as a global setting shared across every Camera Controls instance — configure it once and every cycling button respects the same list.
+
+---
+
+### Cycle Sub-Camera
+
+Cycle sub-cameras within the currently active camera group (e.g., left / right / front nose variants).
+
+##### Details
+
+- **Dial:** Rotation cycles sub-cameras (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Next** (default) — Pressing the button advances to the next sub-camera
+- **Previous** — Pressing the button goes back to the previous sub-camera
+
+---
+
+### Cycle Car
+
+Switch camera focus to the next / previous car in the field.
+
+##### Details
+
+- **Dial:** Rotation cycles cars (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Next** (default) — Pressing the button focuses the next car
+- **Previous** — Pressing the button focuses the previous car
+
+---
+
+### Cycle Driving Camera
+
+Cycle through the driving-style cameras (cockpit, bumper, nose, chase, etc.).
+
+##### Details
+
+- **Dial:** Rotation cycles driving cameras (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Next** (default) — Pressing the button advances to the next driving camera
+- **Previous** — Pressing the button goes back to the previous driving camera
+
+---
+
+### Focus Your Car
+
+Center the camera on your own car.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Focus on Leader
+
+Focus the camera on the current race leader.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Focus on Incident
+
+Focus the camera on the latest incident reported by iRacing.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Focus on Exiting
+
+Focus the camera on a car that is currently exiting pit lane.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Switch by Position
+
+Switch camera focus to the car currently running in a specific race position.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Position
+
+The race position to focus. Integer from `1` up. Defaults to `1` (race leader).
+
+---
+
+### Switch by Car Number
+
+Switch camera focus to a car by its car number.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Car Number
+
+The car number to focus. Integer. Defaults to `0`.
+
+---
+
+### Set Camera State
+
+Apply a predefined iRacing camera state bit flag. Useful for scripting camera setups during replays.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Camera State
+
+The numeric camera state value passed to the iRacing SDK. Integer. Defaults to `0`.

--- a/packages/website/src/content/docs/docs/actions/view-camera/replay-control.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/replay-control.md
@@ -7,65 +7,412 @@ sidebar:
     variant: tip
 ---
 
-Replay Control gives you complete command over iRacing's replay system. Playback transport, progressive speed control, and session/lap/incident navigation are all available as selectable modes on a single action.
+Complete command over iRacing's replay system. Playback transport, progressive speed control, and session / lap / incident / car navigation are all available as selectable modes on a single action. Every mode uses the iRacing SDK replay and camera commands — no keyboard bindings.
 
 :::note
-Replay Control replaces the legacy Replay Transport, Replay Speed, and Replay Navigation actions. Existing button configurations using those actions will continue to work.
+Replay Control replaces the legacy Replay Transport, Replay Speed, and Replay Navigation actions. Existing button configurations using those actions continue to work.
 :::
 
-## Transport
+Fast Forward, Rewind, Frame Forward, Frame Backward, Increase Speed, and Decrease Speed support long-press: hold the button to repeat the command automatically after an initial 500 ms delay, then every 250 ms.
 
-| Mode | Description |
-|------|-------------|
-| Play / Pause | Toggle forward playback. Remembers slow-motion speed across pause/resume. |
-| Play / Pause Backward | Toggle reverse playback. Mirrors slow-motion speed when switching direction. |
-| Stop | Pause and reset speed memory so next play starts at 1x. |
-| Fast Forward | Progressive fast-forward: each press increases speed 2x → 3x → ... → 16x. |
-| Rewind | Progressive rewind: each press increases reverse speed -2x → -3x → ... → -16x. |
-| Slow Motion | Quick shortcut to 1/2x slow motion. |
-| Frame Forward | Advance one frame. |
-| Frame Backward | Step back one frame. |
+## Modes
 
-## Speed
+Select the mode from the **Mode** dropdown in the Property Inspector.
 
-| Mode | Description |
-|------|-------------|
-| Increase Speed | Traverse full speed range upward: 1/16x → ... → 1/2x → 1x → 2x → ... → 16x. Direction-aware. |
-| Decrease Speed | Traverse full speed range downward. Direction-aware (works in reverse too). |
-| Set Speed | Set a specific speed via dropdown (31 options from 1/16x to 16x). |
-| Speed Display | Read-only display of current replay speed from telemetry. |
+### Play / Pause
 
-## Navigation
+Toggle forward playback. Remembers your last slow-motion speed across pause / resume so you can flip between paused and 1/2x without losing the rhythm.
 
-| Mode | Description |
-|------|-------------|
-| Next Session | Jump to the next session. |
-| Previous Session | Jump to the previous session. |
-| Next Lap | Jump to the next lap. |
-| Previous Lap | Jump to the previous lap. |
-| Next Incident | Jump to the next incident. |
-| Previous Incident | Jump to the previous incident. |
-| Jump to Beginning | Jump to the start of the replay. |
-| Jump to Live | Jump to the live session. |
+##### Details
 
-## Camera
+- **Dial:** Rotation steps playback forward or backward by one frame
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — the icon reflects whether the replay is currently playing or paused based on live replay state
 
-| Mode | Description |
-|------|-------------|
-| Jump to My Car | Jump the replay camera to your own car. |
-| Next Car | Switch to the next car ahead on track. Skips cars on pit road. |
-| Previous Car | Switch to the next car behind on track. Skips cars on pit road. |
-| Next Car (Number Order) | Switch to the next car by car number order. Includes all cars (even in pits), skips pace car. |
-| Previous Car (Number Order) | Switch to the previous car by car number order. Includes all cars (even in pits), skips pace car. |
+##### Settings
 
-## Long-Press Repeat
+- No additional settings
 
-Fast Forward, Rewind, Frame Forward, Frame Backward, Increase Speed, and Decrease Speed support long-press: hold the button to repeat the command automatically (500ms initial delay, then every 250ms).
+---
 
-## Encoder Support
+### Play / Pause Backward
 
-Yes — rotation behavior depends on the selected mode:
-- **Speed modes**: rotate adjusts speed progressively
-- **Navigation modes**: rotate cycles next/previous
-- **Camera modes**: rotate cycles next/previous car; push executes the selected action
-- **Transport modes**: rotate steps forward/backward by one frame
+Toggle reverse playback. Mirrors slow-motion speed when switching direction.
+
+##### Details
+
+- **Dial:** Rotation steps playback forward or backward by one frame
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — the icon reflects whether reverse playback is active based on live replay state
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Stop
+
+Pause playback and reset the remembered speed so the next Play / Pause starts at 1x.
+
+##### Details
+
+- **Dial:** Rotation steps playback forward or backward by one frame
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Fast Forward
+
+Progressive fast-forward. Each press doubles the forward speed (2x → 3x → ... → 16x) up to the iRacing maximum.
+
+##### Details
+
+- **Dial:** Rotation steps playback forward or backward by one frame
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Rewind
+
+Progressive rewind. Each press increases the reverse speed (−2x → −3x → ... → −16x) up to the iRacing maximum.
+
+##### Details
+
+- **Dial:** Rotation steps playback forward or backward by one frame
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Slow Motion
+
+Quick shortcut to 1/2x slow motion.
+
+##### Details
+
+- **Dial:** Rotation steps playback forward or backward by one frame
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Frame Forward
+
+Advance exactly one frame.
+
+##### Details
+
+- **Dial:** Rotation steps playback forward or backward by one frame
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Frame Backward
+
+Step back exactly one frame.
+
+##### Details
+
+- **Dial:** Rotation steps playback forward or backward by one frame
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Increase Speed
+
+Traverse the full speed range upward: 1/16x → ... → 1/2x → 1x → 2x → ... → 16x. Direction-aware — works whether playback is forward or reverse.
+
+##### Details
+
+- **Dial:** Rotation progressively adjusts replay speed (clockwise = increase, counter-clockwise = decrease)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Decrease Speed
+
+Traverse the full speed range downward. Direction-aware — works whether playback is forward or reverse.
+
+##### Details
+
+- **Dial:** Rotation progressively adjusts replay speed (clockwise = increase, counter-clockwise = decrease)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Set Speed
+
+Set replay playback to a specific speed selected in the Property Inspector.
+
+##### Details
+
+- **Dial:** Rotation steps playback forward or backward by one frame
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Setting: Speed
+
+The target replay speed. 31 options ranging from `1/16x` slow motion through `1x` up to `16x` fast-forward. Defaults to `1x`.
+
+---
+
+### Speed Display
+
+Read-only display of the current replay speed. Pressing the button does nothing — this is a display-only mode.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — the icon shows the live replay speed pulled from telemetry
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Next Session
+
+Jump to the next session in the replay.
+
+##### Details
+
+- **Dial:** Rotation cycles sessions (clockwise = next, counter-clockwise = previous)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Previous Session
+
+Jump to the previous session in the replay.
+
+##### Details
+
+- **Dial:** Rotation cycles sessions (clockwise = next, counter-clockwise = previous)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Next Lap
+
+Jump forward one lap.
+
+##### Details
+
+- **Dial:** Rotation cycles laps (clockwise = next, counter-clockwise = previous)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Previous Lap
+
+Jump backward one lap.
+
+##### Details
+
+- **Dial:** Rotation cycles laps (clockwise = next, counter-clockwise = previous)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Next Incident
+
+Jump to the next incident.
+
+##### Details
+
+- **Dial:** Rotation cycles incidents (clockwise = next, counter-clockwise = previous)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Previous Incident
+
+Jump to the previous incident.
+
+##### Details
+
+- **Dial:** Rotation cycles incidents (clockwise = next, counter-clockwise = previous)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Jump to Beginning
+
+Jump to the start of the replay.
+
+##### Details
+
+- **Dial:** Rotation cycles incidents (clockwise = next incident, counter-clockwise = previous incident)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Jump to Live
+
+Jump to the live point in the session (end of the replay buffer).
+
+##### Details
+
+- **Dial:** Rotation cycles incidents (clockwise = next incident, counter-clockwise = previous incident)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Jump to My Car
+
+Jump the replay camera to your own car.
+
+##### Details
+
+- **Dial:** Rotation cycles to the next / previous car on track around your position (clockwise = ahead, counter-clockwise = behind)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Next Car
+
+Switch the replay camera to the next car ahead on track. Skips cars currently on pit road.
+
+##### Details
+
+- **Dial:** Rotation cycles cars on track (clockwise = next ahead, counter-clockwise = previous behind)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Previous Car
+
+Switch the replay camera to the next car behind on track. Skips cars currently on pit road.
+
+##### Details
+
+- **Dial:** Rotation cycles cars on track (clockwise = next ahead, counter-clockwise = previous behind)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Next Car (Number Order)
+
+Switch the replay camera to the next car by car number order. Includes all cars — even those in the pits — and skips the pace car.
+
+##### Details
+
+- **Dial:** Rotation cycles cars by number order (clockwise = next, counter-clockwise = previous)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### Previous Car (Number Order)
+
+Switch the replay camera to the previous car by car number order. Includes all cars — even those in the pits — and skips the pace car.
+
+##### Details
+
+- **Dial:** Rotation cycles cars by number order (clockwise = next, counter-clockwise = previous)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings

--- a/packages/website/src/content/docs/docs/actions/view-camera/replay-control.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/replay-control.md
@@ -23,13 +23,13 @@ Select the mode from the **Mode** dropdown in the Property Inspector.
 
 Toggle forward playback. Remembers your last slow-motion speed across pause / resume so you can flip between paused and 1/2x without losing the rhythm.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the icon reflects whether the replay is currently playing or paused based on live replay state
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -39,13 +39,13 @@ Toggle forward playback. Remembers your last slow-motion speed across pause / re
 
 Toggle reverse playback. Mirrors slow-motion speed when switching direction.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the icon reflects whether reverse playback is active based on live replay state
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -55,13 +55,13 @@ Toggle reverse playback. Mirrors slow-motion speed when switching direction.
 
 Pause playback and reset the remembered speed so the next Play / Pause starts at 1x.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -69,15 +69,15 @@ Pause playback and reset the remembered speed so the next Play / Pause starts at
 
 ### Fast Forward
 
-Progressive fast-forward. Each press doubles the forward speed (2x → 3x → ... → 16x) up to the iRacing maximum.
+Progressive fast-forward. Each press steps the forward speed up by one (2x → 3x → 4x → ... → 16x) up to the iRacing maximum.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -85,15 +85,15 @@ Progressive fast-forward. Each press doubles the forward speed (2x → 3x → ..
 
 ### Rewind
 
-Progressive rewind. Each press increases the reverse speed (−2x → −3x → ... → −16x) up to the iRacing maximum.
+Progressive rewind. Each press steps the reverse speed up by one (−2x → −3x → −4x → ... → −16x) up to the iRacing maximum.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -103,13 +103,13 @@ Progressive rewind. Each press increases the reverse speed (−2x → −3x → 
 
 Quick shortcut to 1/2x slow motion.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -119,13 +119,13 @@ Quick shortcut to 1/2x slow motion.
 
 Advance exactly one frame.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -135,13 +135,13 @@ Advance exactly one frame.
 
 Step back exactly one frame.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -151,13 +151,13 @@ Step back exactly one frame.
 
 Traverse the full speed range upward: 1/16x → ... → 1/2x → 1x → 2x → ... → 16x. Direction-aware — works whether playback is forward or reverse.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation progressively adjusts replay speed (clockwise = increase, counter-clockwise = decrease)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -167,13 +167,13 @@ Traverse the full speed range upward: 1/16x → ... → 1/2x → 1x → 2x → .
 
 Traverse the full speed range downward. Direction-aware — works whether playback is forward or reverse.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation progressively adjusts replay speed (clockwise = increase, counter-clockwise = decrease)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -183,13 +183,13 @@ Traverse the full speed range downward. Direction-aware — works whether playba
 
 Set replay playback to a specific speed selected in the Property Inspector.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Setting: Speed
+#### Setting: Speed
 
 The target replay speed. 31 options ranging from `1/16x` slow motion through `1x` up to `16x` fast-forward. Defaults to `1x`.
 
@@ -199,13 +199,13 @@ The target replay speed. 31 options ranging from `1/16x` slow motion through `1x
 
 Read-only display of the current replay speed. Pressing the button does nothing — this is a display-only mode.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the icon shows the live replay speed pulled from telemetry
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -215,13 +215,13 @@ Read-only display of the current replay speed. Pressing the button does nothing 
 
 Jump to the next session in the replay.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles sessions (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -231,13 +231,13 @@ Jump to the next session in the replay.
 
 Jump to the previous session in the replay.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles sessions (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -247,13 +247,13 @@ Jump to the previous session in the replay.
 
 Jump forward one lap.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles laps (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -263,13 +263,13 @@ Jump forward one lap.
 
 Jump backward one lap.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles laps (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -279,13 +279,13 @@ Jump backward one lap.
 
 Jump to the next incident.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles incidents (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -295,13 +295,13 @@ Jump to the next incident.
 
 Jump to the previous incident.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles incidents (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -311,13 +311,13 @@ Jump to the previous incident.
 
 Jump to the start of the replay.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles incidents (clockwise = next incident, counter-clockwise = previous incident)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -327,13 +327,13 @@ Jump to the start of the replay.
 
 Jump to the live point in the session (end of the replay buffer).
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles incidents (clockwise = next incident, counter-clockwise = previous incident)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -343,13 +343,13 @@ Jump to the live point in the session (end of the replay buffer).
 
 Jump the replay camera to your own car.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles to the next / previous car on track around your position (clockwise = ahead, counter-clockwise = behind)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -359,13 +359,13 @@ Jump the replay camera to your own car.
 
 Switch the replay camera to the next car ahead on track. Skips cars currently on pit road.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles cars on track (clockwise = next ahead, counter-clockwise = previous behind)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -375,13 +375,13 @@ Switch the replay camera to the next car ahead on track. Skips cars currently on
 
 Switch the replay camera to the next car behind on track. Skips cars currently on pit road.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles cars on track (clockwise = next ahead, counter-clockwise = previous behind)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -391,13 +391,13 @@ Switch the replay camera to the next car behind on track. Skips cars currently o
 
 Switch the replay camera to the next car by car number order. Includes all cars — even those in the pits — and skips the pace car.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles cars by number order (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -407,12 +407,12 @@ Switch the replay camera to the next car by car number order. Includes all cars 
 
 Switch the replay camera to the previous car by car number order. Includes all cars — even those in the pits — and skips the pace car.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation cycles cars by number order (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings

--- a/packages/website/src/content/docs/docs/actions/view-camera/view-adjustment.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/view-adjustment.md
@@ -17,13 +17,13 @@ Select the mode from the **Adjustment** dropdown in the Property Inspector. Dire
 
 Adjust the field of view.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts FOV (clockwise = wider, counter-clockwise = narrower), regardless of the Direction setting
 - **Default binding:** `]` (increase) and `[` (decrease)
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button widens the field of view
 - **Decrease** — Pressing the button narrows the field of view
@@ -34,13 +34,13 @@ Adjust the field of view.
 
 Adjust the horizon line position.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts horizon (clockwise = up, counter-clockwise = down), regardless of the Direction setting
 - **Default binding:** `Shift+]` (increase/up) and `Shift+[` (decrease/down)
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button moves the horizon line upward
 - **Decrease** — Pressing the button moves the horizon line downward
@@ -51,13 +51,13 @@ Adjust the horizon line position.
 
 Adjust the driver eye position.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts driver height (clockwise = raise, counter-clockwise = lower), regardless of the Direction setting
 - **Default binding:** `Ctrl+]` (increase/up) and `Ctrl+[` (decrease/down)
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button raises the driver eye position
 - **Decrease** — Pressing the button lowers the driver eye position
@@ -68,13 +68,13 @@ Adjust the driver eye position.
 
 Re-center the VR headset view.
 
-##### Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `;`
 - **Telemetry-aware icon:** No
 
-##### Settings
+#### Settings
 
 - No additional settings
 
@@ -84,13 +84,13 @@ Re-center the VR headset view.
 
 Adjust the in-sim UI element size.
 
-##### Details
+#### Details
 
 - **Dial:** Rotation adjusts UI size (clockwise = larger, counter-clockwise = smaller), regardless of the Direction setting
 - **Default binding:** `Ctrl+PageUp` (increase) and `Ctrl+PageDown` (decrease)
 - **Telemetry-aware icon:** No
 
-##### Setting: Direction
+#### Setting: Direction
 
 - **Increase** (default) — Pressing the button makes UI elements larger
 - **Decrease** — Pressing the button makes UI elements smaller

--- a/packages/website/src/content/docs/docs/actions/view-camera/view-adjustment.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/view-adjustment.md
@@ -3,26 +3,94 @@ title: View Adjustment
 description: Adjust FOV, horizon, driver height, VR centering, and UI size from your Stream Deck.
 sidebar:
   badge:
-    text: "9 modes"
+    text: "5 modes"
     variant: tip
 ---
 
-View Adjustment lets you tweak your in-car view settings without leaving the cockpit. Each mode maps to a specific view parameter so you can dial in the perfect perspective.
+Tweak your in-car view settings without leaving the cockpit. Each mode maps to a specific view parameter so you can dial in the perfect perspective.
 
 ## Modes
 
-| Mode | Description |
-|------|-------------|
-| FOV Increase | Widen the field of view |
-| FOV Decrease | Narrow the field of view |
-| Horizon Up | Move the horizon line upward |
-| Horizon Down | Move the horizon line downward |
-| Driver Height Up | Raise the driver eye position |
-| Driver Height Down | Lower the driver eye position |
-| Recenter VR | Re-center the VR headset view |
-| UI Size Increase | Increase the in-sim UI element size |
-| UI Size Decrease | Decrease the in-sim UI element size |
+Select the mode from the **Adjustment** dropdown in the Property Inspector. Directional modes (FOV, Horizon, Driver Height, UI Size) also expose a **Direction** setting for Increase / Decrease.
 
-## Encoder Support
+### FOV
 
-Yes — rotation adjusts the selected parameter incrementally, making it easy to fine-tune values with the Stream Deck+ dial.
+Adjust the field of view.
+
+##### Details
+
+- **Dial:** Rotation adjusts FOV (clockwise = wider, counter-clockwise = narrower), regardless of the Direction setting
+- **Default binding:** `]` (increase) and `[` (decrease)
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button widens the field of view
+- **Decrease** — Pressing the button narrows the field of view
+
+---
+
+### Horizon
+
+Adjust the horizon line position.
+
+##### Details
+
+- **Dial:** Rotation adjusts horizon (clockwise = up, counter-clockwise = down), regardless of the Direction setting
+- **Default binding:** `Shift+]` (increase/up) and `Shift+[` (decrease/down)
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button moves the horizon line upward
+- **Decrease** — Pressing the button moves the horizon line downward
+
+---
+
+### Driver Height
+
+Adjust the driver eye position.
+
+##### Details
+
+- **Dial:** Rotation adjusts driver height (clockwise = raise, counter-clockwise = lower), regardless of the Direction setting
+- **Default binding:** `Ctrl+]` (increase/up) and `Ctrl+[` (decrease/down)
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button raises the driver eye position
+- **Decrease** — Pressing the button lowers the driver eye position
+
+---
+
+### Recenter VR
+
+Re-center the VR headset view.
+
+##### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `;`
+- **Telemetry-aware icon:** No
+
+##### Settings
+
+- No additional settings
+
+---
+
+### UI Size
+
+Adjust the in-sim UI element size.
+
+##### Details
+
+- **Dial:** Rotation adjusts UI size (clockwise = larger, counter-clockwise = smaller), regardless of the Direction setting
+- **Default binding:** `Ctrl+PageUp` (increase) and `Ctrl+PageDown` (decrease)
+- **Telemetry-aware icon:** No
+
+##### Setting: Direction
+
+- **Increase** (default) — Pressing the button makes UI elements larger
+- **Decrease** — Pressing the button makes UI elements smaller

--- a/packages/website/src/content/docs/docs/development/tech-stack.md
+++ b/packages/website/src/content/docs/docs/development/tech-stack.md
@@ -9,7 +9,7 @@ iRaceDeck is a monorepo built with [pnpm](https://pnpm.io/) workspaces. The code
 
 | Package | Description |
 |---------|-------------|
-| `@iracedeck/stream-deck-plugin` | The main Stream Deck plugin — all 33 actions, Property Inspector UI, and icon rendering |
+| `@iracedeck/stream-deck-plugin` | The main Stream Deck plugin — all 30 actions, Property Inspector UI, and icon rendering |
 | `@iracedeck/iracing-sdk` | TypeScript SDK for reading iRacing telemetry and session data via shared memory |
 | `@iracedeck/iracing-native` | Native C++ addon for Windows keyboard simulation and window management |
 | `@iracedeck/icons` | SVG icon library for all Stream Deck button icons |

--- a/packages/website/src/content/docs/docs/index.md
+++ b/packages/website/src/content/docs/docs/index.md
@@ -19,7 +19,7 @@ Welcome to the iRaceDeck documentation. Here you'll find guides for getting star
 
 ## Actions
 
-iRaceDeck provides **33 actions** with **362 controls** across 8 categories. See the [Actions Overview](/docs/actions/overview/) for a full breakdown, or jump to a category:
+iRaceDeck provides **30 actions** with **254 modes** across 8 categories. See the [Actions Overview](/docs/actions/overview/) for a full breakdown, or jump to a category:
 
 - [Display & Session](/docs/actions/display-session/session-info/) — Live session data and telemetry displays
 - [Driving Controls](/docs/actions/driving/ai-spotter-controls/) — AI spotter, audio, black boxes, look direction, car control

--- a/packages/website/src/content/docs/index.mdx
+++ b/packages/website/src/content/docs/index.mdx
@@ -24,13 +24,13 @@ hero:
 
 <div class="stats-row">
   <div class="stat">
-    <span class="stat-value">33</span>
+    <span class="stat-value">30</span>
     <span class="stat-label">Actions</span>
   </div>
   <div class="stat-divider" />
   <div class="stat">
-    <span class="stat-value">362</span>
-    <span class="stat-label">Controls</span>
+    <span class="stat-value">254</span>
+    <span class="stat-label">Modes</span>
   </div>
   <div class="stat-divider" />
   <div class="stat">


### PR DESCRIPTION
## Related Issue

Fixes #319

## What changed?

Converts every action page in `packages/website/src/content/docs/docs/actions/` to the new per-mode format established by the Tire Service page and documented in `.claude/rules/website-action-docs.md`.

**Format reworked in the first two commits:**

- Added a `##### Details` subheader to every mode with three bullet points:
  - **Dial:** rotation behavior (or `No rotation support`)
  - **Default binding:** default keyboard key / `No default key binding` / `No keyboard binding`
  - **Telemetry-aware icon:** `Yes` (with a short note) / `No`
- Renamed the first bullet from `Encoder` to `Dial` — "encoder" is SDK jargon; "dial" is what Elgato and Mirabox call the hardware and what the SDK event names already use (`onDialRotate`, `IDeckDialRotateEvent`). A follow-up rename of remaining user-facing "encoder" mentions is tracked in #323.
- Trailing periods dropped from each Details bullet to keep the block terse.
- `.claude/rules/website-action-docs.md` and the canonical `tire-service.md` updated first so every other page could follow them.

**29 action pages converted**, one commit per action: all seven Car Setup pages, the five Cockpit pages, two Communication pages (chat + race-admin), two Display & Session pages, the remaining four Driving pages, Media Capture, Fuel Service and Pit Quick Actions, view-adjustment, and four view-camera pages (camera-editor-adjustments, camera-editor-controls, camera-focus → Camera Controls, replay-control).

**Badges corrected where the old doc and the current enum disagreed**, for example:

- `setup-chassis` 26 → 13 (old count double-counted directional variants; old prose also mentioned modes that no longer exist)
- `setup-aero` 7 → 4, `setup-brakes` 13 → 7, `setup-engine` 8 → 4, `setup-fuel` 7 → 5, `setup-hybrid` 9 → 6, `setup-traction` 9 → 5, `cockpit-misc` 10 → 7, `force-feedback` 11 → 6, `audio-controls` 6 → 3, `black-box-selector` 13 → 3, `camera-editor-adjustments` 29 → 15, `view-adjustment` 9 → 5
- `camera-editor-controls` 27 → 30 (old doc listed 27 modes that no longer exist — the enum has been completely refactored to 30 different modes)
- `toggle-ui-elements` 8 → 9 (Replay UI was missing from the old count)
- `camera-focus` (Camera Controls) 11 → 12 (Change Camera mode was missing from the old count)

**Stale "dial rotation" claims fixed** on actions that have no `onDialRotate` handler in code — the dial only supports press-to-execute on these (pit-quick-actions, media-capture, session-info, toggle-ui-elements).

**Final commit syncs action and mode totals** everywhere they were counted: landing page stats, `/docs/` landing, Actions Overview table, tech-stack package description, README feature table, and both skill files. "Controls" column renamed to "Modes" so the numbers match the per-action badges. New totals: **30 documented actions, 254 modes**. Legacy actions (Replay Transport/Speed/Navigation, Camera Cycle (Legacy)) still exist in the plugin manifest but are not counted as documented actions.

## How to test

- [x] Run `pnpm --filter @iracedeck/website build` — confirm the site builds with no broken links or front-matter errors
- [x] Spot-check a few converted pages in the rendered site, especially ones with important edge cases:
  - **Tire Service** — the canonical page, should render with the new Details block on every mode
  - **Black Box Selector** — 3 modes with a nested Black Box Setting listing F1–F11 per option
  - **Car Control** — Enter/Exit/Tow state icons documented as a Setting, Escape Auto Hold documented as a Setting
  - **Race Admin** — 27 modes grouped in the prose intro, Driver Target documented once in Shared settings rather than repeated 11 times
  - **Chat** — Shared Icon Color and Key Text settings moved to the end-of-page section so they are not duplicated in every mode
  - **Replay Control** — 25 modes with long-press repeat note at the top
- [x] Verify landing page stats on `/` read **30 Actions / 254 Modes**
- [x] Verify `/docs/actions/overview/` table uses the **Modes** column header and 30 actions / 254 modes total
- [x] Verify the sidebar badges under each converted page match the `### ` mode count in the file

## Checklist

- [x] Linked to an approved issue (#319)
- [x] New code has unit tests — N/A, docs-only change
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — N/A, website docs only
- [x] No unrelated changes included

## Notes

- Follow-up issue #323 is filed for the broader `encoder` → `dial` rename across plugin manifests, PI templates, action docs under `docs/plugins/core/actions/`, and remaining project rules. This PR only does the rename inside the 29 website pages and the website-action-docs rule.
- `docs/reference/actions.json` is intentionally **not** updated in this PR. It is a separately maintained reference file with its own structure; a coordinated update (or regenerator) can come in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized per-mode layout with consistent "Details" and "Settings" sections and clarified headings.
  * Per-mode dial behavior, default binding rules, and telemetry-aware icon flags documented (including three-way default-binding statuses).
  * Introduced a "Direction" (Increase/Decrease) setting workflow for applicable modes.
  * Updated action catalog and category names: 30 actions, 254 modes; refined category organization (e.g., Communication).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->