### PR TITLE
refactor(pi): standardize primary selector to "Mode" label and setting key (#324)

### DIFF
--- a/packages/actions/src/actions/media-capture.test.ts
+++ b/packages/actions/src/actions/media-capture.test.ts
@@ -1,10 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  generateMediaCaptureSvg,
-  MEDIA_CAPTURE_GLOBAL_KEYS,
-  migrateMediaCaptureLegacyAction,
-} from "./media-capture.js";
+import { generateMediaCaptureSvg, MEDIA_CAPTURE_GLOBAL_KEYS } from "./media-capture.js";
 
 vi.mock("@iracedeck/icons/media-capture/start-stop-video.svg", () => ({
   default: '<svg xmlns="http://www.w3.org/2000/svg">{{mainLabel}} {{subLabel}}</svg>',
@@ -56,6 +52,19 @@ vi.mock("@iracedeck/deck-core", () => ({
 
     return b.key;
   }),
+  migrateLegacyActionToMode: (raw: unknown) => {
+    if (!raw || typeof raw !== "object") return { migrated: {}, changed: false };
+
+    const record = raw as Record<string, unknown>;
+
+    if (record.mode !== undefined || record.action === undefined) {
+      return { migrated: { ...record }, changed: false };
+    }
+
+    const { action, ...rest } = record;
+
+    return { migrated: { ...rest, mode: action }, changed: true };
+  },
   getCommands: vi.fn(() => ({
     videoCapture: {
       screenshot: vi.fn(() => true),
@@ -213,49 +222,6 @@ describe("MediaCapture", () => {
         expect(decoded).toContain(labels.mainLabel);
         expect(decoded).toContain(labels.subLabel);
       }
-    });
-  });
-
-  describe("migrateMediaCaptureLegacyAction", () => {
-    it("should rename legacy action key to mode", () => {
-      const result = migrateMediaCaptureLegacyAction({ action: "take-screenshot" });
-
-      expect(result.changed).toBe(true);
-      expect(result.migrated).toEqual({ mode: "take-screenshot" });
-      expect(result.migrated.action).toBeUndefined();
-    });
-
-    it("should preserve other settings keys during migration", () => {
-      const result = migrateMediaCaptureLegacyAction({ action: "take-screenshot", flagsOverlay: true });
-
-      expect(result.changed).toBe(true);
-      expect(result.migrated).toEqual({ mode: "take-screenshot", flagsOverlay: true });
-    });
-
-    it("should not change settings that already use mode", () => {
-      const result = migrateMediaCaptureLegacyAction({ mode: "take-screenshot" });
-
-      expect(result.changed).toBe(false);
-      expect(result.migrated).toEqual({ mode: "take-screenshot" });
-    });
-
-    it("should not migrate when both mode and action are present (mode wins)", () => {
-      const result = migrateMediaCaptureLegacyAction({ mode: "video-timer", action: "take-screenshot" });
-
-      expect(result.changed).toBe(false);
-      expect(result.migrated.mode).toBe("video-timer");
-    });
-
-    it("should handle empty raw settings", () => {
-      const result = migrateMediaCaptureLegacyAction({});
-
-      expect(result.changed).toBe(false);
-      expect(result.migrated).toEqual({});
-    });
-
-    it("should handle null/undefined raw settings", () => {
-      expect(migrateMediaCaptureLegacyAction(null).changed).toBe(false);
-      expect(migrateMediaCaptureLegacyAction(undefined).changed).toBe(false);
     });
   });
 });

--- a/packages/actions/src/actions/media-capture.test.ts
+++ b/packages/actions/src/actions/media-capture.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { generateMediaCaptureSvg, MEDIA_CAPTURE_GLOBAL_KEYS } from "./media-capture.js";
+import {
+  generateMediaCaptureSvg,
+  MEDIA_CAPTURE_GLOBAL_KEYS,
+  migrateMediaCaptureLegacyAction,
+} from "./media-capture.js";
 
 vi.mock("@iracedeck/icons/media-capture/start-stop-video.svg", () => ({
   default: '<svg xmlns="http://www.w3.org/2000/svg">{{mainLabel}} {{subLabel}}</svg>',
@@ -153,28 +157,28 @@ describe("MediaCapture", () => {
 
   describe("generateMediaCaptureSvg", () => {
     it("should generate a valid data URI for start-stop-video", () => {
-      const result = generateMediaCaptureSvg({ action: "start-stop-video" });
+      const result = generateMediaCaptureSvg({ mode: "start-stop-video" });
 
       expect(result).toContain("data:image/svg+xml");
     });
 
     it("should generate valid data URIs for all 7 actions", () => {
-      for (const action of ALL_ACTIONS) {
-        const result = generateMediaCaptureSvg({ action });
+      for (const mode of ALL_ACTIONS) {
+        const result = generateMediaCaptureSvg({ mode });
 
         expect(result).toContain("data:image/svg+xml");
       }
     });
 
     it("should produce different icons for different actions", () => {
-      const startStop = generateMediaCaptureSvg({ action: "start-stop-video" });
-      const screenshot = generateMediaCaptureSvg({ action: "take-screenshot" });
+      const startStop = generateMediaCaptureSvg({ mode: "start-stop-video" });
+      const screenshot = generateMediaCaptureSvg({ mode: "take-screenshot" });
 
       expect(startStop).not.toBe(screenshot);
     });
 
     it("should include correct labels for start-stop-video", () => {
-      const result = generateMediaCaptureSvg({ action: "start-stop-video" });
+      const result = generateMediaCaptureSvg({ mode: "start-stop-video" });
       const decoded = decodeURIComponent(result);
 
       expect(decoded).toContain("START/STOP");
@@ -182,7 +186,7 @@ describe("MediaCapture", () => {
     });
 
     it("should include correct labels for take-screenshot", () => {
-      const result = generateMediaCaptureSvg({ action: "take-screenshot" });
+      const result = generateMediaCaptureSvg({ mode: "take-screenshot" });
       const decoded = decodeURIComponent(result);
 
       expect(decoded).toContain("SCREENSHOT");
@@ -200,15 +204,58 @@ describe("MediaCapture", () => {
         "reload-car-textures": { mainLabel: "RELOAD CAR", subLabel: "TEXTURES" },
       };
 
-      for (const [action, labels] of Object.entries(expectedLabels)) {
+      for (const [mode, labels] of Object.entries(expectedLabels)) {
         const result = generateMediaCaptureSvg({
-          action: action as (typeof ALL_ACTIONS)[number],
+          mode: mode as (typeof ALL_ACTIONS)[number],
         });
         const decoded = decodeURIComponent(result);
 
         expect(decoded).toContain(labels.mainLabel);
         expect(decoded).toContain(labels.subLabel);
       }
+    });
+  });
+
+  describe("migrateMediaCaptureLegacyAction", () => {
+    it("should rename legacy action key to mode", () => {
+      const result = migrateMediaCaptureLegacyAction({ action: "take-screenshot" });
+
+      expect(result.changed).toBe(true);
+      expect(result.migrated).toEqual({ mode: "take-screenshot" });
+      expect(result.migrated.action).toBeUndefined();
+    });
+
+    it("should preserve other settings keys during migration", () => {
+      const result = migrateMediaCaptureLegacyAction({ action: "take-screenshot", flagsOverlay: true });
+
+      expect(result.changed).toBe(true);
+      expect(result.migrated).toEqual({ mode: "take-screenshot", flagsOverlay: true });
+    });
+
+    it("should not change settings that already use mode", () => {
+      const result = migrateMediaCaptureLegacyAction({ mode: "take-screenshot" });
+
+      expect(result.changed).toBe(false);
+      expect(result.migrated).toEqual({ mode: "take-screenshot" });
+    });
+
+    it("should not migrate when both mode and action are present (mode wins)", () => {
+      const result = migrateMediaCaptureLegacyAction({ mode: "video-timer", action: "take-screenshot" });
+
+      expect(result.changed).toBe(false);
+      expect(result.migrated.mode).toBe("video-timer");
+    });
+
+    it("should handle empty raw settings", () => {
+      const result = migrateMediaCaptureLegacyAction({});
+
+      expect(result.changed).toBe(false);
+      expect(result.migrated).toEqual({});
+    });
+
+    it("should handle null/undefined raw settings", () => {
+      expect(migrateMediaCaptureLegacyAction(null).changed).toBe(false);
+      expect(migrateMediaCaptureLegacyAction(undefined).changed).toBe(false);
     });
   });
 });

--- a/packages/actions/src/actions/media-capture.ts
+++ b/packages/actions/src/actions/media-capture.ts
@@ -11,6 +11,7 @@ import {
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
   type IDeckWillAppearEvent,
+  migrateLegacyActionToMode,
   resolveBorderSettings,
   resolveGraphicSettings,
   resolveIconColors,
@@ -79,29 +80,6 @@ type MediaCaptureSettings = z.infer<typeof MediaCaptureSettings>;
 /**
  * @internal Exported for testing
  *
- * Migrates legacy `action` setting key to `mode`. Returns the (possibly migrated)
- * raw settings object and a `changed` flag indicating whether persistence is needed.
- */
-export function migrateMediaCaptureLegacyAction(raw: unknown): {
-  migrated: Record<string, unknown>;
-  changed: boolean;
-} {
-  if (!raw || typeof raw !== "object") return { migrated: {}, changed: false };
-
-  const record = raw as Record<string, unknown>;
-
-  if (record.mode !== undefined || record.action === undefined) {
-    return { migrated: { ...record }, changed: false };
-  }
-
-  const { action, ...rest } = record;
-
-  return { migrated: { ...rest, mode: action }, changed: true };
-}
-
-/**
- * @internal Exported for testing
- *
  * Generates an SVG data URI icon for the media capture action.
  */
 export function generateMediaCaptureSvg(settings: MediaCaptureSettings): string {
@@ -130,7 +108,7 @@ export const MEDIA_CAPTURE_UUID = "com.iracedeck.sd.core.media-capture" as const
 export class MediaCapture extends ConnectionStateAwareAction<MediaCaptureSettings> {
   override async onWillAppear(ev: IDeckWillAppearEvent<MediaCaptureSettings>): Promise<void> {
     await super.onWillAppear(ev);
-    const { migrated, changed } = migrateMediaCaptureLegacyAction(ev.payload.settings);
+    const { migrated, changed } = migrateLegacyActionToMode(ev.payload.settings);
 
     if (changed) {
       try {
@@ -169,7 +147,7 @@ export class MediaCapture extends ConnectionStateAwareAction<MediaCaptureSetting
   }
 
   private parseSettings(settings: unknown): MediaCaptureSettings {
-    const { migrated } = migrateMediaCaptureLegacyAction(settings);
+    const { migrated } = migrateLegacyActionToMode(settings);
     const parsed = MediaCaptureSettings.safeParse(migrated);
 
     return parsed.success ? parsed.data : MediaCaptureSettings.parse({});

--- a/packages/actions/src/actions/media-capture.ts
+++ b/packages/actions/src/actions/media-capture.ts
@@ -71,7 +71,7 @@ export const MEDIA_CAPTURE_GLOBAL_KEYS: Record<string, string> = {
 };
 
 const MediaCaptureSettings = CommonSettings.extend({
-  action: z.enum(ACTION_VALUES).default("start-stop-video"),
+  mode: z.enum(ACTION_VALUES).default("start-stop-video"),
 });
 
 type MediaCaptureSettings = z.infer<typeof MediaCaptureSettings>;
@@ -79,10 +79,33 @@ type MediaCaptureSettings = z.infer<typeof MediaCaptureSettings>;
 /**
  * @internal Exported for testing
  *
+ * Migrates legacy `action` setting key to `mode`. Returns the (possibly migrated)
+ * raw settings object and a `changed` flag indicating whether persistence is needed.
+ */
+export function migrateMediaCaptureLegacyAction(raw: unknown): {
+  migrated: Record<string, unknown>;
+  changed: boolean;
+} {
+  if (!raw || typeof raw !== "object") return { migrated: {}, changed: false };
+
+  const record = raw as Record<string, unknown>;
+
+  if (record.mode !== undefined || record.action === undefined) {
+    return { migrated: { ...record }, changed: false };
+  }
+
+  const { action, ...rest } = record;
+
+  return { migrated: { ...rest, mode: action }, changed: true };
+}
+
+/**
+ * @internal Exported for testing
+ *
  * Generates an SVG data URI icon for the media capture action.
  */
 export function generateMediaCaptureSvg(settings: MediaCaptureSettings): string {
-  const { action: actionType } = settings;
+  const { mode: actionType } = settings;
 
   const iconSvg = ACTION_ICONS[actionType] || ACTION_ICONS["start-stop-video"];
   const defaultTitle = MEDIA_CAPTURE_TITLES[actionType] || MEDIA_CAPTURE_TITLES["start-stop-video"];
@@ -107,8 +130,18 @@ export const MEDIA_CAPTURE_UUID = "com.iracedeck.sd.core.media-capture" as const
 export class MediaCapture extends ConnectionStateAwareAction<MediaCaptureSettings> {
   override async onWillAppear(ev: IDeckWillAppearEvent<MediaCaptureSettings>): Promise<void> {
     await super.onWillAppear(ev);
-    const settings = this.parseSettings(ev.payload.settings);
-    const activeKey = MEDIA_CAPTURE_GLOBAL_KEYS[settings.action];
+    const { migrated, changed } = migrateMediaCaptureLegacyAction(ev.payload.settings);
+
+    if (changed) {
+      try {
+        await ev.action.setSettings(migrated);
+      } catch (error) {
+        this.logger.warn(`Failed to persist migrated settings: ${error instanceof Error ? error.message : error}`);
+      }
+    }
+
+    const settings = this.parseSettings(migrated);
+    const activeKey = MEDIA_CAPTURE_GLOBAL_KEYS[settings.mode];
     this.setActiveBinding(activeKey ?? null);
 
     await this.updateDisplay(ev, settings);
@@ -117,7 +150,7 @@ export class MediaCapture extends ConnectionStateAwareAction<MediaCaptureSetting
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<MediaCaptureSettings>): Promise<void> {
     await super.onDidReceiveSettings(ev);
     const settings = this.parseSettings(ev.payload.settings);
-    const activeKey = MEDIA_CAPTURE_GLOBAL_KEYS[settings.action];
+    const activeKey = MEDIA_CAPTURE_GLOBAL_KEYS[settings.mode];
     this.setActiveBinding(activeKey ?? null);
 
     await this.updateDisplay(ev, settings);
@@ -126,17 +159,18 @@ export class MediaCapture extends ConnectionStateAwareAction<MediaCaptureSetting
   override async onKeyDown(ev: IDeckKeyDownEvent<MediaCaptureSettings>): Promise<void> {
     this.logger.info("Key down received");
     const settings = this.parseSettings(ev.payload.settings);
-    await this.executeAction(settings.action);
+    await this.executeAction(settings.mode);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<MediaCaptureSettings>): Promise<void> {
     this.logger.info("Dial down received");
     const settings = this.parseSettings(ev.payload.settings);
-    await this.executeAction(settings.action);
+    await this.executeAction(settings.mode);
   }
 
   private parseSettings(settings: unknown): MediaCaptureSettings {
-    const parsed = MediaCaptureSettings.safeParse(settings);
+    const { migrated } = migrateMediaCaptureLegacyAction(settings);
+    const parsed = MediaCaptureSettings.safeParse(migrated);
 
     return parsed.success ? parsed.data : MediaCaptureSettings.parse({});
   }

--- a/packages/actions/src/actions/pit-quick-actions.test.ts
+++ b/packages/actions/src/actions/pit-quick-actions.test.ts
@@ -5,7 +5,6 @@ import {
   isFastRepairAvailable,
   isFastRepairOn,
   isWindshieldOn,
-  migratePitQuickActionsLegacyAction,
   PitQuickActions,
   type PitQuickActionTelemetryState,
 } from "./pit-quick-actions.js";
@@ -80,6 +79,19 @@ vi.mock("@iracedeck/deck-core", () => ({
     async onWillDisappear() {}
   },
   getCommands: mockGetCommands,
+  migrateLegacyActionToMode: (raw: unknown) => {
+    if (!raw || typeof raw !== "object") return { migrated: {}, changed: false };
+
+    const record = raw as Record<string, unknown>;
+
+    if (record.mode !== undefined || record.action === undefined) {
+      return { migrated: { ...record }, changed: false };
+    }
+
+    const { action, ...rest } = record;
+
+    return { migrated: { ...rest, mode: action }, changed: true };
+  },
   generateBorderParts: vi.fn(() => ({ defs: "", rects: "" })),
   getGlobalBorderSettings: vi.fn(() => ({})),
   getGlobalColors: vi.fn(() => ({})),
@@ -375,29 +387,7 @@ describe("PitQuickActions", () => {
     });
   });
 
-  describe("migratePitQuickActionsLegacyAction", () => {
-    it("should rename legacy action key to mode", () => {
-      const result = migratePitQuickActionsLegacyAction({ action: "windshield-tearoff" });
-
-      expect(result.changed).toBe(true);
-      expect(result.migrated).toEqual({ mode: "windshield-tearoff" });
-      expect(result.migrated.action).toBeUndefined();
-    });
-
-    it("should preserve other settings keys during migration", () => {
-      const result = migratePitQuickActionsLegacyAction({ action: "request-fast-repair", flagsOverlay: true });
-
-      expect(result.changed).toBe(true);
-      expect(result.migrated).toEqual({ mode: "request-fast-repair", flagsOverlay: true });
-    });
-
-    it("should not change settings that already use mode", () => {
-      const result = migratePitQuickActionsLegacyAction({ mode: "windshield-tearoff" });
-
-      expect(result.changed).toBe(false);
-      expect(result.migrated).toEqual({ mode: "windshield-tearoff" });
-    });
-
+  describe("legacy action -> mode migration", () => {
     it("should persist migrated settings on onWillAppear when legacy action is present", async () => {
       const action = new PitQuickActions();
       const setSettings = vi.fn().mockResolvedValue(undefined);
@@ -408,13 +398,6 @@ describe("PitQuickActions", () => {
       await action.onWillAppear(ev as any);
 
       expect(setSettings).toHaveBeenCalledWith({ mode: "windshield-tearoff" });
-    });
-
-    it("should handle empty raw settings", () => {
-      const result = migratePitQuickActionsLegacyAction({});
-
-      expect(result.changed).toBe(false);
-      expect(result.migrated).toEqual({});
     });
   });
 });

--- a/packages/actions/src/actions/pit-quick-actions.test.ts
+++ b/packages/actions/src/actions/pit-quick-actions.test.ts
@@ -5,6 +5,7 @@ import {
   isFastRepairAvailable,
   isFastRepairOn,
   isWindshieldOn,
+  migratePitQuickActionsLegacyAction,
   PitQuickActions,
   type PitQuickActionTelemetryState,
 } from "./pit-quick-actions.js";
@@ -56,7 +57,7 @@ vi.mock("../icons/status-bar.js", () => ({
 vi.mock("@iracedeck/deck-core", () => ({
   CommonSettings: {
     extend: () => {
-      const defaults = { action: "clear-all-checkboxes" };
+      const defaults = { mode: "clear-all-checkboxes" };
       const schema = {
         parse: (data: Record<string, unknown>) => ({ ...defaults, ...data }),
         safeParse: (data: Record<string, unknown>) => ({ success: true, data: { ...defaults, ...data } }),
@@ -178,13 +179,13 @@ describe("PitQuickActions", () => {
 
   describe("generatePitQuickActionsSvg", () => {
     it("should generate a valid data URI for clear-all-checkboxes", () => {
-      const result = generatePitQuickActionsSvg({ action: "clear-all-checkboxes" });
+      const result = generatePitQuickActionsSvg({ mode: "clear-all-checkboxes" });
 
       expect(result).toContain("data:image/svg+xml");
     });
 
     it("should include correct labels for static action types", () => {
-      const result = generatePitQuickActionsSvg({ action: "clear-all-checkboxes" });
+      const result = generatePitQuickActionsSvg({ mode: "clear-all-checkboxes" });
       const decoded = decodeURIComponent(result);
 
       expect(decoded).toContain("CLEAR ALL");
@@ -193,7 +194,7 @@ describe("PitQuickActions", () => {
 
     it("should show ON status bar for windshield-tearoff when on", () => {
       const telemetryState: PitQuickActionTelemetryState = { windshieldOn: true };
-      const result = generatePitQuickActionsSvg({ action: "windshield-tearoff" }, telemetryState);
+      const result = generatePitQuickActionsSvg({ mode: "windshield-tearoff" }, telemetryState);
       const decoded = decodeURIComponent(result);
 
       expect(decoded).toContain("status-on");
@@ -203,7 +204,7 @@ describe("PitQuickActions", () => {
 
     it("should show OFF status bar for windshield-tearoff when off", () => {
       const telemetryState: PitQuickActionTelemetryState = { windshieldOn: false };
-      const result = generatePitQuickActionsSvg({ action: "windshield-tearoff" }, telemetryState);
+      const result = generatePitQuickActionsSvg({ mode: "windshield-tearoff" }, telemetryState);
       const decoded = decodeURIComponent(result);
 
       expect(decoded).toContain("status-off");
@@ -211,7 +212,7 @@ describe("PitQuickActions", () => {
 
     it("should show ON status bar for fast repair when on and available", () => {
       const telemetryState: PitQuickActionTelemetryState = { fastRepairOn: true, fastRepairAvailable: true };
-      const result = generatePitQuickActionsSvg({ action: "request-fast-repair" }, telemetryState);
+      const result = generatePitQuickActionsSvg({ mode: "request-fast-repair" }, telemetryState);
       const decoded = decodeURIComponent(result);
 
       expect(decoded).toContain("status-on");
@@ -221,7 +222,7 @@ describe("PitQuickActions", () => {
 
     it("should show N/A status bar for fast repair when not available", () => {
       const telemetryState: PitQuickActionTelemetryState = { fastRepairOn: false, fastRepairAvailable: false };
-      const result = generatePitQuickActionsSvg({ action: "request-fast-repair" }, telemetryState);
+      const result = generatePitQuickActionsSvg({ mode: "request-fast-repair" }, telemetryState);
       const decoded = decodeURIComponent(result);
 
       expect(decoded).toContain("status-na");
@@ -229,7 +230,7 @@ describe("PitQuickActions", () => {
 
     it("should use static icon for clear-all-checkboxes regardless of telemetry", () => {
       const telemetryState: PitQuickActionTelemetryState = { windshieldOn: true };
-      const result = generatePitQuickActionsSvg({ action: "clear-all-checkboxes" }, telemetryState);
+      const result = generatePitQuickActionsSvg({ mode: "clear-all-checkboxes" }, telemetryState);
       const decoded = decodeURIComponent(result);
 
       expect(decoded).not.toContain("status-on");
@@ -245,7 +246,7 @@ describe("PitQuickActions", () => {
     });
 
     it("should call pit.clear() on keyDown for clear-all-checkboxes", async () => {
-      await action.onKeyDown(fakeEvent("action-1", { action: "clear-all-checkboxes" }) as any);
+      await action.onKeyDown(fakeEvent("action-1", { mode: "clear-all-checkboxes" }) as any);
 
       expect(mockPitClear).toHaveBeenCalledOnce();
       expect(mockPitWindshield).not.toHaveBeenCalled();
@@ -254,7 +255,7 @@ describe("PitQuickActions", () => {
 
     it("should call pit.windshield() on keyDown when windshield is not set", async () => {
       action.sdkController.getCurrentTelemetry.mockReturnValue({ PitSvFlags: 0 });
-      await action.onKeyDown(fakeEvent("action-1", { action: "windshield-tearoff" }) as any);
+      await action.onKeyDown(fakeEvent("action-1", { mode: "windshield-tearoff" }) as any);
 
       expect(mockPitWindshield).toHaveBeenCalledOnce();
       expect(mockPitClearWindshield).not.toHaveBeenCalled();
@@ -262,7 +263,7 @@ describe("PitQuickActions", () => {
 
     it("should call pit.clearWindshield() on keyDown when windshield is already set", async () => {
       action.sdkController.getCurrentTelemetry.mockReturnValue({ PitSvFlags: 0x0020 });
-      await action.onKeyDown(fakeEvent("action-1", { action: "windshield-tearoff" }) as any);
+      await action.onKeyDown(fakeEvent("action-1", { mode: "windshield-tearoff" }) as any);
 
       expect(mockPitClearWindshield).toHaveBeenCalledOnce();
       expect(mockPitWindshield).not.toHaveBeenCalled();
@@ -270,7 +271,7 @@ describe("PitQuickActions", () => {
 
     it("should call pit.fastRepair() on keyDown when fast repair is not set", async () => {
       action.sdkController.getCurrentTelemetry.mockReturnValue({ PitSvFlags: 0 });
-      await action.onKeyDown(fakeEvent("action-1", { action: "request-fast-repair" }) as any);
+      await action.onKeyDown(fakeEvent("action-1", { mode: "request-fast-repair" }) as any);
 
       expect(mockPitFastRepair).toHaveBeenCalledOnce();
       expect(mockPitClearFastRepair).not.toHaveBeenCalled();
@@ -278,7 +279,7 @@ describe("PitQuickActions", () => {
 
     it("should call pit.clearFastRepair() on keyDown when fast repair is already set", async () => {
       action.sdkController.getCurrentTelemetry.mockReturnValue({ PitSvFlags: 0x0040 });
-      await action.onKeyDown(fakeEvent("action-1", { action: "request-fast-repair" }) as any);
+      await action.onKeyDown(fakeEvent("action-1", { mode: "request-fast-repair" }) as any);
 
       expect(mockPitClearFastRepair).toHaveBeenCalledOnce();
       expect(mockPitFastRepair).not.toHaveBeenCalled();
@@ -286,7 +287,7 @@ describe("PitQuickActions", () => {
 
     it("should not call any pit command when telemetry is null for windshield-tearoff", async () => {
       action.sdkController.getCurrentTelemetry.mockReturnValue(null);
-      await action.onKeyDown(fakeEvent("action-1", { action: "windshield-tearoff" }) as any);
+      await action.onKeyDown(fakeEvent("action-1", { mode: "windshield-tearoff" }) as any);
 
       expect(mockPitWindshield).not.toHaveBeenCalled();
       expect(mockPitClearWindshield).not.toHaveBeenCalled();
@@ -294,7 +295,7 @@ describe("PitQuickActions", () => {
 
     it("should not call any pit command when telemetry is null for request-fast-repair", async () => {
       action.sdkController.getCurrentTelemetry.mockReturnValue(null);
-      await action.onKeyDown(fakeEvent("action-1", { action: "request-fast-repair" }) as any);
+      await action.onKeyDown(fakeEvent("action-1", { mode: "request-fast-repair" }) as any);
 
       expect(mockPitFastRepair).not.toHaveBeenCalled();
       expect(mockPitClearFastRepair).not.toHaveBeenCalled();
@@ -315,14 +316,14 @@ describe("PitQuickActions", () => {
     });
 
     it("should call pit.clear() on dialDown for clear-all-checkboxes", async () => {
-      await action.onDialDown(fakeEvent("action-1", { action: "clear-all-checkboxes" }) as any);
+      await action.onDialDown(fakeEvent("action-1", { mode: "clear-all-checkboxes" }) as any);
 
       expect(mockPitClear).toHaveBeenCalledOnce();
     });
 
     it("should call pit.windshield() on dialDown when windshield is not set", async () => {
       action.sdkController.getCurrentTelemetry.mockReturnValue({ PitSvFlags: 0 });
-      await action.onDialDown(fakeEvent("action-1", { action: "windshield-tearoff" }) as any);
+      await action.onDialDown(fakeEvent("action-1", { mode: "windshield-tearoff" }) as any);
 
       expect(mockPitWindshield).toHaveBeenCalledOnce();
       expect(mockPitClearWindshield).not.toHaveBeenCalled();
@@ -330,7 +331,7 @@ describe("PitQuickActions", () => {
 
     it("should call pit.clearWindshield() on dialDown when windshield is already set", async () => {
       action.sdkController.getCurrentTelemetry.mockReturnValue({ PitSvFlags: 0x0020 });
-      await action.onDialDown(fakeEvent("action-1", { action: "windshield-tearoff" }) as any);
+      await action.onDialDown(fakeEvent("action-1", { mode: "windshield-tearoff" }) as any);
 
       expect(mockPitClearWindshield).toHaveBeenCalledOnce();
       expect(mockPitWindshield).not.toHaveBeenCalled();
@@ -338,7 +339,7 @@ describe("PitQuickActions", () => {
 
     it("should call pit.fastRepair() on dialDown when fast repair is not set", async () => {
       action.sdkController.getCurrentTelemetry.mockReturnValue({ PitSvFlags: 0 });
-      await action.onDialDown(fakeEvent("action-1", { action: "request-fast-repair" }) as any);
+      await action.onDialDown(fakeEvent("action-1", { mode: "request-fast-repair" }) as any);
 
       expect(mockPitFastRepair).toHaveBeenCalledOnce();
       expect(mockPitClearFastRepair).not.toHaveBeenCalled();
@@ -346,7 +347,7 @@ describe("PitQuickActions", () => {
 
     it("should call pit.clearFastRepair() on dialDown when fast repair is already set", async () => {
       action.sdkController.getCurrentTelemetry.mockReturnValue({ PitSvFlags: 0x0040 });
-      await action.onDialDown(fakeEvent("action-1", { action: "request-fast-repair" }) as any);
+      await action.onDialDown(fakeEvent("action-1", { mode: "request-fast-repair" }) as any);
 
       expect(mockPitClearFastRepair).toHaveBeenCalledOnce();
       expect(mockPitFastRepair).not.toHaveBeenCalled();
@@ -361,16 +362,59 @@ describe("PitQuickActions", () => {
     });
 
     it("should subscribe to telemetry on onWillAppear", async () => {
-      await action.onWillAppear(fakeEvent("action-1", { action: "windshield-tearoff" }) as any);
+      await action.onWillAppear(fakeEvent("action-1", { mode: "windshield-tearoff" }) as any);
 
       expect(action.sdkController.subscribe).toHaveBeenCalledWith("action-1", expect.any(Function));
     });
 
     it("should unsubscribe from telemetry on onWillDisappear", async () => {
-      await action.onWillAppear(fakeEvent("action-1", { action: "windshield-tearoff" }) as any);
+      await action.onWillAppear(fakeEvent("action-1", { mode: "windshield-tearoff" }) as any);
       await action.onWillDisappear(fakeEvent("action-1") as any);
 
       expect(action.sdkController.unsubscribe).toHaveBeenCalledWith("action-1");
+    });
+  });
+
+  describe("migratePitQuickActionsLegacyAction", () => {
+    it("should rename legacy action key to mode", () => {
+      const result = migratePitQuickActionsLegacyAction({ action: "windshield-tearoff" });
+
+      expect(result.changed).toBe(true);
+      expect(result.migrated).toEqual({ mode: "windshield-tearoff" });
+      expect(result.migrated.action).toBeUndefined();
+    });
+
+    it("should preserve other settings keys during migration", () => {
+      const result = migratePitQuickActionsLegacyAction({ action: "request-fast-repair", flagsOverlay: true });
+
+      expect(result.changed).toBe(true);
+      expect(result.migrated).toEqual({ mode: "request-fast-repair", flagsOverlay: true });
+    });
+
+    it("should not change settings that already use mode", () => {
+      const result = migratePitQuickActionsLegacyAction({ mode: "windshield-tearoff" });
+
+      expect(result.changed).toBe(false);
+      expect(result.migrated).toEqual({ mode: "windshield-tearoff" });
+    });
+
+    it("should persist migrated settings on onWillAppear when legacy action is present", async () => {
+      const action = new PitQuickActions();
+      const setSettings = vi.fn().mockResolvedValue(undefined);
+      const ev = {
+        action: { id: "action-1", setTitle: vi.fn(), setImage: vi.fn(), setSettings },
+        payload: { settings: { action: "windshield-tearoff" } },
+      };
+      await action.onWillAppear(ev as any);
+
+      expect(setSettings).toHaveBeenCalledWith({ mode: "windshield-tearoff" });
+    });
+
+    it("should handle empty raw settings", () => {
+      const result = migratePitQuickActionsLegacyAction({});
+
+      expect(result.changed).toBe(false);
+      expect(result.migrated).toEqual({});
     });
   });
 });

--- a/packages/actions/src/actions/pit-quick-actions.ts
+++ b/packages/actions/src/actions/pit-quick-actions.ts
@@ -46,10 +46,33 @@ const STATIC_ACTION_ICONS: Partial<Record<PitQuickActionType, string>> = {
 const TELEMETRY_AWARE_ACTIONS = new Set<PitQuickActionType>(["windshield-tearoff", "request-fast-repair"]);
 
 const PitQuickActionsSettings = CommonSettings.extend({
-  action: z.enum(["clear-all-checkboxes", "windshield-tearoff", "request-fast-repair"]).default("clear-all-checkboxes"),
+  mode: z.enum(["clear-all-checkboxes", "windshield-tearoff", "request-fast-repair"]).default("clear-all-checkboxes"),
 });
 
 type PitQuickActionsSettings = z.infer<typeof PitQuickActionsSettings>;
+
+/**
+ * @internal Exported for testing
+ *
+ * Migrates legacy `action` setting key to `mode`. Returns the (possibly migrated)
+ * raw settings object and a `changed` flag indicating whether persistence is needed.
+ */
+export function migratePitQuickActionsLegacyAction(raw: unknown): {
+  migrated: Record<string, unknown>;
+  changed: boolean;
+} {
+  if (!raw || typeof raw !== "object") return { migrated: {}, changed: false };
+
+  const record = raw as Record<string, unknown>;
+
+  if (record.mode !== undefined || record.action === undefined) {
+    return { migrated: { ...record }, changed: false };
+  }
+
+  const { action, ...rest } = record;
+
+  return { migrated: { ...rest, mode: action }, changed: true };
+}
 
 /**
  * @internal Exported for testing
@@ -119,7 +142,7 @@ export function generatePitQuickActionsSvg(
   settings: PitQuickActionsSettings,
   telemetryState?: PitQuickActionTelemetryState,
 ): string {
-  const { action: actionType } = settings;
+  const { mode: actionType } = settings;
 
   // Static mode: clear-all-checkboxes (no telemetry)
   if (!TELEMETRY_AWARE_ACTIONS.has(actionType)) {
@@ -198,7 +221,17 @@ export class PitQuickActions extends ConnectionStateAwareAction<PitQuickActionsS
 
   override async onWillAppear(ev: IDeckWillAppearEvent<PitQuickActionsSettings>): Promise<void> {
     await super.onWillAppear(ev);
-    const settings = this.parseSettings(ev.payload.settings);
+    const { migrated, changed } = migratePitQuickActionsLegacyAction(ev.payload.settings);
+
+    if (changed) {
+      try {
+        await ev.action.setSettings(migrated);
+      } catch (error) {
+        this.logger.warn(`Failed to persist migrated settings: ${error instanceof Error ? error.message : error}`);
+      }
+    }
+
+    const settings = this.parseSettings(migrated);
     this.activeContexts.set(ev.action.id, settings);
     await this.updateDisplay(ev, settings);
 
@@ -229,17 +262,18 @@ export class PitQuickActions extends ConnectionStateAwareAction<PitQuickActionsS
   override async onKeyDown(ev: IDeckKeyDownEvent<PitQuickActionsSettings>): Promise<void> {
     this.logger.info("Key down received");
     const settings = this.parseSettings(ev.payload.settings);
-    this.executeAction(settings.action);
+    this.executeAction(settings.mode);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<PitQuickActionsSettings>): Promise<void> {
     this.logger.info("Dial down received");
     const settings = this.parseSettings(ev.payload.settings);
-    this.executeAction(settings.action);
+    this.executeAction(settings.mode);
   }
 
   private parseSettings(settings: unknown): PitQuickActionsSettings {
-    const parsed = PitQuickActionsSettings.safeParse(settings);
+    const { migrated } = migratePitQuickActionsLegacyAction(settings);
+    const parsed = PitQuickActionsSettings.safeParse(migrated);
 
     return parsed.success ? parsed.data : PitQuickActionsSettings.parse({});
   }
@@ -305,13 +339,13 @@ export class PitQuickActions extends ConnectionStateAwareAction<PitQuickActionsS
     const bo = settings.borderOverrides;
     const borderKey = `${bo?.enabled ?? ""}|${bo?.borderWidth ?? ""}|${bo?.borderColor ?? ""}|${bo?.glowEnabled ?? ""}|${bo?.glowWidth ?? ""}`;
 
-    switch (settings.action) {
+    switch (settings.mode) {
       case "windshield-tearoff":
         return `windshield|${telemetryState.windshieldOn ?? false}|${borderKey}`;
       case "request-fast-repair":
         return `fast-repair|${telemetryState.fastRepairOn ?? false}|${telemetryState.fastRepairAvailable ?? true}|${borderKey}`;
       default:
-        return settings.action;
+        return settings.mode;
     }
   }
 
@@ -320,13 +354,13 @@ export class PitQuickActions extends ConnectionStateAwareAction<PitQuickActionsS
     settings: PitQuickActionsSettings,
   ): Promise<void> {
     const telemetry = this.sdkController.getCurrentTelemetry();
-    const telemetryState = this.getTelemetryState(telemetry, settings.action);
+    const telemetryState = this.getTelemetryState(telemetry, settings.mode);
     const svgDataUri = generatePitQuickActionsSvg(settings, telemetryState);
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
     this.setRegenerateCallback(ev.action.id, () => {
       const currentTelemetry = this.sdkController.getCurrentTelemetry();
-      const currentState = this.getTelemetryState(currentTelemetry, settings.action);
+      const currentState = this.getTelemetryState(currentTelemetry, settings.mode);
 
       return generatePitQuickActionsSvg(settings, currentState);
     });
@@ -339,9 +373,9 @@ export class PitQuickActions extends ConnectionStateAwareAction<PitQuickActionsS
     telemetry: TelemetryData | null,
     settings: PitQuickActionsSettings,
   ): Promise<void> {
-    if (!TELEMETRY_AWARE_ACTIONS.has(settings.action)) return;
+    if (!TELEMETRY_AWARE_ACTIONS.has(settings.mode)) return;
 
-    const telemetryState = this.getTelemetryState(telemetry, settings.action);
+    const telemetryState = this.getTelemetryState(telemetry, settings.mode);
     const stateKey = this.buildStateKey(settings, telemetryState);
     const lastStateKey = this.lastState.get(contextId);
 
@@ -351,7 +385,7 @@ export class PitQuickActions extends ConnectionStateAwareAction<PitQuickActionsS
       await this.updateKeyImage(contextId, svgDataUri);
       this.setRegenerateCallback(contextId, () => {
         const currentTelemetry = this.sdkController.getCurrentTelemetry();
-        const currentState = this.getTelemetryState(currentTelemetry, settings.action);
+        const currentState = this.getTelemetryState(currentTelemetry, settings.mode);
 
         return generatePitQuickActionsSvg(settings, currentState);
       });

--- a/packages/actions/src/actions/pit-quick-actions.ts
+++ b/packages/actions/src/actions/pit-quick-actions.ts
@@ -14,6 +14,7 @@ import {
   type IDeckKeyDownEvent,
   type IDeckWillAppearEvent,
   type IDeckWillDisappearEvent,
+  migrateLegacyActionToMode,
   renderIconTemplate,
   resolveBorderSettings,
   resolveGraphicSettings,
@@ -50,29 +51,6 @@ const PitQuickActionsSettings = CommonSettings.extend({
 });
 
 type PitQuickActionsSettings = z.infer<typeof PitQuickActionsSettings>;
-
-/**
- * @internal Exported for testing
- *
- * Migrates legacy `action` setting key to `mode`. Returns the (possibly migrated)
- * raw settings object and a `changed` flag indicating whether persistence is needed.
- */
-export function migratePitQuickActionsLegacyAction(raw: unknown): {
-  migrated: Record<string, unknown>;
-  changed: boolean;
-} {
-  if (!raw || typeof raw !== "object") return { migrated: {}, changed: false };
-
-  const record = raw as Record<string, unknown>;
-
-  if (record.mode !== undefined || record.action === undefined) {
-    return { migrated: { ...record }, changed: false };
-  }
-
-  const { action, ...rest } = record;
-
-  return { migrated: { ...rest, mode: action }, changed: true };
-}
 
 /**
  * @internal Exported for testing
@@ -221,7 +199,7 @@ export class PitQuickActions extends ConnectionStateAwareAction<PitQuickActionsS
 
   override async onWillAppear(ev: IDeckWillAppearEvent<PitQuickActionsSettings>): Promise<void> {
     await super.onWillAppear(ev);
-    const { migrated, changed } = migratePitQuickActionsLegacyAction(ev.payload.settings);
+    const { migrated, changed } = migrateLegacyActionToMode(ev.payload.settings);
 
     if (changed) {
       try {
@@ -272,7 +250,7 @@ export class PitQuickActions extends ConnectionStateAwareAction<PitQuickActionsS
   }
 
   private parseSettings(settings: unknown): PitQuickActionsSettings {
-    const { migrated } = migratePitQuickActionsLegacyAction(settings);
+    const { migrated } = migrateLegacyActionToMode(settings);
     const parsed = PitQuickActionsSettings.safeParse(migrated);
 
     return parsed.success ? parsed.data : PitQuickActionsSettings.parse({});

--- a/packages/actions/src/actions/telemetry-control.test.ts
+++ b/packages/actions/src/actions/telemetry-control.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { generateTelemetryControlSvg, TELEMETRY_CONTROL_GLOBAL_KEYS } from "./telemetry-control.js";
+import {
+  generateTelemetryControlSvg,
+  migrateTelemetryControlLegacyAction,
+  TELEMETRY_CONTROL_GLOBAL_KEYS,
+} from "./telemetry-control.js";
 
 vi.mock("@iracedeck/icons/telemetry-control/toggle-logging.svg", () => ({
   default: '<svg xmlns="http://www.w3.org/2000/svg">{{mainLabel}} {{subLabel}}</svg>',
@@ -142,28 +146,28 @@ describe("TelemetryControl", () => {
 
   describe("generateTelemetryControlSvg", () => {
     it("should generate a valid data URI for toggle-logging", () => {
-      const result = generateTelemetryControlSvg({ action: "toggle-logging" });
+      const result = generateTelemetryControlSvg({ mode: "toggle-logging" });
 
       expect(result).toContain("data:image/svg+xml");
     });
 
     it("should generate valid data URIs for all 5 actions", () => {
-      for (const action of ALL_ACTIONS) {
-        const result = generateTelemetryControlSvg({ action });
+      for (const mode of ALL_ACTIONS) {
+        const result = generateTelemetryControlSvg({ mode });
 
         expect(result).toContain("data:image/svg+xml");
       }
     });
 
     it("should produce different icons for different actions", () => {
-      const toggleLogging = generateTelemetryControlSvg({ action: "toggle-logging" });
-      const markEvent = generateTelemetryControlSvg({ action: "mark-event" });
+      const toggleLogging = generateTelemetryControlSvg({ mode: "toggle-logging" });
+      const markEvent = generateTelemetryControlSvg({ mode: "mark-event" });
 
       expect(toggleLogging).not.toBe(markEvent);
     });
 
     it("should include correct labels for toggle-logging", () => {
-      const result = generateTelemetryControlSvg({ action: "toggle-logging" });
+      const result = generateTelemetryControlSvg({ mode: "toggle-logging" });
       const decoded = decodeURIComponent(result);
 
       expect(decoded).toContain("LOGGING");
@@ -171,7 +175,7 @@ describe("TelemetryControl", () => {
     });
 
     it("should include correct labels for mark-event", () => {
-      const result = generateTelemetryControlSvg({ action: "mark-event" });
+      const result = generateTelemetryControlSvg({ mode: "mark-event" });
       const decoded = decodeURIComponent(result);
 
       expect(decoded).toContain("MARK");
@@ -187,15 +191,51 @@ describe("TelemetryControl", () => {
         "restart-recording": { mainLabel: "RECORDING", subLabel: "RESTART" },
       };
 
-      for (const [action, labels] of Object.entries(expectedLabels)) {
+      for (const [mode, labels] of Object.entries(expectedLabels)) {
         const result = generateTelemetryControlSvg({
-          action: action as (typeof ALL_ACTIONS)[number],
+          mode: mode as (typeof ALL_ACTIONS)[number],
         });
         const decoded = decodeURIComponent(result);
 
         expect(decoded).toContain(labels.mainLabel);
         expect(decoded).toContain(labels.subLabel);
       }
+    });
+  });
+
+  describe("migrateTelemetryControlLegacyAction", () => {
+    it("should rename legacy action key to mode", () => {
+      const result = migrateTelemetryControlLegacyAction({ action: "mark-event" });
+
+      expect(result.changed).toBe(true);
+      expect(result.migrated).toEqual({ mode: "mark-event" });
+      expect(result.migrated.action).toBeUndefined();
+    });
+
+    it("should preserve other settings keys during migration", () => {
+      const result = migrateTelemetryControlLegacyAction({ action: "mark-event", flagsOverlay: true });
+
+      expect(result.changed).toBe(true);
+      expect(result.migrated).toEqual({ mode: "mark-event", flagsOverlay: true });
+    });
+
+    it("should not change settings that already use mode", () => {
+      const result = migrateTelemetryControlLegacyAction({ mode: "mark-event" });
+
+      expect(result.changed).toBe(false);
+      expect(result.migrated).toEqual({ mode: "mark-event" });
+    });
+
+    it("should handle empty raw settings", () => {
+      const result = migrateTelemetryControlLegacyAction({});
+
+      expect(result.changed).toBe(false);
+      expect(result.migrated).toEqual({});
+    });
+
+    it("should handle null/undefined raw settings", () => {
+      expect(migrateTelemetryControlLegacyAction(null).changed).toBe(false);
+      expect(migrateTelemetryControlLegacyAction(undefined).changed).toBe(false);
     });
   });
 });

--- a/packages/actions/src/actions/telemetry-control.test.ts
+++ b/packages/actions/src/actions/telemetry-control.test.ts
@@ -1,10 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  generateTelemetryControlSvg,
-  migrateTelemetryControlLegacyAction,
-  TELEMETRY_CONTROL_GLOBAL_KEYS,
-} from "./telemetry-control.js";
+import { generateTelemetryControlSvg, TELEMETRY_CONTROL_GLOBAL_KEYS } from "./telemetry-control.js";
 
 vi.mock("@iracedeck/icons/telemetry-control/toggle-logging.svg", () => ({
   default: '<svg xmlns="http://www.w3.org/2000/svg">{{mainLabel}} {{subLabel}}</svg>',
@@ -50,6 +46,19 @@ vi.mock("@iracedeck/deck-core", () => ({
 
     return b.key;
   }),
+  migrateLegacyActionToMode: (raw: unknown) => {
+    if (!raw || typeof raw !== "object") return { migrated: {}, changed: false };
+
+    const record = raw as Record<string, unknown>;
+
+    if (record.mode !== undefined || record.action === undefined) {
+      return { migrated: { ...record }, changed: false };
+    }
+
+    const { action, ...rest } = record;
+
+    return { migrated: { ...rest, mode: action }, changed: true };
+  },
   getCommands: vi.fn(() => ({
     telem: {
       start: vi.fn(() => true),
@@ -200,42 +209,6 @@ describe("TelemetryControl", () => {
         expect(decoded).toContain(labels.mainLabel);
         expect(decoded).toContain(labels.subLabel);
       }
-    });
-  });
-
-  describe("migrateTelemetryControlLegacyAction", () => {
-    it("should rename legacy action key to mode", () => {
-      const result = migrateTelemetryControlLegacyAction({ action: "mark-event" });
-
-      expect(result.changed).toBe(true);
-      expect(result.migrated).toEqual({ mode: "mark-event" });
-      expect(result.migrated.action).toBeUndefined();
-    });
-
-    it("should preserve other settings keys during migration", () => {
-      const result = migrateTelemetryControlLegacyAction({ action: "mark-event", flagsOverlay: true });
-
-      expect(result.changed).toBe(true);
-      expect(result.migrated).toEqual({ mode: "mark-event", flagsOverlay: true });
-    });
-
-    it("should not change settings that already use mode", () => {
-      const result = migrateTelemetryControlLegacyAction({ mode: "mark-event" });
-
-      expect(result.changed).toBe(false);
-      expect(result.migrated).toEqual({ mode: "mark-event" });
-    });
-
-    it("should handle empty raw settings", () => {
-      const result = migrateTelemetryControlLegacyAction({});
-
-      expect(result.changed).toBe(false);
-      expect(result.migrated).toEqual({});
-    });
-
-    it("should handle null/undefined raw settings", () => {
-      expect(migrateTelemetryControlLegacyAction(null).changed).toBe(false);
-      expect(migrateTelemetryControlLegacyAction(undefined).changed).toBe(false);
     });
   });
 });

--- a/packages/actions/src/actions/telemetry-control.ts
+++ b/packages/actions/src/actions/telemetry-control.ts
@@ -11,6 +11,7 @@ import {
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
   type IDeckWillAppearEvent,
+  migrateLegacyActionToMode,
   resolveBorderSettings,
   resolveGraphicSettings,
   resolveIconColors,
@@ -72,29 +73,6 @@ type TelemetryControlSettings = z.infer<typeof TelemetryControlSettings>;
 /**
  * @internal Exported for testing
  *
- * Migrates legacy `action` setting key to `mode`. Returns the (possibly migrated)
- * raw settings object and a `changed` flag indicating whether persistence is needed.
- */
-export function migrateTelemetryControlLegacyAction(raw: unknown): {
-  migrated: Record<string, unknown>;
-  changed: boolean;
-} {
-  if (!raw || typeof raw !== "object") return { migrated: {}, changed: false };
-
-  const record = raw as Record<string, unknown>;
-
-  if (record.mode !== undefined || record.action === undefined) {
-    return { migrated: { ...record }, changed: false };
-  }
-
-  const { action, ...rest } = record;
-
-  return { migrated: { ...rest, mode: action }, changed: true };
-}
-
-/**
- * @internal Exported for testing
- *
  * Generates an SVG data URI icon for the telemetry control action.
  */
 export function generateTelemetryControlSvg(settings: TelemetryControlSettings): string {
@@ -124,7 +102,7 @@ export const TELEMETRY_CONTROL_UUID = "com.iracedeck.sd.core.telemetry-control" 
 export class TelemetryControl extends ConnectionStateAwareAction<TelemetryControlSettings> {
   override async onWillAppear(ev: IDeckWillAppearEvent<TelemetryControlSettings>): Promise<void> {
     await super.onWillAppear(ev);
-    const { migrated, changed } = migrateTelemetryControlLegacyAction(ev.payload.settings);
+    const { migrated, changed } = migrateLegacyActionToMode(ev.payload.settings);
 
     if (changed) {
       try {
@@ -136,10 +114,7 @@ export class TelemetryControl extends ConnectionStateAwareAction<TelemetryContro
 
     const settings = this.parseSettings(migrated);
     const activeKey = TELEMETRY_CONTROL_GLOBAL_KEYS[settings.mode];
-
-    if (activeKey) {
-      this.setActiveBinding(activeKey);
-    }
+    this.setActiveBinding(activeKey ?? null);
 
     await this.updateDisplay(ev, settings);
   }
@@ -148,10 +123,7 @@ export class TelemetryControl extends ConnectionStateAwareAction<TelemetryContro
     await super.onDidReceiveSettings(ev);
     const settings = this.parseSettings(ev.payload.settings);
     const activeKey = TELEMETRY_CONTROL_GLOBAL_KEYS[settings.mode];
-
-    if (activeKey) {
-      this.setActiveBinding(activeKey);
-    }
+    this.setActiveBinding(activeKey ?? null);
 
     await this.updateDisplay(ev, settings);
   }
@@ -169,7 +141,7 @@ export class TelemetryControl extends ConnectionStateAwareAction<TelemetryContro
   }
 
   private parseSettings(settings: unknown): TelemetryControlSettings {
-    const { migrated } = migrateTelemetryControlLegacyAction(settings);
+    const { migrated } = migrateLegacyActionToMode(settings);
     const parsed = TelemetryControlSettings.safeParse(migrated);
 
     return parsed.success ? parsed.data : TelemetryControlSettings.parse({});

--- a/packages/actions/src/actions/telemetry-control.ts
+++ b/packages/actions/src/actions/telemetry-control.ts
@@ -64,7 +64,7 @@ export const TELEMETRY_CONTROL_GLOBAL_KEYS: Record<string, string> = {
 };
 
 const TelemetryControlSettings = CommonSettings.extend({
-  action: z.enum(ACTION_VALUES).default("toggle-logging"),
+  mode: z.enum(ACTION_VALUES).default("toggle-logging"),
 });
 
 type TelemetryControlSettings = z.infer<typeof TelemetryControlSettings>;
@@ -72,10 +72,33 @@ type TelemetryControlSettings = z.infer<typeof TelemetryControlSettings>;
 /**
  * @internal Exported for testing
  *
+ * Migrates legacy `action` setting key to `mode`. Returns the (possibly migrated)
+ * raw settings object and a `changed` flag indicating whether persistence is needed.
+ */
+export function migrateTelemetryControlLegacyAction(raw: unknown): {
+  migrated: Record<string, unknown>;
+  changed: boolean;
+} {
+  if (!raw || typeof raw !== "object") return { migrated: {}, changed: false };
+
+  const record = raw as Record<string, unknown>;
+
+  if (record.mode !== undefined || record.action === undefined) {
+    return { migrated: { ...record }, changed: false };
+  }
+
+  const { action, ...rest } = record;
+
+  return { migrated: { ...rest, mode: action }, changed: true };
+}
+
+/**
+ * @internal Exported for testing
+ *
  * Generates an SVG data URI icon for the telemetry control action.
  */
 export function generateTelemetryControlSvg(settings: TelemetryControlSettings): string {
-  const { action: actionType } = settings;
+  const { mode: actionType } = settings;
 
   const iconSvg = ACTION_ICONS[actionType] || ACTION_ICONS["toggle-logging"];
   const defaultTitle = TELEMETRY_CONTROL_TITLES[actionType] || TELEMETRY_CONTROL_TITLES["toggle-logging"];
@@ -101,8 +124,18 @@ export const TELEMETRY_CONTROL_UUID = "com.iracedeck.sd.core.telemetry-control" 
 export class TelemetryControl extends ConnectionStateAwareAction<TelemetryControlSettings> {
   override async onWillAppear(ev: IDeckWillAppearEvent<TelemetryControlSettings>): Promise<void> {
     await super.onWillAppear(ev);
-    const settings = this.parseSettings(ev.payload.settings);
-    const activeKey = TELEMETRY_CONTROL_GLOBAL_KEYS[settings.action];
+    const { migrated, changed } = migrateTelemetryControlLegacyAction(ev.payload.settings);
+
+    if (changed) {
+      try {
+        await ev.action.setSettings(migrated);
+      } catch (error) {
+        this.logger.warn(`Failed to persist migrated settings: ${error instanceof Error ? error.message : error}`);
+      }
+    }
+
+    const settings = this.parseSettings(migrated);
+    const activeKey = TELEMETRY_CONTROL_GLOBAL_KEYS[settings.mode];
 
     if (activeKey) {
       this.setActiveBinding(activeKey);
@@ -114,7 +147,7 @@ export class TelemetryControl extends ConnectionStateAwareAction<TelemetryContro
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<TelemetryControlSettings>): Promise<void> {
     await super.onDidReceiveSettings(ev);
     const settings = this.parseSettings(ev.payload.settings);
-    const activeKey = TELEMETRY_CONTROL_GLOBAL_KEYS[settings.action];
+    const activeKey = TELEMETRY_CONTROL_GLOBAL_KEYS[settings.mode];
 
     if (activeKey) {
       this.setActiveBinding(activeKey);
@@ -126,17 +159,18 @@ export class TelemetryControl extends ConnectionStateAwareAction<TelemetryContro
   override async onKeyDown(ev: IDeckKeyDownEvent<TelemetryControlSettings>): Promise<void> {
     this.logger.info("Key down received");
     const settings = this.parseSettings(ev.payload.settings);
-    await this.executeAction(settings.action);
+    await this.executeAction(settings.mode);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<TelemetryControlSettings>): Promise<void> {
     this.logger.info("Dial down received");
     const settings = this.parseSettings(ev.payload.settings);
-    await this.executeAction(settings.action);
+    await this.executeAction(settings.mode);
   }
 
   private parseSettings(settings: unknown): TelemetryControlSettings {
-    const parsed = TelemetryControlSettings.safeParse(settings);
+    const { migrated } = migrateTelemetryControlLegacyAction(settings);
+    const parsed = TelemetryControlSettings.safeParse(migrated);
 
     return parsed.success ? parsed.data : TelemetryControlSettings.parse({});
   }

--- a/packages/actions/src/actions/tire-service.test.ts
+++ b/packages/actions/src/actions/tire-service.test.ts
@@ -13,6 +13,7 @@ import {
   getCompoundName,
   getDriverTires,
   isTireSelected,
+  migrateTireServiceLegacyAction,
   migrateTireSettings,
   resolveToggleMode,
   TireService,
@@ -70,7 +71,7 @@ vi.mock("@iracedeck/iracing-sdk", () => ({
 vi.mock("@iracedeck/deck-core", () => ({
   CommonSettings: {
     extend: () => {
-      const defaults = { action: "change-all-tires", tires: ["lf", "rf", "lr", "rr"], addedWithVersion: "0.0.0" };
+      const defaults = { mode: "change-all-tires", tires: ["lf", "rf", "lr", "rr"], addedWithVersion: "0.0.0" };
       const schema = {
         parse: (data: Record<string, unknown>) => ({ ...defaults, ...data }),
         safeParse: (data: Record<string, unknown>) => ({ success: true, data: { ...defaults, ...data } }),
@@ -391,35 +392,35 @@ describe("TireService", () => {
 
   describe("buildTireToggleMacro", () => {
     it("should use shorthand #!t for all tires", () => {
-      expect(buildTireToggleMacro({ action: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] } as any)).toBe("#!t");
+      expect(buildTireToggleMacro({ mode: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] } as any)).toBe("#!t");
     });
 
     it("should use shorthand #!l for left side only", () => {
-      expect(buildTireToggleMacro({ action: "toggle-tires", tires: ["lf", "lr"] } as any)).toBe("#!l");
+      expect(buildTireToggleMacro({ mode: "toggle-tires", tires: ["lf", "lr"] } as any)).toBe("#!l");
     });
 
     it("should use shorthand #!r for right side only", () => {
-      expect(buildTireToggleMacro({ action: "toggle-tires", tires: ["rf", "rr"] } as any)).toBe("#!r");
+      expect(buildTireToggleMacro({ mode: "toggle-tires", tires: ["rf", "rr"] } as any)).toBe("#!r");
     });
 
     it("should use per-tire macro for front tires only", () => {
-      expect(buildTireToggleMacro({ action: "toggle-tires", tires: ["lf", "rf"] } as any)).toBe("#!lf !rf");
+      expect(buildTireToggleMacro({ mode: "toggle-tires", tires: ["lf", "rf"] } as any)).toBe("#!lf !rf");
     });
 
     it("should use per-tire macro for rear tires only", () => {
-      expect(buildTireToggleMacro({ action: "toggle-tires", tires: ["lr", "rr"] } as any)).toBe("#!lr !rr");
+      expect(buildTireToggleMacro({ mode: "toggle-tires", tires: ["lr", "rr"] } as any)).toBe("#!lr !rr");
     });
 
     it("should use per-tire macro for diagonal tires", () => {
-      expect(buildTireToggleMacro({ action: "toggle-tires", tires: ["lf", "rr"] } as any)).toBe("#!lf !rr");
+      expect(buildTireToggleMacro({ mode: "toggle-tires", tires: ["lf", "rr"] } as any)).toBe("#!lf !rr");
     });
 
     it("should build macro for single tire", () => {
-      expect(buildTireToggleMacro({ action: "toggle-tires", tires: ["rr"] } as any)).toBe("#!rr");
+      expect(buildTireToggleMacro({ mode: "toggle-tires", tires: ["rr"] } as any)).toBe("#!rr");
     });
 
     it("should return null when no tires configured", () => {
-      expect(buildTireToggleMacro({ action: "toggle-tires", tires: [] } as any)).toBeNull();
+      expect(buildTireToggleMacro({ mode: "toggle-tires", tires: [] } as any)).toBeNull();
     });
   });
 
@@ -486,7 +487,7 @@ describe("TireService", () => {
   describe("generateToggleTiresIconContent", () => {
     it("should return SVG with 4 tire indicator rects", () => {
       const result = generateToggleTiresIconContent(
-        { action: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] },
+        { mode: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] },
         { lf: false, rf: false, lr: false, rr: false },
       );
       const rects = result.match(/<rect[^>]+>/g) ?? [];
@@ -495,7 +496,7 @@ describe("TireService", () => {
 
     it("should use correct colors per tire position", () => {
       const result = generateToggleTiresIconContent(
-        { action: "toggle-tires", tires: ["lf", "lr"] },
+        { mode: "toggle-tires", tires: ["lf", "lr"] },
         { lf: true, rf: false, lr: false, rr: false },
       );
       // LF: configured + on = green
@@ -518,7 +519,7 @@ describe("TireService", () => {
 
     it("should show all green when all configured and active", () => {
       const result = generateToggleTiresIconContent(
-        { action: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] },
+        { mode: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] },
         { lf: true, rf: true, lr: true, rr: true },
       );
       const rects = result.match(/<rect[^>]+>/g) ?? [];
@@ -531,7 +532,7 @@ describe("TireService", () => {
 
     it("should show all red when all configured but inactive", () => {
       const result = generateToggleTiresIconContent(
-        { action: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] },
+        { mode: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] },
         { lf: false, rf: false, lr: false, rr: false },
       );
       const rects = result.match(/<rect[^>]+>/g) ?? [];
@@ -549,12 +550,12 @@ describe("TireService", () => {
 
     describe("change-all-tires mode", () => {
       it("should generate a valid data URI", () => {
-        const result = generateTireServiceSvg({ action: "change-all-tires", tires: ["lf", "rf", "lr", "rr"] }, noTires);
+        const result = generateTireServiceSvg({ mode: "change-all-tires", tires: ["lf", "rf", "lr", "rr"] }, noTires);
         expect(result).toContain("data:image/svg+xml");
       });
 
       it("should include CHANGE and ALL TIRES labels", () => {
-        const result = generateTireServiceSvg({ action: "change-all-tires", tires: ["lf", "rf", "lr", "rr"] }, noTires);
+        const result = generateTireServiceSvg({ mode: "change-all-tires", tires: ["lf", "rf", "lr", "rr"] }, noTires);
         const decoded = decodeURIComponent(result);
         expect(decoded).toContain("CHANGE");
         expect(decoded).toContain("ALL TIRES");
@@ -563,43 +564,43 @@ describe("TireService", () => {
 
     describe("toggle-tires mode", () => {
       it("should generate a valid data URI", () => {
-        const result = generateTireServiceSvg({ action: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] }, noTires);
+        const result = generateTireServiceSvg({ mode: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] }, noTires);
         expect(result).toContain("data:image/svg+xml");
       });
 
       it("should show red for configured but inactive tires", () => {
-        const result = generateTireServiceSvg({ action: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] }, noTires);
+        const result = generateTireServiceSvg({ mode: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] }, noTires);
         const decoded = decodeURIComponent(result);
         expect(decoded).toContain("#FF4444");
       });
 
       it("should show green for configured and active tires", () => {
-        const result = generateTireServiceSvg({ action: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] }, allTires);
+        const result = generateTireServiceSvg({ mode: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] }, allTires);
         const decoded = decodeURIComponent(result);
         expect(decoded).toContain("#44FF44");
       });
 
       it("should show black for unconfigured tires", () => {
-        const result = generateTireServiceSvg({ action: "toggle-tires", tires: [] }, allTires);
+        const result = generateTireServiceSvg({ mode: "toggle-tires", tires: [] }, allTires);
         const decoded = decodeURIComponent(result);
         expect(decoded).toContain("#000000ff");
       });
 
       it("should include car content in output", () => {
-        const result = generateTireServiceSvg({ action: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] }, noTires);
+        const result = generateTireServiceSvg({ mode: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] }, noTires);
         const decoded = decodeURIComponent(result);
         expect(decoded).toContain("toggle-tires-car");
       });
 
       it("should include title text", () => {
-        const result = generateTireServiceSvg({ action: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] }, noTires);
+        const result = generateTireServiceSvg({ mode: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] }, noTires);
         const decoded = decodeURIComponent(result);
         expect(decoded).toContain("TIRES");
       });
     });
 
     describe("change-compound mode", () => {
-      const compoundSettings = { action: "change-compound" as const, tires: ["lf", "rf", "lr", "rr"] };
+      const compoundSettings = { mode: "change-compound" as const, tires: ["lf", "rf", "lr", "rr"] };
 
       beforeEach(() => {
         mockGetSessionInfo.mockReturnValue({
@@ -662,12 +663,12 @@ describe("TireService", () => {
 
     describe("clear-tires mode", () => {
       it("should generate a valid data URI", () => {
-        const result = generateTireServiceSvg({ action: "clear-tires", tires: ["lf", "rf", "lr", "rr"] }, noTires);
+        const result = generateTireServiceSvg({ mode: "clear-tires", tires: ["lf", "rf", "lr", "rr"] }, noTires);
         expect(result).toContain("data:image/svg+xml");
       });
 
       it("should include CLEAR and TIRES labels", () => {
-        const result = generateTireServiceSvg({ action: "clear-tires", tires: ["lf", "rf", "lr", "rr"] }, noTires);
+        const result = generateTireServiceSvg({ mode: "clear-tires", tires: ["lf", "rf", "lr", "rr"] }, noTires);
         const decoded = decodeURIComponent(result);
         expect(decoded).toContain("CLEAR");
         expect(decoded).toContain("TIRES");
@@ -693,14 +694,14 @@ describe("TireService", () => {
     });
 
     it("should not call setSettings when tires and toggleMode already exist", async () => {
-      const ev = fakeEvent("a1", { action: "toggle-tires", tires: ["lf", "rf"], toggleMode: "select" });
+      const ev = fakeEvent("a1", { mode: "toggle-tires", tires: ["lf", "rf"], toggleMode: "select" });
       await action.onWillAppear(ev as any);
 
       expect(ev.action.setSettings).not.toHaveBeenCalled();
     });
 
     it("should default pre-existing instance to toggle mode (has settings but no addedWithVersion)", async () => {
-      const ev = fakeEvent("a1", { action: "toggle-tires", tires: ["lf", "rf"] });
+      const ev = fakeEvent("a1", { mode: "toggle-tires", tires: ["lf", "rf"] });
       await action.onWillAppear(ev as any);
 
       expect(ev.action.setSettings).toHaveBeenCalledOnce();
@@ -708,7 +709,7 @@ describe("TireService", () => {
     });
 
     it("should default to select when addedWithVersion already exists", async () => {
-      const ev = fakeEvent("a1", { action: "toggle-tires", tires: ["lf", "rf"], addedWithVersion: "1.13.0" });
+      const ev = fakeEvent("a1", { mode: "toggle-tires", tires: ["lf", "rf"], addedWithVersion: "1.13.0" });
       await action.onWillAppear(ev as any);
 
       expect(ev.action.setSettings).toHaveBeenCalledOnce();
@@ -716,7 +717,7 @@ describe("TireService", () => {
     });
 
     it("should call setSettings for legacy boolean settings", async () => {
-      const ev = fakeEvent("a1", { action: "toggle-tires", lf: true, rf: true, lr: false, rr: false });
+      const ev = fakeEvent("a1", { mode: "toggle-tires", lf: true, rf: true, lr: false, rr: false });
       await action.onWillAppear(ev as any);
 
       expect(ev.action.setSettings).toHaveBeenCalledOnce();
@@ -732,7 +733,7 @@ describe("TireService", () => {
     });
 
     it("should not overwrite unrelated settings keys", async () => {
-      const ev = fakeEvent("a1", { action: "toggle-tires", customKey: "userValue" });
+      const ev = fakeEvent("a1", { mode: "toggle-tires", customKey: "userValue" });
       await action.onWillAppear(ev as any);
 
       expect(ev.action.setSettings).toHaveBeenCalledOnce();
@@ -748,6 +749,20 @@ describe("TireService", () => {
       // Should not throw — rendering continues (setKeyImage is on the base class mock)
       expect(action.setKeyImage).toHaveBeenCalled();
     });
+
+    it("should persist action -> mode rename via setSettings for legacy instances", async () => {
+      const ev = fakeEvent("a1", {
+        action: "toggle-tires",
+        tires: ["lf", "rf"],
+        toggleMode: "select",
+      });
+      await action.onWillAppear(ev as any);
+
+      expect(ev.action.setSettings).toHaveBeenCalledOnce();
+      const calledWith = (ev.action.setSettings as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(calledWith).toMatchObject({ mode: "toggle-tires" });
+      expect(calledWith).not.toHaveProperty("action");
+    });
   });
 
   describe("key press behavior", () => {
@@ -759,7 +774,7 @@ describe("TireService", () => {
 
     describe("change-all-tires mode", () => {
       it("should send #t macro", async () => {
-        await action.onKeyDown(fakeEvent("a1", { action: "change-all-tires" }) as any);
+        await action.onKeyDown(fakeEvent("a1", { mode: "change-all-tires" }) as any);
 
         expect(mockSendMessage).toHaveBeenCalledOnce();
         expect(mockSendMessage).toHaveBeenCalledWith("#t");
@@ -772,7 +787,7 @@ describe("TireService", () => {
           mockGetCurrentTelemetry.mockReturnValue({ PitSvFlags: 0x000f, PlayerTireCompound: 0, PitSvTireCompound: 0 });
 
           await action.onKeyDown(
-            fakeEvent("a1", { action: "toggle-tires", toggleMode: "select", tires: ["rf", "rr"] }) as any,
+            fakeEvent("a1", { mode: "toggle-tires", toggleMode: "select", tires: ["rf", "rr"] }) as any,
           );
 
           expect(mockPitClearTires).toHaveBeenCalledOnce();
@@ -783,7 +798,7 @@ describe("TireService", () => {
           mockGetCurrentTelemetry.mockReturnValue({ PitSvFlags: 0x000a, PlayerTireCompound: 0, PitSvTireCompound: 0 });
 
           await action.onKeyDown(
-            fakeEvent("a1", { action: "toggle-tires", toggleMode: "select", tires: ["rf", "rr"] }) as any,
+            fakeEvent("a1", { mode: "toggle-tires", toggleMode: "select", tires: ["rf", "rr"] }) as any,
           );
 
           expect(mockPitClearTires).not.toHaveBeenCalled();
@@ -795,7 +810,7 @@ describe("TireService", () => {
 
           await action.onKeyDown(
             fakeEvent("a1", {
-              action: "toggle-tires",
+              mode: "toggle-tires",
               toggleMode: "select",
               tires: ["lf", "rf", "lr", "rr"],
             }) as any,
@@ -810,7 +825,7 @@ describe("TireService", () => {
 
           await action.onKeyDown(
             fakeEvent("a1", {
-              action: "toggle-tires",
+              mode: "toggle-tires",
               toggleMode: "select",
               tires: ["lf", "rf", "lr", "rr"],
             }) as any,
@@ -826,7 +841,7 @@ describe("TireService", () => {
           mockGetCurrentTelemetry.mockReturnValue({ PitSvFlags: 0x000f, PlayerTireCompound: 0, PitSvTireCompound: 0 });
 
           await action.onKeyDown(
-            fakeEvent("a1", { action: "toggle-tires", toggleMode: "toggle", tires: ["rf", "rr"] }) as any,
+            fakeEvent("a1", { mode: "toggle-tires", toggleMode: "toggle", tires: ["rf", "rr"] }) as any,
           );
 
           expect(mockPitClearTires).not.toHaveBeenCalled();
@@ -837,7 +852,7 @@ describe("TireService", () => {
           // addedWithVersion defaults to "0.0.0" → resolves to "toggle"
           mockGetCurrentTelemetry.mockReturnValue({ PitSvFlags: 0x000f, PlayerTireCompound: 0, PitSvTireCompound: 0 });
 
-          await action.onKeyDown(fakeEvent("a1", { action: "toggle-tires", tires: ["rf", "rr"] }) as any);
+          await action.onKeyDown(fakeEvent("a1", { mode: "toggle-tires", tires: ["rf", "rr"] }) as any);
 
           expect(mockPitClearTires).not.toHaveBeenCalled();
           expect(mockSendMessage).toHaveBeenCalledWith("#!r");
@@ -845,7 +860,7 @@ describe("TireService", () => {
       });
 
       it("should not clear or send message when no tires configured", async () => {
-        await action.onKeyDown(fakeEvent("a1", { action: "toggle-tires", tires: [] }) as any);
+        await action.onKeyDown(fakeEvent("a1", { mode: "toggle-tires", tires: [] }) as any);
 
         expect(mockPitClearTires).not.toHaveBeenCalled();
         expect(mockSendMessage).not.toHaveBeenCalled();
@@ -871,7 +886,7 @@ describe("TireService", () => {
         });
         mockGetCurrentTelemetry.mockReturnValue({ PitSvFlags: 0, PlayerTireCompound: 0, PitSvTireCompound: 0 });
 
-        await action.onKeyDown(fakeEvent("a1", { action: "change-compound" }) as any);
+        await action.onKeyDown(fakeEvent("a1", { mode: "change-compound" }) as any);
 
         expect(mockPitTireCompound).toHaveBeenCalledOnce();
         expect(mockPitTireCompound).toHaveBeenCalledWith(1);
@@ -889,7 +904,7 @@ describe("TireService", () => {
         });
         mockGetCurrentTelemetry.mockReturnValue({ PitSvFlags: 0, PlayerTireCompound: 0, PitSvTireCompound: 1 });
 
-        await action.onKeyDown(fakeEvent("a1", { action: "change-compound" }) as any);
+        await action.onKeyDown(fakeEvent("a1", { mode: "change-compound" }) as any);
 
         expect(mockPitTireCompound).toHaveBeenCalledOnce();
         expect(mockPitTireCompound).toHaveBeenCalledWith(0);
@@ -907,7 +922,7 @@ describe("TireService", () => {
         });
         mockGetCurrentTelemetry.mockReturnValue({ PitSvFlags: 0, PlayerTireCompound: 0, PitSvTireCompound: 1 });
 
-        await action.onKeyDown(fakeEvent("a1", { action: "change-compound" }) as any);
+        await action.onKeyDown(fakeEvent("a1", { mode: "change-compound" }) as any);
 
         expect(mockPitTireCompound).toHaveBeenCalledOnce();
         expect(mockPitTireCompound).toHaveBeenCalledWith(2);
@@ -925,7 +940,7 @@ describe("TireService", () => {
         });
         mockGetCurrentTelemetry.mockReturnValue({ PitSvFlags: 0, PlayerTireCompound: 0, PitSvTireCompound: 2 });
 
-        await action.onKeyDown(fakeEvent("a1", { action: "change-compound" }) as any);
+        await action.onKeyDown(fakeEvent("a1", { mode: "change-compound" }) as any);
 
         expect(mockPitTireCompound).toHaveBeenCalledOnce();
         expect(mockPitTireCompound).toHaveBeenCalledWith(0);
@@ -935,7 +950,7 @@ describe("TireService", () => {
         mockGetSessionInfo.mockReturnValue(null);
         mockGetCurrentTelemetry.mockReturnValue({ PitSvFlags: 0 } as any);
 
-        await action.onKeyDown(fakeEvent("a1", { action: "change-compound" }) as any);
+        await action.onKeyDown(fakeEvent("a1", { mode: "change-compound" }) as any);
 
         expect(mockPitTireCompound).toHaveBeenCalledOnce();
         // Fallback has 1 compound (TireIndex 0), (0+1) % 1 = 0
@@ -945,7 +960,7 @@ describe("TireService", () => {
 
     describe("clear-tires mode", () => {
       it("should call pit.clearTires", async () => {
-        await action.onKeyDown(fakeEvent("a1", { action: "clear-tires" }) as any);
+        await action.onKeyDown(fakeEvent("a1", { mode: "clear-tires" }) as any);
 
         expect(mockPitClearTires).toHaveBeenCalledOnce();
         expect(mockSendMessage).not.toHaveBeenCalled();
@@ -955,7 +970,7 @@ describe("TireService", () => {
     it("should not execute change-all-tires when not connected", async () => {
       mockGetConnectionStatus.mockReturnValue(false);
 
-      await action.onKeyDown(fakeEvent("a1", { action: "change-all-tires" }) as any);
+      await action.onKeyDown(fakeEvent("a1", { mode: "change-all-tires" }) as any);
 
       expect(mockSendMessage).not.toHaveBeenCalled();
       expect(mockPitTireCompound).not.toHaveBeenCalled();
@@ -965,7 +980,7 @@ describe("TireService", () => {
     it("should not execute toggle-tires when not connected", async () => {
       mockGetConnectionStatus.mockReturnValue(false);
 
-      await action.onKeyDown(fakeEvent("a1", { action: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] }) as any);
+      await action.onKeyDown(fakeEvent("a1", { mode: "toggle-tires", tires: ["lf", "rf", "lr", "rr"] }) as any);
 
       expect(mockSendMessage).not.toHaveBeenCalled();
       expect(mockPitTireCompound).not.toHaveBeenCalled();
@@ -981,7 +996,7 @@ describe("TireService", () => {
     });
 
     it("should send #t macro on dial down for change-all-tires", async () => {
-      await action.onDialDown(fakeEvent("a1", { action: "change-all-tires" }) as any);
+      await action.onDialDown(fakeEvent("a1", { mode: "change-all-tires" }) as any);
 
       expect(mockSendMessage).toHaveBeenCalledOnce();
       expect(mockSendMessage).toHaveBeenCalledWith("#t");
@@ -991,7 +1006,7 @@ describe("TireService", () => {
       mockGetCurrentTelemetry.mockReturnValue({ PitSvFlags: 0, PlayerTireCompound: 0, PitSvTireCompound: 0 });
 
       await action.onDialDown(
-        fakeEvent("a1", { action: "toggle-tires", toggleMode: "select", tires: ["lf", "rf", "lr", "rr"] }) as any,
+        fakeEvent("a1", { mode: "toggle-tires", toggleMode: "select", tires: ["lf", "rf", "lr", "rr"] }) as any,
       );
 
       expect(mockPitClearTires).toHaveBeenCalledOnce();
@@ -1003,7 +1018,7 @@ describe("TireService", () => {
       mockGetCurrentTelemetry.mockReturnValue({ PitSvFlags: 0x000f, PlayerTireCompound: 0, PitSvTireCompound: 0 });
 
       await action.onDialDown(
-        fakeEvent("a1", { action: "toggle-tires", toggleMode: "select", tires: ["lf", "rf", "lr", "rr"] }) as any,
+        fakeEvent("a1", { mode: "toggle-tires", toggleMode: "select", tires: ["lf", "rf", "lr", "rr"] }) as any,
       );
 
       expect(mockPitClearTires).not.toHaveBeenCalled();
@@ -1015,7 +1030,7 @@ describe("TireService", () => {
       mockGetCurrentTelemetry.mockReturnValue({ PitSvFlags: 0x000f, PlayerTireCompound: 0, PitSvTireCompound: 0 });
 
       await action.onDialDown(
-        fakeEvent("a1", { action: "toggle-tires", toggleMode: "toggle", tires: ["rf", "rr"] }) as any,
+        fakeEvent("a1", { mode: "toggle-tires", toggleMode: "toggle", tires: ["rf", "rr"] }) as any,
       );
 
       expect(mockPitClearTires).not.toHaveBeenCalled();
@@ -1033,14 +1048,14 @@ describe("TireService", () => {
       });
       mockGetCurrentTelemetry.mockReturnValue({ PitSvFlags: 0, PlayerTireCompound: 0, PitSvTireCompound: 0 });
 
-      await action.onDialDown(fakeEvent("a1", { action: "change-compound" }) as any);
+      await action.onDialDown(fakeEvent("a1", { mode: "change-compound" }) as any);
 
       expect(mockPitTireCompound).toHaveBeenCalledOnce();
       expect(mockPitTireCompound).toHaveBeenCalledWith(1);
     });
 
     it("should call pit.clearTires on dial down for clear-tires", async () => {
-      await action.onDialDown(fakeEvent("a1", { action: "clear-tires" }) as any);
+      await action.onDialDown(fakeEvent("a1", { mode: "clear-tires" }) as any);
 
       expect(mockPitClearTires).toHaveBeenCalledOnce();
     });
@@ -1062,22 +1077,22 @@ describe("TireService", () => {
 
   describe("migrateTireSettings", () => {
     it("should pass through when tires key is present", () => {
-      const result = migrateTireSettings({ action: "toggle-tires", tires: ["lf", "rr"] });
+      const result = migrateTireSettings({ mode: "toggle-tires", tires: ["lf", "rr"] });
       expect(result.tires).toEqual(["lf", "rr"]);
     });
 
     it("should migrate legacy booleans to tires array", () => {
-      const result = migrateTireSettings({ action: "toggle-tires", lf: true, rf: false, lr: true, rr: false });
+      const result = migrateTireSettings({ mode: "toggle-tires", lf: true, rf: false, lr: true, rr: false });
       expect(result.tires).toEqual(["lf", "lr"]);
     });
 
     it("should migrate all true legacy booleans", () => {
-      const result = migrateTireSettings({ action: "toggle-tires", lf: true, rf: true, lr: true, rr: true });
+      const result = migrateTireSettings({ mode: "toggle-tires", lf: true, rf: true, lr: true, rr: true });
       expect(result.tires).toEqual(["lf", "rf", "lr", "rr"]);
     });
 
     it("should migrate all false legacy booleans to empty array", () => {
-      const result = migrateTireSettings({ action: "toggle-tires", lf: false, rf: false, lr: false, rr: false });
+      const result = migrateTireSettings({ mode: "toggle-tires", lf: false, rf: false, lr: false, rr: false });
       expect(result.tires).toEqual([]);
     });
 
@@ -1089,6 +1104,56 @@ describe("TireService", () => {
     it("should not migrate when tires key exists even with legacy booleans", () => {
       const result = migrateTireSettings({ tires: ["rr"], lf: true, rf: true, lr: true, rr: true });
       expect(result.tires).toEqual(["rr"]);
+    });
+
+    it("should migrate legacy action key to mode field", () => {
+      const result = migrateTireSettings({ action: "toggle-tires", tires: ["lf", "rf"] });
+      expect(result.mode).toBe("toggle-tires");
+      expect((result as Record<string, unknown>).action).toBeUndefined();
+    });
+  });
+
+  describe("migrateTireServiceLegacyAction", () => {
+    it("should rename legacy action key to mode", () => {
+      const result = migrateTireServiceLegacyAction({ action: "toggle-tires" });
+
+      expect(result.changed).toBe(true);
+      expect(result.migrated).toEqual({ mode: "toggle-tires" });
+      expect(result.migrated.action).toBeUndefined();
+    });
+
+    it("should preserve other settings keys during migration", () => {
+      const result = migrateTireServiceLegacyAction({
+        action: "toggle-tires",
+        tires: ["lf", "rf"],
+        toggleMode: "select",
+      });
+
+      expect(result.changed).toBe(true);
+      expect(result.migrated).toEqual({
+        mode: "toggle-tires",
+        tires: ["lf", "rf"],
+        toggleMode: "select",
+      });
+    });
+
+    it("should not change settings that already use mode", () => {
+      const result = migrateTireServiceLegacyAction({ mode: "toggle-tires" });
+
+      expect(result.changed).toBe(false);
+      expect(result.migrated).toEqual({ mode: "toggle-tires" });
+    });
+
+    it("should handle empty raw settings", () => {
+      const result = migrateTireServiceLegacyAction({});
+
+      expect(result.changed).toBe(false);
+      expect(result.migrated).toEqual({});
+    });
+
+    it("should handle null/undefined raw settings", () => {
+      expect(migrateTireServiceLegacyAction(null).changed).toBe(false);
+      expect(migrateTireServiceLegacyAction(undefined).changed).toBe(false);
     });
   });
 });

--- a/packages/actions/src/actions/tire-service.test.ts
+++ b/packages/actions/src/actions/tire-service.test.ts
@@ -13,7 +13,6 @@ import {
   getCompoundName,
   getDriverTires,
   isTireSelected,
-  migrateTireServiceLegacyAction,
   migrateTireSettings,
   resolveToggleMode,
   TireService,
@@ -99,6 +98,19 @@ vi.mock("@iracedeck/deck-core", () => ({
     async onWillDisappear() {}
   },
   getCommands: mockGetCommands,
+  migrateLegacyActionToMode: (raw: unknown) => {
+    if (!raw || typeof raw !== "object") return { migrated: {}, changed: false };
+
+    const record = raw as Record<string, unknown>;
+
+    if (record.mode !== undefined || record.action === undefined) {
+      return { migrated: { ...record }, changed: false };
+    }
+
+    const { action, ...rest } = record;
+
+    return { migrated: { ...rest, mode: action }, changed: true };
+  },
   applyGraphicTransform: vi.fn((_content: string) => _content),
   computeGraphicArea: vi.fn(() => ({ x: 8, y: 8, width: 128, height: 128 })),
   extractGraphicContent: vi.fn((svg: string) =>
@@ -1110,50 +1122,6 @@ describe("TireService", () => {
       const result = migrateTireSettings({ action: "toggle-tires", tires: ["lf", "rf"] });
       expect(result.mode).toBe("toggle-tires");
       expect((result as Record<string, unknown>).action).toBeUndefined();
-    });
-  });
-
-  describe("migrateTireServiceLegacyAction", () => {
-    it("should rename legacy action key to mode", () => {
-      const result = migrateTireServiceLegacyAction({ action: "toggle-tires" });
-
-      expect(result.changed).toBe(true);
-      expect(result.migrated).toEqual({ mode: "toggle-tires" });
-      expect(result.migrated.action).toBeUndefined();
-    });
-
-    it("should preserve other settings keys during migration", () => {
-      const result = migrateTireServiceLegacyAction({
-        action: "toggle-tires",
-        tires: ["lf", "rf"],
-        toggleMode: "select",
-      });
-
-      expect(result.changed).toBe(true);
-      expect(result.migrated).toEqual({
-        mode: "toggle-tires",
-        tires: ["lf", "rf"],
-        toggleMode: "select",
-      });
-    });
-
-    it("should not change settings that already use mode", () => {
-      const result = migrateTireServiceLegacyAction({ mode: "toggle-tires" });
-
-      expect(result.changed).toBe(false);
-      expect(result.migrated).toEqual({ mode: "toggle-tires" });
-    });
-
-    it("should handle empty raw settings", () => {
-      const result = migrateTireServiceLegacyAction({});
-
-      expect(result.changed).toBe(false);
-      expect(result.migrated).toEqual({});
-    });
-
-    it("should handle null/undefined raw settings", () => {
-      expect(migrateTireServiceLegacyAction(null).changed).toBe(false);
-      expect(migrateTireServiceLegacyAction(undefined).changed).toBe(false);
     });
   });
 });

--- a/packages/actions/src/actions/tire-service.ts
+++ b/packages/actions/src/actions/tire-service.ts
@@ -63,7 +63,7 @@ const TireCode = z.enum(["lf", "rf", "lr", "rr"]);
 const TOGGLE_MODE_INTRODUCED = "1.13.0";
 
 const TireServiceSettings = CommonSettings.extend({
-  action: z.enum(["change-all-tires", "clear-tires", "toggle-tires", "change-compound"]).default("change-all-tires"),
+  mode: z.enum(["change-all-tires", "clear-tires", "toggle-tires", "change-compound"]).default("change-all-tires"),
   toggleMode: z.enum(["select", "toggle"]).optional(),
   tires: z
     .array(TireCode)
@@ -95,16 +95,43 @@ export function resolveToggleMode(settings: TireServiceSettings): "select" | "to
 /**
  * @internal Exported for testing
  *
- * Migrates legacy boolean tire settings (lf/rf/lr/rr) to the new tires array.
- * Only runs when tires key is absent from the raw settings and legacy booleans are present.
+ * Renames the legacy `action` setting key to `mode`. Returns the (possibly migrated)
+ * raw settings object and a `changed` flag indicating whether persistence is needed.
+ */
+export function migrateTireServiceLegacyAction(raw: unknown): {
+  migrated: Record<string, unknown>;
+  changed: boolean;
+} {
+  if (!raw || typeof raw !== "object") return { migrated: {}, changed: false };
+
+  const record = raw as Record<string, unknown>;
+
+  if (record.mode !== undefined || record.action === undefined) {
+    return { migrated: { ...record }, changed: false };
+  }
+
+  const { action, ...rest } = record;
+
+  return { migrated: { ...rest, mode: action }, changed: true };
+}
+
+/**
+ * @internal Exported for testing
+ *
+ * Migrates legacy boolean tire settings (lf/rf/lr/rr) to the new tires array,
+ * and renames the legacy `action` field to `mode`. Tires migration only runs
+ * when the tires key is absent from the raw settings and legacy booleans are present.
  */
 export function migrateTireSettings(raw: unknown): TireServiceSettings {
-  const parsed = TireServiceSettings.safeParse(raw);
+  const { migrated: rawWithMode } = migrateTireServiceLegacyAction(raw);
+  const parsed = TireServiceSettings.safeParse(rawWithMode);
   const data = parsed.success ? parsed.data : TireServiceSettings.parse({});
 
-  const rawRecord = raw as Record<string, unknown> | undefined;
+  if (!raw || typeof raw !== "object") return data;
 
-  if (!rawRecord || rawRecord.tires !== undefined) {
+  const rawRecord = raw as Record<string, unknown>;
+
+  if (rawRecord.tires !== undefined) {
     return data;
   }
 
@@ -351,7 +378,7 @@ export function generateTireServiceSvg(
   currentState: { lf: boolean; rf: boolean; lr: boolean; rr: boolean },
   compoundState: { player: number; pitSv: number } = { player: 0, pitSv: 0 },
 ): string {
-  switch (settings.action) {
+  switch (settings.mode) {
     case "change-all-tires": {
       const colors = resolveIconColors(changeAllTiresIconSvg, getGlobalColors(), settings.colorOverrides);
       const title = resolveTitleSettings(
@@ -481,15 +508,17 @@ export class TireService extends ConnectionStateAwareAction<TireServiceSettings>
   override async onWillAppear(ev: IDeckWillAppearEvent<TireServiceSettings>): Promise<void> {
     await super.onWillAppear(ev);
     const raw = ev.payload.settings as Record<string, unknown> | undefined;
+    const { migrated: rawWithMode, changed: actionMigrated } = migrateTireServiceLegacyAction(ev.payload.settings);
     const settings = this.parseSettings(ev.payload.settings);
     this.activeContexts.set(ev.action.id, settings);
 
-    // Persist defaults on fresh instances so the PI sees correct values
+    // Persist defaults on fresh instances so the PI sees correct values,
+    // and persist the action -> mode rename for legacy instances
     const needsTires = !raw || raw.tires === undefined;
     const needsToggleMode = !raw?.toggleMode;
 
-    if (needsTires || needsToggleMode) {
-      const updates: Record<string, unknown> = { ...(raw ?? {}) };
+    if (needsTires || needsToggleMode || actionMigrated) {
+      const updates: Record<string, unknown> = { ...rawWithMode };
 
       if (needsTires) updates.tires = settings.tires;
 
@@ -601,8 +630,8 @@ export class TireService extends ConnectionStateAwareAction<TireServiceSettings>
     compound: { player: number; pitSv: number },
   ): string {
     // Static-icon modes don't depend on telemetry — avoid unnecessary re-renders
-    if (settings.action === "change-all-tires" || settings.action === "clear-tires") {
-      return settings.action;
+    if (settings.mode === "change-all-tires" || settings.mode === "clear-tires") {
+      return settings.mode;
     }
 
     const tires = getDriverTires();
@@ -610,7 +639,7 @@ export class TireService extends ConnectionStateAwareAction<TireServiceSettings>
     const bo = settings.borderOverrides;
     const borderKey = `${bo?.enabled ?? ""}|${bo?.borderWidth ?? ""}|${bo?.borderColor ?? ""}|${bo?.glowEnabled ?? ""}|${bo?.glowWidth ?? ""}`;
 
-    return `${settings.action}|${settings.tires.join(",")}|${tireState.lf}|${tireState.rf}|${tireState.lr}|${tireState.rr}|${compound.player}|${compound.pitSv}|${tires.length}|${compoundType}|${borderKey}`;
+    return `${settings.mode}|${settings.tires.join(",")}|${tireState.lf}|${tireState.rf}|${tireState.lr}|${tireState.rr}|${compound.player}|${compound.pitSv}|${tires.length}|${compoundType}|${borderKey}`;
   }
 
   private executeAction(rawSettings: unknown): void {
@@ -622,7 +651,7 @@ export class TireService extends ConnectionStateAwareAction<TireServiceSettings>
 
     const settings = this.parseSettings(rawSettings);
 
-    switch (settings.action) {
+    switch (settings.mode) {
       case "change-all-tires": {
         this.logger.debug("Sending change all tires macro");
         const success = getCommands().chat.sendMessage("#t");
@@ -675,9 +704,9 @@ export class TireService extends ConnectionStateAwareAction<TireServiceSettings>
           return;
         }
 
-        const mode = resolveToggleMode(settings);
+        const toggleMode = resolveToggleMode(settings);
 
-        if (mode === "select") {
+        if (toggleMode === "select") {
           const telemetry = this.sdkController.getCurrentTelemetry();
           const tireState = getTireState(telemetry);
 
@@ -687,7 +716,7 @@ export class TireService extends ConnectionStateAwareAction<TireServiceSettings>
           }
         }
 
-        this.logger.debug(`Sending pit macro: ${macro} (mode=${mode})`);
+        this.logger.debug(`Sending pit macro: ${macro} (toggleMode=${toggleMode})`);
         const success = getCommands().chat.sendMessage(macro);
 
         if (success) {

--- a/packages/actions/src/actions/tire-service.ts
+++ b/packages/actions/src/actions/tire-service.ts
@@ -20,6 +20,7 @@ import {
   type IDeckKeyDownEvent,
   type IDeckWillAppearEvent,
   type IDeckWillDisappearEvent,
+  migrateLegacyActionToMode,
   parseIconArtworkBounds,
   renderIconTemplate,
   resolveBorderSettings,
@@ -95,35 +96,12 @@ export function resolveToggleMode(settings: TireServiceSettings): "select" | "to
 /**
  * @internal Exported for testing
  *
- * Renames the legacy `action` setting key to `mode`. Returns the (possibly migrated)
- * raw settings object and a `changed` flag indicating whether persistence is needed.
- */
-export function migrateTireServiceLegacyAction(raw: unknown): {
-  migrated: Record<string, unknown>;
-  changed: boolean;
-} {
-  if (!raw || typeof raw !== "object") return { migrated: {}, changed: false };
-
-  const record = raw as Record<string, unknown>;
-
-  if (record.mode !== undefined || record.action === undefined) {
-    return { migrated: { ...record }, changed: false };
-  }
-
-  const { action, ...rest } = record;
-
-  return { migrated: { ...rest, mode: action }, changed: true };
-}
-
-/**
- * @internal Exported for testing
- *
  * Migrates legacy boolean tire settings (lf/rf/lr/rr) to the new tires array,
  * and renames the legacy `action` field to `mode`. Tires migration only runs
  * when the tires key is absent from the raw settings and legacy booleans are present.
  */
 export function migrateTireSettings(raw: unknown): TireServiceSettings {
-  const { migrated: rawWithMode } = migrateTireServiceLegacyAction(raw);
+  const { migrated: rawWithMode } = migrateLegacyActionToMode(raw);
   const parsed = TireServiceSettings.safeParse(rawWithMode);
   const data = parsed.success ? parsed.data : TireServiceSettings.parse({});
 
@@ -508,7 +486,7 @@ export class TireService extends ConnectionStateAwareAction<TireServiceSettings>
   override async onWillAppear(ev: IDeckWillAppearEvent<TireServiceSettings>): Promise<void> {
     await super.onWillAppear(ev);
     const raw = ev.payload.settings as Record<string, unknown> | undefined;
-    const { migrated: rawWithMode, changed: actionMigrated } = migrateTireServiceLegacyAction(ev.payload.settings);
+    const { migrated: rawWithMode, changed: actionMigrated } = migrateLegacyActionToMode(ev.payload.settings);
     const settings = this.parseSettings(ev.payload.settings);
     this.activeContexts.set(ev.action.id, settings);
 

--- a/packages/deck-core/src/index.ts
+++ b/packages/deck-core/src/index.ts
@@ -34,6 +34,9 @@ export {
   TitleOverridesSchema,
 } from "./common-settings.js";
 
+// Settings migration helpers
+export { migrateLegacyActionToMode } from "./migrate-legacy-action.js";
+
 // Title, border, and graphic settings (re-exports from icon-composer + global readers)
 export {
   applyGraphicTransform,

--- a/packages/deck-core/src/migrate-legacy-action.test.ts
+++ b/packages/deck-core/src/migrate-legacy-action.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { migrateLegacyActionToMode } from "./migrate-legacy-action.js";
+
+describe("migrateLegacyActionToMode", () => {
+  it("renames legacy action key to mode", () => {
+    const result = migrateLegacyActionToMode({ action: "take-screenshot" });
+
+    expect(result.changed).toBe(true);
+    expect(result.migrated).toEqual({ mode: "take-screenshot" });
+    expect(result.migrated.action).toBeUndefined();
+  });
+
+  it("preserves other settings keys during migration", () => {
+    const result = migrateLegacyActionToMode({
+      action: "take-screenshot",
+      flagsOverlay: true,
+      titleOverrides: { titleText: "X" },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.migrated).toEqual({
+      mode: "take-screenshot",
+      flagsOverlay: true,
+      titleOverrides: { titleText: "X" },
+    });
+  });
+
+  it("does not change settings that already use mode", () => {
+    const result = migrateLegacyActionToMode({ mode: "take-screenshot" });
+
+    expect(result.changed).toBe(false);
+    expect(result.migrated).toEqual({ mode: "take-screenshot" });
+  });
+
+  it("keeps mode when both mode and action are present", () => {
+    const result = migrateLegacyActionToMode({ mode: "video-timer", action: "take-screenshot" });
+
+    expect(result.changed).toBe(false);
+    expect(result.migrated.mode).toBe("video-timer");
+  });
+
+  it("handles empty raw settings", () => {
+    const result = migrateLegacyActionToMode({});
+
+    expect(result.changed).toBe(false);
+    expect(result.migrated).toEqual({});
+  });
+
+  it("handles null and undefined raw settings", () => {
+    expect(migrateLegacyActionToMode(null).changed).toBe(false);
+    expect(migrateLegacyActionToMode(null).migrated).toEqual({});
+    expect(migrateLegacyActionToMode(undefined).changed).toBe(false);
+    expect(migrateLegacyActionToMode(undefined).migrated).toEqual({});
+  });
+
+  it("handles non-object raw settings (string, number, boolean)", () => {
+    expect(migrateLegacyActionToMode("string").changed).toBe(false);
+    expect(migrateLegacyActionToMode(42).changed).toBe(false);
+    expect(migrateLegacyActionToMode(true).changed).toBe(false);
+  });
+});

--- a/packages/deck-core/src/migrate-legacy-action.ts
+++ b/packages/deck-core/src/migrate-legacy-action.ts
@@ -1,0 +1,29 @@
+/**
+ * One-shot in-place migration helper for actions that renamed their primary
+ * settings field from `action` to `mode` (issue #324).
+ *
+ * Detects raw settings with the legacy `action` key but no `mode`, copies the
+ * value across, and drops the old key. Returns the (possibly migrated) raw
+ * settings object alongside a `changed` flag so callers can decide whether to
+ * persist via `setSettings`.
+ *
+ * Used by media-capture, pit-quick-actions, telemetry-control, and tire-service.
+ * Safe to call on any settings shape — non-object inputs return an empty
+ * unchanged result.
+ */
+export function migrateLegacyActionToMode(raw: unknown): {
+  migrated: Record<string, unknown>;
+  changed: boolean;
+} {
+  if (!raw || typeof raw !== "object") return { migrated: {}, changed: false };
+
+  const record = raw as Record<string, unknown>;
+
+  if (record.mode !== undefined || record.action === undefined) {
+    return { migrated: { ...record }, changed: false };
+  }
+
+  const { action, ...rest } = record;
+
+  return { migrated: { ...rest, mode: action }, changed: true };
+}

--- a/packages/stream-deck-plugin/src/pi/media-capture.ejs
+++ b/packages/stream-deck-plugin/src/pi/media-capture.ejs
@@ -6,8 +6,8 @@
 	<body>
 		<%- include('section-header', { title: 'Action Settings' }) %>
 
-		<sdpi-item label="Action">
-			<sdpi-select setting="action" default="start-stop-video">
+		<sdpi-item label="Mode">
+			<sdpi-select setting="mode" default="start-stop-video">
 				<option value="start-stop-video">Start/Stop Video</option>
 				<option value="video-timer">Video Timer</option>
 				<option value="toggle-video-capture">Toggle Video Capture</option>

--- a/packages/stream-deck-plugin/src/pi/pit-quick-actions.ejs
+++ b/packages/stream-deck-plugin/src/pi/pit-quick-actions.ejs
@@ -6,8 +6,8 @@
 	<body>
 		<%- include('section-header', { title: 'Action Settings' }) %>
 
-		<sdpi-item label="Action">
-			<sdpi-select setting="action" default="clear-all-checkboxes">
+		<sdpi-item label="Mode">
+			<sdpi-select setting="mode" default="clear-all-checkboxes">
 				<option value="clear-all-checkboxes">Clear All Checkboxes</option>
 				<option value="windshield-tearoff">Windshield Tearoff</option>
 				<option value="request-fast-repair">Request Fast Repair</option>

--- a/packages/stream-deck-plugin/src/pi/race-admin.ejs
+++ b/packages/stream-deck-plugin/src/pi/race-admin.ejs
@@ -6,7 +6,7 @@
 	<body>
 		<%- include('section-header', { title: 'Action Settings' }) %>
 
-		<sdpi-item label="Command">
+		<sdpi-item label="Mode">
 			<sdpi-select id="mode-select" setting="mode" default="yellow">
 				<optgroup label="Race Control">
 					<option value="yellow">Throw Yellow Flag</option>

--- a/packages/stream-deck-plugin/src/pi/replay-control.ejs
+++ b/packages/stream-deck-plugin/src/pi/replay-control.ejs
@@ -6,7 +6,7 @@
 	<body>
 		<%- include('section-header', { title: 'Action Settings' }) %>
 
-		<sdpi-item label="Control">
+		<sdpi-item label="Mode">
 			<sdpi-select id="mode-select" setting="mode" default="play-pause">
 				<optgroup label="Transport">
 					<option value="play-pause">Play / Pause</option>

--- a/packages/stream-deck-plugin/src/pi/session-info.ejs
+++ b/packages/stream-deck-plugin/src/pi/session-info.ejs
@@ -6,7 +6,7 @@
 	<body>
 		<%- include('section-header', { title: 'Action Settings' }) %>
 
-		<sdpi-item label="Display Mode">
+		<sdpi-item label="Mode">
 			<sdpi-select id="mode-select" setting="mode" default="incidents">
 				<option value="incidents">Incident Points</option>
 				<option value="time-remaining">Time Remaining</option>

--- a/packages/stream-deck-plugin/src/pi/telemetry-control.ejs
+++ b/packages/stream-deck-plugin/src/pi/telemetry-control.ejs
@@ -6,8 +6,8 @@
 	<body>
 		<%- include('section-header', { title: 'Action Settings' }) %>
 
-		<sdpi-item label="Action">
-			<sdpi-select setting="action" default="toggle-logging">
+		<sdpi-item label="Mode">
+			<sdpi-select setting="mode" default="toggle-logging">
 				<option value="toggle-logging">Toggle Logging</option>
 				<option value="mark-event">Mark Event</option>
 				<option value="start-recording">Start Recording</option>

--- a/packages/stream-deck-plugin/src/pi/tire-service.ejs
+++ b/packages/stream-deck-plugin/src/pi/tire-service.ejs
@@ -6,8 +6,8 @@
 	<body>
 		<%- include('section-header', { title: 'Action Settings' }) %>
 
-		<sdpi-item label="Action">
-			<sdpi-select id="action-select" setting="action" default="change-all-tires">
+		<sdpi-item label="Mode">
+			<sdpi-select id="mode-select" setting="mode" default="change-all-tires">
 				<option value="change-all-tires">Change All Tires</option>
 				<option value="clear-tires">Clear Tires</option>
 				<option value="toggle-tires">Toggle Tires</option>
@@ -37,32 +37,32 @@
 			async function initialize() {
 				await customElements.whenDefined("sdpi-select");
 
-				const actionSelect = document.getElementById("action-select");
-				if (actionSelect) {
-					updateVisibility(actionSelect.value || "change-all-tires");
+				const modeSelect = document.getElementById("mode-select");
+				if (modeSelect) {
+					updateVisibility(modeSelect.value || "change-all-tires");
 
-					actionSelect.addEventListener("change", (ev) => {
+					modeSelect.addEventListener("change", (ev) => {
 						updateVisibility(ev.target.value || "change-all-tires");
 					});
-					actionSelect.addEventListener("input", (ev) => {
+					modeSelect.addEventListener("input", (ev) => {
 						updateVisibility(ev.target.value || "change-all-tires");
 					});
 
 					// Polling fallback for reliable detection
-					let lastAction = actionSelect.value || "change-all-tires";
+					let lastMode = modeSelect.value || "change-all-tires";
 					setInterval(() => {
-						const currentAction = actionSelect.value;
-						if (currentAction && currentAction !== lastAction) {
-							lastAction = currentAction;
-							updateVisibility(currentAction);
+						const currentMode = modeSelect.value;
+						if (currentMode && currentMode !== lastMode) {
+							lastMode = currentMode;
+							updateVisibility(currentMode);
 						}
 					}, 100);
 				}
 			}
 
-			function updateVisibility(actionType) {
+			function updateVisibility(mode) {
 				const toggleSettings = document.getElementById("toggle-settings");
-				if (actionType === "toggle-tires") {
+				if (mode === "toggle-tires") {
 					toggleSettings?.classList.remove("hidden");
 				} else {
 					toggleSettings?.classList.add("hidden");

--- a/packages/website/src/content/docs/docs/actions/pit-service/tire-service.md
+++ b/packages/website/src/content/docs/docs/actions/pit-service/tire-service.md
@@ -15,7 +15,7 @@ Tire Service is telemetry-aware — the icon updates with live data from the sim
 
 ## Modes
 
-Select the mode from the **Action** dropdown in the Property Inspector.
+Select the mode from the **Mode** dropdown in the Property Inspector.
 
 ### Change All Tires
 


### PR DESCRIPTION
## Related Issue

Fixes #324

## What changed?

The primary top-level variant selector across action Property Inspectors used inconsistent labels (Action / Command / Control / Display Mode), which was confusing for users and made cross-action documentation harder to write. This PR standardizes all 7 affected primary selectors to `label="Mode"`.

For the 3 selectors that already used `setting="mode"` (race-admin, replay-control, session-info), this is a label-only change.

For the 4 selectors that used `setting="action"` (media-capture, pit-quick-actions, telemetry-control, tire-service), this PR also renames the Zod settings field from `action` → `mode`. Per the [scope discussion on the issue](https://github.com/niklam/iracedeck/issues/324#issuecomment-4231327077), this is paired with a one-shot in-place migration so existing user configurations are preserved with no breakage:

1. On first `onWillAppear`, each affected action runs a `migrate*LegacyAction` helper that detects raw settings with the legacy `action` key but no `mode`, copies the value across, drops `action`, and sets `mode`.
2. The migrated payload is persisted via `ev.action.setSettings(...)`. Failures are caught and warn-logged; rendering continues regardless because the in-memory migrated settings are used either way.
3. Subsequent `onDidReceiveSettings` events work directly with the new `mode` key.

Tire-service folds the new rename into its existing `migrateTireSettings` function and the existing `onWillAppear` persistence path that already handled `tires` / `toggleMode` defaults. The other 3 actions get a new top-level `migrate*LegacyAction` helper plus a small block in `onWillAppear`.

Out of scope (intentional, per the issue): secondary selectors (e.g. `audio-controls.ejs`'s sub-action selector), and the many actions whose primary selector uses non-mode keys like `setting="control"`, `"direction"`, `"navigation"`, etc. — those describe their own concept and aren't mode selectors.

Website doc (`tire-service.md`) updated to refer to the **Mode** dropdown.

## How to test

**Automated:**
- `pnpm build` — passes
- `pnpm test` — 2843 tests pass, including new migration unit tests for each of the 4 actions and an end-to-end `onWillAppear` `setSettings` test for tire-service and pit-quick-actions

**Manual (Stream Deck):**
1. Before checking out the branch, place each of the 7 affected actions (Media Capture, Pit Quick Actions, Race Admin, Replay Control, Session Info, Telemetry Control, Tire Service) on a deck and configure each with a non-default mode/action.
2. Check out this branch and rebuild the plugin.
3. Open the Property Inspector for each placed action — the top selector should be labelled **Mode** and should still display the previously-configured value.
4. For the 4 setting-key-rename actions, restart the plugin and verify (via Stream Deck's settings JSON, or by re-opening the PI) that the persisted settings now contain `mode: "..."` and no longer contain `action: "..."`.
5. Press each placed button — the action should still execute the previously-configured behavior.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests (migration helpers + e2e setSettings tests)
- [x] Changes registered in all applicable plugins (Stream Deck only — no Mirabox PI templates exist yet)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic backward compatibility for existing saved settings, ensuring legacy configurations migrate seamlessly without manual intervention.

* **Style**
  * Standardized configuration UI labels across multiple actions (Media Capture, Pit Quick Actions, Telemetry Control, Tire Service) from "Action" to "Mode" for improved clarity.

* **Documentation**
  * Updated documentation to reflect UI label terminology changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->