### PR TITLE
docs(website): expand development/setup with Mirabox, .env.local, and rebuild workflow (#364)

### DIFF
--- a/packages/website/src/content/docs/docs/development/setup.md
+++ b/packages/website/src/content/docs/docs/development/setup.md
@@ -8,7 +8,8 @@ description: How to clone, build, and run iRaceDeck locally for development.
 - **Node.js** 24 or newer
 - **pnpm** (install with `npm install -g pnpm`)
 - **Windows** (required for the native addon and iRacing integration)
-- **Stream Deck software** 7.1 or newer
+- **Stream Deck software** 7.1 or newer — required to run the Elgato plugin
+- **HotSpot StreamDock** (or another QT5 SVG Tiny 1.2 compatible Mirabox host) — only required if you're developing or testing the Mirabox plugin
 
 ## Getting Started
 
@@ -22,15 +23,57 @@ pnpm install
 
 # Build all packages
 pnpm build
+```
 
-# Link the plugin to Stream Deck for testing
+After the initial install and build, link the plugin to whichever host(s) you're developing against.
+
+### Stream Deck
+
+```bash
+# Link the built plugin to the Stream Deck software
 pnpm link:stream-deck
 
-# Start watching for changes (auto-rebuilds on save)
+# Watch mode — auto-rebuilds on save
 pnpm watch:stream-deck
 ```
 
-After linking, restart the Stream Deck software. The plugin will appear in the action list as **iRaceDeck**. Changes you make will be picked up automatically when using `watch:stream-deck`.
+Restart the Stream Deck software. The plugin appears in the action list as **iRaceDeck**.
+
+### Mirabox
+
+```bash
+# Link the built plugin to the Mirabox host
+pnpm link:mirabox
+
+# Watch mode for the Mirabox plugin (no root-level shortcut yet)
+pnpm --filter @iracedeck/iracing-plugin-mirabox run watch
+```
+
+On Windows, `link:mirabox` defaults to the standard HotSpot StreamDock install path (`%APPDATA%\HotSpot\StreamDock\plugins`). If you're using a different host (e.g. VSD Craft), point `MIRABOX_PLUGINS_DIR` at its plugins directory in `.env.local` (see below).
+
+## `.env.local`
+
+Some dev scripts read per-developer settings from `.env.local` at the repo root. The file is gitignored and never committed. Copy `.env.local.example` as a starting point:
+
+```bash
+cp .env.local.example .env.local
+```
+
+Keys currently supported:
+
+| Key | Used by | Purpose |
+|-----|---------|---------|
+| `MIRABOX_PLUGINS_DIR` | `pnpm link:mirabox` / `unlink:mirabox` / `relink:mirabox` | Path to your Mirabox host's plugins directory. Optional on Windows when using HotSpot StreamDock — the scripts default to `%APPDATA%\HotSpot\StreamDock\plugins`. Set this only to override (e.g. `C:\Users\you\AppData\Roaming\VSD Craft\Plugins`). |
+
+## Picking up changes after a rebuild
+
+Both Stream Deck and Mirabox host apps cache plugin metadata aggressively. If your changes affect `manifest.json`, Property Inspector templates, static icons, or the action registration layer, the reliable flow is:
+
+1. **Quit the host software from the task bar** (right-click the tray icon → Quit / Exit). Closing the window is not enough — the app keeps running in the background.
+2. Run `pnpm build` (or let your watch process rebuild automatically).
+3. Start the host software again.
+
+For pure action-code edits, the watch process plus the host's built-in refresh usually suffices, but when in doubt, run the full stop–build–start cycle.
 
 ## Useful Commands
 
@@ -38,8 +81,15 @@ After linking, restart the Stream Deck software. The plugin will appear in the a
 |---------|-------------|
 | `pnpm build` | Build all packages |
 | `pnpm build:stream-deck` | Build only the Stream Deck plugin |
-| `pnpm watch:stream-deck` | Watch mode — rebuild on file changes |
+| `pnpm watch:stream-deck` | Watch mode — rebuild on file changes (Stream Deck) |
+| `pnpm --filter @iracedeck/iracing-plugin-mirabox run watch` | Watch mode for the Mirabox plugin |
 | `pnpm link:stream-deck` | Register the plugin with Stream Deck |
-| `pnpm unlink:stream-deck` | Unregister the plugin |
-| `pnpm relink:stream-deck` | Unlink + link (useful when switching branches) |
+| `pnpm unlink:stream-deck` | Unregister the Stream Deck plugin |
+| `pnpm relink:stream-deck` | Unlink + link Stream Deck (useful when switching branches) |
+| `pnpm link:mirabox` | Register the plugin with the Mirabox host (uses `MIRABOX_PLUGINS_DIR` if set, otherwise the Windows HotSpot StreamDock default) |
+| `pnpm unlink:mirabox` | Unregister the Mirabox plugin |
+| `pnpm relink:mirabox` | Unlink + link Mirabox (useful when switching branches) |
+| `pnpm switch-test-env` | Install + build + relink for both platforms |
+| `pnpm switch-test-env:stream-deck` | Install + build + relink only Stream Deck |
+| `pnpm switch-test-env:mirabox` | Install + build + relink only Mirabox |
 | `pnpm test` | Run all tests |


### PR DESCRIPTION
## Related Issue

Fixes #364

## What changed?

`packages/website/src/content/docs/docs/development/setup.md` was Stream Deck-only. This PR expands it with:

- **Prerequisites** — adds Stream Deck software 7.1+ explicitly, plus HotSpot StreamDock (or another QT5-compatible Mirabox host) as an optional prereq.
- **Getting Started** — split into a shared install/build block followed by per-host `Stream Deck` and `Mirabox` sub-sections that mirror each other.
- **`.env.local`** — new section explaining the per-developer config file with a key table (currently just `MIRABOX_PLUGINS_DIR`).
- **Picking up changes after a rebuild** — new section documenting the stop-from-task-bar / rebuild / restart loop that both hosts need when manifest, PI templates, static icons, or registration changes.
- **Useful Commands** — table grows Mirabox parallels (link/unlink/relink + watch via `--filter`) and `switch-test-env` / `:stream-deck` / `:mirabox` rows.

Per the conversation that produced this issue, the docs describe the **post-#366** behavior:
- `MIRABOX_PLUGINS_DIR` is documented as optional on Windows (scripts default to `%APPDATA%\HotSpot\StreamDock\plugins`).
- Plain `pnpm switch-test-env` is documented as covering both platforms.

**This PR therefore depends on #366 merging first** (or being rebased onto a master that includes it). Per the issue's "Either add one as part of this issue or document the `--filter` form" note, no new root scripts are added — the existing `--filter` form is documented instead.

## How to test

- [x] `pnpm --filter @iracedeck/website build` succeeds and prints no warnings for the setup page.
- [x] Rendered headings on `/docs/development/setup/` match the new structure (Prerequisites, Getting Started → Stream Deck / Mirabox, .env.local, Picking up changes after a rebuild, Useful Commands).
- [x] `.env.local` table matches what `scripts/link-mirabox.mjs` actually reads (post-#366: optional on Windows, default to HotSpot StreamDock).
- [ ] After #366 merges and this branch is rebased, follow only the Mirabox section from a fresh clone and confirm a contributor can go from clone → linked Mirabox plugin without extra context.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests — N/A (docs-only change)
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — N/A (docs cover both)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Stream Deck guidance and added Mirabox as a supported development/testing workflow.
  * Documented Mirabox linking and watch commands and a MIRABOX_PLUGINS_DIR configuration option (with Windows default behavior).
  * Added a “Picking up changes after a rebuild” section describing an explicit stop–build–start restart flow.
  * Expanded the Useful Commands list with Mirabox watch/link/unlink/relink and cross-platform relink helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->