### PR TITLE
fix(scripts): make switch-test-env tolerate no-plugin-linked state (#354)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "unlink:stream-deck": "streamdeck unlink -d com.iracedeck.sd.core",
     "relink:stream-deck": "streamdeck unlink -d com.iracedeck.sd.core 2>NUL & streamdeck link .\\packages\\iracing-plugin-stream-deck\\com.iracedeck.sd.core.sdPlugin",
     "switch-test-env": "pnpm switch-test-env:stream-deck",
-    "switch-test-env:stream-deck": "pnpm unlink:stream-deck -d && pnpm install && pnpm build && pnpm link:stream-deck",
+    "switch-test-env:stream-deck": "pnpm install && pnpm build && pnpm relink:stream-deck",
     "telemetry-snapshot": "pnpm --filter @iracedeck/iracing-sdk telemetry-snapshot -- --include-session --output-dir=local",
     "watch:stream-deck": "pnpm --filter \"@iracedeck/iracing-plugin-stream-deck\" run watch",
     "release": "node scripts/release.mjs",


### PR DESCRIPTION
## Related Issue

Fixes #354

## What changed?

`pnpm switch-test-env` aborted when no Stream Deck plugin was currently linked, because `streamdeck unlink` exits with code 1 on "Plugin not found" and the `&&` pipeline stopped before `pnpm install`, `pnpm build`, or the re-link ran.

New `switch-test-env:stream-deck` pipeline:

```diff
- "switch-test-env:stream-deck": "pnpm unlink:stream-deck -d && pnpm install && pnpm build && pnpm link:stream-deck"
+ "switch-test-env:stream-deck": "pnpm install && pnpm build && pnpm relink:stream-deck"
```

- Delegates the unlink-then-link sequence to the existing `relink:stream-deck` script, which already handles the not-linked case via Windows cmd's `streamdeck unlink ... 2>/dev/null & streamdeck link ...` (single `&` always runs the next command; `2>NUL` suppresses the "Plugin not found" error text).
- Reuses a working pattern that's already in the same `package.json`.
- Incidentally drops the stray `-d` arg that was being forwarded as an extra positional to `unlink:stream-deck` (harmless duplicate, but tidier gone).

## How to test

1. Make sure the Stream Deck plugin is **not** currently linked (e.g. fresh worktree, or run `pnpm unlink:stream-deck` manually first)
2. Run `pnpm switch-test-env`
3. Observe the pipeline runs to completion — `pnpm install` → `pnpm build` → `pnpm relink:stream-deck` — without aborting on the unlink step
4. Confirm the plugin is now linked (Stream Deck shows the iRaceDeck action category)
5. Run `pnpm switch-test-env` again from the linked state — it should still complete cleanly (the unlink portion removes the existing link, the link portion re-adds it)

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests (n/a — shell pipeline change with no testable TS/JS code)
- [x] Changes registered in all applicable plugins (only Stream Deck plugin has a `switch-test-env`; Mirabox doesn't have one yet — tracked in #355)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the Stream Deck test environment setup process by consolidating build workflow steps for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->