### PR TITLE
docs: reconcile #340 leftovers and PR review nits (#348)

### DIFF
--- a/.claude/rules/keyboard-shortcuts.md
+++ b/.claude/rules/keyboard-shortcuts.md
@@ -126,9 +126,9 @@ override async onWillDisappear(ev: IDeckWillDisappearEvent<Settings>): Promise<v
 ```
 
 ### Reference implementations
-- Tap action with global key bindings: `packages/iracing-actions/src/actions/black-box-selector.ts`
-- Cycle action with global key bindings: `packages/iracing-actions/src/actions/splits-delta-cycle.ts`
-- Long-press (key hold): `packages/iracing-actions/src/actions/look-direction.ts`
+- Tap action with global key bindings: `packages/iracing-actions/src/actions/black-box-selector/black-box-selector.ts`
+- Cycle action with global key bindings: `packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ts`
+- Long-press (key hold): `packages/iracing-actions/src/actions/look-direction/look-direction.ts`
 
 ## Direct Keyboard Access (Plugin-Level Only)
 
@@ -225,9 +225,9 @@ if (binding && !isSimHubBinding(binding)) {
 ```
 
 ## Reference Implementations
-- Binding dispatch (tap): `packages/iracing-actions/src/actions/black-box-selector.ts`
-- Binding dispatch (cycle): `packages/iracing-actions/src/actions/splits-delta-cycle.ts`
-- Binding dispatch (hold/release): `packages/iracing-actions/src/actions/look-direction.ts`
+- Binding dispatch (tap): `packages/iracing-actions/src/actions/black-box-selector/black-box-selector.ts`
+- Binding dispatch (cycle): `packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ts`
+- Binding dispatch (hold/release): `packages/iracing-actions/src/actions/look-direction/look-direction.ts`
 - Binding dispatcher service: `packages/deck-core/src/binding-dispatcher.ts`
 
 ## Do NOT Use

--- a/.claude/rules/plugin-structure.md
+++ b/.claude/rules/plugin-structure.md
@@ -22,7 +22,7 @@ Both plugins register the same actions from `@iracedeck/iracing-actions`. When a
 
 Use `iracing-plugin-stream-deck` as the reference implementation for Elgato plugins, and `iracing-plugin-mirabox` for Mirabox/VSD plugins. Create the following structure:
 
-```
+```text
 packages/iracing-plugin-stream-deck-{name}/
 ├── package.json                           # @iracedeck/iracing-plugin-stream-deck-{name}
 ├── tsconfig.json                          # Extends ../../tsconfig.base.json

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -99,4 +99,4 @@ describe("MyAction", () => {
 
 ### Reference Implementation
 
-See `packages/iracing-actions/src/actions/splits-delta-cycle.test.ts` for a complete example.
+See `packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.test.ts` for a complete example.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ packages/
 
 | Package                           | Role                                                                                      |
 | --------------------------------- | ----------------------------------------------------------------------------------------- |
-| `@iracedeck/iracing-actions`              | All 28 action implementations, platform-agnostic                                          |
+| `@iracedeck/iracing-actions`              | All 30 action implementations, platform-agnostic                                          |
 | `@iracedeck/deck-core`            | Base classes, types, keyboard service, icon templates, global settings                    |
 | `@iracedeck/deck-adapter-elgato`  | Bridges the Elgato SDK to deck-core's `IDeckPlatformAdapter` interface                    |
 | `@iracedeck/deck-adapter-mirabox` | Bridges the Mirabox VSD Craft WebSocket protocol to deck-core                             |
@@ -193,7 +193,7 @@ Actions live in `packages/iracing-actions/src/actions/<action-name>/`, one folde
 3. `<action-name>.ejs` — Property Inspector template (compiled to `ui/<action-name>.html`)
 4. `icon.svg` + `key.svg` — static category and key icons (copied into each plugin's `imgs/actions/<name>/` at build time)
 5. Mustache SVGs in `packages/icons/<action-name>/` for any dynamic variants
-6. Registration in both `iracing-plugin-stream-deck/src/plugin.ts` and `iracing-plugin-mirabox/src/plugin.ts`
+6. Registration in both `packages/iracing-plugin-stream-deck/src/plugin.ts` and `packages/iracing-plugin-mirabox/src/plugin.ts`
 7. Manifest entry in each plugin's `manifest.json`
 8. Entries in `packages/iracing-actions/src/actions/data/{key-bindings,docs-urls,icon-defaults}.json` where applicable
 

--- a/docs/architecture/pi-template-system.md
+++ b/docs/architecture/pi-template-system.md
@@ -197,9 +197,9 @@ plugins: [
 ## Verification
 
 1. Run `pnpm build` in iracing-plugin-stream-deck
-3. Check `ui/black-box-selector.html` contains compiled accordion
-4. Open Stream Deck, verify PI renders with collapsible key bindings
-5. Verify key binding changes persist to global settings
+2. Check `ui/black-box-selector.html` contains compiled accordion
+3. Open Stream Deck, verify PI renders with collapsible key bindings
+4. Verify key binding changes persist to global settings
 
 ## Files to Modify
 

--- a/packages/iracing-actions/CLAUDE.md
+++ b/packages/iracing-actions/CLAUDE.md
@@ -1,21 +1,30 @@
 # @iracedeck/iracing-actions
 
-All 33 platform-agnostic iRaceDeck action classes. These actions contain no platform-specific code — they import from `@iracedeck/deck-core` and are registered by platform-specific entry points (e.g., `iracing-plugin-stream-deck/src/plugin.ts`).
+All 30 platform-agnostic iRaceDeck action classes. These actions contain no platform-specific code — they import from `@iracedeck/deck-core` and are registered by platform-specific entry points (e.g., `iracing-plugin-stream-deck/src/plugin.ts`).
 
 ## Package Structure
 
 ```text
 src/
-  index.ts                    # Barrel export of all actions + UUIDs
+  index.ts                               # Barrel export of all actions + UUIDs
   actions/
-    splits-delta-cycle.ts     # Action class + UUID constant
-    splits-delta-cycle.test.ts
-    black-box-selector.ts
-    ...                       # 33 action files + 33 test files
-    race-admin-commands.ts    # Helper (no action class)
-    race-admin-modes.ts       # Helper (no action class)
-icons/
-  car-control.svg             # Dynamic SVG templates (telemetry-driven)
+    <action-name>/                       # One folder per action, self-contained
+      <action-name>.ts                   # Action class + UUID constant
+      <action-name>.test.ts              # Unit tests
+      <action-name>.ejs                  # Property Inspector template
+      icon.svg                           # Category icon (20x20)
+      key.svg                            # Key icon (72x72)
+    race-admin/                          # Same layout plus helpers
+      race-admin-commands.ts             # Helper (no action class)
+      race-admin-modes.ts                # Helper (no action class)
+    data/                                # Shared template data
+      icon-defaults.json
+      key-bindings.json
+      docs-urls.json
+    settings/                            # Plugin-global PI template
+      settings.ejs
+icons/                                   # Dynamic SVG templates (telemetry-driven)
+  car-control.svg
   session-info.svg
   telemetry-display.svg
   tire-service.svg
@@ -53,4 +62,4 @@ Tests mock `@iracedeck/deck-core` (not `@elgato/streamdeck`). The mock `Connecti
 
 ## Adding a New Action
 
-See `packages/iracing-plugin-stream-deck/CLAUDE.md` for the full step-by-step guide. The action source file goes in this package; registration and PI templates go in `iracing-plugin-stream-deck`.
+See `packages/iracing-plugin-stream-deck/CLAUDE.md` for the full step-by-step guide. The action source file and PI template (`<name>.ejs`) stay in this package alongside the action code; action registration and `manifest.json` entries are done in each plugin package (`packages/iracing-plugin-stream-deck/src/plugin.ts` and `packages/iracing-plugin-mirabox/src/plugin.ts`).


### PR DESCRIPTION
## Related Issue

Fixes #348

## What changed?

Cleans up stale documentation references and count mismatches noticed by CodeRabbit during PRs #346 and #347 — leftovers from the per-action subfolder refactor in #340, plus a couple of unrelated lint/style nits. Documentation only; no code changes.

- `packages/iracing-actions/CLAUDE.md`: tree diagram rewritten to show per-action subfolders (`<name>/<name>.ts` + `<name>.test.ts` + `<name>.ejs` + `icon.svg` + `key.svg` side-by-side), plus `data/` and `settings/` directories. Action count corrected `33` → `30`. Clarified that PI templates stay with the action source; only action registration and `manifest.json` entries live in each plugin package.
- `.claude/rules/keyboard-shortcuts.md`: reference-implementation paths now include the action subfolder (both occurrences at lines 129-131 and 228-230, covering `black-box-selector`, `splits-delta-cycle`, `look-direction`).
- `.claude/rules/testing.md`: same subfolder fix for the `splits-delta-cycle` reference test path.
- `README.md`: package table action count corrected `28` → `30` to match the Features section and the authoritative count in `.claude/skills/iracedeck-actions/SKILL.md`. Restored `packages/` prefix on the registration-list `plugin.ts` entries for consistency with adjacent items.
- `.claude/rules/plugin-structure.md`: added `text` language tag to the fenced code block at line 25 (markdownlint MD040).
- `docs/architecture/pi-template-system.md`: renumbered the Verification block `1/3/4/5` → `1/2/3/4`.

## How to test

- `pnpm -r build && pnpm test` — all 2912 tests pass (no code changes).
- `pnpm lint` — clean.
- `pnpm format` — clean (the pre-existing `.astro` generated-file warnings are gone as of master).
- Spot-checked that the referenced paths resolve to real files: `packages/iracing-actions/src/actions/<name>/<name>.ts` and `<name>.test.ts` exist for `black-box-selector`, `splits-delta-cycle`, `look-direction`.
- Action count `30` matches the authoritative source (`SKILL.md` Category Overview total).

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation to reflect current project structure and organization.
  * Corrected file path references across reference guides.
  * Action count updated to 30 (previously 28).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->