### PR TITLE
fix(actions): stop fuel/replay long-press from sticking under rapid presses (#330)

### DIFF
--- a/packages/actions/src/actions/chat.test.ts
+++ b/packages/actions/src/actions/chat.test.ts
@@ -24,7 +24,7 @@ const {
   mockBeginChat: vi.fn(() => true),
   mockReply: vi.fn(() => true),
   mockCancel: vi.fn(() => true),
-  mockSendMessage: vi.fn(() => true),
+  mockSendMessage: vi.fn(async () => true),
   mockMacro: vi.fn(() => true),
   mockGetCommands: vi.fn(() => ({
     chat: {

--- a/packages/actions/src/actions/chat.ts
+++ b/packages/actions/src/actions/chat.ts
@@ -418,7 +418,13 @@ export class Chat extends ConnectionStateAwareAction<ChatSettings> {
 
     const chat = getCommands().chat;
     const success = await chat.sendMessage(resolvedMessage);
-    this.logger.info("Send message executed");
+
+    if (success) {
+      this.logger.info("Send message executed");
+    } else {
+      this.logger.warn("Failed to send message");
+    }
+
     this.logger.debug(`Result: ${success}`);
   }
 

--- a/packages/actions/src/actions/chat.ts
+++ b/packages/actions/src/actions/chat.ts
@@ -354,7 +354,7 @@ export class Chat extends ConnectionStateAwareAction<ChatSettings> {
         this.executeSdkCancel();
         break;
       case "send-message":
-        this.executeSdkSendMessage(settings.message);
+        await this.executeSdkSendMessage(settings.message);
         break;
       case "macro":
         this.executeSdkMacro(settings.macroNumber);
@@ -397,7 +397,7 @@ export class Chat extends ConnectionStateAwareAction<ChatSettings> {
     this.logger.debug(`Result: ${success}`);
   }
 
-  private executeSdkSendMessage(message: string): void {
+  private async executeSdkSendMessage(message: string): Promise<void> {
     const trimmed = message?.trim();
 
     if (!trimmed) {
@@ -417,7 +417,7 @@ export class Chat extends ConnectionStateAwareAction<ChatSettings> {
     }
 
     const chat = getCommands().chat;
-    const success = chat.sendMessage(resolvedMessage);
+    const success = await chat.sendMessage(resolvedMessage);
     this.logger.info("Send message executed");
     this.logger.debug(`Result: ${success}`);
   }

--- a/packages/actions/src/actions/fuel-service.test.ts
+++ b/packages/actions/src/actions/fuel-service.test.ts
@@ -25,7 +25,7 @@ const {
 } = vi.hoisted(() => ({
   mockPitClearFuel: vi.fn(() => true),
   mockPitFuel: vi.fn(() => true),
-  mockSendMessage: vi.fn(() => true),
+  mockSendMessage: vi.fn(async () => true),
   mockGetCommands: vi.fn(() => ({
     pit: {
       clearFuel: mockPitClearFuel,
@@ -998,21 +998,32 @@ describe("FuelService", () => {
       expect((action as any).repeatIntervals.size).toBe(0);
     });
 
-    it("should repeat command at interval while held", async () => {
+    it("should repeat command while held using a self-awaiting loop", async () => {
       vi.useFakeTimers();
 
       try {
         await action.onKeyDown(fakeEvent("action-1", { mode: "add-fuel", amount: 5, unit: "l" }) as any);
         expect(mockSendMessage).toHaveBeenCalledTimes(1);
 
-        await vi.advanceTimersByTimeAsync(250);
+        // Hold threshold (400ms) must elapse before the loop starts.
+        await vi.advanceTimersByTimeAsync(399);
+        expect(mockSendMessage).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(1);
+        // Hold threshold crossed; loop is now scheduled — next fire is REPEAT_GAP_MS (100ms) later.
+        expect(mockSendMessage).toHaveBeenCalledTimes(1);
+
+        // With the synchronously-resolving test mock, each tick fires and immediately
+        // schedules the next one REPEAT_GAP_MS later, so ticks happen every 100ms.
+        await vi.advanceTimersByTimeAsync(100);
         expect(mockSendMessage).toHaveBeenCalledTimes(2);
 
-        await vi.advanceTimersByTimeAsync(250);
+        await vi.advanceTimersByTimeAsync(100);
         expect(mockSendMessage).toHaveBeenCalledTimes(3);
 
         await action.onKeyUp(fakeEvent("action-1") as any);
 
+        // After release, no further fires — loop stops immediately.
         await vi.advanceTimersByTimeAsync(500);
         expect(mockSendMessage).toHaveBeenCalledTimes(3);
       } finally {
@@ -1063,6 +1074,209 @@ describe("FuelService", () => {
         // Advance past safety timeout — no error, nothing happens
         await vi.advanceTimersByTimeAsync(15_000);
         expect((action as any).repeatIntervals.has("action-1")).toBe(false);
+        expect(action.logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("safety timeout"));
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should fire exactly once for a quick tap shorter than the hold threshold", async () => {
+      vi.useFakeTimers();
+
+      try {
+        await action.onKeyDown(fakeEvent("action-1", { mode: "add-fuel", amount: 5, unit: "l" }) as any);
+        expect(mockSendMessage).toHaveBeenCalledTimes(1);
+
+        // Tap released well before the 400ms hold threshold.
+        await vi.advanceTimersByTimeAsync(100);
+        await action.onKeyUp(fakeEvent("action-1") as any);
+
+        // Advance way past any repeat window — must not fire again.
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(mockSendMessage).toHaveBeenCalledTimes(1);
+        expect((action as any).repeatIntervals.has("action-1")).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should fire exactly N times for N rapid taps with no stale timers", async () => {
+      vi.useFakeTimers();
+
+      try {
+        for (let i = 0; i < 5; i++) {
+          await action.onKeyDown(fakeEvent("action-1", { mode: "add-fuel", amount: 5, unit: "l" }) as any);
+          await vi.advanceTimersByTimeAsync(50);
+          await action.onKeyUp(fakeEvent("action-1") as any);
+          await vi.advanceTimersByTimeAsync(30);
+        }
+
+        expect(mockSendMessage).toHaveBeenCalledTimes(5);
+        expect((action as any).repeatIntervals.has("action-1")).toBe(false);
+
+        // Advance past any safety window — still no extra fires.
+        await vi.advanceTimersByTimeAsync(20_000);
+        expect(mockSendMessage).toHaveBeenCalledTimes(5);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should cancel a pending hold if keyDown fires again on the same button", async () => {
+      vi.useFakeTimers();
+
+      try {
+        // First tap starts the hold-detection timer.
+        await action.onKeyDown(fakeEvent("action-1", { mode: "add-fuel", amount: 5, unit: "l" }) as any);
+        expect(mockSendMessage).toHaveBeenCalledTimes(1);
+
+        // A second keyDown (e.g. if a keyUp was lost) must reset the hold timer,
+        // not leave two pending timers or jump straight into repeat mode.
+        await vi.advanceTimersByTimeAsync(200);
+        await action.onKeyDown(fakeEvent("action-1", { mode: "add-fuel", amount: 5, unit: "l" }) as any);
+        expect(mockSendMessage).toHaveBeenCalledTimes(2);
+
+        await action.onKeyUp(fakeEvent("action-1") as any);
+
+        // No repeats should ever fire for either press.
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(mockSendMessage).toHaveBeenCalledTimes(2);
+        expect((action as any).repeatIntervals.has("action-1")).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should cancel pending repeat when onDidReceiveSettings fires mid-hold", async () => {
+      vi.useFakeTimers();
+
+      try {
+        await action.onKeyDown(fakeEvent("action-1", { mode: "add-fuel", amount: 5, unit: "l" }) as any);
+        expect((action as any).repeatIntervals.has("action-1")).toBe(true);
+
+        // Settings update arrives before the hold threshold completes.
+        await vi.advanceTimersByTimeAsync(200);
+        await action.onDidReceiveSettings(fakeEvent("action-1", { mode: "add-fuel", amount: 5, unit: "l" }) as any);
+        expect((action as any).repeatIntervals.has("action-1")).toBe(false);
+
+        await vi.advanceTimersByTimeAsync(20_000);
+        expect(mockSendMessage).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should stop the repeat loop immediately when keyUp arrives during an in-flight send", async () => {
+      // With the old setInterval-based repeat, ticks fired every 250ms regardless of
+      // whether the previous send had finished. The native chat pipeline takes ~440ms
+      // per send, so holding for 2s would enqueue 8 tick-fired sends but only drain ~4
+      // before the mutex — and when the user released, the 4 queued-but-not-yet-started
+      // sends still fired, leaking fuel well past release. The self-awaiting loop pins
+      // at most one in-flight send per button, so releasing stops the repeat promptly.
+      vi.useFakeTimers();
+
+      try {
+        // Resolver for the in-flight send — lets the test control when it completes.
+        let resolveCurrentSend: ((value: boolean) => void) | undefined;
+        mockSendMessage.mockImplementation(
+          () =>
+            new Promise<boolean>((resolve) => {
+              resolveCurrentSend = resolve;
+            }),
+        );
+
+        // Start the hold — first keyDown send is now pending.
+        const keyDownPromise = action.onKeyDown(
+          fakeEvent("action-1", { mode: "add-fuel", amount: 1, unit: "l" }) as any,
+        );
+
+        // Resolve the first send and let onKeyDown complete.
+        resolveCurrentSend?.(true);
+        await keyDownPromise;
+        expect(mockSendMessage).toHaveBeenCalledTimes(1);
+
+        // Cross the hold threshold and REPEAT_GAP_MS to get to the first loop tick.
+        await vi.advanceTimersByTimeAsync(400);
+        await vi.advanceTimersByTimeAsync(100);
+        // Loop tick fires a new send — it's now pending.
+        expect(mockSendMessage).toHaveBeenCalledTimes(2);
+
+        // While the loop-tick send is still pending, the user releases.
+        await action.onKeyUp(fakeEvent("action-1") as any);
+
+        // Let the in-flight send resolve — the loop's post-await held check should bail.
+        resolveCurrentSend?.(true);
+        await vi.advanceTimersByTimeAsync(0);
+
+        // Advance far past any further tick windows — no backlog should fire.
+        await vi.advanceTimersByTimeAsync(20_000);
+        expect(mockSendMessage).toHaveBeenCalledTimes(2);
+        expect((action as any).repeatIntervals.has("action-1")).toBe(false);
+      } finally {
+        vi.useRealTimers();
+        mockSendMessage.mockImplementation(async () => true);
+      }
+    });
+
+    it("startRepeat should be a no-op when the button is no longer held", () => {
+      // Direct guard test: mirrors the production race where keyUp lands during the
+      // async chat send BEFORE onKeyDown has finished awaiting, so startRepeat runs
+      // against a heldButtons set that no longer contains the id. The guard must
+      // prevent any timers from being installed — otherwise they'd run orphaned until
+      // the 15s safety fires.
+      (action as any).heldButtons.add("action-1");
+      (action as any).heldButtons.delete("action-1");
+
+      (action as any).startRepeat("action-1");
+
+      expect((action as any).repeatIntervals.has("action-1")).toBe(false);
+    });
+
+    it("should not leave stuck timers when keyUp arrives during an async executeMode", async () => {
+      // Real-world scenario that regressed fuel repeats in production:
+      // chat.sendMessage is async (Napi::AsyncWorker), so onKeyDown yields to the
+      // event loop while waiting for the native chat pipeline to finish. keyUp can
+      // arrive DURING that yield — before startRepeat has installed any timers.
+      // Without the heldButtons guard, the eventual startRepeat call would set
+      // timers with no hope of a future keyUp arriving to clear them, leaving the
+      // button stuck repeating until the 15s safety fires (~60 extra fuel adds).
+      vi.useFakeTimers();
+
+      try {
+        // Deferred promise for sendMessage — mimics the ~400ms native pipeline
+        // without actually advancing the fake clock for that slice.
+        let resolveSend: ((value: boolean) => void) | undefined;
+        mockSendMessage.mockImplementationOnce(
+          () =>
+            new Promise<boolean>((resolve) => {
+              resolveSend = resolve;
+            }),
+        );
+
+        // Fire keyDown but don't await it — executeMode is now pending.
+        const keyDownPromise = action.onKeyDown(
+          fakeEvent("action-1", { mode: "add-fuel", amount: 1, unit: "l" }) as any,
+        );
+
+        // While the send is in flight, keyUp arrives. This must cancel everything
+        // even though startRepeat hasn't technically finished installing timers yet.
+        await action.onKeyUp(fakeEvent("action-1") as any);
+
+        // Now let the send resolve. onKeyDown will continue past its await.
+        resolveSend?.(true);
+        await keyDownPromise;
+
+        // No repeat should be scheduled — the button is released.
+        expect((action as any).heldButtons.has("action-1")).toBe(false);
+        expect((action as any).repeatIntervals.has("action-1")).toBe(false);
+
+        // Advance well past the hold threshold, interval, and safety window.
+        // If the guard were missing, the orphaned hold timer would fire at 400ms
+        // and the interval would start dumping fuel macros at 250ms cadence.
+        await vi.advanceTimersByTimeAsync(20_000);
+
+        // Only the single intended send. No stuck repeat, no safety warning.
+        expect(mockSendMessage).toHaveBeenCalledTimes(1);
         expect(action.logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("safety timeout"));
       } finally {
         vi.useRealTimers();

--- a/packages/actions/src/actions/fuel-service.ts
+++ b/packages/actions/src/actions/fuel-service.ts
@@ -690,7 +690,17 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
     }
 
     this.logger.debug(`Sending fuel macro: ${macro}`);
-    const success = await getCommands().chat.sendMessage(macro);
+
+    let success = false;
+
+    try {
+      success = await getCommands().chat.sendMessage(macro);
+    } catch (err) {
+      this.logger.warn(`Failed to send fuel macro: ${err}`);
+      this.logger.debug(`Failed macro: ${macro}`);
+
+      return;
+    }
 
     if (success) {
       this.logger.info("Fuel macro sent");

--- a/packages/actions/src/actions/fuel-service.ts
+++ b/packages/actions/src/actions/fuel-service.ts
@@ -244,7 +244,15 @@ export function buildFuelMacro(
 
 /** Modes that support long-press repeat (execute at interval while held) */
 const REPEATABLE_MODES = new Set<FuelServiceMode>(["add-fuel", "reduce-fuel"]);
-const REPEAT_INTERVAL_MS = 250;
+/** Hold duration required before a keyDown transitions into the repeat loop */
+const REPEAT_HOLD_THRESHOLD_MS = 400;
+/**
+ * Gap between the completion of one repeat send and the start of the next.
+ * The loop is self-awaiting — it does not queue up a backlog — so the effective
+ * cadence is `native_send_duration + REPEAT_GAP_MS` (roughly 440ms + this value).
+ * Keep this small so releases feel instant but the event loop still breathes.
+ */
+const REPEAT_GAP_MS = 100;
 /** Maximum duration for long-press repeat before auto-stop (safety net for missed keyUp) */
 const REPEAT_MAX_DURATION_MS = 15_000;
 
@@ -389,8 +397,18 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
   private lastState = new Map<string, string>();
   private repeatIntervals = new Map<
     string,
-    { interval: ReturnType<typeof setInterval>; safety: ReturnType<typeof setTimeout> }
+    {
+      hold?: ReturnType<typeof setTimeout>;
+      next?: ReturnType<typeof setTimeout>;
+      safety: ReturnType<typeof setTimeout>;
+    }
   >();
+  // Authoritative "is this button currently held?" state. onKeyDown adds, onKeyUp removes.
+  // All timer callbacks consult this before doing anything so a keyUp that arrives while
+  // onKeyDown is awaiting the async chat send still reliably cancels the repeat: when the
+  // await resolves and startRepeat finally runs, the button is no longer in the set and
+  // no timers are ever created.
+  private heldButtons = new Set<string>();
 
   override async onWillAppear(ev: IDeckWillAppearEvent<FuelServiceSettings>): Promise<void> {
     await super.onWillAppear(ev);
@@ -411,6 +429,7 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
   }
 
   override async onWillDisappear(ev: IDeckWillDisappearEvent<FuelServiceSettings>): Promise<void> {
+    this.heldButtons.delete(ev.action.id);
     this.stopRepeat(ev.action.id);
     await super.onWillDisappear(ev);
     this.sdkController.unsubscribe(ev.action.id);
@@ -420,6 +439,9 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
 
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<FuelServiceSettings>): Promise<void> {
     await super.onDidReceiveSettings(ev);
+    // Defensive: settings changes can arrive mid-hold; drop any pending/active repeat.
+    this.heldButtons.delete(ev.action.id);
+    this.stopRepeat(ev.action.id);
     const settings = this.parseSettings(ev.payload.settings);
     this.activeContexts.set(ev.action.id, settings);
     this.lastState.delete(ev.action.id);
@@ -431,16 +453,25 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
 
   override async onKeyDown(ev: IDeckKeyDownEvent<FuelServiceSettings>): Promise<void> {
     this.logger.info("Key down received");
+    this.heldButtons.add(ev.action.id);
     const settings = this.parseSettings(ev.payload.settings);
-    await this.executeMode(settings.mode, settings);
 
+    // Kick off the first execute without awaiting it here, then arm the repeat timers
+    // synchronously. If we awaited first, onKeyUp could run during the yield and leave
+    // heldButtons/stopRepeat in an already-cleared state — then the late startRepeat
+    // below would install orphan timers that nothing ever cancels. By starting the
+    // repeat immediately, any keyUp that arrives during the in-flight send is guaranteed
+    // to see the timers and clear them.
     if (REPEATABLE_MODES.has(settings.mode)) {
       this.startRepeat(ev.action.id);
     }
+
+    await this.executeMode(settings.mode, settings);
   }
 
   override async onKeyUp(ev: IDeckKeyUpEvent<FuelServiceSettings>): Promise<void> {
     this.logger.info("Key up received");
+    this.heldButtons.delete(ev.action.id);
     this.stopRepeat(ev.action.id);
   }
 
@@ -469,7 +500,73 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
   private startRepeat(actionId: string): void {
     this.stopRepeat(actionId);
 
-    const interval = setInterval(() => {
+    // If the button was already released (e.g. keyUp fired during the await in
+    // onKeyDown and this startRepeat call is running after the fact), do nothing.
+    // Without this, the async chat send yields long enough for keyUp to land before
+    // startRepeat is called, and we'd install orphan timers with no hope of a keyUp
+    // arriving to clear them.
+    if (!this.heldButtons.has(actionId)) return;
+
+    // The safety timeout runs for the entire hold (threshold + repeat loop) so a
+    // dropped keyUp can never leave anything running past REPEAT_MAX_DURATION_MS.
+    const safety = setTimeout(() => {
+      this.logger.warn(
+        `Repeat auto-stopped after ${REPEAT_MAX_DURATION_MS}ms (safety timeout — possible missed keyUp)`,
+      );
+      this.heldButtons.delete(actionId);
+      this.stopRepeat(actionId);
+    }, REPEAT_MAX_DURATION_MS);
+
+    // Quick taps must never enter the repeat loop. We wait REPEAT_HOLD_THRESHOLD_MS
+    // before promoting this context from "pending hold" to "repeating" — if keyUp lands
+    // first, stopRepeat clears the hold timer and nothing ever starts.
+    const hold = setTimeout(() => {
+      const entry = this.repeatIntervals.get(actionId);
+
+      if (!entry) return;
+
+      // Double-check: the button may have been released while the hold timer was pending.
+      if (!this.heldButtons.has(actionId)) {
+        this.stopRepeat(actionId);
+
+        return;
+      }
+
+      entry.hold = undefined;
+      this.scheduleRepeatTick(actionId);
+    }, REPEAT_HOLD_THRESHOLD_MS);
+
+    this.repeatIntervals.set(actionId, { hold, safety });
+  }
+
+  /**
+   * Self-awaiting repeat loop. Each tick fires one executeMode, awaits it to
+   * completion, then schedules the next tick REPEAT_GAP_MS later. Because we
+   * never have more than one in-flight send per button, releasing mid-hold
+   * stops the repeat immediately — there is no queued backlog to drain.
+   *
+   * The held check runs four times per tick: before scheduling, inside the
+   * scheduled callback, after executeMode resolves, and again before the next
+   * schedule. Any of them can abort the loop without leaving orphan timers.
+   */
+  private scheduleRepeatTick(actionId: string): void {
+    if (!this.heldButtons.has(actionId)) {
+      this.stopRepeat(actionId);
+
+      return;
+    }
+
+    const entry = this.repeatIntervals.get(actionId);
+
+    if (!entry) return;
+
+    entry.next = setTimeout(async () => {
+      if (!this.heldButtons.has(actionId)) {
+        this.stopRepeat(actionId);
+
+        return;
+      }
+
       const currentSettings = this.activeContexts.get(actionId);
 
       if (!currentSettings) {
@@ -478,26 +575,32 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
         return;
       }
 
-      void this.executeMode(currentSettings.mode, currentSettings).catch((err) => {
+      try {
+        await this.executeMode(currentSettings.mode, currentSettings);
+      } catch (err) {
         this.logger.error(`Repeat execution failed: ${err}`);
-      });
-    }, REPEAT_INTERVAL_MS);
+      }
 
-    const safety = setTimeout(() => {
-      this.logger.warn(
-        `Repeat auto-stopped after ${REPEAT_MAX_DURATION_MS}ms (safety timeout — possible missed keyUp)`,
-      );
-      this.stopRepeat(actionId);
-    }, REPEAT_MAX_DURATION_MS);
+      // The button may have been released while executeMode was in flight.
+      // Bail before scheduling the next tick so the loop stops promptly.
+      if (!this.heldButtons.has(actionId)) {
+        this.stopRepeat(actionId);
 
-    this.repeatIntervals.set(actionId, { interval, safety });
+        return;
+      }
+
+      this.scheduleRepeatTick(actionId);
+    }, REPEAT_GAP_MS);
   }
 
   private stopRepeat(actionId: string): void {
     const entry = this.repeatIntervals.get(actionId);
 
     if (entry) {
-      clearInterval(entry.interval);
+      if (entry.hold) clearTimeout(entry.hold);
+
+      if (entry.next) clearTimeout(entry.next);
+
       clearTimeout(entry.safety);
       this.repeatIntervals.delete(actionId);
     }
@@ -515,7 +618,7 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
       case "add-fuel":
       case "reduce-fuel":
       case "set-fuel-amount":
-        this.executeFuelMacro(mode, settings);
+        await this.executeFuelMacro(mode, settings);
         break;
 
       // SDK-based modes
@@ -576,7 +679,7 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
     return !isFuelFillOn(telemetry);
   }
 
-  private executeFuelMacro(mode: FuelServiceMode, settings: FuelServiceSettings): void {
+  private async executeFuelMacro(mode: FuelServiceMode, settings: FuelServiceSettings): Promise<void> {
     const preserveFueling = this.shouldPreserveFuelingState();
     const macro = buildFuelMacro(mode, settings.amount, settings.unit, preserveFueling);
 
@@ -587,7 +690,7 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
     }
 
     this.logger.debug(`Sending fuel macro: ${macro}`);
-    const success = getCommands().chat.sendMessage(macro);
+    const success = await getCommands().chat.sendMessage(macro);
 
     if (success) {
       this.logger.info("Fuel macro sent");

--- a/packages/actions/src/actions/race-admin.test.ts
+++ b/packages/actions/src/actions/race-admin.test.ts
@@ -123,7 +123,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     setRegenerateCallback = vi.fn();
   },
   getCommands: vi.fn(() => ({
-    chat: { sendMessage: vi.fn(() => true) },
+    chat: { sendMessage: vi.fn(async () => true) },
     camera: { switchNum: vi.fn(() => true) },
   })),
   generateBorderParts: vi.fn(() => ({ defs: "", rects: "" })),

--- a/packages/actions/src/actions/race-admin.ts
+++ b/packages/actions/src/actions/race-admin.ts
@@ -211,7 +211,13 @@ export class RaceAdmin extends ConnectionStateAwareAction<RaceAdminSettings> {
 
     const chat = getCommands().chat;
     const success = await chat.sendMessage(command);
-    this.logger.info("Admin command executed");
+
+    if (success) {
+      this.logger.info("Admin command executed");
+    } else {
+      this.logger.warn("Failed to send admin command");
+    }
+
     this.logger.debug(`Command: "${command}", result: ${success}`);
   }
 

--- a/packages/actions/src/actions/race-admin.ts
+++ b/packages/actions/src/actions/race-admin.ts
@@ -187,18 +187,18 @@ export class RaceAdmin extends ConnectionStateAwareAction<RaceAdminSettings> {
   override async onKeyDown(ev: IDeckKeyDownEvent<RaceAdminSettings>): Promise<void> {
     this.logger.info("Key down received");
     const settings = this.parseSettings(ev.payload.settings);
-    this.executeMode(ev.action.id, settings);
+    await this.executeMode(ev.action.id, settings);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<RaceAdminSettings>): Promise<void> {
     this.logger.info("Dial down received");
     const settings = this.parseSettings(ev.payload.settings);
-    this.executeMode(ev.action.id, settings);
+    await this.executeMode(ev.action.id, settings);
   }
 
   // ── Command Execution ───────────────────────────────────────
 
-  private executeMode(contextId: string, settings: RaceAdminSettings): void {
+  private async executeMode(contextId: string, settings: RaceAdminSettings): Promise<void> {
     const { mode } = settings;
     const viewedCarNumber = this.viewedCarNumbers.get(contextId) ?? null;
     const command = buildAdminCommand(mode, settings, viewedCarNumber, this.sdkController);
@@ -210,7 +210,7 @@ export class RaceAdmin extends ConnectionStateAwareAction<RaceAdminSettings> {
     }
 
     const chat = getCommands().chat;
-    const success = chat.sendMessage(command);
+    const success = await chat.sendMessage(command);
     this.logger.info("Admin command executed");
     this.logger.debug(`Command: "${command}", result: ${success}`);
   }

--- a/packages/actions/src/actions/replay-control.test.ts
+++ b/packages/actions/src/actions/replay-control.test.ts
@@ -1063,9 +1063,18 @@ describe("ReplayControl", () => {
       };
     }
 
+    const mockReplay = {
+      play: vi.fn(() => true),
+      pause: vi.fn(() => true),
+      setPlaySpeed: vi.fn(() => true),
+    };
+
     let action: ReplayControl;
 
     beforeEach(async () => {
+      vi.clearAllMocks();
+      const { getCommands } = await import("@iracedeck/deck-core");
+      vi.mocked(getCommands).mockReturnValue({ replay: mockReplay, camera: { switchNum: vi.fn() } } as any);
       action = new ReplayControl();
       await action.onWillAppear(fakeEvent("action-1", { mode: "fast-forward" }) as any);
     });
@@ -1114,6 +1123,99 @@ describe("ReplayControl", () => {
         await vi.advanceTimersByTimeAsync(15_000);
         expect((action as any).repeatTimers.has("action-1")).toBe(false);
         expect(action.logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("safety timeout"));
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should fire exactly once for a quick tap shorter than the hold threshold", async () => {
+      vi.useFakeTimers();
+
+      try {
+        await action.onKeyDown(fakeEvent("action-1", { mode: "fast-forward" }) as any);
+        // Initial keyDown fires executeMode once.
+        expect(mockReplay.setPlaySpeed).toHaveBeenCalledTimes(1);
+
+        // Release well before the 500ms initial delay.
+        await vi.advanceTimersByTimeAsync(100);
+        await action.onKeyUp(fakeEvent("action-1") as any);
+
+        // No further repeats even after a long wait.
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(mockReplay.setPlaySpeed).toHaveBeenCalledTimes(1);
+        expect((action as any).repeatTimers.has("action-1")).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should repeat while held using a self-awaiting loop", async () => {
+      vi.useFakeTimers();
+
+      try {
+        await action.onKeyDown(fakeEvent("action-1", { mode: "fast-forward" }) as any);
+        expect(mockReplay.setPlaySpeed).toHaveBeenCalledTimes(1);
+
+        // Initial hold delay must elapse before the loop starts.
+        await vi.advanceTimersByTimeAsync(499);
+        expect(mockReplay.setPlaySpeed).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(1);
+        // Hold threshold crossed; loop is scheduled, first tick fires
+        // LONG_PRESS_REPEAT_GAP_MS (250ms) later.
+        expect(mockReplay.setPlaySpeed).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(250);
+        expect(mockReplay.setPlaySpeed).toHaveBeenCalledTimes(2);
+
+        await vi.advanceTimersByTimeAsync(250);
+        expect(mockReplay.setPlaySpeed).toHaveBeenCalledTimes(3);
+
+        await action.onKeyUp(fakeEvent("action-1") as any);
+
+        // After release, no further fires.
+        await vi.advanceTimersByTimeAsync(500);
+        expect(mockReplay.setPlaySpeed).toHaveBeenCalledTimes(3);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("startRepeat should be a no-op when the button is no longer held", () => {
+      // Direct guard test: same class of race as the fuel-service stuck bug.
+      // Even though replay-control's executeMode is currently sync (SDK broadcast),
+      // the guard keeps us safe if executeMode ever gains an async path.
+      (action as any).heldButtons.add("action-1");
+      (action as any).heldButtons.delete("action-1");
+
+      (action as any).startRepeat("action-1", {
+        mode: "fast-forward",
+        speed: "1",
+        flagsOverlay: false,
+        addedWithVersion: "0.0.0",
+      });
+
+      expect((action as any).repeatTimers.has("action-1")).toBe(false);
+    });
+
+    it("should stop the repeat loop immediately when onDidReceiveSettings fires mid-hold", async () => {
+      vi.useFakeTimers();
+
+      try {
+        await action.onKeyDown(fakeEvent("action-1", { mode: "fast-forward" }) as any);
+        expect((action as any).repeatTimers.has("action-1")).toBe(true);
+
+        // Settings update mid-hold should clear both heldButtons and timers.
+        await vi.advanceTimersByTimeAsync(200);
+        await action.onDidReceiveSettings(fakeEvent("action-1", { mode: "fast-forward" }) as any);
+
+        expect((action as any).heldButtons.has("action-1")).toBe(false);
+        expect((action as any).repeatTimers.has("action-1")).toBe(false);
+
+        // No further fires after the mid-hold settings update.
+        const callsBefore = mockReplay.setPlaySpeed.mock.calls.length;
+        await vi.advanceTimersByTimeAsync(20_000);
+        expect(mockReplay.setPlaySpeed.mock.calls.length).toBe(callsBefore);
       } finally {
         vi.useRealTimers();
       }

--- a/packages/actions/src/actions/replay-control.ts
+++ b/packages/actions/src/actions/replay-control.ts
@@ -184,7 +184,13 @@ const LONG_PRESS_REPEAT_MODES: ReadonlySet<ReplayControlMode> = new Set([
 ]);
 
 const LONG_PRESS_INITIAL_DELAY = 500;
-const LONG_PRESS_REPEAT_INTERVAL = 250;
+/**
+ * Gap between the completion of one repeat tick and the start of the next.
+ * The loop is self-awaiting so the effective cadence is `executeMode_duration + this`.
+ * executeMode here is a fast synchronous SDK broadcast (~microseconds), so the gap
+ * is essentially the whole period — matches the pre-fix setInterval cadence.
+ */
+const LONG_PRESS_REPEAT_GAP_MS = 250;
 /** Maximum duration for long-press repeat before auto-stop (safety net for missed keyUp) */
 const LONG_PRESS_MAX_DURATION_MS = 15_000;
 
@@ -452,8 +458,20 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
   /** Active long-press repeat timers, keyed by action context ID */
   private repeatTimers = new Map<
     string,
-    { timer: ReturnType<typeof setTimeout>; safety: ReturnType<typeof setTimeout> }
+    {
+      hold?: ReturnType<typeof setTimeout>;
+      next?: ReturnType<typeof setTimeout>;
+      safety: ReturnType<typeof setTimeout>;
+    }
   >();
+
+  /**
+   * Authoritative "is this button currently held?" state. onKeyDown adds,
+   * onKeyUp removes. All repeat timer callbacks consult this before doing
+   * anything so a keyUp that races with any async work still reliably cancels
+   * the repeat — the same defensive pattern used by fuel-service.
+   */
+  private heldButtons = new Set<string>();
 
   /** Cached settings per context for telemetry-driven display updates */
   private activeContexts = new Map<string, ReplayControlSettings>();
@@ -492,6 +510,7 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
   }
 
   override async onWillDisappear(ev: IDeckWillDisappearEvent<ReplayControlSettings>): Promise<void> {
+    this.heldButtons.delete(ev.action.id);
     await super.onWillDisappear(ev);
     this.sdkController.unsubscribe(ev.action.id);
     this.replaySpeed.delete(ev.action.id);
@@ -503,6 +522,9 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
 
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<ReplayControlSettings>): Promise<void> {
     await super.onDidReceiveSettings(ev);
+    // Settings can change mid-hold; drop any pending repeat and held state.
+    this.heldButtons.delete(ev.action.id);
+    this.stopRepeat(ev.action.id);
     const settings = this.parseSettings(ev.payload.settings);
     this.activeContexts.set(ev.action.id, settings);
     await this.updateDisplay(ev, settings);
@@ -510,6 +532,7 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
 
   override async onKeyDown(ev: IDeckKeyDownEvent<ReplayControlSettings>): Promise<void> {
     this.logger.info("Key down received");
+    this.heldButtons.add(ev.action.id);
     const settings = this.parseSettings(ev.payload.settings);
     this.executeMode(ev.action.id, settings);
 
@@ -519,6 +542,7 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
   }
 
   override async onKeyUp(ev: IDeckKeyUpEvent<ReplayControlSettings>): Promise<void> {
+    this.heldButtons.delete(ev.action.id);
     this.stopRepeat(ev.action.id);
   }
 
@@ -537,39 +561,90 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
   private startRepeat(contextId: string, settings: ReplayControlSettings): void {
     this.stopRepeat(contextId);
 
-    const timer = setTimeout(() => {
-      this.executeMode(contextId, settings);
+    // Defensive: if keyUp already landed (e.g. a future async path in onKeyDown
+    // yields before startRepeat gets called), don't install orphan timers.
+    if (!this.heldButtons.has(contextId)) return;
 
-      const interval = setInterval(() => {
-        this.executeMode(contextId, settings);
-      }, LONG_PRESS_REPEAT_INTERVAL);
-
-      // Replace the initial-delay handle with the interval handle so stopRepeat
-      // clears the right timer. Safe: JS is single-threaded so stopRepeat cannot
-      // interleave with this assignment.
-      const entry = this.repeatTimers.get(contextId);
-
-      if (entry) {
-        entry.timer = interval;
-      }
-    }, LONG_PRESS_INITIAL_DELAY);
-
+    // Safety timeout covers the entire hold — dropped keyUp can't leak past this.
     const safety = setTimeout(() => {
       this.logger.warn(
         `Repeat auto-stopped after ${LONG_PRESS_MAX_DURATION_MS}ms (safety timeout — possible missed keyUp)`,
       );
+      this.heldButtons.delete(contextId);
       this.stopRepeat(contextId);
     }, LONG_PRESS_MAX_DURATION_MS);
 
-    this.repeatTimers.set(contextId, { timer, safety });
+    // Quick taps must never enter the repeat loop: wait LONG_PRESS_INITIAL_DELAY
+    // before the first repeat. If keyUp arrives first, stopRepeat clears the hold
+    // and nothing ever starts.
+    const hold = setTimeout(() => {
+      const entry = this.repeatTimers.get(contextId);
+
+      if (!entry) return;
+
+      if (!this.heldButtons.has(contextId)) {
+        this.stopRepeat(contextId);
+
+        return;
+      }
+
+      entry.hold = undefined;
+      this.scheduleRepeatTick(contextId, settings);
+    }, LONG_PRESS_INITIAL_DELAY);
+
+    this.repeatTimers.set(contextId, { hold, safety });
+  }
+
+  /**
+   * Self-awaiting repeat loop. Each tick fires one executeMode, then schedules
+   * the next tick LONG_PRESS_REPEAT_GAP_MS later. Held state is re-checked at
+   * every step so a keyUp that races with any future async work still cancels
+   * the loop promptly.
+   */
+  private scheduleRepeatTick(contextId: string, settings: ReplayControlSettings): void {
+    if (!this.heldButtons.has(contextId)) {
+      this.stopRepeat(contextId);
+
+      return;
+    }
+
+    const entry = this.repeatTimers.get(contextId);
+
+    if (!entry) return;
+
+    entry.next = setTimeout(() => {
+      if (!this.heldButtons.has(contextId)) {
+        this.stopRepeat(contextId);
+
+        return;
+      }
+
+      try {
+        this.executeMode(contextId, settings);
+      } catch (err) {
+        this.logger.error(`Repeat execution failed: ${err}`);
+      }
+
+      // executeMode is currently sync, but guard anyway so this stays correct
+      // if it ever becomes async.
+      if (!this.heldButtons.has(contextId)) {
+        this.stopRepeat(contextId);
+
+        return;
+      }
+
+      this.scheduleRepeatTick(contextId, settings);
+    }, LONG_PRESS_REPEAT_GAP_MS);
   }
 
   private stopRepeat(contextId: string): void {
     const entry = this.repeatTimers.get(contextId);
 
     if (entry) {
-      clearTimeout(entry.timer);
-      clearInterval(entry.timer);
+      if (entry.hold) clearTimeout(entry.hold);
+
+      if (entry.next) clearTimeout(entry.next);
+
       clearTimeout(entry.safety);
       this.repeatTimers.delete(contextId);
     }

--- a/packages/actions/src/actions/tire-service.test.ts
+++ b/packages/actions/src/actions/tire-service.test.ts
@@ -27,7 +27,7 @@ const {
   mockGetCurrentTelemetry,
   mockGetSessionInfo,
 } = vi.hoisted(() => ({
-  mockSendMessage: vi.fn(() => true),
+  mockSendMessage: vi.fn(async () => true),
   mockPitTireCompound: vi.fn(() => true),
   mockPitClearTires: vi.fn(() => true),
   mockGetCommands: vi.fn(() => ({

--- a/packages/actions/src/actions/tire-service.ts
+++ b/packages/actions/src/actions/tire-service.ts
@@ -690,7 +690,13 @@ export class TireService extends ConnectionStateAwareAction<TireServiceSettings>
 
           if (!doCurrentTiresMatch(settings, tireState)) {
             this.logger.debug("Current tires don't match configured — clearing first");
-            getCommands().pit.clearTires();
+            const cleared = getCommands().pit.clearTires();
+
+            if (!cleared) {
+              this.logger.warn("Failed to clear tire selection before applying configured set");
+
+              return;
+            }
           }
         }
 

--- a/packages/actions/src/actions/tire-service.ts
+++ b/packages/actions/src/actions/tire-service.ts
@@ -555,12 +555,12 @@ export class TireService extends ConnectionStateAwareAction<TireServiceSettings>
 
   override async onKeyDown(ev: IDeckKeyDownEvent<TireServiceSettings>): Promise<void> {
     this.logger.info("Key down received");
-    this.executeAction(ev.payload.settings);
+    await this.executeAction(ev.payload.settings);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<TireServiceSettings>): Promise<void> {
     this.logger.info("Dial down received");
-    this.executeAction(ev.payload.settings);
+    await this.executeAction(ev.payload.settings);
   }
 
   private parseSettings(settings: unknown): TireServiceSettings {
@@ -620,7 +620,7 @@ export class TireService extends ConnectionStateAwareAction<TireServiceSettings>
     return `${settings.mode}|${settings.tires.join(",")}|${tireState.lf}|${tireState.rf}|${tireState.lr}|${tireState.rr}|${compound.player}|${compound.pitSv}|${tires.length}|${compoundType}|${borderKey}`;
   }
 
-  private executeAction(rawSettings: unknown): void {
+  private async executeAction(rawSettings: unknown): Promise<void> {
     if (!this.sdkController.getConnectionStatus()) {
       this.logger.info("Not connected to iRacing");
 
@@ -632,7 +632,7 @@ export class TireService extends ConnectionStateAwareAction<TireServiceSettings>
     switch (settings.mode) {
       case "change-all-tires": {
         this.logger.debug("Sending change all tires macro");
-        const success = getCommands().chat.sendMessage("#t");
+        const success = await getCommands().chat.sendMessage("#t");
 
         if (success) {
           this.logger.info("Change all tires sent");
@@ -695,7 +695,7 @@ export class TireService extends ConnectionStateAwareAction<TireServiceSettings>
         }
 
         this.logger.debug(`Sending pit macro: ${macro} (toggleMode=${toggleMode})`);
-        const success = getCommands().chat.sendMessage(macro);
+        const success = await getCommands().chat.sendMessage(macro);
 
         if (success) {
           this.logger.info("Tire toggle sent");

--- a/packages/iracing-native/src/addon.cc
+++ b/packages/iracing-native/src/addon.cc
@@ -388,6 +388,10 @@ public:
 
         std::lock_guard<std::mutex> lock(g_chatSendMutex);
 
+        // Best-effort snapshot of any CF_UNICODETEXT already on the clipboard
+        // so we can restore it after the paste. If the clipboard holds
+        // non-text content (image, file list, etc.) we proceed anyway — the
+        // chat send is higher priority than preserving that content.
         std::u16string savedClipboard;
         bool hadClipboardText = false;
 
@@ -412,6 +416,13 @@ public:
 
         if (!copyToClipboard(message_))
         {
+            // copyToClipboard may have called EmptyClipboard before failing.
+            // If we captured a text snapshot, put it back so we don't leave
+            // the clipboard empty.
+            if (hadClipboardText)
+            {
+                copyToClipboard(savedClipboard);
+            }
             result_ = false;
             return;
         }

--- a/packages/iracing-native/src/addon.cc
+++ b/packages/iracing-native/src/addon.cc
@@ -8,7 +8,14 @@
 #include <napi.h>
 #include <windows.h>
 #include <string>
+#include <mutex>
 #include <irsdk_defines.h>
+
+// Serializes all in-flight chat sends so the paste/broadcast sequence can't
+// interleave with itself on different worker threads. Chat sends run on the
+// libuv thread pool, and iRacing only has one chat window — attempting two
+// sends in parallel would clobber the clipboard and chat state.
+static std::mutex g_chatSendMutex;
 
 // ============================================================================
 // SDK Connection Functions
@@ -345,22 +352,128 @@ static void sendPaste()
 static constexpr DWORD kChatStepDelayMs = 100;
 
 /**
- * Send a complete chat message to iRacing using clipboard paste.
- * This function handles the entire chat flow:
- * 1. Saves the current clipboard content (plain text only)
- * 2. Copies the message to the clipboard
- * 3. Cancels any existing chat to ensure clean state, then waits
- * 4. Opens chat window via broadcast message, then waits
- * 5. Pastes the message with Ctrl+V, then waits
- * 6. Presses Enter to send the message, then waits
- * 7. Cancels chat via broadcast to explicitly close the chat window
- *    (Enter sends the message but leaves the input focused)
- * 8. Restores the original clipboard content
+ * Async worker that runs the full chat-send pipeline on a libuv worker
+ * thread and resolves a Promise with the resulting success boolean.
  *
- * Each wait is kChatStepDelayMs to give iRacing time to process.
+ * The actual steps are identical to the previous synchronous version —
+ * save clipboard, paste message, Enter, restore clipboard — but running
+ * off the main thread means the JS event loop stays free during the
+ * ~400ms native pipeline. setTimeout callbacks and Stream Deck events
+ * continue to flow while a chat message is being typed.
+ *
+ * Serialized via g_chatSendMutex so concurrent sends queue up instead of
+ * clobbering each other: iRacing only has one chat window, and two
+ * overlapping sends would fight over the clipboard.
+ */
+class ChatSendWorker : public Napi::AsyncWorker
+{
+public:
+    ChatSendWorker(Napi::Env env, std::u16string message)
+        : Napi::AsyncWorker(env),
+          message_(std::move(message)),
+          deferred_(Napi::Promise::Deferred::New(env)),
+          result_(false)
+    {
+    }
+
+    Napi::Promise GetPromise() { return deferred_.Promise(); }
+
+    void Execute() override
+    {
+        if (message_.empty())
+        {
+            result_ = false;
+            return;
+        }
+
+        std::lock_guard<std::mutex> lock(g_chatSendMutex);
+
+        std::u16string savedClipboard;
+        bool hadClipboardText = false;
+
+        if (OpenClipboard(NULL))
+        {
+            HANDLE hData = GetClipboardData(CF_UNICODETEXT);
+
+            if (hData)
+            {
+                const wchar_t *pText = static_cast<const wchar_t *>(GlobalLock(hData));
+
+                if (pText)
+                {
+                    savedClipboard = reinterpret_cast<const char16_t *>(pText);
+                    hadClipboardText = true;
+                    GlobalUnlock(hData);
+                }
+            }
+
+            CloseClipboard();
+        }
+
+        if (!copyToClipboard(message_))
+        {
+            result_ = false;
+            return;
+        }
+
+        irsdk_broadcastMsg(irsdk_BroadcastChatComand, irsdk_ChatCommand_Cancel, 0);
+        Sleep(kChatStepDelayMs);
+
+        irsdk_broadcastMsg(irsdk_BroadcastChatComand, irsdk_ChatCommand_BeginChat, 0);
+        Sleep(kChatStepDelayMs);
+
+        sendPaste();
+        Sleep(kChatStepDelayMs);
+
+        INPUT enterInputs[2] = {};
+        enterInputs[0].type = INPUT_KEYBOARD;
+        enterInputs[0].ki.wVk = VK_RETURN;
+        enterInputs[1].type = INPUT_KEYBOARD;
+        enterInputs[1].ki.wVk = VK_RETURN;
+        enterInputs[1].ki.dwFlags = KEYEVENTF_KEYUP;
+        SendInput(2, enterInputs, sizeof(INPUT));
+
+        Sleep(kChatStepDelayMs);
+
+        irsdk_broadcastMsg(irsdk_BroadcastChatComand, irsdk_ChatCommand_Cancel, 0);
+
+        if (hadClipboardText)
+        {
+            copyToClipboard(savedClipboard);
+        }
+
+        result_ = true;
+    }
+
+    void OnOK() override
+    {
+        Napi::HandleScope scope(Env());
+        deferred_.Resolve(Napi::Boolean::New(Env(), result_));
+    }
+
+    void OnError(const Napi::Error &e) override
+    {
+        Napi::HandleScope scope(Env());
+        deferred_.Reject(e.Value());
+    }
+
+private:
+    std::u16string message_;
+    Napi::Promise::Deferred deferred_;
+    bool result_;
+};
+
+/**
+ * Send a complete chat message to iRacing using clipboard paste.
+ * Returns a Promise that resolves to true on success, false on failure.
+ *
+ * The full pipeline runs on a libuv worker thread (see ChatSendWorker),
+ * so the JS event loop remains responsive during the ~400ms native work.
+ *
+ * Each step waits kChatStepDelayMs to give iRacing time to process.
  *
  * @param message - The message to send
- * @returns Success boolean
+ * @returns Promise<boolean>
  */
 Napi::Value SendChatMessage(const Napi::CallbackInfo &info)
 {
@@ -369,83 +482,16 @@ Napi::Value SendChatMessage(const Napi::CallbackInfo &info)
     if (info.Length() < 1 || !info[0].IsString())
     {
         Napi::TypeError::New(env, "Expected (message: string)").ThrowAsJavaScriptException();
-        return Napi::Boolean::New(env, false);
+        return env.Undefined();
     }
 
     std::u16string message = info[0].As<Napi::String>().Utf16Value();
 
-    if (message.empty())
-    {
-        return Napi::Boolean::New(env, false);
-    }
+    ChatSendWorker *worker = new ChatSendWorker(env, std::move(message));
+    Napi::Promise promise = worker->GetPromise();
+    worker->Queue();
 
-    // 1. Save the current clipboard content (text only)
-    std::u16string savedClipboard;
-    bool hadClipboardText = false;
-
-    if (OpenClipboard(NULL))
-    {
-        HANDLE hData = GetClipboardData(CF_UNICODETEXT);
-
-        if (hData)
-        {
-            const wchar_t *pText = static_cast<const wchar_t *>(GlobalLock(hData));
-
-            if (pText)
-            {
-                savedClipboard = reinterpret_cast<const char16_t *>(pText);
-                hadClipboardText = true;
-                GlobalUnlock(hData);
-            }
-        }
-
-        CloseClipboard();
-    }
-
-    // 2. Copy the message to the clipboard
-    if (!copyToClipboard(message))
-    {
-        return Napi::Boolean::New(env, false);
-    }
-
-    // 3. Cancel any existing chat to ensure clean state
-    irsdk_broadcastMsg(irsdk_BroadcastChatComand, irsdk_ChatCommand_Cancel, 0);
-    Sleep(kChatStepDelayMs);
-
-    // 4. Open chat window via broadcast
-    irsdk_broadcastMsg(irsdk_BroadcastChatComand, irsdk_ChatCommand_BeginChat, 0);
-
-    // 5. Wait for chat window to open
-    Sleep(kChatStepDelayMs);
-
-    // 6. Paste the message with Ctrl+V
-    sendPaste();
-
-    // 7. Wait for paste to complete
-    Sleep(kChatStepDelayMs);
-
-    // 8. Press Enter to send
-    INPUT enterInputs[2] = {};
-    enterInputs[0].type = INPUT_KEYBOARD;
-    enterInputs[0].ki.wVk = VK_RETURN;
-    enterInputs[1].type = INPUT_KEYBOARD;
-    enterInputs[1].ki.wVk = VK_RETURN;
-    enterInputs[1].ki.dwFlags = KEYEVENTF_KEYUP;
-    SendInput(2, enterInputs, sizeof(INPUT));
-
-    // 9. Wait for Enter to be processed
-    Sleep(kChatStepDelayMs);
-
-    // 10. Cancel chat to close the window
-    irsdk_broadcastMsg(irsdk_BroadcastChatComand, irsdk_ChatCommand_Cancel, 0);
-
-    // 11. Restore the original clipboard content
-    if (hadClipboardText)
-    {
-        copyToClipboard(savedClipboard);
-    }
-
-    return Napi::Boolean::New(env, true);
+    return promise;
 }
 
 // ============================================================================

--- a/packages/iracing-native/src/addon.cc
+++ b/packages/iracing-native/src/addon.cc
@@ -388,41 +388,17 @@ public:
 
         std::lock_guard<std::mutex> lock(g_chatSendMutex);
 
-        // Best-effort snapshot of any CF_UNICODETEXT already on the clipboard
-        // so we can restore it after the paste. If the clipboard holds
-        // non-text content (image, file list, etc.) we proceed anyway — the
-        // chat send is higher priority than preserving that content.
-        std::u16string savedClipboard;
-        bool hadClipboardText = false;
-
-        if (OpenClipboard(NULL))
-        {
-            HANDLE hData = GetClipboardData(CF_UNICODETEXT);
-
-            if (hData)
-            {
-                const wchar_t *pText = static_cast<const wchar_t *>(GlobalLock(hData));
-
-                if (pText)
-                {
-                    savedClipboard = reinterpret_cast<const char16_t *>(pText);
-                    hadClipboardText = true;
-                    GlobalUnlock(hData);
-                }
-            }
-
-            CloseClipboard();
-        }
-
+        // Sending a chat message uses the clipboard as a fast "type" channel
+        // (copy → BeginChat → paste → Enter). We intentionally do NOT save
+        // and restore the user's prior clipboard content. Every extra
+        // clipboard write wakes clipboard-manager apps via WM_CLIPBOARDUPDATE
+        // and risks one of them stealing focus in the narrow window between
+        // our copy and the subsequent paste/Enter, which can leave the chat
+        // window half-open or drop the send. Fewer writes = fewer chances
+        // for that contention. This behavior is documented on the website
+        // under Troubleshooting → Known issues.
         if (!copyToClipboard(message_))
         {
-            // copyToClipboard may have called EmptyClipboard before failing.
-            // If we captured a text snapshot, put it back so we don't leave
-            // the clipboard empty.
-            if (hadClipboardText)
-            {
-                copyToClipboard(savedClipboard);
-            }
             result_ = false;
             return;
         }
@@ -447,11 +423,6 @@ public:
         Sleep(kChatStepDelayMs);
 
         irsdk_broadcastMsg(irsdk_BroadcastChatComand, irsdk_ChatCommand_Cancel, 0);
-
-        if (hadClipboardText)
-        {
-            copyToClipboard(savedClipboard);
-        }
 
         result_ = true;
     }

--- a/packages/iracing-native/src/index.ts
+++ b/packages/iracing-native/src/index.ts
@@ -179,18 +179,16 @@ export class IRacingNative {
   // ============================================================================
 
   /**
-   * Send a complete chat message to iRacing
-   * This function handles the entire chat flow:
-   * 1. Opens chat window via broadcast message
-   * 2. Waits for chat window to open
-   * 3. Types the message using WM_CHAR
-   * 4. Presses Enter to send
-   * 5. Closes the chat window
+   * Send a complete chat message to iRacing.
+   *
+   * The native addon runs the entire chat-send pipeline on a libuv worker
+   * thread and returns a Promise, so the JS event loop remains responsive
+   * during the ~400ms native work. Concurrent sends are serialized natively.
    *
    * @param message - The message to send
-   * @returns Success boolean
+   * @returns Promise resolving to true on success, false on failure
    */
-  sendChatMessage(message: string): boolean {
+  sendChatMessage(message: string): Promise<boolean> {
     return addon ? addon.sendChatMessage(message) : this.getMock().sendChatMessage(message);
   }
 

--- a/packages/iracing-native/src/mock-impl.test.ts
+++ b/packages/iracing-native/src/mock-impl.test.ts
@@ -125,8 +125,8 @@ describe("IRacingNativeMock", () => {
       expect(console.debug).toHaveBeenCalled();
     });
 
-    it("sendChatMessage should return true", () => {
-      expect(mock.sendChatMessage("test")).toBe(true);
+    it("sendChatMessage should resolve to true", async () => {
+      await expect(mock.sendChatMessage("test")).resolves.toBe(true);
       expect(console.debug).toHaveBeenCalled();
     });
 

--- a/packages/iracing-native/src/mock-impl.ts
+++ b/packages/iracing-native/src/mock-impl.ts
@@ -90,7 +90,7 @@ export class IRacingNativeMock {
     console.debug(`[IRacingNativeMock] broadcastMsg(${msg}, ${var1}, ${var2 ?? 0}, ${var3 ?? 0})`);
   }
 
-  sendChatMessage(message: string): boolean {
+  async sendChatMessage(message: string): Promise<boolean> {
     console.debug(`[IRacingNativeMock] sendChatMessage("${message}")`);
 
     return true;

--- a/packages/iracing-sdk/src/IRacingSDK.test.ts
+++ b/packages/iracing-sdk/src/IRacingSDK.test.ts
@@ -28,7 +28,7 @@ function createMockNative(): INativeSDK {
     getVarHeaderEntry: vi.fn(),
     varNameToIndex: vi.fn().mockReturnValue(-1),
     broadcastMsg: vi.fn(),
-    sendChatMessage: vi.fn().mockReturnValue(true),
+    sendChatMessage: vi.fn().mockResolvedValue(true),
   };
 }
 
@@ -189,15 +189,15 @@ describe("IRacingSDK", () => {
   });
 
   describe("sendChatMessage", () => {
-    it("should return false when not connected", () => {
-      expect(sdk.sendChatMessage("test")).toBe(false);
+    it("should resolve to false when not connected", async () => {
+      await expect(sdk.sendChatMessage("test")).resolves.toBe(false);
     });
 
-    it("should call native sendChatMessage when connected", () => {
+    it("should call native sendChatMessage when connected", async () => {
       vi.mocked(mockNative.getVarHeaderEntry).mockReturnValue(null);
       sdk.connect();
 
-      const result = sdk.sendChatMessage("Hello");
+      const result = await sdk.sendChatMessage("Hello");
 
       expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello");
       expect(result).toBe(true);

--- a/packages/iracing-sdk/src/IRacingSDK.ts
+++ b/packages/iracing-sdk/src/IRacingSDK.ts
@@ -261,12 +261,13 @@ export class IRacingSDK {
   /**
    * Send a custom chat message to iRacing
    * @param message The message to send
+   * @returns Promise resolving to true on success, false on failure
    */
-  sendChatMessage(message: string): boolean {
+  sendChatMessage(message: string): Promise<boolean> {
     if (!this.isConnected()) {
       this.logger.warn("[IRacingSDK] Cannot send chat message - not connected");
 
-      return false;
+      return Promise.resolve(false);
     }
 
     return this.native.sendChatMessage(message);

--- a/packages/iracing-sdk/src/SDKController.test.ts
+++ b/packages/iracing-sdk/src/SDKController.test.ts
@@ -16,7 +16,7 @@ function createMockSDK(): IRacingSDK {
     getVarNames: vi.fn().mockReturnValue([]),
     getVarHeader: vi.fn().mockReturnValue(null),
     broadcast: vi.fn(),
-    sendChatMessage: vi.fn().mockReturnValue(true),
+    sendChatMessage: vi.fn().mockResolvedValue(true),
   } as unknown as IRacingSDK;
 }
 
@@ -136,16 +136,16 @@ describe("SDKController", () => {
   });
 
   describe("sendChatMessage", () => {
-    it("should delegate to SDK", () => {
-      controller.sendChatMessage("Hello");
+    it("should delegate to SDK", async () => {
+      await controller.sendChatMessage("Hello");
 
       expect(mockSdk.sendChatMessage).toHaveBeenCalledWith("Hello");
     });
 
-    it("should return SDK result", () => {
-      vi.mocked(mockSdk.sendChatMessage).mockReturnValue(false);
+    it("should return SDK result", async () => {
+      vi.mocked(mockSdk.sendChatMessage).mockResolvedValue(false);
 
-      expect(controller.sendChatMessage("test")).toBe(false);
+      await expect(controller.sendChatMessage("test")).resolves.toBe(false);
     });
   });
 

--- a/packages/iracing-sdk/src/SDKController.ts
+++ b/packages/iracing-sdk/src/SDKController.ts
@@ -261,8 +261,9 @@ export class SDKController {
   /**
    * Send a custom chat message to iRacing
    * @param message The message to send
+   * @returns Promise resolving to true on success, false on failure
    */
-  sendChatMessage(message: string): boolean {
+  sendChatMessage(message: string): Promise<boolean> {
     return this.sdk.sendChatMessage(message);
   }
 }

--- a/packages/iracing-sdk/src/commands/ChatCommand.test.ts
+++ b/packages/iracing-sdk/src/commands/ChatCommand.test.ts
@@ -108,66 +108,64 @@ describe("ChatCommand", () => {
   });
 
   describe("sendMessage", () => {
-    it("should call native sendChatMessage with message", () => {
-      vi.mocked(mockNative.sendChatMessage).mockReturnValue(true);
+    it("should call native sendChatMessage with message", async () => {
+      vi.mocked(mockNative.sendChatMessage).mockResolvedValue(true);
 
-      chatCommand.sendMessage("Hello world");
+      await chatCommand.sendMessage("Hello world");
 
       expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello world");
     });
 
-    it("should return true when sendChatMessage succeeds", () => {
-      vi.mocked(mockNative.sendChatMessage).mockReturnValue(true);
+    it("should return true when sendChatMessage succeeds", async () => {
+      vi.mocked(mockNative.sendChatMessage).mockResolvedValue(true);
 
-      const result = chatCommand.sendMessage("Test message");
+      const result = await chatCommand.sendMessage("Test message");
 
       expect(result).toBe(true);
     });
 
-    it("should return false when sendChatMessage fails", () => {
-      vi.mocked(mockNative.sendChatMessage).mockReturnValue(false);
+    it("should return false when sendChatMessage fails", async () => {
+      vi.mocked(mockNative.sendChatMessage).mockResolvedValue(false);
 
-      const result = chatCommand.sendMessage("Test message");
+      const result = await chatCommand.sendMessage("Test message");
 
       expect(result).toBe(false);
     });
 
-    it("should return false for empty message", () => {
-      const result = chatCommand.sendMessage("");
-
-      expect(result).toBe(false);
-      expect(mockNative.sendChatMessage).not.toHaveBeenCalled();
-    });
-
-    it("should return false for whitespace-only message", () => {
-      const result = chatCommand.sendMessage("   ");
+    it("should return false for empty message", async () => {
+      const result = await chatCommand.sendMessage("");
 
       expect(result).toBe(false);
       expect(mockNative.sendChatMessage).not.toHaveBeenCalled();
     });
 
-    it("should return false for null-ish message", () => {
+    it("should return false for whitespace-only message", async () => {
+      const result = await chatCommand.sendMessage("   ");
+
+      expect(result).toBe(false);
+      expect(mockNative.sendChatMessage).not.toHaveBeenCalled();
+    });
+
+    it("should return false for null-ish message", async () => {
       // Testing edge case where message might be coerced
-      const result = chatCommand.sendMessage(null as unknown as string);
+      const result = await chatCommand.sendMessage(null as unknown as string);
 
       expect(result).toBe(false);
       expect(mockNative.sendChatMessage).not.toHaveBeenCalled();
     });
 
-    it("should return false when sendChatMessage throws", () => {
-      vi.mocked(mockNative.sendChatMessage).mockImplementation(() => {
-        throw new Error("Native error");
-      });
+    it("should return false when sendChatMessage rejects", async () => {
+      vi.mocked(mockNative.sendChatMessage).mockRejectedValue(new Error("Native error"));
 
-      const result = chatCommand.sendMessage("Test message");
+      const result = await chatCommand.sendMessage("Test message");
 
       expect(result).toBe(false);
     });
 
-    it("should handle messages with special characters", () => {
-      vi.mocked(mockNative.sendChatMessage).mockReturnValue(true);
+    it("should handle messages with special characters", async () => {
+      vi.mocked(mockNative.sendChatMessage).mockResolvedValue(true);
 
-      const result = chatCommand.sendMessage("Hello! @driver #1 - good race!");
+      const result = await chatCommand.sendMessage("Hello! @driver #1 - good race!");
 
       expect(result).toBe(true);
       expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello! @driver #1 - good race!");

--- a/packages/iracing-sdk/src/commands/ChatCommand.ts
+++ b/packages/iracing-sdk/src/commands/ChatCommand.ts
@@ -75,12 +75,15 @@ export class ChatCommand extends BroadcastCommand {
   }
 
   /**
-   * Send a custom chat message to iRacing
-   * Opens chat, types the message, sends it, and closes the chat window
+   * Send a custom chat message to iRacing.
+   * Opens chat, types the message, sends it, and closes the chat window.
+   * The native pipeline runs on a worker thread so the JS event loop
+   * remains responsive during the ~400ms native work.
+   *
    * @param message The message to send
-   * @returns Success
+   * @returns Promise resolving to true on success, false on failure
    */
-  sendMessage(message: string): boolean {
+  async sendMessage(message: string): Promise<boolean> {
     if (!message || message.trim().length === 0) {
       this.logger.warn("Cannot send empty message");
 
@@ -90,7 +93,7 @@ export class ChatCommand extends BroadcastCommand {
     try {
       this.logger.info(`Sending chat message: "${message}"`);
 
-      const result = this.native.sendChatMessage(message);
+      const result = await this.native.sendChatMessage(message);
 
       if (result) {
         this.logger.info("Chat message sent successfully");

--- a/packages/iracing-sdk/src/interfaces.ts
+++ b/packages/iracing-sdk/src/interfaces.ts
@@ -27,5 +27,5 @@ export interface INativeSDK {
   broadcastMsg(msg: BroadcastMsg | number, var1: number, var2?: number, var3?: number): void;
 
   // Chat
-  sendChatMessage(message: string): boolean;
+  sendChatMessage(message: string): Promise<boolean>;
 }

--- a/packages/website/src/content/docs/docs/getting-started/troubleshooting.md
+++ b/packages/website/src/content/docs/docs/getting-started/troubleshooting.md
@@ -23,6 +23,16 @@ If an action uses keyboard shortcuts (like black box selection), make sure:
 2. iRacing is the focused window when you press the button
 3. You haven't changed the default iRacing key bindings without updating the action settings
 
+## Known issues
+
+### iRaceDeck replaces your clipboard when sending chat messages
+
+Actions that send a chat message to iRacing (fuel service, tire service, chat, race admin, and anything else that uses the in-sim chat) copy the message text to the Windows clipboard and trigger a paste — it's much faster and more reliable than typing the message character by character, which matters during a race.
+
+This means **whatever you had on your clipboard before pressing the button will be replaced** by the last chat message iRaceDeck sent. iRaceDeck does not try to save and restore the previous clipboard content: doing so used to add extra clipboard writes that woke up clipboard-manager apps (Windows clipboard history, Ditto, 1Password, Bitwarden, screenshot tools, etc.) in the narrow window between the copy and the paste, which could steal focus from iRacing and cause chat messages to fail to send or leave the chat window half-open.
+
+If you need to keep something on your clipboard, copy it again **after** using an iRaceDeck chat action.
+
 ## Need more help?
 
 - **Discord**: [Join the community](https://discord.gg/c6nRYywpah) for real-time support


### PR DESCRIPTION
## Related Issue

Fixes #330

## What changed?

Fuel service's long-press repeat could get stuck firing for up to 15 seconds after the last keyUp, adding ~60 unintended fuel increments under rapid presses. Two problems conspired:

1. **`SendChatMessage` was synchronous native code** — blocking the Node event loop for ~440ms per send (clipboard ops + broadcasts + 4× `Sleep(100)`). Rapid presses queued events and let keyUps go missing under backpressure.
2. **onKeyDown's `await` couldn't yield in time** — promoting the chat send to a `Napi::AsyncWorker` lets onKeyDown's await yield the event loop long enough for onKeyUp to land *before* `startRepeat` installs any timers. The late `startRepeat` then created orphan timers nothing would cancel until the safety timeout.

### Fixes

- **Async chat send** — convert `SendChatMessage` to `Napi::AsyncWorker` with a native `std::mutex` serializing concurrent sends. JS event loop stays responsive during the ~400ms native pipeline. `Promise<boolean>` is propagated through `iracing-native`, `iracing-sdk`, `ChatCommand`, and all chat callers (`fuel-service`, `chat`, `race-admin`, `tire-service`).
- **Authoritative `heldButtons` state** — add `heldButtons: Set<string>` to `FuelService` and `ReplayControl`. `onKeyDown` adds; `onKeyUp` / `onWillDisappear` / `onDidReceiveSettings` all remove. Every timer callback re-checks `heldButtons` (before scheduling, inside the callback, and after any await), so a keyUp racing async work still reliably cancels the repeat.
- **`setTimeout` self-awaiting repeat loop** — replace `setInterval`-based repeat with `scheduleRepeatTick`, which pins at most one in-flight send per button. No backlog accumulation; releases stop the loop immediately.
- **400ms hold threshold in fuel-service** — quick taps can never enter repeat mode.
- **Port same discipline to `ReplayControl`** — structurally identical long-press pattern. `executeMode` is currently sync (SDK broadcasts) but the guard future-proofs it against any async migration.

## How to test

**Repro for the original bug (should no longer stick):**
- Bind fuel add/remove to a Stream Deck key.
- Hold the key for ~2s, release, then hold + release rapidly several times.
- Observe fuel increments stop immediately on release — no delayed increments, no 15-second safety-timeout cleanup.

**Regression coverage:**
- Quick tap (under 400ms) → no repeat mode, single increment only.
- Sustained hold → per-tick verification, one in-flight send at a time.
- Rapid-tap bursts → every keyUp cancels cleanly, no orphan timers.
- Lost keyUp → safety timeout still fires as the last-resort cleanup.
- keyUp during in-flight send → deferred-promise race path cancels repeat.
- Mid-hold settings change → `heldButtons` cleared, repeat stops.
- Same scenarios for `ReplayControl`.

All 2893 tests passing locally.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) <!-- N/A: action-level fix, both plugins share the same actions package -->
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved long-press repeat: quick taps no longer trigger repeats, repeats stop immediately on release, and stuck/orphaned timers are prevented.

* **Performance Improvements**
  * Chat sending is now asynchronous and executed on a serialized worker thread so the app stays responsive and messages won’t interleave.

* **Documentation**
  * Added a Known Issues note about chat actions replacing the clipboard and guidance to re-copy content after use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->