### PR TITLE
fix(replay): cycle next/previous car on track during formation lap (#307)

### DIFF
--- a/packages/actions/src/actions/replay-control.test.ts
+++ b/packages/actions/src/actions/replay-control.test.ts
@@ -1,4 +1,4 @@
-import { getAllCarNumbers, getCarNumberFromSessionInfo } from "@iracedeck/iracing-sdk";
+import { getAllCarNumbers, getCarNumberFromSessionInfo, TrkLoc } from "@iracedeck/iracing-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -578,24 +578,19 @@ describe("ReplayControl", () => {
   });
 
   describe("findAdjacentCarOnTrack", () => {
-    // TrkLoc values — mirrored from @iracedeck/iracing-sdk to avoid a cross-package import
-    // in this unit test (the SDK module is mocked above).
-    const TRK_LOC_NOT_IN_WORLD = -1;
-    const TRK_LOC_ON_TRACK = 3;
-
     function makeTelemetry(
       camCarIdx: number,
-      cars: Array<{ idx: number; laps: number; dist: number; trackSurface?: number }>,
+      cars: Array<{ idx: number; laps: number; dist: number; trackSurface?: TrkLoc }>,
     ) {
       const maxIdx = Math.max(...cars.map((c) => c.idx), camCarIdx, 0);
       const lapCompleted = new Array(maxIdx + 1).fill(-1);
       const lapDistPct = new Array(maxIdx + 1).fill(-1);
-      const trackSurface = new Array(maxIdx + 1).fill(TRK_LOC_NOT_IN_WORLD);
+      const trackSurface = new Array(maxIdx + 1).fill(TrkLoc.NotInWorld);
 
       for (const car of cars) {
         lapCompleted[car.idx] = car.laps;
         lapDistPct[car.idx] = car.dist;
-        trackSurface[car.idx] = car.trackSurface ?? TRK_LOC_ON_TRACK;
+        trackSurface[car.idx] = car.trackSurface ?? TrkLoc.OnTrack;
       }
 
       return {
@@ -663,7 +658,7 @@ describe("ReplayControl", () => {
     it("should skip disconnected cars (NotInWorld)", () => {
       const telemetry = makeTelemetry(3, [
         { idx: 1, laps: 5, dist: 0.8 },
-        { idx: 2, laps: 5, dist: 0.5, trackSurface: TRK_LOC_NOT_IN_WORLD },
+        { idx: 2, laps: 5, dist: 0.5, trackSurface: TrkLoc.NotInWorld },
         { idx: 3, laps: 5, dist: 0.2 },
       ]);
 

--- a/packages/actions/src/actions/replay-control.test.ts
+++ b/packages/actions/src/actions/replay-control.test.ts
@@ -578,20 +578,31 @@ describe("ReplayControl", () => {
   });
 
   describe("findAdjacentCarOnTrack", () => {
-    function makeTelemetry(camCarIdx: number, cars: Array<{ idx: number; laps: number; dist: number }>) {
+    // TrkLoc values — mirrored from @iracedeck/iracing-sdk to avoid a cross-package import
+    // in this unit test (the SDK module is mocked above).
+    const TRK_LOC_NOT_IN_WORLD = -1;
+    const TRK_LOC_ON_TRACK = 3;
+
+    function makeTelemetry(
+      camCarIdx: number,
+      cars: Array<{ idx: number; laps: number; dist: number; trackSurface?: number }>,
+    ) {
       const maxIdx = Math.max(...cars.map((c) => c.idx), camCarIdx, 0);
       const lapCompleted = new Array(maxIdx + 1).fill(-1);
       const lapDistPct = new Array(maxIdx + 1).fill(-1);
+      const trackSurface = new Array(maxIdx + 1).fill(TRK_LOC_NOT_IN_WORLD);
 
       for (const car of cars) {
         lapCompleted[car.idx] = car.laps;
         lapDistPct[car.idx] = car.dist;
+        trackSurface[car.idx] = car.trackSurface ?? TRK_LOC_ON_TRACK;
       }
 
       return {
         CamCarIdx: camCarIdx,
         CarIdxLapCompleted: lapCompleted,
         CarIdxLapDistPct: lapDistPct,
+        CarIdxTrackSurface: trackSurface,
       };
     }
 
@@ -649,14 +660,28 @@ describe("ReplayControl", () => {
       expect(findAdjacentCarOnTrack(telemetry, "ahead")).toBe(2);
     });
 
-    it("should skip inactive cars", () => {
+    it("should skip disconnected cars (NotInWorld)", () => {
       const telemetry = makeTelemetry(3, [
         { idx: 1, laps: 5, dist: 0.8 },
-        { idx: 2, laps: -1, dist: 0.5 },
+        { idx: 2, laps: 5, dist: 0.5, trackSurface: TRK_LOC_NOT_IN_WORLD },
         { idx: 3, laps: 5, dist: 0.2 },
       ]);
 
       expect(findAdjacentCarOnTrack(telemetry, "ahead")).toBe(1);
+    });
+
+    it("should include cars during a warmup/pace lap (CarIdxLapCompleted still -1)", () => {
+      // Regression: snapshot 20260417-081043 had everyone at laps=-1 during the formation lap,
+      // which previously caused findNearestCarOnTrack to reject every candidate.
+      const telemetry = makeTelemetry(14, [
+        { idx: 1, laps: -1, dist: 0.8173747 },
+        { idx: 11, laps: -1, dist: 0.8009607 },
+        { idx: 14, laps: -1, dist: 0.8019581 },
+        { idx: 17, laps: -1, dist: 0.8063871 },
+      ]);
+
+      expect(findAdjacentCarOnTrack(telemetry, "ahead")).toBe(17);
+      expect(findAdjacentCarOnTrack(telemetry, "behind")).toBe(11);
     });
 
     it("should return null when telemetry is null", () => {

--- a/packages/iracing-sdk/src/track-utils.test.ts
+++ b/packages/iracing-sdk/src/track-utils.test.ts
@@ -1,20 +1,28 @@
 import { describe, expect, it } from "vitest";
 
 import { findNearestCarOnTrack } from "./track-utils.js";
+import { TrkLoc } from "./types.js";
 
-function makeTelemetry(refCarIdx: number, cars: Array<{ idx: number; laps: number; dist: number }>) {
+function makeTelemetry(
+  refCarIdx: number,
+  cars: Array<{ idx: number; laps: number; dist: number; trackSurface?: TrkLoc }>,
+) {
   const maxIdx = Math.max(...cars.map((c) => c.idx), refCarIdx, 0);
   const lapCompleted = new Array(maxIdx + 1).fill(-1);
   const lapDistPct = new Array(maxIdx + 1).fill(-1);
+  // Empty slots default to NotInWorld; listed cars default to OnTrack unless overridden.
+  const trackSurface = new Array(maxIdx + 1).fill(TrkLoc.NotInWorld);
 
   for (const car of cars) {
     lapCompleted[car.idx] = car.laps;
     lapDistPct[car.idx] = car.dist;
+    trackSurface[car.idx] = car.trackSurface ?? TrkLoc.OnTrack;
   }
 
   return {
     CarIdxLapCompleted: lapCompleted,
     CarIdxLapDistPct: lapDistPct,
+    CarIdxTrackSurface: trackSurface,
   };
 }
 
@@ -70,14 +78,38 @@ describe("findNearestCarOnTrack", () => {
     expect(findNearestCarOnTrack(telemetry, 2, "behind")).toBe(1);
   });
 
-  it("should skip inactive cars", () => {
+  it("should skip cars with no track position", () => {
     const telemetry = makeTelemetry(3, [
       { idx: 1, laps: 5, dist: 0.8 },
-      { idx: 2, laps: -1, dist: 0.5 },
+      { idx: 2, laps: 5, dist: -1 },
       { idx: 3, laps: 5, dist: 0.2 },
     ]);
 
     expect(findNearestCarOnTrack(telemetry, 3, "ahead")).toBe(1);
+  });
+
+  it("should skip cars flagged as NotInWorld even with a stale track position", () => {
+    const telemetry = makeTelemetry(3, [
+      { idx: 1, laps: 5, dist: 0.8 },
+      { idx: 2, laps: 5, dist: 0.5, trackSurface: TrkLoc.NotInWorld },
+      { idx: 3, laps: 5, dist: 0.2 },
+    ]);
+
+    expect(findNearestCarOnTrack(telemetry, 3, "ahead")).toBe(1);
+  });
+
+  it("should include cars during a warmup/pace lap (CarIdxLapCompleted still -1)", () => {
+    // Real scenario from telemetry-snapshot-20260417-081043: everyone is on the formation
+    // lap, so CarIdxLapCompleted is -1 for all cars even though CarIdxLapDistPct is valid.
+    const telemetry = makeTelemetry(14, [
+      { idx: 1, laps: -1, dist: 0.8173747 },
+      { idx: 11, laps: -1, dist: 0.8009607 },
+      { idx: 14, laps: -1, dist: 0.8019581 },
+      { idx: 17, laps: -1, dist: 0.8063871 },
+    ]);
+
+    expect(findNearestCarOnTrack(telemetry, 14, "ahead")).toBe(17);
+    expect(findNearestCarOnTrack(telemetry, 14, "behind")).toBe(11);
   });
 
   it("should apply skipIdx filter", () => {

--- a/packages/iracing-sdk/src/track-utils.ts
+++ b/packages/iracing-sdk/src/track-utils.ts
@@ -1,3 +1,4 @@
+import { TrkLoc } from "./types.js";
 import type { TelemetryData } from "./types.js";
 
 export interface FindNearestCarOptions {
@@ -24,12 +25,12 @@ export function findNearestCarOnTrack(
   direction: "ahead" | "behind",
   options?: FindNearestCarOptions,
 ): number | null {
-  if (!telemetry?.CarIdxLapCompleted || !telemetry?.CarIdxLapDistPct) return null;
+  if (!telemetry?.CarIdxLapDistPct) return null;
 
   if (referenceCarIdx < 0) return null;
 
-  const lapCompleted = telemetry.CarIdxLapCompleted as number[];
   const lapDistPct = telemetry.CarIdxLapDistPct as number[];
+  const trackSurface = telemetry.CarIdxTrackSurface as number[] | undefined;
   const skipIdx = options?.skipIdx;
 
   const currentDist = lapDistPct[referenceCarIdx];
@@ -38,12 +39,15 @@ export function findNearestCarOnTrack(
   let bestIdx: number | null = null;
   let bestDist = Infinity;
 
-  for (let idx = 0; idx < lapCompleted.length; idx++) {
+  for (let idx = 0; idx < lapDistPct.length; idx++) {
     if (idx === referenceCarIdx) continue;
 
-    if (lapCompleted[idx] === undefined || lapCompleted[idx] < 0) continue;
-
     if (lapDistPct[idx] === undefined || lapDistPct[idx] < 0) continue;
+
+    // Skip disconnected/empty slots. During a warmup/pace lap CarIdxLapCompleted is
+    // still -1 for active cars, so lap count is not a safe "is active" signal — the
+    // authoritative signals are CarIdxLapDistPct and CarIdxTrackSurface.
+    if (trackSurface?.[idx] === TrkLoc.NotInWorld) continue;
 
     if (skipIdx?.(idx)) continue;
 


### PR DESCRIPTION
## Related Issue

Fixes #307

## What changed?

`findNearestCarOnTrack` (in `@iracedeck/iracing-sdk`) was filtering out every car whose `CarIdxLapCompleted < 0`. During a race's formation/pace lap no one has finished a lap yet, so the filter rejected every candidate and the replay `next-car` / `prev-car` commands became no-ops. Cycling by car number still worked because that path reads session info rather than telemetry lap counts — matching the reporter's and Niklas' observations.

- Dropped the lap-count filter (it duplicated the already-present `CarIdxLapDistPct >= 0` check for disconnected cars and wrongly rejected warmup-lap cars).
- Added an explicit `CarIdxTrackSurface !== NotInWorld` check as defense against disconnected / empty slots, since telemetry snapshots are only a single point in time and other states may set these fields inconsistently.
- Updated tests: split the former "skip inactive cars" case into explicit "no track position" and "NotInWorld" cases, and added a formation-lap regression test seeded from `telemetry-snapshot-20260417-081043` (all cars at `CarIdxLapCompleted = -1`, valid `CarIdxLapDistPct`).

## How to test

- Join a race and press the `Replay Control` action in `Next Car` / `Previous Car` mode while still on the warmup / formation lap (before any car has completed lap 1). The camera should now switch to the physically adjacent car.
- Verify mid-race behaviour is unchanged: cycle through cars ahead / behind on track during green-flag racing.
- Verify disconnected drivers are still skipped.
- `pnpm test` — 2909/2909 pass.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — fix is in shared `@iracedeck/iracing-sdk`, no per-plugin changes needed
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable car detection: disconnected vehicles are excluded and adjacent ahead/behind identification works during warm-up, pace, and formation laps.

* **Tests**
  * Expanded test coverage for disconnected/stale-position scenarios and for adjacent-car selection when lap-completion data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->