### PR TITLE
refactor(actions): extract shared RepeatController from fuel-service and replay-control (#333)

### DIFF
--- a/packages/actions/src/actions/fuel-service.ts
+++ b/packages/actions/src/actions/fuel-service.ts
@@ -37,6 +37,7 @@ import z from "zod";
 
 import fuelServiceTemplate from "../../icons/fuel-service.svg";
 import { borderColorForState, statusBarNA, statusBarOff, statusBarOn } from "../icons/status-bar.js";
+import { RepeatController } from "../shared/repeat-controller.js";
 
 type FuelServiceMode =
   | "toggle-fuel-fill"
@@ -395,20 +396,41 @@ export const FUEL_SERVICE_UUID = "com.iracedeck.sd.core.fuel-service" as const;
 export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings> {
   private activeContexts = new Map<string, FuelServiceSettings>();
   private lastState = new Map<string, string>();
-  private repeatIntervals = new Map<
-    string,
-    {
-      hold?: ReturnType<typeof setTimeout>;
-      next?: ReturnType<typeof setTimeout>;
-      safety: ReturnType<typeof setTimeout>;
-    }
-  >();
-  // Authoritative "is this button currently held?" state. onKeyDown adds, onKeyUp removes.
-  // All timer callbacks consult this before doing anything so a keyUp that arrives while
-  // onKeyDown is awaiting the async chat send still reliably cancels the repeat: when the
-  // await resolves and startRepeat finally runs, the button is no longer in the set and
-  // no timers are ever created.
-  private heldButtons = new Set<string>();
+  private readonly repeat = new RepeatController(this.logger);
+
+  /** @internal Compat accessor — tests read repeat state via this field. */
+  private get repeatIntervals() {
+    return this.repeat.timers;
+  }
+
+  /** @internal Compat accessor — tests read held state via this field. */
+  private get heldButtons() {
+    return this.repeat.heldButtons;
+  }
+
+  /**
+   * @internal Compat shim — preserves the pre-refactor `startRepeat` guard test.
+   * Tests install/remove heldButtons entries manually and then call this method to
+   * verify timers are not armed when the button is no longer held.
+   */
+  private startRepeat(actionId: string): void {
+    if (!this.repeat.isHeld(actionId)) return;
+
+    this.repeat.onKeyDown(actionId, {
+      holdMs: REPEAT_HOLD_THRESHOLD_MS,
+      intervalMs: REPEAT_GAP_MS,
+      safetyMs: REPEAT_MAX_DURATION_MS,
+      execute: async () => {
+        const current = this.activeContexts.get(actionId);
+
+        if (!current) return false;
+
+        await this.executeMode(current.mode, current);
+
+        return true;
+      },
+    });
+  }
 
   override async onWillAppear(ev: IDeckWillAppearEvent<FuelServiceSettings>): Promise<void> {
     await super.onWillAppear(ev);
@@ -429,8 +451,7 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
   }
 
   override async onWillDisappear(ev: IDeckWillDisappearEvent<FuelServiceSettings>): Promise<void> {
-    this.heldButtons.delete(ev.action.id);
-    this.stopRepeat(ev.action.id);
+    this.repeat.clear(ev.action.id);
     await super.onWillDisappear(ev);
     this.sdkController.unsubscribe(ev.action.id);
     this.activeContexts.delete(ev.action.id);
@@ -440,8 +461,7 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<FuelServiceSettings>): Promise<void> {
     await super.onDidReceiveSettings(ev);
     // Defensive: settings changes can arrive mid-hold; drop any pending/active repeat.
-    this.heldButtons.delete(ev.action.id);
-    this.stopRepeat(ev.action.id);
+    this.repeat.clear(ev.action.id);
     const settings = this.parseSettings(ev.payload.settings);
     this.activeContexts.set(ev.action.id, settings);
     this.lastState.delete(ev.action.id);
@@ -453,17 +473,28 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
 
   override async onKeyDown(ev: IDeckKeyDownEvent<FuelServiceSettings>): Promise<void> {
     this.logger.info("Key down received");
-    this.heldButtons.add(ev.action.id);
     const settings = this.parseSettings(ev.payload.settings);
 
-    // Kick off the first execute without awaiting it here, then arm the repeat timers
-    // synchronously. If we awaited first, onKeyUp could run during the yield and leave
-    // heldButtons/stopRepeat in an already-cleared state — then the late startRepeat
-    // below would install orphan timers that nothing ever cancels. By starting the
-    // repeat immediately, any keyUp that arrives during the in-flight send is guaranteed
-    // to see the timers and clear them.
+    // Arm the repeat timers synchronously before awaiting the first execute. If we
+    // awaited first, onKeyUp could run during the yield and leave heldButtons cleared —
+    // then a late repeat.onKeyDown would install orphan timers nothing ever cancels.
+    // Starting the repeat immediately guarantees any keyUp during the in-flight send
+    // finds the timers and clears them.
     if (REPEATABLE_MODES.has(settings.mode)) {
-      this.startRepeat(ev.action.id);
+      this.repeat.onKeyDown(ev.action.id, {
+        holdMs: REPEAT_HOLD_THRESHOLD_MS,
+        intervalMs: REPEAT_GAP_MS,
+        safetyMs: REPEAT_MAX_DURATION_MS,
+        execute: async () => {
+          const current = this.activeContexts.get(ev.action.id);
+
+          if (!current) return false;
+
+          await this.executeMode(current.mode, current);
+
+          return true;
+        },
+      });
     }
 
     await this.executeMode(settings.mode, settings);
@@ -471,8 +502,7 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
 
   override async onKeyUp(ev: IDeckKeyUpEvent<FuelServiceSettings>): Promise<void> {
     this.logger.info("Key up received");
-    this.heldButtons.delete(ev.action.id);
-    this.stopRepeat(ev.action.id);
+    this.repeat.onKeyUp(ev.action.id);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<FuelServiceSettings>): Promise<void> {
@@ -495,115 +525,6 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
     const effectiveMode = ev.payload.ticks > 0 ? settings.mode : (ROTATION_PAIRS[settings.mode] ?? settings.mode);
 
     await this.executeMode(effectiveMode, settings);
-  }
-
-  private startRepeat(actionId: string): void {
-    this.stopRepeat(actionId);
-
-    // If the button was already released (e.g. keyUp fired during the await in
-    // onKeyDown and this startRepeat call is running after the fact), do nothing.
-    // Without this, the async chat send yields long enough for keyUp to land before
-    // startRepeat is called, and we'd install orphan timers with no hope of a keyUp
-    // arriving to clear them.
-    if (!this.heldButtons.has(actionId)) return;
-
-    // The safety timeout runs for the entire hold (threshold + repeat loop) so a
-    // dropped keyUp can never leave anything running past REPEAT_MAX_DURATION_MS.
-    const safety = setTimeout(() => {
-      this.logger.warn(
-        `Repeat auto-stopped after ${REPEAT_MAX_DURATION_MS}ms (safety timeout — possible missed keyUp)`,
-      );
-      this.heldButtons.delete(actionId);
-      this.stopRepeat(actionId);
-    }, REPEAT_MAX_DURATION_MS);
-
-    // Quick taps must never enter the repeat loop. We wait REPEAT_HOLD_THRESHOLD_MS
-    // before promoting this context from "pending hold" to "repeating" — if keyUp lands
-    // first, stopRepeat clears the hold timer and nothing ever starts.
-    const hold = setTimeout(() => {
-      const entry = this.repeatIntervals.get(actionId);
-
-      if (!entry) return;
-
-      // Double-check: the button may have been released while the hold timer was pending.
-      if (!this.heldButtons.has(actionId)) {
-        this.stopRepeat(actionId);
-
-        return;
-      }
-
-      entry.hold = undefined;
-      this.scheduleRepeatTick(actionId);
-    }, REPEAT_HOLD_THRESHOLD_MS);
-
-    this.repeatIntervals.set(actionId, { hold, safety });
-  }
-
-  /**
-   * Self-awaiting repeat loop. Each tick fires one executeMode, awaits it to
-   * completion, then schedules the next tick REPEAT_GAP_MS later. Because we
-   * never have more than one in-flight send per button, releasing mid-hold
-   * stops the repeat immediately — there is no queued backlog to drain.
-   *
-   * The held check runs four times per tick: before scheduling, inside the
-   * scheduled callback, after executeMode resolves, and again before the next
-   * schedule. Any of them can abort the loop without leaving orphan timers.
-   */
-  private scheduleRepeatTick(actionId: string): void {
-    if (!this.heldButtons.has(actionId)) {
-      this.stopRepeat(actionId);
-
-      return;
-    }
-
-    const entry = this.repeatIntervals.get(actionId);
-
-    if (!entry) return;
-
-    entry.next = setTimeout(async () => {
-      if (!this.heldButtons.has(actionId)) {
-        this.stopRepeat(actionId);
-
-        return;
-      }
-
-      const currentSettings = this.activeContexts.get(actionId);
-
-      if (!currentSettings) {
-        this.stopRepeat(actionId);
-
-        return;
-      }
-
-      try {
-        await this.executeMode(currentSettings.mode, currentSettings);
-      } catch (err) {
-        this.logger.error(`Repeat execution failed: ${err}`);
-      }
-
-      // The button may have been released while executeMode was in flight.
-      // Bail before scheduling the next tick so the loop stops promptly.
-      if (!this.heldButtons.has(actionId)) {
-        this.stopRepeat(actionId);
-
-        return;
-      }
-
-      this.scheduleRepeatTick(actionId);
-    }, REPEAT_GAP_MS);
-  }
-
-  private stopRepeat(actionId: string): void {
-    const entry = this.repeatIntervals.get(actionId);
-
-    if (entry) {
-      if (entry.hold) clearTimeout(entry.hold);
-
-      if (entry.next) clearTimeout(entry.next);
-
-      clearTimeout(entry.safety);
-      this.repeatIntervals.delete(actionId);
-    }
   }
 
   private parseSettings(settings: unknown): FuelServiceSettings {

--- a/packages/actions/src/actions/replay-control.ts
+++ b/packages/actions/src/actions/replay-control.ts
@@ -63,6 +63,8 @@ import {
 } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
+import { RepeatController } from "../shared/repeat-controller.js";
+
 const REPLAY_CONTROL_MODES = [
   "play-pause",
   "play-backward",
@@ -455,23 +457,17 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
   /** Current slow-motion state from telemetry, keyed by action context ID */
   private replaySlowMotion = new Map<string, boolean>();
 
-  /** Active long-press repeat timers, keyed by action context ID */
-  private repeatTimers = new Map<
-    string,
-    {
-      hold?: ReturnType<typeof setTimeout>;
-      next?: ReturnType<typeof setTimeout>;
-      safety: ReturnType<typeof setTimeout>;
-    }
-  >();
+  private readonly repeat = new RepeatController(this.logger);
 
-  /**
-   * Authoritative "is this button currently held?" state. onKeyDown adds,
-   * onKeyUp removes. All repeat timer callbacks consult this before doing
-   * anything so a keyUp that races with any async work still reliably cancels
-   * the repeat — the same defensive pattern used by fuel-service.
-   */
-  private heldButtons = new Set<string>();
+  /** @internal Compat accessor — tests read repeat state via this field. */
+  private get repeatTimers() {
+    return this.repeat.timers;
+  }
+
+  /** @internal Compat accessor — tests read held state via this field. */
+  private get heldButtons() {
+    return this.repeat.heldButtons;
+  }
 
   /** Cached settings per context for telemetry-driven display updates */
   private activeContexts = new Map<string, ReplayControlSettings>();
@@ -510,12 +506,11 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
   }
 
   override async onWillDisappear(ev: IDeckWillDisappearEvent<ReplayControlSettings>): Promise<void> {
-    this.heldButtons.delete(ev.action.id);
+    this.repeat.clear(ev.action.id);
     await super.onWillDisappear(ev);
     this.sdkController.unsubscribe(ev.action.id);
     this.replaySpeed.delete(ev.action.id);
     this.replaySlowMotion.delete(ev.action.id);
-    this.stopRepeat(ev.action.id);
     this.activeContexts.delete(ev.action.id);
     this.lastState.delete(ev.action.id);
   }
@@ -523,8 +518,7 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<ReplayControlSettings>): Promise<void> {
     await super.onDidReceiveSettings(ev);
     // Settings can change mid-hold; drop any pending repeat and held state.
-    this.heldButtons.delete(ev.action.id);
-    this.stopRepeat(ev.action.id);
+    this.repeat.clear(ev.action.id);
     const settings = this.parseSettings(ev.payload.settings);
     this.activeContexts.set(ev.action.id, settings);
     await this.updateDisplay(ev, settings);
@@ -532,18 +526,25 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
 
   override async onKeyDown(ev: IDeckKeyDownEvent<ReplayControlSettings>): Promise<void> {
     this.logger.info("Key down received");
-    this.heldButtons.add(ev.action.id);
     const settings = this.parseSettings(ev.payload.settings);
     this.executeMode(ev.action.id, settings);
 
     if (LONG_PRESS_REPEAT_MODES.has(settings.mode)) {
-      this.startRepeat(ev.action.id, settings);
+      this.repeat.onKeyDown(ev.action.id, {
+        holdMs: LONG_PRESS_INITIAL_DELAY,
+        intervalMs: LONG_PRESS_REPEAT_GAP_MS,
+        safetyMs: LONG_PRESS_MAX_DURATION_MS,
+        execute: () => {
+          this.executeMode(ev.action.id, settings);
+
+          return true;
+        },
+      });
     }
   }
 
   override async onKeyUp(ev: IDeckKeyUpEvent<ReplayControlSettings>): Promise<void> {
-    this.heldButtons.delete(ev.action.id);
-    this.stopRepeat(ev.action.id);
+    this.repeat.onKeyUp(ev.action.id);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<ReplayControlSettings>): Promise<void> {
@@ -558,96 +559,24 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
     this.executeDialRotate(ev.action.id, settings.mode, ev.payload.ticks);
   }
 
-  private startRepeat(contextId: string, settings: ReplayControlSettings): void {
-    this.stopRepeat(contextId);
-
-    // Defensive: if keyUp already landed (e.g. a future async path in onKeyDown
-    // yields before startRepeat gets called), don't install orphan timers.
-    if (!this.heldButtons.has(contextId)) return;
-
-    // Safety timeout covers the entire hold — dropped keyUp can't leak past this.
-    const safety = setTimeout(() => {
-      this.logger.warn(
-        `Repeat auto-stopped after ${LONG_PRESS_MAX_DURATION_MS}ms (safety timeout — possible missed keyUp)`,
-      );
-      this.heldButtons.delete(contextId);
-      this.stopRepeat(contextId);
-    }, LONG_PRESS_MAX_DURATION_MS);
-
-    // Quick taps must never enter the repeat loop: wait LONG_PRESS_INITIAL_DELAY
-    // before the first repeat. If keyUp arrives first, stopRepeat clears the hold
-    // and nothing ever starts.
-    const hold = setTimeout(() => {
-      const entry = this.repeatTimers.get(contextId);
-
-      if (!entry) return;
-
-      if (!this.heldButtons.has(contextId)) {
-        this.stopRepeat(contextId);
-
-        return;
-      }
-
-      entry.hold = undefined;
-      this.scheduleRepeatTick(contextId, settings);
-    }, LONG_PRESS_INITIAL_DELAY);
-
-    this.repeatTimers.set(contextId, { hold, safety });
-  }
-
   /**
-   * Self-awaiting repeat loop. Each tick fires one executeMode, then schedules
-   * the next tick LONG_PRESS_REPEAT_GAP_MS later. Held state is re-checked at
-   * every step so a keyUp that races with any future async work still cancels
-   * the loop promptly.
+   * @internal Compat shim — preserves the pre-refactor `startRepeat` guard test.
+   * Tests install/remove heldButtons entries manually and then call this method to
+   * verify timers are not armed when the button is no longer held.
    */
-  private scheduleRepeatTick(contextId: string, settings: ReplayControlSettings): void {
-    if (!this.heldButtons.has(contextId)) {
-      this.stopRepeat(contextId);
+  private startRepeat(contextId: string, settings: ReplayControlSettings): void {
+    if (!this.repeat.isHeld(contextId)) return;
 
-      return;
-    }
-
-    const entry = this.repeatTimers.get(contextId);
-
-    if (!entry) return;
-
-    entry.next = setTimeout(() => {
-      if (!this.heldButtons.has(contextId)) {
-        this.stopRepeat(contextId);
-
-        return;
-      }
-
-      try {
+    this.repeat.onKeyDown(contextId, {
+      holdMs: LONG_PRESS_INITIAL_DELAY,
+      intervalMs: LONG_PRESS_REPEAT_GAP_MS,
+      safetyMs: LONG_PRESS_MAX_DURATION_MS,
+      execute: () => {
         this.executeMode(contextId, settings);
-      } catch (err) {
-        this.logger.error(`Repeat execution failed: ${err}`);
-      }
 
-      // executeMode is currently sync, but guard anyway so this stays correct
-      // if it ever becomes async.
-      if (!this.heldButtons.has(contextId)) {
-        this.stopRepeat(contextId);
-
-        return;
-      }
-
-      this.scheduleRepeatTick(contextId, settings);
-    }, LONG_PRESS_REPEAT_GAP_MS);
-  }
-
-  private stopRepeat(contextId: string): void {
-    const entry = this.repeatTimers.get(contextId);
-
-    if (entry) {
-      if (entry.hold) clearTimeout(entry.hold);
-
-      if (entry.next) clearTimeout(entry.next);
-
-      clearTimeout(entry.safety);
-      this.repeatTimers.delete(contextId);
-    }
+        return true;
+      },
+    });
   }
 
   private parseSettings(settings: unknown): ReplayControlSettings {

--- a/packages/actions/src/shared/repeat-controller.test.ts
+++ b/packages/actions/src/shared/repeat-controller.test.ts
@@ -243,6 +243,39 @@ describe("RepeatController", () => {
 
       controller.onKeyUp("btn");
     });
+
+    it("does not install a duplicate loop when a new onKeyDown replaces the entry during an in-flight async execute", async () => {
+      // Race: the stale tick callback resumes from its await AFTER a new onKeyDown
+      // has replaced the entry. Without ownership checking it would call
+      // scheduleRepeatTick on the new entry, installing an orphan `next` timer
+      // alongside the new entry's hold-timer-driven loop — two overlapping loops.
+      let resolveFirst!: (value: boolean) => void;
+      const firstPromise = new Promise<boolean>((resolve) => {
+        resolveFirst = resolve;
+      });
+      const execute = vi.fn<() => Promise<boolean>>().mockReturnValueOnce(firstPromise).mockResolvedValue(true);
+
+      // t=0: first press
+      controller.onKeyDown("btn", { ...DEFAULTS, execute });
+      // t=500: hold (400) + first interval (100) fire → first execute awaited
+      await vi.advanceTimersByTimeAsync(500);
+      expect(execute).toHaveBeenCalledTimes(1);
+
+      // t=500: overlapping onKeyDown replaces the entry while the first execute is mid-await.
+      // The new entry's hold timer is armed at t=500, firing at t=900.
+      controller.onKeyDown("btn", { ...DEFAULTS, execute });
+
+      // Resolve the first execute and let its continuation run on the microtask queue.
+      resolveFirst(true);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Advance to t=899 — still inside the new entry's hold phase (hold fires at t=900),
+      // so a clean implementation must not have called execute again.
+      await vi.advanceTimersByTimeAsync(399);
+      expect(execute).toHaveBeenCalledTimes(1);
+
+      controller.onKeyUp("btn");
+    });
   });
 
   describe("multiple concurrent buttons", () => {

--- a/packages/actions/src/shared/repeat-controller.test.ts
+++ b/packages/actions/src/shared/repeat-controller.test.ts
@@ -1,0 +1,285 @@
+import { type ILogger, LogLevel } from "@iracedeck/logger";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RepeatController } from "./repeat-controller.js";
+
+function createSpyLogger(): ILogger & {
+  trace: ReturnType<typeof vi.fn>;
+  debug: ReturnType<typeof vi.fn>;
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+} {
+  const logger = {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withLevel: (_level: LogLevel): ILogger => logger,
+    createScope: (_scope: string): ILogger => logger,
+  };
+
+  return logger;
+}
+
+const DEFAULTS = {
+  holdMs: 400,
+  intervalMs: 100,
+  safetyMs: 15_000,
+};
+
+describe("RepeatController", () => {
+  let logger: ReturnType<typeof createSpyLogger>;
+  let controller: RepeatController;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    logger = createSpyLogger();
+    controller = new RepeatController(logger);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("quick tap (shorter than holdMs)", () => {
+    it("never invokes execute when released before the hold threshold", async () => {
+      const execute = vi.fn().mockResolvedValue(true);
+
+      controller.onKeyDown("btn", { ...DEFAULTS, execute });
+      await vi.advanceTimersByTimeAsync(399);
+      controller.onKeyUp("btn");
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(execute).not.toHaveBeenCalled();
+    });
+
+    it("never invokes execute when released exactly at the hold threshold - 1 ms", async () => {
+      const execute = vi.fn().mockResolvedValue(true);
+
+      controller.onKeyDown("btn", { ...DEFAULTS, execute });
+      await vi.advanceTimersByTimeAsync(399);
+      controller.onKeyUp("btn");
+
+      expect(execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("sustained hold", () => {
+    it("fires execute once per intervalMs after holdMs", async () => {
+      const execute = vi.fn().mockResolvedValue(true);
+
+      controller.onKeyDown("btn", { ...DEFAULTS, execute });
+
+      // Before hold threshold: nothing
+      await vi.advanceTimersByTimeAsync(399);
+      expect(execute).not.toHaveBeenCalled();
+
+      // Cross the hold threshold — first repeat tick schedules
+      await vi.advanceTimersByTimeAsync(1);
+      // At this point the hold timer has fired and scheduled the first `next` timer.
+      // The next tick itself has not yet run.
+      expect(execute).not.toHaveBeenCalled();
+
+      // First repeat tick fires after intervalMs
+      await vi.advanceTimersByTimeAsync(100);
+      expect(execute).toHaveBeenCalledTimes(1);
+
+      // Second
+      await vi.advanceTimersByTimeAsync(100);
+      expect(execute).toHaveBeenCalledTimes(2);
+
+      // Third
+      await vi.advanceTimersByTimeAsync(100);
+      expect(execute).toHaveBeenCalledTimes(3);
+
+      controller.onKeyUp("btn");
+    });
+  });
+
+  describe("execute returns false", () => {
+    it("stops the loop when execute returns false", async () => {
+      const execute = vi.fn().mockResolvedValueOnce(false);
+
+      controller.onKeyDown("btn", { ...DEFAULTS, execute });
+      await vi.advanceTimersByTimeAsync(500); // hold + first interval
+      expect(execute).toHaveBeenCalledTimes(1);
+
+      // No further calls even if button is still held
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops the loop when a synchronous execute returns false", async () => {
+      const execute = vi.fn(() => false);
+
+      controller.onKeyDown("btn", { ...DEFAULTS, execute });
+      await vi.advanceTimersByTimeAsync(500);
+      expect(execute).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("onKeyUp during an in-flight async execute", () => {
+    it("does not fire a further execute after the in-flight promise resolves", async () => {
+      let resolveFirst!: (value: boolean) => void;
+      const firstPromise = new Promise<boolean>((resolve) => {
+        resolveFirst = resolve;
+      });
+      const execute = vi.fn<() => Promise<boolean>>().mockReturnValueOnce(firstPromise).mockResolvedValue(true);
+
+      controller.onKeyDown("btn", { ...DEFAULTS, execute });
+      await vi.advanceTimersByTimeAsync(500); // hold + first interval → in-flight
+      expect(execute).toHaveBeenCalledTimes(1);
+
+      // keyUp arrives while the first execute is still pending
+      controller.onKeyUp("btn");
+
+      // Now the first execute finally resolves
+      resolveFirst(true);
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("onKeyUp between ticks", () => {
+    it("stops the loop immediately and never fires another execute", async () => {
+      const execute = vi.fn().mockResolvedValue(true);
+
+      controller.onKeyDown("btn", { ...DEFAULTS, execute });
+      await vi.advanceTimersByTimeAsync(600); // hold + first + part of second
+      expect(execute).toHaveBeenCalledTimes(2);
+
+      controller.onKeyUp("btn");
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(execute).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("clear", () => {
+    it("behaves identically to onKeyUp", async () => {
+      const execute = vi.fn().mockResolvedValue(true);
+
+      controller.onKeyDown("btn", { ...DEFAULTS, execute });
+      await vi.advanceTimersByTimeAsync(500);
+      expect(execute).toHaveBeenCalledTimes(1);
+
+      controller.clear("btn");
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(controller.isHeld("btn")).toBe(false);
+    });
+  });
+
+  describe("clearAll", () => {
+    it("clears every held button", async () => {
+      const exec1 = vi.fn().mockResolvedValue(true);
+      const exec2 = vi.fn().mockResolvedValue(true);
+
+      controller.onKeyDown("btn1", { ...DEFAULTS, execute: exec1 });
+      controller.onKeyDown("btn2", { ...DEFAULTS, execute: exec2 });
+      await vi.advanceTimersByTimeAsync(500);
+      expect(exec1).toHaveBeenCalledTimes(1);
+      expect(exec2).toHaveBeenCalledTimes(1);
+
+      controller.clearAll();
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(exec1).toHaveBeenCalledTimes(1);
+      expect(exec2).toHaveBeenCalledTimes(1);
+      expect(controller.isHeld("btn1")).toBe(false);
+      expect(controller.isHeld("btn2")).toBe(false);
+    });
+  });
+
+  describe("safety timeout", () => {
+    it("auto-stops after safetyMs when keyUp is lost, logs a warning, and releases held state", async () => {
+      const execute = vi.fn().mockResolvedValue(true);
+
+      controller.onKeyDown("btn", { ...DEFAULTS, execute });
+      // Let it repeat for a while
+      await vi.advanceTimersByTimeAsync(14_999);
+      expect(controller.isHeld("btn")).toBe(true);
+      const callsBefore = execute.mock.calls.length;
+      expect(callsBefore).toBeGreaterThan(0);
+
+      // Cross the safety deadline
+      await vi.advanceTimersByTimeAsync(2);
+
+      expect(controller.isHeld("btn")).toBe(false);
+      expect(logger.warn).toHaveBeenCalled();
+
+      // No further calls after safety fires
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(execute.mock.calls.length).toBeLessThanOrEqual(callsBefore + 1);
+
+      const finalCalls = execute.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(execute).toHaveBeenCalledTimes(finalCalls);
+    });
+  });
+
+  describe("re-keyDown on an already-held button", () => {
+    it("resets timers so a single stream of repeats happens, not two concurrent loops", async () => {
+      const execute = vi.fn().mockResolvedValue(true);
+
+      controller.onKeyDown("btn", { ...DEFAULTS, execute });
+      await vi.advanceTimersByTimeAsync(500);
+      expect(execute).toHaveBeenCalledTimes(1);
+
+      // Second keyDown without a keyUp — should reset, not stack
+      controller.onKeyDown("btn", { ...DEFAULTS, execute });
+
+      // No extra calls just from the re-down
+      expect(execute).toHaveBeenCalledTimes(1);
+
+      // Drive one more full interval; only one call should be added, not two
+      await vi.advanceTimersByTimeAsync(500);
+      expect(execute).toHaveBeenCalledTimes(2);
+
+      controller.onKeyUp("btn");
+    });
+  });
+
+  describe("multiple concurrent buttons", () => {
+    it("repeats each button independently", async () => {
+      const exec1 = vi.fn().mockResolvedValue(true);
+      const exec2 = vi.fn().mockResolvedValue(true);
+
+      controller.onKeyDown("btn1", { ...DEFAULTS, execute: exec1 });
+      await vi.advanceTimersByTimeAsync(500);
+      expect(exec1).toHaveBeenCalledTimes(1);
+
+      controller.onKeyDown("btn2", { ...DEFAULTS, execute: exec2 });
+      await vi.advanceTimersByTimeAsync(500);
+      expect(exec1).toHaveBeenCalledTimes(6); // 5 more 100ms ticks
+      expect(exec2).toHaveBeenCalledTimes(1);
+
+      // Release btn1, btn2 keeps repeating
+      controller.onKeyUp("btn1");
+      await vi.advanceTimersByTimeAsync(300);
+      expect(exec1).toHaveBeenCalledTimes(6);
+      expect(exec2).toHaveBeenCalledTimes(4);
+
+      controller.onKeyUp("btn2");
+    });
+  });
+
+  describe("isHeld", () => {
+    it("reflects current held state", () => {
+      const execute = vi.fn().mockResolvedValue(true);
+
+      expect(controller.isHeld("btn")).toBe(false);
+
+      controller.onKeyDown("btn", { ...DEFAULTS, execute });
+      expect(controller.isHeld("btn")).toBe(true);
+
+      controller.onKeyUp("btn");
+      expect(controller.isHeld("btn")).toBe(false);
+    });
+  });
+});

--- a/packages/actions/src/shared/repeat-controller.ts
+++ b/packages/actions/src/shared/repeat-controller.ts
@@ -152,6 +152,9 @@ export class RepeatController {
         return;
       }
 
+      // Intentional: on exception keepGoing stays true so a transient failure
+      // does not kill the repeat loop. The safety timeout caps how long a
+      // broken execute can spam errors (at most safetyMs / intervalMs attempts).
       let keepGoing = true;
 
       try {

--- a/packages/actions/src/shared/repeat-controller.ts
+++ b/packages/actions/src/shared/repeat-controller.ts
@@ -123,6 +123,12 @@ export class RepeatController {
    * The held check runs four times per tick: before scheduling, inside the
    * scheduled callback, after execute resolves, and again before the next
    * schedule. Any of them can abort the loop without leaving orphan timers.
+   *
+   * Ownership: the scheduled callback closes over the entry object it was
+   * armed for. If an overlapping onKeyDown replaces that entry mid-await,
+   * the stale callback must not touch `this.timers` or recurse — otherwise
+   * it would install an orphan tick on top of the new entry's hold-driven
+   * loop and produce two overlapping streams of executes.
    */
   private scheduleRepeatTick(buttonId: string): void {
     if (!this.heldButtons.has(buttonId)) {
@@ -136,6 +142,10 @@ export class RepeatController {
     if (!entry) return;
 
     entry.next = setTimeout(async () => {
+      // Ownership check: a new onKeyDown may have replaced this entry before
+      // the setTimeout fired. If so, the new entry owns the loop now — bail.
+      if (this.timers.get(buttonId) !== entry) return;
+
       if (!this.heldButtons.has(buttonId)) {
         this.clearTimers(buttonId);
 
@@ -149,6 +159,11 @@ export class RepeatController {
       } catch (err) {
         this.logger.error(`Repeat execution failed: ${String(err)}`);
       }
+
+      // Ownership check after the await: an overlapping onKeyDown may have
+      // replaced the entry while execute was in flight. The new entry's own
+      // hold timer will drive its loop — do not touch anything here.
+      if (this.timers.get(buttonId) !== entry) return;
 
       if (!keepGoing) {
         this.heldButtons.delete(buttonId);

--- a/packages/actions/src/shared/repeat-controller.ts
+++ b/packages/actions/src/shared/repeat-controller.ts
@@ -1,0 +1,183 @@
+import type { ILogger } from "@iracedeck/logger";
+
+/**
+ * Options for a single long-press hold registered with {@link RepeatController}.
+ */
+export interface RepeatOptions {
+  /** Delay before the repeat loop starts. Quick taps shorter than this never repeat. */
+  holdMs: number;
+  /** Delay between repeat ticks once the loop is running. */
+  intervalMs: number;
+  /** Hard cap for the entire hold — catches dropped keyUp events. */
+  safetyMs: number;
+  /**
+   * Per-tick work. Return `false` to stop the loop (e.g. settings went stale).
+   * May be async; the loop awaits it before scheduling the next tick, so there
+   * is at most one in-flight execution per button.
+   */
+  execute: () => Promise<boolean> | boolean;
+}
+
+export interface RepeatEntry {
+  hold?: ReturnType<typeof setTimeout>;
+  next?: ReturnType<typeof setTimeout>;
+  safety: ReturnType<typeof setTimeout>;
+  options: RepeatOptions;
+}
+
+/**
+ * Shared long-press repeat state machine.
+ *
+ * Owns `heldButtons` and per-button `hold`/`next`/`safety` timers, and runs a
+ * self-awaiting repeat loop that fires `options.execute` at most once at a
+ * time. Releasing the button (onKeyUp/clear/clearAll) stops the loop promptly
+ * even when an execute is in flight, and a safety timeout guarantees the loop
+ * cannot outlive `options.safetyMs` if the keyUp is ever lost.
+ */
+export class RepeatController {
+  /** @internal Exposed for action classes and test compat. */
+  readonly heldButtons = new Set<string>();
+  /** @internal Exposed for action classes and test compat. */
+  readonly timers = new Map<string, RepeatEntry>();
+
+  constructor(private readonly logger: ILogger) {}
+
+  /**
+   * Register a button as held and arm the hold/safety timers.
+   *
+   * Call this synchronously from the action's `onKeyDown` — before any await —
+   * so a racing `onKeyUp` during an async first execute is guaranteed to find
+   * the timers and clear them.
+   */
+  onKeyDown(buttonId: string, options: RepeatOptions): void {
+    // Reset any previous state for this button before installing new timers.
+    this.clearTimers(buttonId);
+    this.heldButtons.add(buttonId);
+
+    // Safety timeout covers the entire hold — dropped keyUp can't leak past this.
+    const safety = setTimeout(() => {
+      this.logger.warn(`Repeat auto-stopped after ${options.safetyMs}ms (safety timeout — possible missed keyUp)`);
+      this.heldButtons.delete(buttonId);
+      this.clearTimers(buttonId);
+    }, options.safetyMs);
+
+    // Quick taps must never enter the repeat loop: wait holdMs before the first
+    // repeat. If keyUp arrives first, clearTimers clears the hold and nothing ever
+    // starts.
+    const hold = setTimeout(() => {
+      const entry = this.timers.get(buttonId);
+
+      if (!entry) return;
+
+      // Double-check: the button may have been released while the hold timer was pending.
+      if (!this.heldButtons.has(buttonId)) {
+        this.clearTimers(buttonId);
+
+        return;
+      }
+
+      entry.hold = undefined;
+      this.scheduleRepeatTick(buttonId);
+    }, options.holdMs);
+
+    this.timers.set(buttonId, { hold, safety, options });
+  }
+
+  /** Mark the button released and clear all of its timers. */
+  onKeyUp(buttonId: string): void {
+    // Delete from heldButtons BEFORE clearing timers so any in-flight timer
+    // callback that re-checks `heldButtons` sees the released state.
+    this.heldButtons.delete(buttonId);
+    this.clearTimers(buttonId);
+  }
+
+  /**
+   * Clear a button's state without distinguishing it from a normal release.
+   * Used for `onWillDisappear` and `onDidReceiveSettings`.
+   */
+  clear(buttonId: string): void {
+    this.heldButtons.delete(buttonId);
+    this.clearTimers(buttonId);
+  }
+
+  /** Clear every known button. Used during teardown. */
+  clearAll(): void {
+    this.heldButtons.clear();
+
+    for (const buttonId of [...this.timers.keys()]) {
+      this.clearTimers(buttonId);
+    }
+  }
+
+  /** Whether the given button is currently held. */
+  isHeld(buttonId: string): boolean {
+    return this.heldButtons.has(buttonId);
+  }
+
+  /**
+   * Self-awaiting repeat loop. Each tick fires one execute, awaits it, then
+   * schedules the next tick `intervalMs` later. Because we never have more
+   * than one in-flight execution per button, releasing mid-hold stops the
+   * repeat immediately — there is no queued backlog to drain.
+   *
+   * The held check runs four times per tick: before scheduling, inside the
+   * scheduled callback, after execute resolves, and again before the next
+   * schedule. Any of them can abort the loop without leaving orphan timers.
+   */
+  private scheduleRepeatTick(buttonId: string): void {
+    if (!this.heldButtons.has(buttonId)) {
+      this.clearTimers(buttonId);
+
+      return;
+    }
+
+    const entry = this.timers.get(buttonId);
+
+    if (!entry) return;
+
+    entry.next = setTimeout(async () => {
+      if (!this.heldButtons.has(buttonId)) {
+        this.clearTimers(buttonId);
+
+        return;
+      }
+
+      let keepGoing = true;
+
+      try {
+        keepGoing = (await entry.options.execute()) !== false;
+      } catch (err) {
+        this.logger.error(`Repeat execution failed: ${String(err)}`);
+      }
+
+      if (!keepGoing) {
+        this.heldButtons.delete(buttonId);
+        this.clearTimers(buttonId);
+
+        return;
+      }
+
+      // The button may have been released while execute was in flight.
+      if (!this.heldButtons.has(buttonId)) {
+        this.clearTimers(buttonId);
+
+        return;
+      }
+
+      this.scheduleRepeatTick(buttonId);
+    }, entry.options.intervalMs);
+  }
+
+  private clearTimers(buttonId: string): void {
+    const entry = this.timers.get(buttonId);
+
+    if (entry) {
+      if (entry.hold) clearTimeout(entry.hold);
+
+      if (entry.next) clearTimeout(entry.next);
+
+      clearTimeout(entry.safety);
+      this.timers.delete(buttonId);
+    }
+  }
+}


### PR DESCRIPTION
## Related Issue

Fixes #333

## What changed?

`FuelService` and `ReplayControl` grew the same long-press repeat state machine in #332 (`heldButtons` set, per-button `hold`/`next`/`safety` timers, self-awaiting tick loop with four held-state re-checks, safety-timeout auto-stop). CodeRabbit flagged the duplication as a maintenance risk on #332 — the next stuck-repeat fix would drift between the two copies.

This PR extracts that state machine into a shared helper and wires both actions through it.

- **New `packages/actions/src/shared/repeat-controller.ts`** — owns `heldButtons`, per-button timers, the self-awaiting `scheduleRepeatTick` loop, and the safety timeout. Per-caller `holdMs` / `intervalMs` / `safetyMs`, and an `execute` callback that may be sync or async and may return `false` to stop the loop.
- **New `packages/actions/src/shared/repeat-controller.test.ts`** — 13 tests with `vi.useFakeTimers()` covering: quick tap, sustained hold, `execute` returning `false` (sync + async), `onKeyUp` during an in-flight async `execute`, `clear`, `clearAll`, safety timeout (auto-stop + warn + release), re-`onKeyDown` reset, two concurrent buttons repeating independently, and `isHeld`.
- **`FuelService` refactor** — delegates to `RepeatController`. `REPEAT_HOLD_THRESHOLD_MS` / `REPEAT_GAP_MS` / `REPEAT_MAX_DURATION_MS` unchanged (400 / 100 / 15000). The fresh-settings-per-tick semantics are preserved: the `execute` callback re-reads `this.activeContexts.get(id)` each tick and returns `false` if the context is gone. The `startRepeat`-before-first-execute ordering (defensive against `onKeyUp` racing the async chat send) is preserved.
- **`ReplayControl` refactor** — delegates to `RepeatController`. `LONG_PRESS_INITIAL_DELAY` / `LONG_PRESS_REPEAT_GAP_MS` / `LONG_PRESS_MAX_DURATION_MS` unchanged (500 / 250 / 15000). Captures `settings` once at `onKeyDown` (same behavior as before). First execute still runs before `repeat.onKeyDown`.
- **Test-compat shims** — `fuel-service.test.ts` and `replay-control.test.ts` poke at private state (`repeatIntervals`, `repeatTimers`, `heldButtons`, `startRepeat`). Both classes keep those names as private getters/methods that delegate to the controller so the existing test files pass **unchanged** (acceptance criterion).
- **Net deletion:** `fuel-service.ts` −195/+96, `replay-control.ts` −147/+51 — ~200 lines of duplication removed.

Pure refactor: no behavioral change, no constant changes, no manifest/PI/docs changes required.

## How to test

- [x] `npx vitest run` — 2906 tests across 85 files pass
- [x] `npx vitest run packages/actions/src/shared/repeat-controller.test.ts` — 13 new tests pass
- [x] `npx vitest run packages/actions/src/actions/fuel-service.test.ts` — all 114 existing tests pass **without edits**
- [x] `npx vitest run packages/actions/src/actions/replay-control.test.ts` — all 120 existing tests pass **without edits**
- [x] `pnpm build` — all 10 turbo tasks succeed
- [x] `pnpm lint` — clean
- [x] `pnpm format` — clean
- [ ] Manual smoke on hardware (optional for a pure refactor): hold Add Fuel → 1 tick immediately, then repeats every 100 ms after 400 ms; hold Fast Forward → 1 tick immediately, then every 250 ms after 500 ms; release mid-hold stops promptly.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — N/A, this is a platform-agnostic refactor inside `@iracedeck/actions`; both plugins consume the shared class automatically
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized long-press repeat behavior into a shared RepeatController, simplifying and unifying hold/repeat/safety handling to eliminate duplicate timers and reduce race conditions.

* **Tests**
  * Added comprehensive tests covering hold timing, repeat intervals, safety timeouts, cancellation semantics, overlapping presses, and concurrent button behavior to ensure reliable repeat interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->