### PR TITLE
fix(actions): remove Mute option from Master audio-controls category (#351)

### DIFF
--- a/packages/iracing-actions/src/actions/audio-controls/audio-controls.ejs
+++ b/packages/iracing-actions/src/actions/audio-controls/audio-controls.ejs
@@ -42,28 +42,38 @@
 		<%- include('global-common-settings') %>
 
 		<script>
+			// Master doesn't support mute. The option is removed from the DOM when Master
+			// is selected (style.display is ignored by sdpi-select, which re-renders options
+			// from the source list via a MutationObserver).
+			let muteOption = null;
+			let muteOptionParent = null;
+
 			function updateVisibility(category) {
 				const actionItem = document.getElementById("action-item");
 				const actionSelect = document.getElementById("action-select");
-				const muteOption = document.querySelector('#action-select option[value="mute"]');
 
 				if (category === "push-to-talk") {
 					// Hide the entire action dropdown for PTT
 					if (actionItem) actionItem.classList.add("hidden");
-				} else {
-					if (actionItem) actionItem.classList.remove("hidden");
+					return;
+				}
 
-					if (muteOption) {
-						if (category === "master") {
-							muteOption.style.display = "none";
-							// If mute was selected, switch to volume-up
-							if (actionSelect && actionSelect.value === "mute") {
-								actionSelect.value = "volume-up";
-							}
-						} else {
-							muteOption.style.display = "";
-						}
+				if (actionItem) actionItem.classList.remove("hidden");
+				if (!muteOption || !muteOptionParent) return;
+
+				const isAttached = muteOption.parentNode === muteOptionParent;
+
+				if (category === "master") {
+					// Switch selection away from mute before detaching the option so the
+					// persisted setting stays consistent with what's rendered.
+					if (actionSelect && actionSelect.value === "mute") {
+						actionSelect.value = "volume-up";
+						actionSelect.dispatchEvent(new Event("input", { bubbles: true }));
+						actionSelect.dispatchEvent(new Event("change", { bubbles: true }));
 					}
+					if (isAttached) muteOption.remove();
+				} else if (!isAttached) {
+					muteOptionParent.appendChild(muteOption);
 				}
 			}
 
@@ -71,6 +81,8 @@
 				await customElements.whenDefined("sdpi-select");
 
 				const categorySelect = document.getElementById("category-select");
+				muteOption = document.querySelector('#action-select option[value="mute"]');
+				muteOptionParent = muteOption ? muteOption.parentNode : null;
 
 				if (categorySelect) {
 					const initialValue = categorySelect.value || "push-to-talk";


### PR DESCRIPTION
## Related Issue

Fixes #351

## What changed?

- `packages/iracing-actions/src/actions/audio-controls/audio-controls.ejs` — fix the Master-category visibility logic so the "Mute" option is truly unreachable.
- Master audio has no `master-mute` entry in `AUDIO_CONTROLS_GLOBAL_KEYS`, so picking Mute under Master was a silent no-op.
- The previous attempt used `muteOption.style.display = "none"`, but `sdpi-select` re-renders options from the source list via a MutationObserver and doesn't propagate inline style on source `<option>` elements — the option remained visible and selectable.
- New behavior: detach the `<option>` from the DOM when Master is selected, re-attach it when switching to another category. If Mute is currently selected, switch the action to `volume-up` and dispatch `input`+`change` events before detaching so the persisted setting stays in sync with what's rendered.

## How to test

1. `pnpm build`
2. `streamdeck link packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin` (or use the Mirabox plugin)
3. Add an **Audio Controls** action to a key, open the Property Inspector
4. Set **Mode** to **Voice Chat** — confirm the **Action** dropdown shows Volume Up / Volume Down / Mute
5. Switch **Mode** to **Master** — confirm **Mute** is no longer in the dropdown
6. Switch **Mode** back to **Voice Chat** — confirm **Mute** returns
7. Set action to **Mute**, switch **Mode** to **Master** — confirm action resets to **Volume Up** (persisted) and Mute disappears from the dropdown
8. Set **Mode** to **Push to Talk** — confirm the whole Action dropdown is hidden

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests (PI-only change; no action-code paths modified — existing audio-controls unit tests still pass)
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox — same `.ejs` consumed by both)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the mute action option visibility behavior when switching between audio control categories. The option now properly appears and disappears, and automatically switches away from mute when selecting the master category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->