### PR TITLE
fix(scripts): make Mirabox link/unlink robust + cover both platforms in switch-test-env (#362)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,10 +1,11 @@
 # Copy this file to .env.local (gitignored) and fill in your own values.
 # Referenced by scripts that need per-developer configuration.
 
-# Destination directory for the Mirabox plugin dev symlink. The directory
-# depends on which host app you use — the path below is for VSD Craft on
-# Windows. Other Mirabox-compatible hosts may install plugins elsewhere.
+# Destination directory for the Mirabox plugin dev symlink. On Windows,
+# the scripts default to the standard HotSpot StreamDock install path
+# (%APPDATA%\HotSpot\StreamDock\plugins) when this is unset. Override only
+# if you run a different host app (e.g. VSD Craft).
 #
 # Used by: pnpm link:mirabox / unlink:mirabox / relink:mirabox / switch-test-env:mirabox
 #
-# MIRABOX_PLUGINS_DIR=C:\Users\you\AppData\Roaming\VSD Craft\Plugins
+# MIRABOX_PLUGINS_DIR=C:\Users\you\AppData\Roaming\HotSpot\StreamDock\plugins

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "link:mirabox": "node scripts/link-mirabox.mjs",
     "unlink:mirabox": "node scripts/unlink-mirabox.mjs",
     "relink:mirabox": "pnpm unlink:mirabox && pnpm link:mirabox",
-    "switch-test-env": "pnpm switch-test-env:stream-deck",
+    "switch-test-env": "pnpm install && pnpm build && pnpm relink:stream-deck && pnpm relink:mirabox",
     "switch-test-env:stream-deck": "pnpm install && pnpm build && pnpm relink:stream-deck",
     "switch-test-env:mirabox": "pnpm install && pnpm build && pnpm relink:mirabox",
     "telemetry-snapshot": "pnpm --filter @iracedeck/iracing-sdk telemetry-snapshot -- --include-session --output-dir=local",

--- a/scripts/link-mirabox.mjs
+++ b/scripts/link-mirabox.mjs
@@ -4,14 +4,13 @@
  * directory, so the host loads the dev build directly (the Mirabox-side
  * equivalent of `streamdeck link` for Elgato).
  *
- * The destination is per-developer because there is no first-party
- * Mirabox CLI and the host app (VSD Craft or another vendor's build)
- * installs plugins to a vendor-specific path. Set MIRABOX_PLUGINS_DIR
- * in your shell or in a gitignored .env.local at the repo root:
+ * On Windows the destination defaults to the standard HotSpot StreamDock
+ * install path (`%APPDATA%\HotSpot\StreamDock\plugins`). Set
+ * MIRABOX_PLUGINS_DIR in your shell or in a gitignored .env.local at the
+ * repo root to override (e.g. for VSD Craft or another vendor's build):
  *
- *   MIRABOX_PLUGINS_DIR=C:\Users\you\AppData\Roaming\VSD Craft\Plugins
+ *   MIRABOX_PLUGINS_DIR=C:\Users\you\AppData\Roaming\HotSpot\StreamDock\plugins
  */
-
 import { existsSync, lstatSync, readFileSync, symlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -37,11 +36,18 @@ function loadEnvLocal() {
 
 loadEnvLocal();
 
-const dest = process.env.MIRABOX_PLUGINS_DIR;
+// Default to the standard HotSpot StreamDock install path on Windows when
+// MIRABOX_PLUGINS_DIR is not explicitly set. Other host apps (e.g. VSD Craft)
+// install elsewhere — set MIRABOX_PLUGINS_DIR in .env.local to override.
+const dest =
+  process.env.MIRABOX_PLUGINS_DIR ??
+  (process.platform === "win32" && process.env.APPDATA
+    ? join(process.env.APPDATA, "HotSpot", "StreamDock", "plugins")
+    : undefined);
 if (!dest) {
-  console.error("Error: MIRABOX_PLUGINS_DIR is not set.");
+  console.error("Error: MIRABOX_PLUGINS_DIR is not set and no default could be derived.");
   console.error("Set it in your shell or in .env.local at the repo root, e.g.:");
-  console.error('  MIRABOX_PLUGINS_DIR="C:\\\\Users\\\\you\\\\AppData\\\\Roaming\\\\VSD Craft\\\\Plugins"');
+  console.error('  MIRABOX_PLUGINS_DIR="C:\\\\Users\\\\you\\\\AppData\\\\Roaming\\\\HotSpot\\\\StreamDock\\\\plugins"');
   process.exit(1);
 }
 

--- a/scripts/unlink-mirabox.mjs
+++ b/scripts/unlink-mirabox.mjs
@@ -1,13 +1,10 @@
 #!/usr/bin/env node
 /**
- * Removes the Mirabox plugin symlink created by link-mirabox.mjs.
+ * Removes the Mirabox plugin entry created by link-mirabox.mjs, or a real
+ * plugin directory installed by the host app from a packaged build.
  * Tolerates the not-linked state (exits 0 with an info message).
- *
- * Refuses to delete anything that is not a symlink/junction, to avoid
- * accidentally wiping a real plugin copy someone placed there manually.
  */
-
-import { existsSync, lstatSync, readFileSync, unlinkSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, rmSync, unlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -44,10 +41,13 @@ if (!stat) {
   process.exit(0);
 }
 
-if (!stat.isSymbolicLink()) {
-  console.error(`Error: ${link} exists but is not a symlink — refusing to delete.`);
-  process.exit(1);
+// Branch on entry type. `rmSync(..., { recursive, force })` on a Windows
+// junction with a missing target silently no-ops (recurse fails, force
+// swallows the error, the junction itself is never unlinked). So unlink
+// symlinks/junctions explicitly; only recursively remove real directories.
+if (stat.isSymbolicLink()) {
+  unlinkSync(link);
+} else {
+  rmSync(link, { recursive: true, force: true });
 }
-
-unlinkSync(link);
-console.log(`Unlinked ${link}`);
+console.log(`Removed ${link}`);

--- a/scripts/unlink-mirabox.mjs
+++ b/scripts/unlink-mirabox.mjs
@@ -24,7 +24,14 @@ function loadEnvLocal() {
 
 loadEnvLocal();
 
-const dest = process.env.MIRABOX_PLUGINS_DIR;
+// Default to the standard HotSpot StreamDock install path on Windows when
+// MIRABOX_PLUGINS_DIR is not explicitly set. Other host apps (e.g. VSD Craft)
+// install elsewhere — set MIRABOX_PLUGINS_DIR in .env.local to override.
+const dest =
+  process.env.MIRABOX_PLUGINS_DIR ??
+  (process.platform === "win32" && process.env.APPDATA
+    ? join(process.env.APPDATA, "HotSpot", "StreamDock", "plugins")
+    : undefined);
 if (!dest) {
   console.log("MIRABOX_PLUGINS_DIR not set — nothing to unlink.");
   process.exit(0);


### PR DESCRIPTION
## Related Issue

Fixes #362

## What changed?

Three logical commits on top of `master`:

1. **`fix(scripts): unlink-mirabox handles real dirs and dangling junctions`** — drops the symlink-only guard so `unlink:mirabox` / `relink:mirabox` succeeds when the host app installed the plugin as a real directory (copied from a packaged `.streamDeckPlugin`). Branches on entry type because `rmSync(..., { recursive, force })` silently no-ops on a Windows junction whose target has been deleted (recurse fails, `force: true` swallows the error, the junction is never unlinked). Uses `unlinkSync` for symlinks/junctions and `rmSync` only for real directories.
2. **`improve(scripts): switch-test-env covers both platforms in one shot`** — plain `pnpm switch-test-env` now runs `install + build + relink:stream-deck + relink:mirabox`. The `:stream-deck` and `:mirabox` variants stay for targeted switching.
3. **`improve(scripts): default MIRABOX_PLUGINS_DIR to HotSpot StreamDock on Windows`** — link/unlink scripts derive `%APPDATA%\HotSpot\StreamDock\plugins` on Windows when `MIRABOX_PLUGINS_DIR` is unset. `.env.local` is only needed when overriding for a different host (e.g. VSD Craft). Out of scope of the original issue but addresses the same root friction — agreed in conversation.

## How to test

- [x] `pnpm relink:mirabox` succeeds when the prior install was a dangling junction (the original failure mode that surfaced this).
- [x] `pnpm relink:mirabox` succeeds when the prior install was a real directory (simulated via temp dir).
- [x] `pnpm relink:mirabox` is still a no-op when nothing exists at the target path.
- [x] `pnpm relink:mirabox` works with `.env.local` removed (Windows fallback to `%APPDATA%\HotSpot\StreamDock\plugins`).
- [x] `pnpm relink:mirabox` still works when `MIRABOX_PLUGINS_DIR` is explicitly set in `.env.local`.
- [ ] `pnpm switch-test-env` on a clean worktree links both plugins (verify on reviewer's machine — full install + build).

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests — N/A (dev tooling scripts; no test harness for them)
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — N/A (root-level dev scripts, both platforms covered)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default plugin directory configuration to use HotSpot StreamDock path instead of VSD Craft path.
  * Enhanced build workflow to run installation and compilation before relinking plugins.
  * Improved plugin cleanup process to properly handle both symlinked and installed directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->