### PR TITLE
improve(actions): show gray N/A status bar when no telemetry (#308)

### DIFF
--- a/packages/actions/src/actions/car-control.test.ts
+++ b/packages/actions/src/actions/car-control.test.ts
@@ -6,7 +6,9 @@ import {
   generateCarControlSvg,
   getEnterExitTowState,
   getPitSpeedLimit,
+  isDrsActive,
   isPitLimiterActive,
+  isPushToPassActive,
   parsePitSpeedLimit,
   pitLimiterActiveIcon,
   pitLimiterInactiveIcon,
@@ -324,6 +326,42 @@ describe("CarControl", () => {
 
     it("should return true when pit speed limiter is set among other flags", () => {
       expect(isPitLimiterActive({ EngineWarnings: 0x0011 } as any)).toBe(true);
+    });
+  });
+
+  describe("isDrsActive", () => {
+    it("should return false when telemetry is null", () => {
+      expect(isDrsActive(null)).toBe(false);
+    });
+
+    it("should return false when DRS_Status is undefined (connected car without DRS)", () => {
+      expect(isDrsActive({} as any)).toBe(false);
+    });
+
+    it("should return false when DRS_Status is 0", () => {
+      expect(isDrsActive({ DRS_Status: 0 } as any)).toBe(false);
+    });
+
+    it("should return true when DRS_Status is greater than 0", () => {
+      expect(isDrsActive({ DRS_Status: 1 } as any)).toBe(true);
+    });
+  });
+
+  describe("isPushToPassActive", () => {
+    it("should return false when telemetry is null", () => {
+      expect(isPushToPassActive(null)).toBe(false);
+    });
+
+    it("should return false when P2P_Status is undefined (connected car without P2P)", () => {
+      expect(isPushToPassActive({} as any)).toBe(false);
+    });
+
+    it("should return false when P2P_Status is false", () => {
+      expect(isPushToPassActive({ P2P_Status: false } as any)).toBe(false);
+    });
+
+    it("should return true when P2P_Status is true", () => {
+      expect(isPushToPassActive({ P2P_Status: true } as any)).toBe(true);
     });
   });
 

--- a/packages/actions/src/actions/car-control.test.ts
+++ b/packages/actions/src/actions/car-control.test.ts
@@ -450,6 +450,64 @@ describe("CarControl", () => {
 
       expect(starter).toBe(starterDefault);
     });
+
+    it("should render DRS ON status bar when drsActive is true", () => {
+      const result = generateCarControlSvg({ control: "drs" }, { drsActive: true });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain(">ON<");
+    });
+
+    it("should render DRS OFF status bar when drsActive is false", () => {
+      const result = generateCarControlSvg({ control: "drs" }, { drsActive: false });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain(">OFF<");
+    });
+
+    it("should render DRS N/A status bar when drsActive is undefined (no telemetry)", () => {
+      const result = generateCarControlSvg({ control: "drs" }, {});
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain(">N/A<");
+      expect(decoded).not.toContain(">OFF<");
+    });
+
+    it("should render DRS N/A status bar when telemetryState is not provided", () => {
+      const result = generateCarControlSvg({ control: "drs" });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain(">N/A<");
+    });
+
+    it("should render Push-to-Pass ON status bar when pushToPassActive is true", () => {
+      const result = generateCarControlSvg({ control: "push-to-pass" }, { pushToPassActive: true });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain(">ON<");
+    });
+
+    it("should render Push-to-Pass OFF status bar when pushToPassActive is false", () => {
+      const result = generateCarControlSvg({ control: "push-to-pass" }, { pushToPassActive: false });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain(">OFF<");
+    });
+
+    it("should render Push-to-Pass N/A status bar when pushToPassActive is undefined (no telemetry)", () => {
+      const result = generateCarControlSvg({ control: "push-to-pass" }, {});
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain(">N/A<");
+      expect(decoded).not.toContain(">OFF<");
+    });
+
+    it("should render Push-to-Pass N/A status bar when telemetryState is not provided", () => {
+      const result = generateCarControlSvg({ control: "push-to-pass" });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain(">N/A<");
+    });
   });
 
   describe("telemetry-aware lifecycle", () => {

--- a/packages/actions/src/actions/car-control.ts
+++ b/packages/actions/src/actions/car-control.ts
@@ -42,7 +42,7 @@ import z from "zod";
 import drsTemplate from "../../icons/car-control-drs.svg";
 import pushToPassTemplate from "../../icons/car-control-push-to-pass.svg";
 import carControlTemplate from "../../icons/car-control.svg";
-import { borderColorForState, statusBarOff, statusBarOn } from "../icons/status-bar.js";
+import { borderColorForState, statusBarNA, statusBarOff, statusBarOn } from "../icons/status-bar.js";
 
 const WHITE = "#ffffff";
 const GRAY = "#888888";
@@ -179,8 +179,11 @@ export function pitLimiterInactiveIcon(speed: number): string {
  * @internal Exported for testing
  *
  * DRS icon — status bar only (title text handled by title settings system).
+ * Undefined `active` means no telemetry available → gray N/A.
  */
-export function drsIcon(active: boolean): string {
+export function drsIcon(active: boolean | undefined): string {
+  if (active === undefined) return statusBarNA();
+
   return active ? statusBarOn() : statusBarOff();
 }
 
@@ -188,8 +191,11 @@ export function drsIcon(active: boolean): string {
  * @internal Exported for testing
  *
  * Push To Pass icon — status bar only (title text handled by title settings system).
+ * Undefined `active` means no telemetry available → gray N/A.
  */
-export function pushToPassIcon(active: boolean): string {
+export function pushToPassIcon(active: boolean | undefined): string {
+  if (active === undefined) return statusBarNA();
+
   return active ? statusBarOn() : statusBarOff();
 }
 
@@ -353,9 +359,9 @@ export function generateCarControlSvg(settings: CarControlSettings, telemetrySta
   if (control === "push-to-pass" || control === "drs") {
     const template = control === "push-to-pass" ? pushToPassTemplate : drsTemplate;
     const colors = resolveIconColors(template, getGlobalColors(), settings.colorOverrides) as Record<string, string>;
-    const isActive =
-      control === "push-to-pass" ? (telemetryState?.pushToPassActive ?? false) : (telemetryState?.drsActive ?? false);
-    const iconContent = control === "push-to-pass" ? pushToPassIcon(isActive) : drsIcon(isActive);
+    const activeValue = control === "push-to-pass" ? telemetryState?.pushToPassActive : telemetryState?.drsActive;
+    const iconContent = control === "push-to-pass" ? pushToPassIcon(activeValue) : drsIcon(activeValue);
+    const toggleState: "on" | "off" | "na" = activeValue === undefined ? "na" : activeValue ? "on" : "off";
 
     const resolvedTitle = resolveTitleSettings(template, getGlobalTitleSettings(), settings.titleOverrides);
 
@@ -374,7 +380,7 @@ export function generateCarControlSvg(settings: CarControlSettings, telemetrySta
       template,
       getGlobalBorderSettings(),
       settings.borderOverrides,
-      borderColorForState(isActive ? "on" : "off"),
+      borderColorForState(toggleState),
     );
     const borderSvg = generateBorderParts(border);
 
@@ -659,9 +665,9 @@ export class CarControl extends ConnectionStateAwareAction<CarControlSettings> {
       state.pitLimiterActive = isPitLimiterActive(telemetry);
       state.pitSpeedLimit = getPitSpeedLimit();
     } else if (control === "push-to-pass") {
-      state.pushToPassActive = isPushToPassActive(telemetry);
+      if (telemetry) state.pushToPassActive = isPushToPassActive(telemetry);
     } else if (control === "drs") {
-      state.drsActive = isDrsActive(telemetry);
+      if (telemetry) state.drsActive = isDrsActive(telemetry);
     } else if (control === "enter-exit-tow") {
       const sessionInfo = this.sdkController.getSessionInfo();
       state.enterExitTowState = getEnterExitTowState(telemetry, sessionInfo);
@@ -701,11 +707,11 @@ export class CarControl extends ConnectionStateAwareAction<CarControlSettings> {
     }
 
     if (settings.control === "push-to-pass") {
-      return `push-to-pass|${telemetryState.pushToPassActive ?? false}|${borderKey}`;
+      return `push-to-pass|${telemetryState.pushToPassActive ?? "na"}|${borderKey}`;
     }
 
     if (settings.control === "drs") {
-      return `drs|${telemetryState.drsActive ?? false}|${borderKey}`;
+      return `drs|${telemetryState.drsActive ?? "na"}|${borderKey}`;
     }
 
     if (settings.control === "enter-exit-tow") {

--- a/packages/actions/src/actions/fuel-service.test.ts
+++ b/packages/actions/src/actions/fuel-service.test.ts
@@ -705,14 +705,21 @@ describe("FuelService", () => {
         expect(decoded).toContain("+0 L");
       });
 
-      it("should show '--' placeholder when no telemetry is available", () => {
+      it("should show '--' placeholder and N/A status bar when no telemetry is available", () => {
         const telemetryState: FuelServiceTelemetryState = {};
         const result = generateFuelServiceSvg({ mode: "toggle-fuel-fill", amount: 1, unit: "l" }, telemetryState);
         const decoded = decodeURIComponent(result);
 
         expect(decoded).toContain("--");
         expect(decoded).not.toContain("+0");
-        expect(decoded).toContain("status-off");
+        expect(decoded).toContain("status-na");
+      });
+
+      it("should show N/A status bar when telemetryState is undefined", () => {
+        const result = generateFuelServiceSvg({ mode: "toggle-fuel-fill", amount: 1, unit: "l" });
+        const decoded = decodeURIComponent(result);
+
+        expect(decoded).toContain("status-na");
       });
 
       it("should show '--' placeholder when fuelAmount is undefined but fuelFillOn is set", () => {
@@ -858,11 +865,11 @@ describe("FuelService", () => {
         expect(decoded).not.toContain("status-on");
       });
 
-      it("should show OFF status bar when no telemetry state is provided", () => {
+      it("should show N/A status bar when no telemetry state is provided", () => {
         const result = generateFuelServiceSvg({ mode: "toggle-autofuel", amount: 1, unit: "l" });
         const decoded = decodeURIComponent(result);
 
-        expect(decoded).toContain("status-off");
+        expect(decoded).toContain("status-na");
       });
 
       it("should show N/A status bar and -- text when autofuel system is not available", () => {

--- a/packages/actions/src/actions/fuel-service.ts
+++ b/packages/actions/src/actions/fuel-service.ts
@@ -306,13 +306,17 @@ export function generateFuelServiceSvg(
     let toggleState: "on" | "off" | "na";
 
     if (mode === "toggle-autofuel") {
-      if (state.autofuelEnabled === false) {
+      if (state.autofuelActive === undefined || state.autofuelEnabled === false) {
         toggleState = "na";
       } else {
         toggleState = state.autofuelActive ? "on" : "off";
       }
     } else {
-      toggleState = state.fuelFillOn ? "on" : "off";
+      if (state.fuelFillOn === undefined) {
+        toggleState = "na";
+      } else {
+        toggleState = state.fuelFillOn ? "on" : "off";
+      }
     }
 
     // Show fuel amount when available; show "--" when the system is unavailable
@@ -618,10 +622,14 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
   }
 
   private getTelemetryState(telemetry: TelemetryData | null): FuelServiceTelemetryState {
+    if (!telemetry) {
+      return {};
+    }
+
     return {
       fuelFillOn: isFuelFillOn(telemetry),
       fuelAmount: getFuelAmount(telemetry),
-      displayUnits: telemetry?.DisplayUnits,
+      displayUnits: telemetry.DisplayUnits,
       autofuelActive: isAutofuelActive(telemetry),
       autofuelEnabled: isAutofuelEnabled(telemetry),
     };
@@ -632,11 +640,11 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
     const borderKey = `${bo?.enabled ?? ""}|${bo?.borderWidth ?? ""}|${bo?.borderColor ?? ""}|${bo?.glowEnabled ?? ""}|${bo?.glowWidth ?? ""}`;
 
     if (settings.mode === "toggle-fuel-fill") {
-      return `fuel-fill|${telemetryState.fuelFillOn ?? false}|${telemetryState.fuelAmount ?? "none"}|${telemetryState.displayUnits ?? 0}|${borderKey}`;
+      return `fuel-fill|${telemetryState.fuelFillOn ?? "na"}|${telemetryState.fuelAmount ?? "none"}|${telemetryState.displayUnits ?? 0}|${borderKey}`;
     }
 
     if (settings.mode === "toggle-autofuel") {
-      return `autofuel|${telemetryState.autofuelEnabled ?? true}|${telemetryState.autofuelActive ?? false}|${telemetryState.fuelAmount ?? "none"}|${telemetryState.displayUnits ?? 0}|${borderKey}`;
+      return `autofuel|${telemetryState.autofuelEnabled ?? true}|${telemetryState.autofuelActive ?? "na"}|${telemetryState.fuelAmount ?? "none"}|${telemetryState.displayUnits ?? 0}|${borderKey}`;
     }
 
     return settings.mode;

--- a/packages/actions/src/actions/pit-quick-actions.test.ts
+++ b/packages/actions/src/actions/pit-quick-actions.test.ts
@@ -248,6 +248,38 @@ describe("PitQuickActions", () => {
       expect(decoded).not.toContain("status-on");
       expect(decoded).not.toContain("status-off");
     });
+
+    it("should show N/A status bar for windshield-tearoff when no telemetry is available", () => {
+      const telemetryState: PitQuickActionTelemetryState = {};
+      const result = generatePitQuickActionsSvg({ mode: "windshield-tearoff" }, telemetryState);
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain("status-na");
+      expect(decoded).not.toContain("status-off");
+    });
+
+    it("should show N/A status bar for windshield-tearoff when telemetryState is undefined", () => {
+      const result = generatePitQuickActionsSvg({ mode: "windshield-tearoff" });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain("status-na");
+    });
+
+    it("should show N/A status bar for fast repair when no telemetry is available", () => {
+      const telemetryState: PitQuickActionTelemetryState = {};
+      const result = generatePitQuickActionsSvg({ mode: "request-fast-repair" }, telemetryState);
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain("status-na");
+      expect(decoded).not.toContain("status-off");
+    });
+
+    it("should show N/A status bar for fast repair when telemetryState is undefined", () => {
+      const result = generatePitQuickActionsSvg({ mode: "request-fast-repair" });
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain("status-na");
+    });
   });
 
   describe("key press behavior", () => {

--- a/packages/actions/src/actions/pit-quick-actions.ts
+++ b/packages/actions/src/actions/pit-quick-actions.ts
@@ -99,9 +99,11 @@ function pitQuickActionDynamicIcon(
 ): string {
   switch (actionType) {
     case "windshield-tearoff":
+      if (telemetryState.windshieldOn === undefined) return statusBarNA();
+
       return telemetryState.windshieldOn ? statusBarOn() : statusBarOff();
     case "request-fast-repair":
-      if (telemetryState.fastRepairAvailable === false) {
+      if (telemetryState.fastRepairOn === undefined || telemetryState.fastRepairAvailable === false) {
         return statusBarNA();
       }
 
@@ -158,10 +160,14 @@ export function generatePitQuickActionsSvg(
   // Determine toggle state for border color
   let toggleState: "on" | "off" | "na";
 
-  if (actionType === "request-fast-repair" && state.fastRepairAvailable === false) {
+  if (actionType === "request-fast-repair") {
+    if (state.fastRepairOn === undefined || state.fastRepairAvailable === false) {
+      toggleState = "na";
+    } else {
+      toggleState = state.fastRepairOn ? "on" : "off";
+    }
+  } else if (state.windshieldOn === undefined) {
     toggleState = "na";
-  } else if (actionType === "request-fast-repair") {
-    toggleState = state.fastRepairOn ? "on" : "off";
   } else {
     toggleState = state.windshieldOn ? "on" : "off";
   }
@@ -303,6 +309,10 @@ export class PitQuickActions extends ConnectionStateAwareAction<PitQuickActionsS
   ): PitQuickActionTelemetryState {
     const state: PitQuickActionTelemetryState = {};
 
+    if (!telemetry) {
+      return state;
+    }
+
     if (actionType === "windshield-tearoff") {
       state.windshieldOn = isWindshieldOn(telemetry);
     } else if (actionType === "request-fast-repair") {
@@ -319,9 +329,9 @@ export class PitQuickActions extends ConnectionStateAwareAction<PitQuickActionsS
 
     switch (settings.mode) {
       case "windshield-tearoff":
-        return `windshield|${telemetryState.windshieldOn ?? false}|${borderKey}`;
+        return `windshield|${telemetryState.windshieldOn ?? "na"}|${borderKey}`;
       case "request-fast-repair":
-        return `fast-repair|${telemetryState.fastRepairOn ?? false}|${telemetryState.fastRepairAvailable ?? true}|${borderKey}`;
+        return `fast-repair|${telemetryState.fastRepairOn ?? "na"}|${telemetryState.fastRepairAvailable ?? true}|${borderKey}`;
       default:
         return settings.mode;
     }


### PR DESCRIPTION
## Related Issue

Fixes #308

## What changed?

Toggle actions (DRS, Push-to-Pass, Fuel Fill, Autofuel, Windshield Tearoff, Fast Repair) previously showed a red **OFF** status bar when iRacing was disconnected, making it impossible to tell whether the feature was actually off or simply unavailable. They now show a gray **N/A** bar when there is no telemetry at all.

Implementation:

- `car-control.ts` — `drsIcon`/`pushToPassIcon` accept `boolean | undefined`; `getTelemetryState` leaves `drsActive`/`pushToPassActive` undefined when `telemetry === null`. Border `toggleState` includes `"na"`; `buildStateKey` encodes N/A distinctly so transitions in/out of N/A trigger a redraw.
- `fuel-service.ts` — `getTelemetryState` returns `{}` when telemetry is null. The generator adds an `fuelFillOn === undefined` → N/A branch, and extends the autofuel N/A branch (previously only "system disabled") to also trigger on undefined `autofuelActive`.
- `pit-quick-actions.ts` — `getTelemetryState` returns `{}` when telemetry is null. `pitQuickActionDynamicIcon` and the border `toggleState` switch to N/A for undefined. Windshield now gets an N/A state (previously only fast-repair had one via `fastRepairAvailable`).

A telemetry-connected car that simply doesn't support a feature (e.g., `DRS_Status` undefined) still shows red OFF — N/A is reserved for "no telemetry at all", per the issue scope.

## How to test

1. Start the plugin without iRacing running. All of the affected toggle actions should show a **gray N/A** bar instead of a red OFF bar.
2. Launch iRacing and load a session. Bars should transition to green **ON** / red **OFF** based on live telemetry.
3. Exit iRacing mid-session. Bars should return to **N/A**.
4. Verify per action:
   - DRS, Push-to-Pass (car-control)
   - Fuel Fill Toggle, Toggle Autofuel (fuel-service)
   - Windshield Tearoff, Fast Repair (pit-quick-actions)
5. Confirm existing behavior still works: Fast Repair shows N/A when `FastRepairAvailable === 0` even with live telemetry; Toggle Autofuel shows N/A when the car/series has autofuel disabled.
6. Run `pnpm test` — 2843 tests pass (12 new, 2 updated).

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved telemetry handling: Status indicators now display "N/A" instead of "OFF" when telemetry data is unavailable for vehicle controls (DRS, push-to-pass), fuel management (fuel fill, auto-fuel), and pit actions (windshield tearoff, fast repair).

* **Tests**
  * Added test coverage validating proper "N/A" status display for unavailable telemetry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->