### PR TITLE
feat(core): platform feature flags with local override (#258)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -45,6 +45,7 @@ You can import or reference specific rule files from other markdown using `@.cla
 - `keyboard-shortcuts.md`: SDK-first principle, key binding architecture, Property Inspector setup for `ird-key-binding`, Zod schemas for key bindings, sending key combinations (tap and long-press/hold), global vs per-action bindings, and cross-package sync rules.
 - `logging.md`: Log levels, info vs debug separation, `createScope()` usage, and dependency-injected logger patterns.
 - `pi-templates.md`: EJS templates for Property Inspector HTML: directory structure, available partials, Rollup plugin config, key bindings JSON format.
+- `platform-feature-flags.md`: Build-time feature flags per plugin (capabilities + features) with a gitignored `feature-flags.local.json` dev override; compile-time `__FEATURE_*__` / `__CAPABILITY_*__` constants for tree-shaking; PI template gating via `locals.platform`.
 - `plugin-structure.md`: Plugin package naming conventions, Rollup config, native module handling (`keysender`), app monitoring, and critical initialization order in `plugin.ts`.
 - `sdpi-components.md`: Comprehensive reference for the `sdpi-components` web component library used in all Property Inspectors: every component's attributes and value types, Stream Deck client communication helpers, data sources, and localization. Scoped to PI files.
 - `stream-deck-actions.md`: Action requirements (`ConnectionStateAwareAction`), SDK-first principle, PI components (`sdpi-select` quirks, conditional visibility), global settings setup, and encoder support.

--- a/.claude/rules/platform-feature-flags.md
+++ b/.claude/rules/platform-feature-flags.md
@@ -1,0 +1,126 @@
+# Platform Feature Flags
+
+Per-plugin build-time flags that gate features dependent on SVG rendering-engine capabilities. Used to strip unsupported code and PI controls from the Mirabox bundle (QT5) while keeping them on Stream Deck (QT6.7+).
+
+## Layout
+
+- `packages/iracing-plugin-stream-deck/platform-features.json` — committed Stream Deck flags (all true by default).
+- `packages/iracing-plugin-mirabox/platform-features.json` — committed Mirabox flags (QT5-incompatible features off).
+- `feature-flags.local.json` — **optional, gitignored** developer override at repo root. Deep-merges over both plugins' committed flags at build time.
+- `feature-flags.local.json.example` — committed example showing the file shape.
+
+## Flag categories
+
+- **Capabilities** (`capabilities.*`) — raw SVG engine support (`svgFilters`, `svgMasks`, `svgPatterns`). These are the source of truth.
+- **Features** (`features.*`) — product-level flags that depend on one or more capabilities (`borderGlow`). When adding a new feature that requires a capability, document the dependency in the flag name or a comment.
+
+## How flags reach runtime + PI
+
+Both plugins' `rollup.config.mjs`:
+
+1. Read their `platform-features.json`.
+2. If `feature-flags.local.json` exists at the repo root, deep-merge it on top.
+3. Feed the merged object to three consumers:
+   - `@rollup/plugin-replace` — injects `__CAPABILITY_SVG_FILTERS__`, `__CAPABILITY_SVG_MASKS__`, `__CAPABILITY_SVG_PATTERNS__`, `__FEATURE_BORDER_GLOW__` as JSON-stringified boolean literals. Terser then tree-shakes the dead branches.
+   - `emit-plugin-config` — writes the merged object as `featureFlags` in `/bin/config.json` (readable via `getFeatureFlag()` / `getPlatformFeatures()`).
+   - `piTemplatePlugin` — passes the object to EJS render context as `platform` (and `locals.platform`).
+
+## Using a flag in code
+
+Ambient globals are declared in `packages/icon-composer/src/platform-features.d.ts`. Reference the `__FEATURE_*__` constant directly:
+
+```ts
+// packages/icon-composer/src/icon-base.ts
+if (!border.glowEnabled || !__FEATURE_BORDER_GLOW__) {
+  return { defs: "", rects: borderRect };
+}
+```
+
+Put the gating in shared `icon-composer` / `deck-core` utilities — **not in individual action files**. Actions call the utilities and stay platform-agnostic.
+
+For resolved settings, force the flag's state so downstream callers don't see the feature enabled:
+
+```ts
+// packages/icon-composer/src/title-settings.ts — resolveBorderSettings
+glowEnabled:
+  __FEATURE_BORDER_GLOW__ &&
+  resolve(actionOverrides?.glowEnabled, globalBorderSettings.glowEnabled, undefined, BORDER_DEFAULTS.glowEnabled),
+```
+
+## Using a flag in PI templates
+
+Gate `sdpi-item` controls and any related JS in the shared partial:
+
+```ejs
+<% var borderGlowEnabled = (locals.platform?.features?.borderGlow !== false); %>
+<% if (borderGlowEnabled) { %>
+  <sdpi-item id="ird-border-glow" class="hidden" label="Show Glow">...</sdpi-item>
+<% } %>
+```
+
+The `!== false` check makes the default-enabled behavior explicit: when a caller doesn't set `platformFeatures` (e.g., tests), the control still renders.
+
+## Runtime access (rare)
+
+Most code should use the compile-time constants. If a runtime check is genuinely needed:
+
+```ts
+import { getFeatureFlag, getPlatformFeatures } from "@iracedeck/deck-core";
+
+if (getFeatureFlag("borderGlow") === true) { /* ... */ }
+const all = getPlatformFeatures(); // full object or undefined
+```
+
+Runtime checks don't participate in tree-shaking — prefer the compile-time constants when the decision can be made at build time.
+
+## Testing
+
+Root `test-setup.ts` sets `globalThis.__FEATURE_BORDER_GLOW__ = true` (and the capabilities) so tests see the defaults. Cover both paths with `vi.stubGlobal`:
+
+```ts
+afterEach(() => vi.unstubAllGlobals());
+
+it("strips glow when flag is false", () => {
+  vi.stubGlobal("__FEATURE_BORDER_GLOW__", false);
+  // ... assertion
+});
+```
+
+## Adding a new flag
+
+1. Add to both `platform-features.json` files under `capabilities` or `features` (enabled/disabled per platform).
+2. Add the `__CAPABILITY_*__` / `__FEATURE_*__` ambient declaration to `packages/icon-composer/src/platform-features.d.ts`.
+3. Add the replace entry to **both** `rollup.config.mjs` files.
+4. If it's a new feature, add its key to `PlatformFeatureFlags` in `packages/deck-core/src/plugin-config.ts`.
+5. Gate the relevant code in `icon-composer` / `deck-core` utilities and any relevant PI partial.
+6. Add default to `test-setup.ts` and true/false path tests that `vi.stubGlobal` the constant.
+7. Update the example file (`feature-flags.local.json.example`).
+
+## Watch mode caveat
+
+Both plugin Rollup configs call `this.addWatchFile(localFeaturesPath)` **only when the file already exists at `buildStart`**. If you start `pnpm watch:*` and then create `feature-flags.local.json` afterwards, the watcher won't see it — trigger one manual rebuild (edit any watched file, or restart the watcher) to pick it up. Once the file exists at watcher start, edits are picked up normally.
+
+## Local override round-trip
+
+```bash
+# Force borderGlow off on this machine:
+cat > feature-flags.local.json <<'EOF'
+{ "features": { "borderGlow": false } }
+EOF
+pnpm build
+
+# Verify:
+grep -c feGaussianBlur packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/bin/plugin.js   # -> 0
+grep -c ird-border-glow packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/bin/plugin.js # -> 0
+
+# Revert:
+rm feature-flags.local.json
+pnpm build
+```
+
+## Related files
+
+- `@.claude/rules/svg-platform-compatibility.md` — which SVG features are safe on each platform.
+- `packages/icon-composer/src/icon-base.ts` / `title-settings.ts` — gating for `borderGlow`.
+- `packages/pi-components/partials/border-overrides.ejs`, `global-border-defaults.ejs`, `head-common.ejs` — PI glow gating.
+- `packages/deck-core/src/plugin-config.ts` — `PluginConfig`, `getFeatureFlag`, `getPlatformFeatures`.

--- a/.claude/rules/platform-feature-flags.md
+++ b/.claude/rules/platform-feature-flags.md
@@ -98,7 +98,12 @@ it("strips glow when flag is false", () => {
 
 ## Watch mode caveat
 
-Both plugin Rollup configs call `this.addWatchFile(localFeaturesPath)` **only when the file already exists at `buildStart`**. If you start `pnpm watch:*` and then create `feature-flags.local.json` afterwards, the watcher won't see it — trigger one manual rebuild (edit any watched file, or restart the watcher) to pick it up. Once the file exists at watcher start, edits are picked up normally.
+Rollup loads each plugin config module **once per watcher session**, so the resolved `platformFeatures` object is captured at watcher startup and held for the lifetime of the watcher. Consequences:
+
+- Creating `feature-flags.local.json` while a watcher is running: the file isn't in the watch set yet, and even once a rebuild is triggered by some other change, the resolved flags are still the ones from startup.
+- Editing an existing `platform-features.json` or `feature-flags.local.json` while a watcher is running: a rebuild fires (the file is in the watch set), but it uses the flags captured at startup — the edit won't affect the output.
+
+**Always restart the watcher after changing any flag file.** This is a deliberate trade-off: refreshing the flags on every rebuild would require either reinstantiating `@rollup/plugin-replace` (not possible mid-watch) or threading mutable state through `replace`, `piTemplatePlugin`, and `emit-plugin-config`, which adds complexity for a scenario that's already covered by a one-line restart.
 
 ## Local override round-trip
 

--- a/.claude/rules/platform-feature-flags.md
+++ b/.claude/rules/platform-feature-flags.md
@@ -109,9 +109,12 @@ cat > feature-flags.local.json <<'EOF'
 EOF
 pnpm build
 
-# Verify:
+# Verify bundle (tree-shaken by @rollup/plugin-replace + terser):
 grep -c feGaussianBlur packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/bin/plugin.js   # -> 0
 grep -c ird-border-glow packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/bin/plugin.js # -> 0
+
+# Verify PI output (emitted by piTemplatePlugin; `ird-border-glow` is the control id):
+grep -R -l ird-border-glow packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/ui         # -> (no matches)
 
 # Revert:
 rm feature-flags.local.json

--- a/.claude/rules/svg-platform-compatibility.md
+++ b/.claude/rules/svg-platform-compatibility.md
@@ -10,6 +10,8 @@ This project renders SVG icons on two platforms with different SVG engines:
 
 **Rule: All icons must render correctly on the lowest common denominator (QT5 / SVG Tiny 1.2 static).** Features unsupported by QT5 are silently ignored — the icon renders but without the effect.
 
+For code paths that generate QT6-only SVG (e.g., filters), gate them behind platform feature flags so the Mirabox bundle doesn't ship unused code and the Mirabox PI doesn't show controls that have no effect. See `@.claude/rules/platform-feature-flags.md`.
+
 ## Safe to Use (both platforms)
 
 These features are part of SVG Tiny 1.2 static and work on both Elgato and Mirabox:

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ desktop.ini
 .env.local
 .env.*.local
 
+# Platform feature flag local override (dev-only, merges over platform-features.json at build time)
+feature-flags.local.json
+
 # Debug
 *.pdb
 

--- a/feature-flags.local.json.example
+++ b/feature-flags.local.json.example
@@ -1,0 +1,10 @@
+{
+  "capabilities": {
+    "svgFilters": true,
+    "svgMasks": true,
+    "svgPatterns": true
+  },
+  "features": {
+    "borderGlow": true
+  }
+}

--- a/packages/deck-core/src/icon-base.test.ts
+++ b/packages/deck-core/src/icon-base.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { generateBorderParts } from "./icon-base.js";
 import type { ResolvedBorderSettings } from "./title-settings.js";
@@ -79,5 +79,28 @@ describe("generateBorderParts", () => {
     expect(result.rects).toContain('x="20"');
     expect(result.rects).toContain('width="104"');
     expect(result.rects).toContain('rx="4"');
+  });
+
+  describe("__FEATURE_BORDER_GLOW__ gating", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("should skip glow when flag is false (even if glowEnabled=true)", () => {
+      vi.stubGlobal("__FEATURE_BORDER_GLOW__", false);
+      const result = generateBorderParts({ ...DEFAULTS, enabled: true, glowEnabled: true });
+      expect(result.defs).toBe("");
+      expect(result.rects).not.toContain("ird-border-glow");
+      expect(result.rects).not.toContain("feGaussianBlur");
+      expect(result.rects).toContain('stroke="#00aaff"');
+      expect(result.rects).toContain('stroke-width="7"');
+    });
+
+    it("should emit glow when flag is true and glowEnabled=true", () => {
+      vi.stubGlobal("__FEATURE_BORDER_GLOW__", true);
+      const result = generateBorderParts({ ...DEFAULTS, enabled: true, glowEnabled: true });
+      expect(result.defs).toContain("ird-border-glow");
+      expect(result.defs).toContain("feGaussianBlur");
+    });
   });
 });

--- a/packages/deck-core/src/index.ts
+++ b/packages/deck-core/src/index.ts
@@ -204,6 +204,11 @@ export {
   getPluginVersion,
   getPluginPlatform,
   isPluginConfigInitialized,
+  getFeatureFlag,
+  getPlatformFeatures,
   _resetPluginConfig,
   type PluginConfig,
+  type PlatformCapabilities,
+  type PlatformFeatureFlags,
+  type PlatformFeatures,
 } from "./plugin-config.js";

--- a/packages/deck-core/src/plugin-config.test.ts
+++ b/packages/deck-core/src/plugin-config.test.ts
@@ -2,11 +2,24 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   _resetPluginConfig,
+  getFeatureFlag,
+  getPlatformFeatures,
   getPluginPlatform,
   getPluginVersion,
   initPluginConfig,
   isPluginConfigInitialized,
+  type PlatformFeatures,
 } from "./plugin-config.js";
+
+const ALL_TRUE_FEATURES: PlatformFeatures = {
+  capabilities: { svgFilters: true, svgMasks: true, svgPatterns: true },
+  features: { borderGlow: true },
+};
+
+const ALL_FALSE_FEATURES: PlatformFeatures = {
+  capabilities: { svgFilters: false, svgMasks: false, svgPatterns: false },
+  features: { borderGlow: false },
+};
 
 describe("plugin-config", () => {
   afterEach(() => {
@@ -79,6 +92,39 @@ describe("plugin-config", () => {
 
       expect(getPluginVersion()).toBe("2.0.0");
       expect(getPluginPlatform()).toBe("mirabox");
+    });
+  });
+
+  describe("getPlatformFeatures", () => {
+    it("should throw if not initialized", () => {
+      expect(() => getPlatformFeatures()).toThrow("not initialized");
+    });
+
+    it("should return undefined when featureFlags not provided", () => {
+      initPluginConfig({ version: "1.0.0", platform: "stream-deck" });
+      expect(getPlatformFeatures()).toBeUndefined();
+    });
+
+    it("should return the full platform features object when provided", () => {
+      initPluginConfig({ version: "1.0.0", platform: "stream-deck", featureFlags: ALL_TRUE_FEATURES });
+      expect(getPlatformFeatures()).toEqual(ALL_TRUE_FEATURES);
+    });
+  });
+
+  describe("getFeatureFlag", () => {
+    it("should return undefined when featureFlags not provided", () => {
+      initPluginConfig({ version: "1.0.0", platform: "stream-deck" });
+      expect(getFeatureFlag("borderGlow")).toBeUndefined();
+    });
+
+    it("should return true when flag is enabled", () => {
+      initPluginConfig({ version: "1.0.0", platform: "stream-deck", featureFlags: ALL_TRUE_FEATURES });
+      expect(getFeatureFlag("borderGlow")).toBe(true);
+    });
+
+    it("should return false when flag is disabled", () => {
+      initPluginConfig({ version: "1.0.0", platform: "mirabox", featureFlags: ALL_FALSE_FEATURES });
+      expect(getFeatureFlag("borderGlow")).toBe(false);
     });
   });
 });

--- a/packages/deck-core/src/plugin-config.ts
+++ b/packages/deck-core/src/plugin-config.ts
@@ -9,9 +9,42 @@
  * 2. Import getPluginVersion() wherever the version is needed
  */
 
+/**
+ * Platform capabilities — SVG rendering engine support.
+ * These are the source of truth that feature flags depend on.
+ */
+export interface PlatformCapabilities {
+  svgFilters: boolean;
+  svgMasks: boolean;
+  svgPatterns: boolean;
+}
+
+/**
+ * Product-level feature flags that gate user-visible features.
+ * Each flag typically depends on one or more capabilities.
+ */
+export interface PlatformFeatureFlags {
+  borderGlow: boolean;
+}
+
+export interface PlatformFeatures {
+  capabilities: PlatformCapabilities;
+  features: PlatformFeatureFlags;
+}
+
 export interface PluginConfig {
   version: string;
   platform: string;
+  /**
+   * Merged platform feature flags written into /bin/config.json at build time
+   * (committed platform-features.json deep-merged with optional root
+   * feature-flags.local.json). Absent in tests that don't supply it.
+   *
+   * Runtime consumers should normally rely on the `__FEATURE_*__` and
+   * `__CAPABILITY_*__` compile-time constants — this field exists for cases
+   * where a runtime check is needed, and for symmetry with version/platform.
+   */
+  featureFlags?: PlatformFeatures;
 }
 
 let config: PluginConfig | null = null;
@@ -62,6 +95,30 @@ export function getPluginPlatform(): string {
  */
 export function isPluginConfigInitialized(): boolean {
   return config !== null;
+}
+
+/**
+ * Get the full platform feature flags object (capabilities + features) as
+ * baked into this build's config.json, or `undefined` if not set.
+ *
+ * @throws Error if initPluginConfig() has not been called
+ */
+export function getPlatformFeatures(): PlatformFeatures | undefined {
+  if (!config) {
+    throw new Error("Plugin config not initialized. Call initPluginConfig() first.");
+  }
+
+  return config.featureFlags;
+}
+
+/**
+ * Check whether a named product feature flag is enabled for this build.
+ * Returns `undefined` if feature flags are not present in the config.
+ *
+ * @throws Error if initPluginConfig() has not been called
+ */
+export function getFeatureFlag(name: keyof PlatformFeatureFlags): boolean | undefined {
+  return getPlatformFeatures()?.features[name];
 }
 
 /**

--- a/packages/deck-core/src/title-settings.test.ts
+++ b/packages/deck-core/src/title-settings.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { TitleOverrides } from "./common-settings.js";
 import { getGlobalSettings } from "./global-settings.js";
@@ -474,6 +474,27 @@ describe("resolveBorderSettings", () => {
     const result = resolveBorderSettings(GRAPHIC_NO_BORDER, global);
     expect(result.glowEnabled).toBe(false);
     expect(result.glowWidth).toBe(50);
+  });
+
+  describe("__FEATURE_BORDER_GLOW__ gating", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("should force glowEnabled to false when the flag is false", () => {
+      vi.stubGlobal("__FEATURE_BORDER_GLOW__", false);
+      const global: GlobalBorderSettings = { glowEnabled: true };
+      const overrides = { glowEnabled: true };
+      const result = resolveBorderSettings(GRAPHIC_NO_BORDER, global, overrides);
+      expect(result.glowEnabled).toBe(false);
+    });
+
+    it("should respect resolved glowEnabled when the flag is true", () => {
+      vi.stubGlobal("__FEATURE_BORDER_GLOW__", true);
+      const overrides = { glowEnabled: true };
+      const result = resolveBorderSettings(GRAPHIC_NO_BORDER, {}, overrides);
+      expect(result.glowEnabled).toBe(true);
+    });
   });
 });
 

--- a/packages/icon-composer/src/icon-base.ts
+++ b/packages/icon-composer/src/icon-base.ts
@@ -27,7 +27,7 @@ export function generateBorderParts(border: ResolvedBorderSettings): {
   const borderRx = Math.max(0, 24 - borderInset);
   const borderRect = `<rect x="${borderInset}" y="${borderInset}" width="${144 - 2 * borderInset}" height="${144 - 2 * borderInset}" rx="${borderRx}" fill="none" stroke="${border.borderColor}" stroke-width="${border.borderWidth}"/>`;
 
-  if (!border.glowEnabled) {
+  if (!border.glowEnabled || !__FEATURE_BORDER_GLOW__) {
     return { defs: "", rects: borderRect };
   }
 

--- a/packages/icon-composer/src/platform-features.d.ts
+++ b/packages/icon-composer/src/platform-features.d.ts
@@ -1,0 +1,4 @@
+declare const __CAPABILITY_SVG_FILTERS__: boolean;
+declare const __CAPABILITY_SVG_MASKS__: boolean;
+declare const __CAPABILITY_SVG_PATTERNS__: boolean;
+declare const __FEATURE_BORDER_GLOW__: boolean;

--- a/packages/icon-composer/src/title-settings.ts
+++ b/packages/icon-composer/src/title-settings.ts
@@ -329,12 +329,9 @@ export function resolveBorderSettings(
       BORDER_DEFAULTS.borderWidth,
     ),
     borderColor,
-    glowEnabled: resolve(
-      actionOverrides?.glowEnabled,
-      globalBorderSettings.glowEnabled,
-      undefined,
-      BORDER_DEFAULTS.glowEnabled,
-    ),
+    glowEnabled:
+      __FEATURE_BORDER_GLOW__ &&
+      resolve(actionOverrides?.glowEnabled, globalBorderSettings.glowEnabled, undefined, BORDER_DEFAULTS.glowEnabled),
     glowWidth: resolve(
       actionOverrides?.glowWidth,
       globalBorderSettings.glowWidth,

--- a/packages/iracing-plugin-mirabox/package.json
+++ b/packages/iracing-plugin-mirabox/package.json
@@ -14,9 +14,9 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@iracedeck/iracing-actions": "workspace:*",
     "@iracedeck/deck-adapter-mirabox": "workspace:*",
     "@iracedeck/deck-core": "workspace:*",
+    "@iracedeck/iracing-actions": "workspace:*",
     "@iracedeck/iracing-native": "workspace:*",
     "@iracedeck/iracing-sdk": "workspace:*",
     "@iracedeck/logger": "workspace:*",
@@ -25,11 +25,12 @@
     "zod": "4.3.6"
   },
   "devDependencies": {
+    "@elgato/cli": "1.7.3",
     "@rollup/plugin-commonjs": "29.0.2",
     "@rollup/plugin-node-resolve": "16.0.3",
+    "@rollup/plugin-replace": "6.0.3",
     "@rollup/plugin-terser": "1.0.0",
     "@rollup/plugin-typescript": "12.3.0",
-    "@elgato/cli": "1.7.3",
     "@tsconfig/node22": "22.0.5",
     "@types/node": "25.6.0",
     "rimraf": "6.1.3",

--- a/packages/iracing-plugin-mirabox/platform-features.json
+++ b/packages/iracing-plugin-mirabox/platform-features.json
@@ -1,0 +1,10 @@
+{
+  "capabilities": {
+    "svgFilters": false,
+    "svgMasks": false,
+    "svgPatterns": false
+  },
+  "features": {
+    "borderGlow": false
+  }
+}

--- a/packages/iracing-plugin-mirabox/rollup.config.mjs
+++ b/packages/iracing-plugin-mirabox/rollup.config.mjs
@@ -33,24 +33,38 @@ function deepMergeObjects(base, override) {
 	return result;
 }
 
+function isPlainObject(value) {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 /**
- * Split `override` into `known` (keys whose path exists in `committed`) and
- * `unknown` (dotted paths that don't). Lets us warn about typos in the local
- * override file while guaranteeing they don't leak into the merged flags.
+ * Split `override` into `known` (keys whose path and shape exist in `committed`)
+ * and `unknown` (dotted paths that don't match). Lets us warn about typos and
+ * shape mismatches in the local override file while guaranteeing they don't
+ * leak into the merged flags or crash the build.
  */
 function partitionOverride(committed, override, prefix = "") {
 	const known = {};
 	const unknown = [];
 	for (const key of Object.keys(override)) {
-		if (!(key in committed)) {
+		if (!Object.prototype.hasOwnProperty.call(committed, key)) {
 			unknown.push(`${prefix}${key}`);
 			continue;
 		}
+		const committedVal = committed[key];
 		const overrideVal = override[key];
-		if (overrideVal && typeof overrideVal === "object" && !Array.isArray(overrideVal)) {
-			const nested = partitionOverride(committed[key], overrideVal, `${prefix}${key}.`);
+		if (isPlainObject(overrideVal)) {
+			if (!isPlainObject(committedVal)) {
+				// Nested object where committed has a leaf → treat as unknown
+				unknown.push(`${prefix}${key}`);
+				continue;
+			}
+			const nested = partitionOverride(committedVal, overrideVal, `${prefix}${key}.`);
 			known[key] = nested.known;
 			unknown.push(...nested.unknown);
+		} else if (isPlainObject(committedVal)) {
+			// Leaf override for a nested branch → treat as unknown
+			unknown.push(`${prefix}${key}`);
 		} else {
 			known[key] = overrideVal;
 		}

--- a/packages/iracing-plugin-mirabox/rollup.config.mjs
+++ b/packages/iracing-plugin-mirabox/rollup.config.mjs
@@ -34,11 +34,12 @@ function deepMergeObjects(base, override) {
 }
 
 /**
- * Collect keys in `override` that have no matching key in `committed`, returning
- * dotted paths (e.g. `features.brorderGlow`). Used to warn about typos in
- * `feature-flags.local.json` that would otherwise silently have no effect.
+ * Split `override` into `known` (keys whose path exists in `committed`) and
+ * `unknown` (dotted paths that don't). Lets us warn about typos in the local
+ * override file while guaranteeing they don't leak into the merged flags.
  */
-function findUnknownKeys(committed, override, prefix = "") {
+function partitionOverride(committed, override, prefix = "") {
+	const known = {};
 	const unknown = [];
 	for (const key of Object.keys(override)) {
 		if (!(key in committed)) {
@@ -47,19 +48,24 @@ function findUnknownKeys(committed, override, prefix = "") {
 		}
 		const overrideVal = override[key];
 		if (overrideVal && typeof overrideVal === "object" && !Array.isArray(overrideVal)) {
-			unknown.push(...findUnknownKeys(committed[key], overrideVal, `${prefix}${key}.`));
+			const nested = partitionOverride(committed[key], overrideVal, `${prefix}${key}.`);
+			known[key] = nested.known;
+			unknown.push(...nested.unknown);
+		} else {
+			known[key] = overrideVal;
 		}
 	}
-	return unknown;
+	return { known, unknown };
 }
 
 /**
  * Resolve platform feature flags for this build:
  * 1. Read committed `platform-features.json` next to this rollup config.
- * 2. If `feature-flags.local.json` exists at the repo root, deep-merge it on top.
+ * 2. If `feature-flags.local.json` exists at the repo root, strip any keys
+ *    not declared in the committed file (warning about each), then deep-merge
+ *    what remains on top of the committed values.
  * The merged object feeds `@rollup/plugin-replace` (compile-time constants),
  * `piTemplatePlugin` (EJS `platform` variable), and the emitted `config.json`.
- * Unknown keys in the local file are warned about and ignored (never merged).
  */
 const platformFeaturesPath = path.resolve(__dirname, "platform-features.json");
 const localFeaturesPath = path.resolve(__dirname, "../../feature-flags.local.json");
@@ -67,13 +73,13 @@ const committedFeatures = JSON.parse(readFileSync(platformFeaturesPath, "utf-8")
 let platformFeatures = committedFeatures;
 if (existsSync(localFeaturesPath)) {
 	const localFeatures = JSON.parse(readFileSync(localFeaturesPath, "utf-8"));
-	const unknown = findUnknownKeys(committedFeatures, localFeatures);
+	const { known, unknown } = partitionOverride(committedFeatures, localFeatures);
 	if (unknown.length > 0) {
 		console.warn(
 			`[platform-features] feature-flags.local.json has unknown keys (ignored): ${unknown.join(", ")}`,
 		);
 	}
-	platformFeatures = deepMergeObjects(committedFeatures, localFeatures);
+	platformFeatures = deepMergeObjects(committedFeatures, known);
 }
 
 /**

--- a/packages/iracing-plugin-mirabox/rollup.config.mjs
+++ b/packages/iracing-plugin-mirabox/rollup.config.mjs
@@ -1,5 +1,6 @@
 import commonjs from "@rollup/plugin-commonjs";
 import nodeResolve from "@rollup/plugin-node-resolve";
+import replace from "@rollup/plugin-replace";
 import terser from "@rollup/plugin-terser";
 import typescript from "@rollup/plugin-typescript";
 import path from "node:path";
@@ -14,6 +15,66 @@ const iconsPackagePath = path.resolve(__dirname, "../icons");
 const actionsPackagePath = path.resolve(__dirname, "../iracing-actions/src");
 const actionTemplatesDir = path.join(actionsPackagePath, "actions");
 const elgatoPluginPath = path.resolve(__dirname, "../iracing-plugin-stream-deck");
+
+/**
+ * Deep-merge two plain objects. `override` keys win on collision. Nested
+ * objects are merged recursively; arrays and primitives are replaced.
+ */
+function deepMergeObjects(base, override) {
+	const result = { ...base };
+	for (const key of Object.keys(override)) {
+		const overrideVal = override[key];
+		if (overrideVal && typeof overrideVal === "object" && !Array.isArray(overrideVal)) {
+			result[key] = deepMergeObjects(base[key] ?? {}, overrideVal);
+		} else {
+			result[key] = overrideVal;
+		}
+	}
+	return result;
+}
+
+/**
+ * Collect keys in `override` that have no matching key in `committed`, returning
+ * dotted paths (e.g. `features.brorderGlow`). Used to warn about typos in
+ * `feature-flags.local.json` that would otherwise silently have no effect.
+ */
+function findUnknownKeys(committed, override, prefix = "") {
+	const unknown = [];
+	for (const key of Object.keys(override)) {
+		if (!(key in committed)) {
+			unknown.push(`${prefix}${key}`);
+			continue;
+		}
+		const overrideVal = override[key];
+		if (overrideVal && typeof overrideVal === "object" && !Array.isArray(overrideVal)) {
+			unknown.push(...findUnknownKeys(committed[key], overrideVal, `${prefix}${key}.`));
+		}
+	}
+	return unknown;
+}
+
+/**
+ * Resolve platform feature flags for this build:
+ * 1. Read committed `platform-features.json` next to this rollup config.
+ * 2. If `feature-flags.local.json` exists at the repo root, deep-merge it on top.
+ * The merged object feeds `@rollup/plugin-replace` (compile-time constants),
+ * `piTemplatePlugin` (EJS `platform` variable), and the emitted `config.json`.
+ * Unknown keys in the local file are warned about and ignored (never merged).
+ */
+const platformFeaturesPath = path.resolve(__dirname, "platform-features.json");
+const localFeaturesPath = path.resolve(__dirname, "../../feature-flags.local.json");
+const committedFeatures = JSON.parse(readFileSync(platformFeaturesPath, "utf-8"));
+let platformFeatures = committedFeatures;
+if (existsSync(localFeaturesPath)) {
+	const localFeatures = JSON.parse(readFileSync(localFeaturesPath, "utf-8"));
+	const unknown = findUnknownKeys(committedFeatures, localFeatures);
+	if (unknown.length > 0) {
+		console.warn(
+			`[platform-features] feature-flags.local.json has unknown keys (ignored): ${unknown.join(", ")}`,
+		);
+	}
+	platformFeatures = deepMergeObjects(committedFeatures, localFeatures);
+}
 
 /**
  * Rollup plugin to import SVG files as strings.
@@ -152,12 +213,22 @@ const config = {
 			},
 		},
 		svgPlugin(),
+		replace({
+			preventAssignment: true,
+			values: {
+				__CAPABILITY_SVG_FILTERS__: JSON.stringify(platformFeatures.capabilities.svgFilters),
+				__CAPABILITY_SVG_MASKS__: JSON.stringify(platformFeatures.capabilities.svgMasks),
+				__CAPABILITY_SVG_PATTERNS__: JSON.stringify(platformFeatures.capabilities.svgPatterns),
+				__FEATURE_BORDER_GLOW__: JSON.stringify(platformFeatures.features.borderGlow),
+			},
+		}),
 		// Compile PI templates from @iracedeck/iracing-actions
 		piTemplatePlugin({
 			templatesDir: actionTemplatesDir,
 			outputDir: `${sdPlugin}/ui`,
 			partialsDir,
 			version: rootPackageJson.version,
+			platformFeatures,
 		}),
 		// Copy imgs/ from the Elgato plugin and PI browser assets from @iracedeck/pi-components
 		copyAssetsPlugin(sdPlugin),
@@ -165,6 +236,8 @@ const config = {
 			name: "watch-externals",
 			buildStart: function () {
 				this.addWatchFile(`${sdPlugin}/manifest.json`);
+				this.addWatchFile(platformFeaturesPath);
+				if (existsSync(localFeaturesPath)) this.addWatchFile(localFeaturesPath);
 				// Recursively watch SVG files in a directory
 				const watchSvgsRecursive = (dir) => {
 					try {
@@ -225,6 +298,7 @@ const config = {
 				const config = {
 					version: rootPackageJson.version,
 					platform: "mirabox",
+					featureFlags: platformFeatures,
 				};
 				this.emitFile({ fileName: "config.json", source: JSON.stringify(config, null, 2), type: "asset" });
 			},

--- a/packages/iracing-plugin-stream-deck/package.json
+++ b/packages/iracing-plugin-stream-deck/package.json
@@ -14,9 +14,9 @@
   },
   "dependencies": {
     "@elgato/streamdeck": "2.0.4",
-    "@iracedeck/iracing-actions": "workspace:*",
     "@iracedeck/deck-adapter-elgato": "workspace:*",
     "@iracedeck/deck-core": "workspace:*",
+    "@iracedeck/iracing-actions": "workspace:*",
     "@iracedeck/iracing-native": "workspace:*",
     "@iracedeck/iracing-sdk": "workspace:*",
     "@iracedeck/logger": "workspace:*",
@@ -28,6 +28,7 @@
     "@elgato/utils": "0.4.4",
     "@rollup/plugin-commonjs": "29.0.2",
     "@rollup/plugin-node-resolve": "16.0.3",
+    "@rollup/plugin-replace": "6.0.3",
     "@rollup/plugin-terser": "1.0.0",
     "@rollup/plugin-typescript": "12.3.0",
     "@tsconfig/node22": "22.0.5",

--- a/packages/iracing-plugin-stream-deck/platform-features.json
+++ b/packages/iracing-plugin-stream-deck/platform-features.json
@@ -1,0 +1,10 @@
+{
+  "capabilities": {
+    "svgFilters": true,
+    "svgMasks": true,
+    "svgPatterns": true
+  },
+  "features": {
+    "borderGlow": true
+  }
+}

--- a/packages/iracing-plugin-stream-deck/rollup.config.mjs
+++ b/packages/iracing-plugin-stream-deck/rollup.config.mjs
@@ -1,5 +1,6 @@
 import commonjs from "@rollup/plugin-commonjs";
 import nodeResolve from "@rollup/plugin-node-resolve";
+import replace from "@rollup/plugin-replace";
 import terser from "@rollup/plugin-terser";
 import typescript from "@rollup/plugin-typescript";
 import path from "node:path";
@@ -13,6 +14,66 @@ const rootPackageJson = JSON.parse(readFileSync(path.resolve(__dirname, "../../p
 const iconsPackagePath = path.resolve(__dirname, "../icons");
 const actionsPackagePath = path.resolve(__dirname, "../iracing-actions/src");
 const actionTemplatesDir = path.join(actionsPackagePath, "actions");
+
+/**
+ * Deep-merge two plain objects. `override` keys win on collision. Nested
+ * objects are merged recursively; arrays and primitives are replaced.
+ */
+function deepMergeObjects(base, override) {
+	const result = { ...base };
+	for (const key of Object.keys(override)) {
+		const overrideVal = override[key];
+		if (overrideVal && typeof overrideVal === "object" && !Array.isArray(overrideVal)) {
+			result[key] = deepMergeObjects(base[key] ?? {}, overrideVal);
+		} else {
+			result[key] = overrideVal;
+		}
+	}
+	return result;
+}
+
+/**
+ * Collect keys in `override` that have no matching key in `committed`, returning
+ * dotted paths (e.g. `features.brorderGlow`). Used to warn about typos in
+ * `feature-flags.local.json` that would otherwise silently have no effect.
+ */
+function findUnknownKeys(committed, override, prefix = "") {
+	const unknown = [];
+	for (const key of Object.keys(override)) {
+		if (!(key in committed)) {
+			unknown.push(`${prefix}${key}`);
+			continue;
+		}
+		const overrideVal = override[key];
+		if (overrideVal && typeof overrideVal === "object" && !Array.isArray(overrideVal)) {
+			unknown.push(...findUnknownKeys(committed[key], overrideVal, `${prefix}${key}.`));
+		}
+	}
+	return unknown;
+}
+
+/**
+ * Resolve platform feature flags for this build:
+ * 1. Read committed `platform-features.json` next to this rollup config.
+ * 2. If `feature-flags.local.json` exists at the repo root, deep-merge it on top.
+ * The merged object feeds `@rollup/plugin-replace` (compile-time constants),
+ * `piTemplatePlugin` (EJS `platform` variable), and the emitted `config.json`.
+ * Unknown keys in the local file are warned about and ignored (never merged).
+ */
+const platformFeaturesPath = path.resolve(__dirname, "platform-features.json");
+const localFeaturesPath = path.resolve(__dirname, "../../feature-flags.local.json");
+const committedFeatures = JSON.parse(readFileSync(platformFeaturesPath, "utf-8"));
+let platformFeatures = committedFeatures;
+if (existsSync(localFeaturesPath)) {
+	const localFeatures = JSON.parse(readFileSync(localFeaturesPath, "utf-8"));
+	const unknown = findUnknownKeys(committedFeatures, localFeatures);
+	if (unknown.length > 0) {
+		console.warn(
+			`[platform-features] feature-flags.local.json has unknown keys (ignored): ${unknown.join(", ")}`,
+		);
+	}
+	platformFeatures = deepMergeObjects(committedFeatures, localFeatures);
+}
 
 /**
  * Rollup plugin to import SVG files as strings.
@@ -78,11 +139,21 @@ const config = {
 			},
 		},
 		svgPlugin(),
+		replace({
+			preventAssignment: true,
+			values: {
+				__CAPABILITY_SVG_FILTERS__: JSON.stringify(platformFeatures.capabilities.svgFilters),
+				__CAPABILITY_SVG_MASKS__: JSON.stringify(platformFeatures.capabilities.svgMasks),
+				__CAPABILITY_SVG_PATTERNS__: JSON.stringify(platformFeatures.capabilities.svgPatterns),
+				__FEATURE_BORDER_GLOW__: JSON.stringify(platformFeatures.features.borderGlow),
+			},
+		}),
 		piTemplatePlugin({
 			templatesDir: actionTemplatesDir,
 			outputDir: `${sdPlugin}/ui`,
 			partialsDir,
 			version: rootPackageJson.version,
+			platformFeatures,
 		}),
 		// Copy per-action static icons from @iracedeck/iracing-actions into {sdPlugin}/imgs/actions/<name>/.
 		// Source of truth: `packages/iracing-actions/src/actions/<name>/{icon,key}.svg`.
@@ -123,6 +194,8 @@ const config = {
 			name: "watch-externals",
 			buildStart: function () {
 				this.addWatchFile(`${sdPlugin}/manifest.json`);
+				this.addWatchFile(platformFeaturesPath);
+				if (existsSync(localFeaturesPath)) this.addWatchFile(localFeaturesPath);
 				// Recursively watch SVG files in a directory
 				const watchSvgsRecursive = (dir) => {
 					try {
@@ -180,6 +253,7 @@ const config = {
 				const config = {
 					version: rootPackageJson.version,
 					platform: "stream-deck",
+					featureFlags: platformFeatures,
 				};
 				this.emitFile({ fileName: "config.json", source: JSON.stringify(config, null, 2), type: "asset" });
 			},

--- a/packages/iracing-plugin-stream-deck/rollup.config.mjs
+++ b/packages/iracing-plugin-stream-deck/rollup.config.mjs
@@ -33,11 +33,12 @@ function deepMergeObjects(base, override) {
 }
 
 /**
- * Collect keys in `override` that have no matching key in `committed`, returning
- * dotted paths (e.g. `features.brorderGlow`). Used to warn about typos in
- * `feature-flags.local.json` that would otherwise silently have no effect.
+ * Split `override` into `known` (keys whose path exists in `committed`) and
+ * `unknown` (dotted paths that don't). Lets us warn about typos in the local
+ * override file while guaranteeing they don't leak into the merged flags.
  */
-function findUnknownKeys(committed, override, prefix = "") {
+function partitionOverride(committed, override, prefix = "") {
+	const known = {};
 	const unknown = [];
 	for (const key of Object.keys(override)) {
 		if (!(key in committed)) {
@@ -46,19 +47,24 @@ function findUnknownKeys(committed, override, prefix = "") {
 		}
 		const overrideVal = override[key];
 		if (overrideVal && typeof overrideVal === "object" && !Array.isArray(overrideVal)) {
-			unknown.push(...findUnknownKeys(committed[key], overrideVal, `${prefix}${key}.`));
+			const nested = partitionOverride(committed[key], overrideVal, `${prefix}${key}.`);
+			known[key] = nested.known;
+			unknown.push(...nested.unknown);
+		} else {
+			known[key] = overrideVal;
 		}
 	}
-	return unknown;
+	return { known, unknown };
 }
 
 /**
  * Resolve platform feature flags for this build:
  * 1. Read committed `platform-features.json` next to this rollup config.
- * 2. If `feature-flags.local.json` exists at the repo root, deep-merge it on top.
+ * 2. If `feature-flags.local.json` exists at the repo root, strip any keys
+ *    not declared in the committed file (warning about each), then deep-merge
+ *    what remains on top of the committed values.
  * The merged object feeds `@rollup/plugin-replace` (compile-time constants),
  * `piTemplatePlugin` (EJS `platform` variable), and the emitted `config.json`.
- * Unknown keys in the local file are warned about and ignored (never merged).
  */
 const platformFeaturesPath = path.resolve(__dirname, "platform-features.json");
 const localFeaturesPath = path.resolve(__dirname, "../../feature-flags.local.json");
@@ -66,13 +72,13 @@ const committedFeatures = JSON.parse(readFileSync(platformFeaturesPath, "utf-8")
 let platformFeatures = committedFeatures;
 if (existsSync(localFeaturesPath)) {
 	const localFeatures = JSON.parse(readFileSync(localFeaturesPath, "utf-8"));
-	const unknown = findUnknownKeys(committedFeatures, localFeatures);
+	const { known, unknown } = partitionOverride(committedFeatures, localFeatures);
 	if (unknown.length > 0) {
 		console.warn(
 			`[platform-features] feature-flags.local.json has unknown keys (ignored): ${unknown.join(", ")}`,
 		);
 	}
-	platformFeatures = deepMergeObjects(committedFeatures, localFeatures);
+	platformFeatures = deepMergeObjects(committedFeatures, known);
 }
 
 /**

--- a/packages/iracing-plugin-stream-deck/rollup.config.mjs
+++ b/packages/iracing-plugin-stream-deck/rollup.config.mjs
@@ -32,24 +32,38 @@ function deepMergeObjects(base, override) {
 	return result;
 }
 
+function isPlainObject(value) {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 /**
- * Split `override` into `known` (keys whose path exists in `committed`) and
- * `unknown` (dotted paths that don't). Lets us warn about typos in the local
- * override file while guaranteeing they don't leak into the merged flags.
+ * Split `override` into `known` (keys whose path and shape exist in `committed`)
+ * and `unknown` (dotted paths that don't match). Lets us warn about typos and
+ * shape mismatches in the local override file while guaranteeing they don't
+ * leak into the merged flags or crash the build.
  */
 function partitionOverride(committed, override, prefix = "") {
 	const known = {};
 	const unknown = [];
 	for (const key of Object.keys(override)) {
-		if (!(key in committed)) {
+		if (!Object.prototype.hasOwnProperty.call(committed, key)) {
 			unknown.push(`${prefix}${key}`);
 			continue;
 		}
+		const committedVal = committed[key];
 		const overrideVal = override[key];
-		if (overrideVal && typeof overrideVal === "object" && !Array.isArray(overrideVal)) {
-			const nested = partitionOverride(committed[key], overrideVal, `${prefix}${key}.`);
+		if (isPlainObject(overrideVal)) {
+			if (!isPlainObject(committedVal)) {
+				// Nested object where committed has a leaf → treat as unknown
+				unknown.push(`${prefix}${key}`);
+				continue;
+			}
+			const nested = partitionOverride(committedVal, overrideVal, `${prefix}${key}.`);
 			known[key] = nested.known;
 			unknown.push(...nested.unknown);
+		} else if (isPlainObject(committedVal)) {
+			// Leaf override for a nested branch → treat as unknown
+			unknown.push(`${prefix}${key}`);
 		} else {
 			known[key] = overrideVal;
 		}

--- a/packages/pi-components/partials/border-overrides.ejs
+++ b/packages/pi-components/partials/border-overrides.ejs
@@ -9,6 +9,7 @@
     - defaults: Object with per-action border defaults (e.g., { color: "#5a5a5a" })
 -->
 <% var defaultColor = (defaults && defaults.borderColor) || '#00aaff'; %>
+<% var borderGlowEnabled = (locals.platform?.features?.borderGlow !== false); %>
 <%- include('accordion', {
   title: 'Border Overrides',
   open: false,
@@ -26,16 +27,18 @@
     '<sdpi-item id="ird-border-color" class="hidden" label="Color">' +
       '<ird-color-picker id="ird-border-color-picker" setting="borderOverrides.borderColor" data-default-color="' + defaultColor + '"></ird-color-picker>' +
     '</sdpi-item>' +
-    '<sdpi-item id="ird-border-glow" class="hidden" label="Show Glow">' +
-      '<sdpi-select id="ird-border-glow-select" setting="borderOverrides.glowEnabled" default="inherit">' +
-        '<option value="inherit">Inherit</option>' +
-        '<option value="true">Yes</option>' +
-        '<option value="false">No</option>' +
-      '</sdpi-select>' +
-    '</sdpi-item>' +
-    '<sdpi-item id="ird-border-glow-width" class="hidden" label="Glow Width">' +
-      '<ird-range-input setting="borderOverrides.glowWidth" min="1" max="30" step="1" default="18" showlabels></ird-range-input>' +
-    '</sdpi-item>'
+    (borderGlowEnabled ? (
+      '<sdpi-item id="ird-border-glow" class="hidden" label="Show Glow">' +
+        '<sdpi-select id="ird-border-glow-select" setting="borderOverrides.glowEnabled" default="inherit">' +
+          '<option value="inherit">Inherit</option>' +
+          '<option value="true">Yes</option>' +
+          '<option value="false">No</option>' +
+        '</sdpi-select>' +
+      '</sdpi-item>' +
+      '<sdpi-item id="ird-border-glow-width" class="hidden" label="Glow Width">' +
+        '<ird-range-input setting="borderOverrides.glowWidth" min="1" max="30" step="1" default="18" showlabels></ird-range-input>' +
+      '</sdpi-item>'
+    ) : '')
 }) %>
 
 <script>
@@ -43,7 +46,11 @@
   async function initBorderOverrides() {
     await customElements.whenDefined('sdpi-select');
     var borderSelect = document.getElementById('ird-border-enabled');
+    <% if (borderGlowEnabled) { %>
     var glowSelect = document.getElementById('ird-border-glow-select');
+    <% } else { %>
+    var glowSelect = null;
+    <% } %>
     if (!borderSelect) return;
 
     function clearField(selector) {
@@ -64,13 +71,17 @@
     function clearAllBorderOverrides() {
       clearField('[setting="borderOverrides.borderWidth"]');
       clearField('[setting="borderOverrides.borderColor"]');
+      <% if (borderGlowEnabled) { %>
       clearSelect(glowSelect);
       clearField('[setting="borderOverrides.glowWidth"]');
+      <% } %>
     }
 
+    <% if (borderGlowEnabled) { %>
     function clearGlowOverrides() {
       clearField('[setting="borderOverrides.glowWidth"]');
     }
+    <% } %>
 
     function isBorderEnabled() {
       return borderSelect.value === 'true';
@@ -78,22 +89,26 @@
 
     function updateVisibility() {
       var showBorderSettings = isBorderEnabled();
-      var items = ['ird-border-width', 'ird-border-color', 'ird-border-glow'];
+      var items = ['ird-border-width', 'ird-border-color'<% if (borderGlowEnabled) { %>, 'ird-border-glow'<% } %>];
       items.forEach(function(id) {
         var el = document.getElementById(id);
         if (el) el.classList.toggle('hidden', !showBorderSettings);
       });
 
+      <% if (borderGlowEnabled) { %>
       // Glow width visible only when border settings are shown AND glow is not "false"
       var glowVal = glowSelect ? glowSelect.value : 'inherit';
       var showGlowWidth = showBorderSettings && glowVal !== 'false';
       var glowWidthEl = document.getElementById('ird-border-glow-width');
       if (glowWidthEl) glowWidthEl.classList.toggle('hidden', !showGlowWidth);
+      <% } %>
     }
 
     // Track previous values to detect intentional user changes (not re-fires from settings reload)
     var prevBorderVal = borderSelect.value || 'inherit';
+    <% if (borderGlowEnabled) { %>
     var prevGlowVal = glowSelect ? (glowSelect.value || 'inherit') : 'inherit';
+    <% } %>
 
     updateVisibility();
 
@@ -122,6 +137,7 @@
       updateVisibility();
     }
 
+    <% if (borderGlowEnabled) { %>
     function onGlowChange() {
       var cur = glowSelect ? (glowSelect.value || 'inherit') : 'inherit';
       if (prevGlowVal === 'true' && cur !== 'true') {
@@ -130,24 +146,31 @@
       prevGlowVal = cur;
       updateVisibility();
     }
+    <% } %>
 
     borderSelect.addEventListener('change', onBorderChange);
     borderSelect.addEventListener('input', onBorderChange);
+    <% if (borderGlowEnabled) { %>
     if (glowSelect) {
       glowSelect.addEventListener('change', onGlowChange);
       glowSelect.addEventListener('input', onGlowChange);
     }
+    <% } %>
 
     // Polling fallback (sdpi-select events are unreliable)
     setInterval(function() {
       var curBorder = borderSelect.value || 'inherit';
+      <% if (borderGlowEnabled) { %>
       var curGlow = glowSelect ? (glowSelect.value || 'inherit') : 'inherit';
+      <% } %>
       if (curBorder !== prevBorderVal) {
         onBorderChange();
       }
+      <% if (borderGlowEnabled) { %>
       if (curGlow !== prevGlowVal) {
         onGlowChange();
       }
+      <% } %>
     }, 100);
   }
 

--- a/packages/pi-components/partials/global-border-defaults.ejs
+++ b/packages/pi-components/partials/global-border-defaults.ejs
@@ -5,6 +5,7 @@
   Settings are stored in global settings (shared across all action instances).
   Collapsed by default.
 -->
+<% var borderGlowEnabled = (locals.platform?.features?.borderGlow !== false); %>
 <%- include('accordion', {
   title: 'Border Defaults',
   open: false,
@@ -22,6 +23,7 @@
     <sdpi-item id="global-border-color-item" class="hidden" label="Color">
       <ird-color-picker id="global-border-color" setting="borderColor" global></ird-color-picker>
     </sdpi-item>
+  ` + (borderGlowEnabled ? `
     <sdpi-item id="global-border-glow-item" class="hidden" label="Show Glow">
       <sdpi-select id="global-border-glow-enabled" setting="borderGlowEnabled" default="default" global>
         <option value="default">Default</option>
@@ -32,5 +34,5 @@
     <sdpi-item id="global-border-glow-width-item" class="hidden" label="Glow Width">
       <ird-range-input setting="borderGlowWidth" min="1" max="30" step="1" default="18" global showlabels></ird-range-input>
     </sdpi-item>
-  `
+  ` : ``)
 }) %>

--- a/packages/pi-components/partials/head-common.ejs
+++ b/packages/pi-components/partials/head-common.ejs
@@ -442,44 +442,66 @@
   // Note: titleOverrides.titleText uses sdpi-textarea with setting attribute.
   // Persistence is handled automatically by sdpi-components.
 
-  // Global Border Defaults — show/hide sub-settings based on Show Border and Show Glow
+  <% var borderGlowEnabled = (locals.platform?.features?.borderGlow !== false); %>
+  // Global Border Defaults — show/hide sub-settings based on Show Border<% if (borderGlowEnabled) { %> and Show Glow<% } %>
   (function() {
     async function initGlobalBorderToggle() {
       await customElements.whenDefined('sdpi-select');
       var borderSelect = document.getElementById('global-border-enabled');
+      <% if (borderGlowEnabled) { %>
       var glowSelect = document.getElementById('global-border-glow-enabled');
+      <% } else { %>
+      var glowSelect = null;
+      <% } %>
       if (!borderSelect) return;
 
       function updateGlobalBorderVisibility() {
         var show = borderSelect.value === 'true';
-        ['global-border-width-item', 'global-border-color-item', 'global-border-glow-item'].forEach(function(id) {
+        [
+          'global-border-width-item',
+          'global-border-color-item'
+          <% if (borderGlowEnabled) { %>, 'global-border-glow-item'<% } %>
+        ].forEach(function(id) {
           var el = document.getElementById(id);
           if (el) el.classList.toggle('hidden', !show);
         });
+        <% if (borderGlowEnabled) { %>
         var glowVal = glowSelect ? glowSelect.value : 'default';
         var showGlowWidth = show && glowVal === 'true';
         var glowWidthEl = document.getElementById('global-border-glow-width-item');
         if (glowWidthEl) glowWidthEl.classList.toggle('hidden', !showGlowWidth);
+        <% } %>
       }
 
       updateGlobalBorderVisibility();
       borderSelect.addEventListener('change', updateGlobalBorderVisibility);
       borderSelect.addEventListener('input', updateGlobalBorderVisibility);
+      <% if (borderGlowEnabled) { %>
       if (glowSelect) {
         glowSelect.addEventListener('change', updateGlobalBorderVisibility);
         glowSelect.addEventListener('input', updateGlobalBorderVisibility);
       }
+      <% } %>
 
       var lastBorder = borderSelect.value || 'default';
+      <% if (borderGlowEnabled) { %>
       var lastGlow = glowSelect ? (glowSelect.value || 'default') : 'default';
+      <% } %>
       setInterval(function() {
         var curBorder = borderSelect.value || 'default';
+        <% if (borderGlowEnabled) { %>
         var curGlow = glowSelect ? (glowSelect.value || 'default') : 'default';
         if (curBorder !== lastBorder || curGlow !== lastGlow) {
           lastBorder = curBorder;
           lastGlow = curGlow;
           updateGlobalBorderVisibility();
         }
+        <% } else { %>
+        if (curBorder !== lastBorder) {
+          lastBorder = curBorder;
+          updateGlobalBorderVisibility();
+        }
+        <% } %>
       }, 100);
     }
 

--- a/packages/pi-components/src/build/pi-template-plugin.mjs
+++ b/packages/pi-components/src/build/pi-template-plugin.mjs
@@ -98,7 +98,14 @@ function createTemplateRequire(templatesDir) {
  * Rollup plugin for compiling EJS Property Inspector templates
  */
 export function piTemplatePlugin(options) {
-  const { templatesDir, outputDir, partialsDir, additionalPartialsDirs = [], version } = options;
+  const {
+    templatesDir,
+    outputDir,
+    partialsDir,
+    additionalPartialsDirs = [],
+    version,
+    platformFeatures = { capabilities: {}, features: {} },
+  } = options;
 
   if (!version) {
     throw new Error("piTemplatePlugin: version option is required");
@@ -192,6 +199,8 @@ export function piTemplatePlugin(options) {
             version: version,
             // Documentation URL for this action (empty string if not mapped)
             docsUrl,
+            // Platform capabilities + feature flags for this plugin build
+            platform: platformFeatures,
             // Also expose a require function for inline requires (resolved from templatesDir)
             require: createTemplateRequire(templatesDir),
             // Expose locals for checking if variables are defined
@@ -199,6 +208,7 @@ export function piTemplatePlugin(options) {
               data: dataFiles,
               version: version,
               docsUrl,
+              platform: platformFeatures,
             },
           }, {
             // Search directories for includes

--- a/packages/pi-components/src/build/pi-template-plugin.test.ts
+++ b/packages/pi-components/src/build/pi-template-plugin.test.ts
@@ -334,6 +334,81 @@ describe("piTemplatePlugin", () => {
     expect(context.error).toHaveBeenCalledWith(expect.stringContaining("basename collision"));
   });
 
+  it("should expose platformFeatures as locals.platform to templates", async () => {
+    writeFileSync(
+      path.join(templatesDir, "flags.ejs"),
+      "<!DOCTYPE html><html><body>" +
+        "<% if (locals.platform?.features?.borderGlow !== false) { %>GLOW<% } %>" +
+        "|<%= locals.platform?.capabilities?.svgFilters %>" +
+        "</body></html>",
+    );
+
+    const plugin = piTemplatePlugin({
+      templatesDir,
+      outputDir,
+      partialsDir,
+      version: "1.0.0",
+      platformFeatures: {
+        capabilities: { svgFilters: false, svgMasks: false, svgPatterns: false },
+        features: { borderGlow: false },
+      },
+    });
+
+    const context = {
+      addWatchFile: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+
+    if (plugin.buildStart) {
+      await (plugin.buildStart as AnyFunction).call(context);
+    }
+    if (plugin.generateBundle) {
+      await (plugin.generateBundle as AnyFunction).call(context);
+    }
+
+    const content = readFileSync(path.join(outputDir, "flags.html"), "utf-8");
+    expect(content).not.toContain("GLOW");
+    expect(content).toContain("|false");
+  });
+
+  it("should default platformFeatures to empty objects so templates without flags still render", async () => {
+    writeFileSync(
+      path.join(templatesDir, "no-flags.ejs"),
+      "<!DOCTYPE html><html><body>" +
+        "<% if (locals.platform?.features?.borderGlow !== false) { %>GLOW<% } %>" +
+        "</body></html>",
+    );
+
+    const plugin = piTemplatePlugin({
+      templatesDir,
+      outputDir,
+      partialsDir,
+      version: "1.0.0",
+    });
+
+    const context = {
+      addWatchFile: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+
+    if (plugin.buildStart) {
+      await (plugin.buildStart as AnyFunction).call(context);
+    }
+    if (plugin.generateBundle) {
+      await (plugin.generateBundle as AnyFunction).call(context);
+    }
+
+    // With default platformFeatures = { capabilities: {}, features: {} },
+    // features.borderGlow is undefined (!== false), so GLOW is emitted — preserving
+    // backward-compatible behavior for templates without platform gating.
+    const content = readFileSync(path.join(outputDir, "no-flags.html"), "utf-8");
+    expect(content).toContain("GLOW");
+  });
+
   it("should pass variables to partials", async () => {
     // Create a partial that uses a variable
     writeFileSync(path.join(partialsDir, "title.ejs"), "<title><%= title %></title>");

--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -191,6 +191,7 @@ export default defineConfig({
             { slug: "docs/development/tech-stack" },
             { slug: "docs/development/contributing" },
             { slug: "docs/development/setup" },
+            { slug: "docs/development/feature-flags" },
           ],
         },
         {

--- a/packages/website/src/content/docs/docs/development/feature-flags.md
+++ b/packages/website/src/content/docs/docs/development/feature-flags.md
@@ -58,7 +58,7 @@ Each plugin's build deep-merges this file on top of its own committed `platform-
 
 **You must rebuild for the override to take effect** (`pnpm build` or restart `pnpm watch:*`). There's no runtime reload — flags are baked into the bundle.
 
-If you create `feature-flags.local.json` while `pnpm watch:*` is already running, the file isn't in the watcher's file set yet — trigger one manual rebuild (edit any watched file, or restart the watcher) to pick it up. After that, edits are picked up normally.
+**Always restart the watcher after editing a flag file.** Rollup resolves the flags once when its config module loads, and that resolution is held for the lifetime of the watcher — editing `platform-features.json` or `feature-flags.local.json` mid-watch will trigger a rebuild but the output will still reflect the flag values from watcher startup.
 
 Unknown keys in the local file are **ignored with a warning** during the build — watch the console for `[platform-features] feature-flags.local.json has unknown keys (ignored): …` to catch typos.
 

--- a/packages/website/src/content/docs/docs/development/feature-flags.md
+++ b/packages/website/src/content/docs/docs/development/feature-flags.md
@@ -1,0 +1,91 @@
+---
+title: Feature Flags
+description: How iRaceDeck gates platform-specific features at build time, and how to override flags locally for testing.
+---
+
+iRaceDeck ships two plugins — the Elgato Stream Deck plugin and the Mirabox VSD Craft plugin. They share most code, but the two hosts use different SVG engines (Stream Deck is QT 6.7+, Mirabox is QT 5), so some features work on one platform and are silently ignored on the other.
+
+Feature flags let us gate those features at **build time**: unsupported code is stripped from the bundle, and Property Inspector controls that would have no effect are hidden. Flags also provide a lightweight way for contributors to test in-development features locally without shipping them to everyone.
+
+## How the flags are structured
+
+Each plugin has a committed `platform-features.json`:
+
+- `packages/iracing-plugin-stream-deck/platform-features.json`
+- `packages/iracing-plugin-mirabox/platform-features.json`
+
+The file has two top-level keys:
+
+- **`capabilities`** — raw SVG engine support (`svgFilters`, `svgMasks`, `svgPatterns`). Source of truth.
+- **`features`** — product-level flags that depend on one or more capabilities (e.g., `borderGlow`). These are the ones you'll typically toggle.
+
+Example (Mirabox, glow disabled):
+
+```json
+{
+  "capabilities": {
+    "svgFilters": false,
+    "svgMasks": false,
+    "svgPatterns": false
+  },
+  "features": {
+    "borderGlow": false
+  }
+}
+```
+
+## Where the flags take effect
+
+The plugin build pipeline reads the merged flags once and fans them out to three places:
+
+1. **Bundle code** — `@rollup/plugin-replace` substitutes `__FEATURE_BORDER_GLOW__` with `true` / `false` at compile time. Terser then drops unreachable branches, so disabled code doesn't ship.
+2. **Property Inspector HTML** — the same flags are passed into EJS templates as `locals.platform`. Controls wrapped in `<% if (locals.platform?.features?.borderGlow !== false) { %>` disappear from the compiled HTML.
+3. **Runtime `config.json`** — the merged flags are written to `com.iracedeck.sd.core.sdPlugin/bin/config.json` as a `featureFlags` field. Readable at runtime via `getFeatureFlag("borderGlow")` / `getPlatformFeatures()` from `@iracedeck/deck-core` if a dynamic check is ever needed.
+
+## Overriding flags locally
+
+For local testing — without editing committed files — create `feature-flags.local.json` at the **repo root**:
+
+```json
+{
+  "features": {
+    "borderGlow": false
+  }
+}
+```
+
+Each plugin's build deep-merges this file on top of its own committed `platform-features.json`. Any keys you don't include fall through to the committed values. The file is listed in `.gitignore`, so it never lands in a commit.
+
+**You must rebuild for the override to take effect** (`pnpm build` or restart `pnpm watch:*`). There's no runtime reload — flags are baked into the bundle.
+
+If you create `feature-flags.local.json` while `pnpm watch:*` is already running, the file isn't in the watcher's file set yet — trigger one manual rebuild (edit any watched file, or restart the watcher) to pick it up. After that, edits are picked up normally.
+
+Unknown keys in the local file are **ignored with a warning** during the build — watch the console for `[platform-features] feature-flags.local.json has unknown keys (ignored): …` to catch typos.
+
+A committed `feature-flags.local.json.example` at the repo root documents the shape; copy it if you'd like a starting point.
+
+## Typical use cases
+
+- **Test a Mirabox-only scenario on your Stream Deck build.** Set `features.borderGlow: false` in the local file, rebuild Stream Deck — the glow code and controls disappear from your Stream Deck build too. Flip it back and they return.
+- **Develop a beta feature locally without shipping it.** (Once issue #363 lands.) Commit the feature with its flag defaulting to `false` everywhere. Testers opt in via `feature-flags.local.json`.
+- **Strip an unsupported capability** when experimenting with a new host or SVG engine — set the relevant `capabilities.*` flag to `false` and see what still works.
+
+## Current flags
+
+| Flag | Category | Stream Deck | Mirabox | Purpose |
+|------|----------|-------------|---------|---------|
+| `svgFilters` | capability | `true` | `false` | SVG `<filter>` support (required by `feGaussianBlur`, etc.) |
+| `svgMasks` | capability | `true` | `false` | SVG `<mask>` support |
+| `svgPatterns` | capability | `true` | `false` | SVG `<pattern>` support |
+| `borderGlow` | feature | `true` | `false` | The glow halo around border overlays — uses `feGaussianBlur` and only renders on Stream Deck |
+
+## Adding a new flag
+
+Short version (see the in-repo rule `.claude/rules/platform-feature-flags.md` for full details):
+
+1. Add the flag to both `platform-features.json` files with the correct per-platform default.
+2. Add it to the `PlatformFeatureFlags` interface in `packages/deck-core/src/plugin-config.ts`.
+3. Declare the `__FEATURE_*__` ambient global in `packages/icon-composer/src/platform-features.d.ts`.
+4. Add a replace entry in **both** plugin `rollup.config.mjs` files.
+5. Gate the affected code and/or PI partials (`locals.platform?.features?.yourFlag !== false`).
+6. Seed the default in `test-setup.ts` and cover both the `true` and `false` paths with `vi.stubGlobal`.

--- a/packages/website/src/content/docs/docs/development/feature-flags.md
+++ b/packages/website/src/content/docs/docs/development/feature-flags.md
@@ -84,8 +84,8 @@ A committed `feature-flags.local.json.example` at the repo root documents the sh
 Short version (see the in-repo rule `.claude/rules/platform-feature-flags.md` for full details):
 
 1. Add the flag to both `platform-features.json` files with the correct per-platform default.
-2. Add it to the `PlatformFeatureFlags` interface in `packages/deck-core/src/plugin-config.ts`.
-3. Declare the `__FEATURE_*__` ambient global in `packages/icon-composer/src/platform-features.d.ts`.
+2. For a new `features.*` flag, add it to the `PlatformFeatureFlags` interface in `packages/deck-core/src/plugin-config.ts`. For a new `capabilities.*` flag, add it to the `PlatformCapabilities` interface in the same file.
+3. Declare the `__FEATURE_*__` or `__CAPABILITY_*__` ambient global in `packages/icon-composer/src/platform-features.d.ts`.
 4. Add a replace entry in **both** plugin `rollup.config.mjs` files.
-5. Gate the affected code and/or PI partials (`locals.platform?.features?.yourFlag !== false`).
+5. Gate the affected code and/or PI partials (`locals.platform?.features?.yourFlag !== false`, or `locals.platform?.capabilities?.yourCapability` for capability checks).
 6. Seed the default in `test-setup.ts` and cover both the `true` and `false` paths with `vi.stubGlobal`.

--- a/packages/website/src/content/docs/docs/development/index.md
+++ b/packages/website/src/content/docs/docs/development/index.md
@@ -29,3 +29,4 @@ If you find iRaceDeck useful, consider supporting its development: [Support iRac
 - [Tech Stack](/docs/development/tech-stack/) — packages, architecture, and how iRacing communication works
 - [Contributing](/docs/development/contributing/) — how to report issues, submit code, and join the community
 - [Setup](/docs/development/setup/) — clone, build, and run iRaceDeck locally for development
+- [Feature Flags](/docs/development/feature-flags/) — how platform-specific features are gated at build time and how to override flags locally

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: 16.0.3
         version: 16.0.3(rollup@4.60.1)
+      '@rollup/plugin-replace':
+        specifier: 6.0.3
+        version: 6.0.3(rollup@4.60.1)
       '@rollup/plugin-terser':
         specifier: 1.0.0
         version: 1.0.0(rollup@4.60.1)
@@ -350,6 +353,9 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: 16.0.3
         version: 16.0.3(rollup@4.60.1)
+      '@rollup/plugin-replace':
+        specifier: 6.0.3
+        version: 6.0.3(rollup@4.60.1)
       '@rollup/plugin-terser':
         specifier: 1.0.0
         version: 1.0.0(rollup@4.60.1)
@@ -1495,6 +1501,15 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.78.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-replace@6.0.3':
+    resolution: {integrity: sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -7287,6 +7302,13 @@ snapshots:
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.11
+    optionalDependencies:
+      rollup: 4.60.1
+
+  '@rollup/plugin-replace@6.0.3(rollup@4.60.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      magic-string: 0.30.21
     optionalDependencies:
       rollup: 4.60.1
 

--- a/test-setup.ts
+++ b/test-setup.ts
@@ -1,0 +1,19 @@
+/**
+ * Test setup — declares runtime defaults for the platform feature flag constants
+ * that `@rollup/plugin-replace` injects into plugin builds.
+ *
+ * Tests exercising the `false` path can override via `vi.stubGlobal(name, false)`;
+ * `vi.unstubAllGlobals()` restores these defaults.
+ */
+interface FeatureFlagGlobals {
+  __CAPABILITY_SVG_FILTERS__: boolean;
+  __CAPABILITY_SVG_MASKS__: boolean;
+  __CAPABILITY_SVG_PATTERNS__: boolean;
+  __FEATURE_BORDER_GLOW__: boolean;
+}
+
+const featureFlagGlobals = globalThis as unknown as FeatureFlagGlobals;
+featureFlagGlobals.__CAPABILITY_SVG_FILTERS__ = true;
+featureFlagGlobals.__CAPABILITY_SVG_MASKS__ = true;
+featureFlagGlobals.__CAPABILITY_SVG_PATTERNS__ = true;
+featureFlagGlobals.__FEATURE_BORDER_GLOW__ = true;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@iracedeck/deck-core": resolve(__dirname, "packages/deck-core/src/index.ts"),
+      "@iracedeck/icon-composer": resolve(__dirname, "packages/icon-composer/src/index.ts"),
       "@iracedeck/iracing-sdk": resolve(__dirname, "packages/iracing-sdk/src/index.ts"),
       "@iracedeck/iracing-native": resolve(__dirname, "packages/iracing-native/src/index.ts"),
       "@iracedeck/logger": resolve(__dirname, "packages/logger/src/index.ts"),
@@ -46,6 +47,7 @@ export default defineConfig({
   },
   test: {
     globals: true,
+    setupFiles: ["./test-setup.ts"],
     include: ["packages/*/src/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## Related Issue

Fixes #258

## What changed?

Build-time platform feature flags per plugin, with a gitignored developer override. First use case: border glow (`feGaussianBlur`, QT6.7+ only) is tree-shaken out of the Mirabox bundle and hidden from its Property Inspector, while Stream Deck keeps it.

- Each plugin has a committed `platform-features.json` with two sections: `capabilities` (raw SVG engine support) and `features` (product-level flags).
- Optional `feature-flags.local.json` at repo root deep-merges on top of both plugins' committed flags at build time. Typos emit a `[platform-features] … unknown keys (ignored): …` warning.
- Rollup fans the merged object to three consumers:
  - `@rollup/plugin-replace` injects `__FEATURE_*__` / `__CAPABILITY_*__` as compile-time constants; Terser drops dead branches.
  - `piTemplatePlugin` exposes `locals.platform` to EJS so PI partials (`border-overrides`, `global-border-defaults`, `head-common`) conditionally omit glow controls and their related JS.
  - `emit-plugin-config` writes the merged object to `/bin/config.json` as `featureFlags`; accessible at runtime via `getFeatureFlag()` / `getPlatformFeatures()` on `@iracedeck/deck-core`.
- Ambient globals declared in `packages/icon-composer/src/platform-features.d.ts`. Tests default all flags to `true` via root `test-setup.ts`; false-path tests use `vi.stubGlobal`.
- Docs: new `.claude/rules/platform-feature-flags.md`, cross-referenced from `svg-platform-compatibility.md` and the project `CLAUDE.md`; user-facing page at `/docs/development/feature-flags/` on the website.
- Follow-ups filed as #363 (`_featureFlag` gating inside manifest.json) and #364 (website setup.md — Mirabox + `.env.local` + rebuild workflow).

## How to test

```bash
pnpm install
pnpm build
pnpm test
```

Verify bundle tree-shaking:

```bash
# Stream Deck keeps glow:
grep -c feGaussianBlur packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/bin/plugin.js   # 1
grep -c ird-border-glow packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/bin/plugin.js # 1

# Mirabox strips glow:
grep -c feGaussianBlur packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/bin/plugin.js      # 0
grep -c ird-border-glow packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/bin/plugin.js    # 0
```

Verify PI output:

```bash
# Stream Deck has glow controls in PI HTML:
grep -l 'ird-border-glow' packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/ui/*.html | wc -l   # 34
# Mirabox has none:
grep -l 'ird-border-glow\|global-border-glow\|Show Glow' packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/ui/*.html | wc -l   # 0
```

Round-trip the local override:

```bash
echo '{"features":{"borderGlow":false}}' > feature-flags.local.json
pnpm --filter @iracedeck/iracing-plugin-stream-deck build
grep -c feGaussianBlur packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/bin/plugin.js   # 0
rm feature-flags.local.json
pnpm --filter @iracedeck/iracing-plugin-stream-deck build                                                 # glow restored
```

Verify unknown-key warning:

```bash
echo '{"features":{"brorderGlow":false}}' > feature-flags.local.json
pnpm --filter @iracedeck/iracing-plugin-stream-deck build 2>&1 | grep platform-features
# -> [platform-features] feature-flags.local.json has unknown keys (ignored): features.brorderGlow
rm feature-flags.local.json
```

Manual UI check (on real hardware):

- Stream Deck: enable border + glow on any action → glow renders on device; PI still shows Show Glow / Glow Width controls.
- Mirabox: border works normally; PI has no Show Glow / Glow Width controls, and the bundle no longer ships the glow SVG code.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a build-time platform feature-flag system to enable/disable capabilities and product features per plugin.

* **Documentation**
  * Added user-facing docs, a local override example, and a Development sidebar link.

* **Behavior**
  * Border-glow UI and generation are now conditionally omitted when the relevant capability/feature is disabled.

* **Tests**
  * Added test setup and tests validating feature-flag handling.

* **Chores**
  * Local feature-flag override file is ignored by version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->