### PR TITLE
improve(actions): drop fuel amount from Auto Fuel Toggle display (#335)

### DIFF
--- a/packages/actions/src/actions/fuel-service.test.ts
+++ b/packages/actions/src/actions/fuel-service.test.ts
@@ -872,7 +872,7 @@ describe("FuelService", () => {
         expect(decoded).toContain("status-na");
       });
 
-      it("should show N/A status bar and -- text when autofuel system is not available", () => {
+      it("should show N/A status bar when autofuel system is not available", () => {
         const telemetryState: FuelServiceTelemetryState = {
           autofuelEnabled: false,
           autofuelActive: false,
@@ -885,11 +885,9 @@ describe("FuelService", () => {
         expect(decoded).toContain("status-na");
         expect(decoded).not.toContain("status-on");
         expect(decoded).not.toContain("status-off");
-        expect(decoded).toContain("--");
-        expect(decoded).not.toContain("+50 L");
       });
 
-      it("should include fuel amount graphic content", () => {
+      it("should not include fuel amount graphic content", () => {
         const telemetryState: FuelServiceTelemetryState = {
           autofuelActive: true,
           fuelAmount: 50.0,
@@ -898,15 +896,8 @@ describe("FuelService", () => {
         const result = generateFuelServiceSvg({ mode: "toggle-autofuel", amount: 1, unit: "l" }, telemetryState);
         const decoded = decodeURIComponent(result);
 
-        expect(decoded).toContain("+50 L");
-      });
-
-      it("should show -- when no fuel amount is available", () => {
-        const telemetryState: FuelServiceTelemetryState = { autofuelActive: true };
-        const result = generateFuelServiceSvg({ mode: "toggle-autofuel", amount: 1, unit: "l" }, telemetryState);
-        const decoded = decodeURIComponent(result);
-
-        expect(decoded).toContain("--");
+        expect(decoded).not.toContain("+50 L");
+        expect(decoded).not.toContain("--");
       });
 
       it("should include title content from metadata SVG", () => {

--- a/packages/actions/src/actions/fuel-service.ts
+++ b/packages/actions/src/actions/fuel-service.ts
@@ -328,9 +328,13 @@ export function generateFuelServiceSvg(
       }
     }
 
-    // Show fuel amount when available; show "--" when the system is unavailable
+    // toggle-fuel-fill shows the fuel amount; toggle-autofuel shows only the status bar
     const graphicContent =
-      toggleState === "na" ? fuelFillGraphicContent({}, graphic1) : fuelFillGraphicContent(state, graphic1);
+      mode === "toggle-autofuel"
+        ? ""
+        : toggleState === "na"
+          ? fuelFillGraphicContent({}, graphic1)
+          : fuelFillGraphicContent(state, graphic1);
 
     const statusBar = toggleState === "na" ? statusBarNA() : toggleState === "on" ? statusBarOn() : statusBarOff();
 
@@ -678,7 +682,7 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
     }
 
     if (settings.mode === "toggle-autofuel") {
-      return `autofuel|${telemetryState.autofuelEnabled ?? true}|${telemetryState.autofuelActive ?? "na"}|${telemetryState.fuelAmount ?? "none"}|${telemetryState.displayUnits ?? 0}|${borderKey}`;
+      return `autofuel|${telemetryState.autofuelEnabled ?? true}|${telemetryState.autofuelActive ?? "na"}|${borderKey}`;
     }
 
     return settings.mode;

--- a/packages/icons/fuel-service/toggle-autofuel.svg
+++ b/packages/icons/fuel-service/toggle-autofuel.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
-  <desc>{"colors":{"backgroundColor":"#3a2a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"AUTO FUEL","position":"top","fontSize":11,"showTitle":true,"locked":["showTitle","fontSize","position"]}}</desc>
+  <desc>{"colors":{"backgroundColor":"#3a2a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"AUTO\nFUEL","position":"top","fontSize":18,"showTitle":true,"locked":["showTitle","fontSize","position"]}}</desc>
 </svg>

--- a/packages/icons/preview/fuel-service/toggle-autofuel.svg
+++ b/packages/icons/preview/fuel-service/toggle-autofuel.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
-  <desc>{"colors":{"backgroundColor":"#3a2a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"AUTO FUEL","position":"top","fontSize":11,"showTitle":true,"locked":["showTitle","fontSize","position"]}}</desc>
+  <desc>{"colors":{"backgroundColor":"#3a2a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"AUTO\nFUEL","position":"top","fontSize":18,"showTitle":true,"locked":["showTitle","fontSize","position"]}}</desc>
 </svg>

--- a/packages/website/src/content/docs/docs/actions/pit-service/fuel-service.md
+++ b/packages/website/src/content/docs/docs/actions/pit-service/fuel-service.md
@@ -117,13 +117,13 @@ Clear the pending fuel request via the iRacing SDK. Removes the fuel line from t
 
 ### Toggle Autofuel
 
-Toggle iRacing's autofuel checkbox on or off. The icon shows the current refuel amount and a green ON / red OFF status bar plus matching border color reflecting whether autofuel is active.
+Toggle iRacing's autofuel checkbox on or off. The icon shows a green ON / red OFF status bar plus matching border color reflecting whether autofuel is active.
 
 #### Details
 
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Ctrl+A`
-- **Telemetry-aware icon:** Yes — shows the current refuel amount and an on/off indicator driven by `PitSvFlags.FuelAutofill`
+- **Telemetry-aware icon:** Yes — shows an on/off indicator driven by `PitSvFlags.FuelAutofill`
 
 #### Settings
 

--- a/packages/website/src/content/docs/docs/actions/pit-service/fuel-service.md
+++ b/packages/website/src/content/docs/docs/actions/pit-service/fuel-service.md
@@ -123,7 +123,7 @@ Toggle iRacing's autofuel checkbox on or off. The icon shows a green ON / red OF
 
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Ctrl+A`
-- **Telemetry-aware icon:** Yes — shows an on/off indicator driven by `PitSvFlags.FuelAutofill`
+- **Telemetry-aware icon:** Yes — shows an on/off indicator driven by `dpFuelAutoFillActive`
 
 #### Settings
 


### PR DESCRIPTION
## Summary

- Remove the `+X L` / `+X g` fuel amount text from the `toggle-autofuel` mode so the key shows only the title and on/off status bar, matching Fast Repair's visual treatment
- Update the title to two-line "AUTO\nFUEL" at 18px font size with locked title fields
- Simplify the `buildStateKey()` to exclude `fuelAmount`/`displayUnits`, preventing unnecessary icon re-renders on every fuel tick

Closes #335

## Test plan

- [x] All 113 fuel-service tests pass (updated 3 tests to verify fuel amount is NOT shown)
- [x] 371 icon preview freshness tests pass
- [x] Full build passes (10/10 packages)
- [x] Manual verification: toggle-autofuel key shows "AUTO\nFUEL" title + status bar, no fuel amount text
- [x] Manual verification: toggle-fuel-fill still shows `+X L` / `+X g` as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Autofuel toggle now displays status indicator only (ON/OFF), removing fuel amount display
  * Fuel-fill toggle retains fuel amount display functionality
* **Tests**
  * Updated test expectations for autofuel SVG rendering validation
* **Documentation**
  * Updated autofuel feature description to reflect status-only display behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->