### PR TITLE
feat(actions): add Auto-hold options to Enter/Exit/Tow car control (#212)

### DIFF
--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -66,7 +66,7 @@ Mode counts reflect the PI Mode/Setting dropdown choices documented in each acti
 | Audio Controls | 3 | push-to-talk (hold), voice-chat (with volume-up/down/mute action), master (with volume-up/down action) |
 | Black Box Selector | 3 | direct (with 11 Black Box options), next, previous |
 | Look Direction | 4 | look-left, look-right, look-up, look-down (all hold pattern) |
-| Car Control | 10 | pit-speed-limiter (telemetry-aware), push-to-pass (telemetry-aware), drs (telemetry-aware), headlight-flash (hold), tear-off-visor, ignition, starter (hold), enter-exit-tow (hold, telemetry-aware), escape (hardcoded ESC, auto-hold option), pause-sim |
+| Car Control | 10 | pit-speed-limiter (telemetry-aware), push-to-pass (telemetry-aware), drs (telemetry-aware), headlight-flash (hold), tear-off-visor, ignition, starter (hold), enter-exit-tow (hold, telemetry-aware, per-state auto-hold options for exit/reset/tow), escape (hardcoded ESC, auto-hold option), pause-sim |
 
 ### Cockpit & Interface
 

--- a/docs/reference/actions.json
+++ b/docs/reference/actions.json
@@ -121,7 +121,7 @@
             { "value": "tear-off-visor", "label": "Tear Off Visor" },
             { "value": "ignition", "label": "Ignition" },
             { "value": "starter", "label": "Starter", "controlType": "hold" },
-            { "value": "enter-exit-tow", "label": "Enter/Exit/Tow" },
+            { "value": "enter-exit-tow", "label": "Enter/Exit/Tow", "controlType": "hold", "telemetryAware": true },
             { "value": "escape", "label": "Escape", "controlType": "hold" },
             { "value": "pause-sim", "label": "Pause Sim" }
           ]

--- a/packages/iracing-actions/src/actions/car-control/car-control.ejs
+++ b/packages/iracing-actions/src/actions/car-control/car-control.ejs
@@ -25,6 +25,14 @@
 			<sdpi-checkbox setting="autoHold"></sdpi-checkbox>
 		</sdpi-item>
 
+		<sdpi-item id="auto-hold-states-item" label="Auto-hold" class="hidden">
+			<sdpi-checkbox-list setting="autoHoldStates" columns="1">
+				<option value="exit-car">Exit</option>
+				<option value="reset-to-pits">Reset</option>
+				<option value="tow">Tow</option>
+			</sdpi-checkbox-list>
+		</sdpi-item>
+
 		<%- include('title-overrides') %>
 
 		<script>
@@ -56,11 +64,10 @@
 
 			function updateAutoHoldVisibility(control) {
 				const autoHoldItem = document.getElementById("auto-hold-item");
-				if (control === "escape") {
-					autoHoldItem?.classList.remove("hidden");
-				} else {
-					autoHoldItem?.classList.add("hidden");
-				}
+				const autoHoldStatesItem = document.getElementById("auto-hold-states-item");
+
+				autoHoldItem?.classList.toggle("hidden", control !== "escape");
+				autoHoldStatesItem?.classList.toggle("hidden", control !== "enter-exit-tow");
 			}
 
 			if (document.readyState === "loading") {

--- a/packages/iracing-actions/src/actions/car-control/car-control.test.ts
+++ b/packages/iracing-actions/src/actions/car-control/car-control.test.ts
@@ -964,4 +964,253 @@ describe("CarControl", () => {
       expect(action["autoHoldTimers"].has("action-1")).toBe(false);
     });
   });
+
+  describe("enter-exit-tow auto-hold", () => {
+    type State = "enter-car" | "exit-car" | "reset-to-pits" | "tow";
+
+    function telemetryFor(state: State): Record<string, unknown> | null {
+      switch (state) {
+        case "enter-car":
+          return null;
+        case "exit-car":
+          return { IsOnTrack: true, PlayerCarInPitStall: true, SessionNum: 0 };
+        case "reset-to-pits":
+        case "tow":
+          return { IsOnTrack: true, PlayerCarInPitStall: false, SessionNum: 0 };
+      }
+    }
+
+    function sessionInfoFor(state: State): Record<string, unknown> | null {
+      if (state !== "tow" && state !== "reset-to-pits") return null;
+
+      const sessionType = state === "tow" ? "Race" : "Practice";
+
+      return { SessionInfo: { Sessions: [{ SessionNum: 0, SessionType: sessionType }] } };
+    }
+
+    function primeTelemetry(action: CarControl, state: State): void {
+      (action as any).sdkController.getCurrentTelemetry = vi.fn(() => telemetryFor(state));
+      (action as any).sdkController.getSessionInfo = vi.fn(() => sessionInfoFor(state));
+    }
+
+    describe("manual hold (autoHoldStates empty)", () => {
+      let action: CarControl;
+
+      beforeEach(() => {
+        action = new CarControl();
+      });
+
+      it.each(["enter-car", "exit-car", "reset-to-pits", "tow"] as const)(
+        "should hold on keyDown and release on keyUp when state is not in autoHoldStates (state=%s)",
+        async (state) => {
+          primeTelemetry(action, state);
+          const settings = { control: "enter-exit-tow", autoHoldStates: [] as string[] };
+
+          await action.onKeyDown(fakeEvent("action-1", settings) as any);
+
+          expect(mockHoldBinding).toHaveBeenCalledWith("action-1", "carControlEnterExitTow");
+
+          await action.onKeyUp(fakeEvent("action-1", settings) as any);
+
+          expect(mockReleaseBinding).toHaveBeenCalledWith("action-1");
+        },
+      );
+
+      it("should release via releaseBinding on onWillDisappear", async () => {
+        primeTelemetry(action, "exit-car");
+        const settings = { control: "enter-exit-tow" };
+
+        await action.onKeyDown(fakeEvent("action-1", settings) as any);
+        await action.onWillDisappear(fakeEvent("action-1", settings) as any);
+
+        expect(mockReleaseBinding).toHaveBeenCalledWith("action-1");
+        expect(mockReleaseKeyCombination).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("auto-hold ON per state", () => {
+      let action: CarControl;
+
+      beforeEach(() => {
+        vi.useFakeTimers();
+        action = new CarControl();
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      const cases: Array<{ state: State }> = [{ state: "exit-car" }, { state: "reset-to-pits" }, { state: "tow" }];
+
+      it.each(cases)("should hold and start auto-release timer on keyDown (state=$state)", async ({ state }) => {
+        primeTelemetry(action, state);
+
+        await action.onKeyDown(fakeEvent("action-1", { control: "enter-exit-tow", autoHoldStates: [state] }) as any);
+
+        expect(mockHoldBinding).toHaveBeenCalledWith("action-1", "carControlEnterExitTow");
+        expect(mockReleaseBinding).not.toHaveBeenCalled();
+      });
+
+      it.each(cases)("should not release on keyUp when timer is running (state=$state)", async ({ state }) => {
+        primeTelemetry(action, state);
+        const settings = { control: "enter-exit-tow", autoHoldStates: [state] };
+
+        await action.onKeyDown(fakeEvent("action-1", settings) as any);
+        await action.onKeyUp(fakeEvent("action-1", settings) as any);
+
+        expect(mockReleaseBinding).not.toHaveBeenCalled();
+      });
+
+      it.each(cases)("should auto-release after 1.5 seconds (state=$state)", async ({ state }) => {
+        primeTelemetry(action, state);
+
+        await action.onKeyDown(fakeEvent("action-1", { control: "enter-exit-tow", autoHoldStates: [state] }) as any);
+
+        expect(mockReleaseBinding).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1500);
+
+        expect(mockReleaseBinding).toHaveBeenCalledWith("action-1");
+      });
+
+      it.each(cases)("should not release before 1.5 seconds (state=$state)", async ({ state }) => {
+        primeTelemetry(action, state);
+
+        await action.onKeyDown(fakeEvent("action-1", { control: "enter-exit-tow", autoHoldStates: [state] }) as any);
+
+        await vi.advanceTimersByTimeAsync(1000);
+
+        expect(mockReleaseBinding).not.toHaveBeenCalled();
+      });
+
+      it.each(cases)("should cancel timer and release on second press (state=$state)", async ({ state }) => {
+        primeTelemetry(action, state);
+        const settings = { control: "enter-exit-tow", autoHoldStates: [state] };
+
+        await action.onKeyDown(fakeEvent("action-1", settings) as any);
+
+        expect(mockHoldBinding).toHaveBeenCalledTimes(1);
+
+        await action.onKeyDown(fakeEvent("action-1", settings) as any);
+
+        expect(mockReleaseBinding).toHaveBeenCalledWith("action-1");
+        expect(mockHoldBinding).toHaveBeenCalledTimes(1);
+      });
+
+      it.each(cases)("should not double-release after cancel+timer expiration (state=$state)", async ({ state }) => {
+        primeTelemetry(action, state);
+        const settings = { control: "enter-exit-tow", autoHoldStates: [state] };
+
+        await action.onKeyDown(fakeEvent("action-1", settings) as any);
+        await action.onKeyDown(fakeEvent("action-1", settings) as any);
+
+        mockReleaseBinding.mockClear();
+
+        await vi.advanceTimersByTimeAsync(2000);
+
+        expect(mockReleaseBinding).not.toHaveBeenCalled();
+      });
+
+      it("should work via dialDown/dialUp as well", async () => {
+        primeTelemetry(action, "tow");
+        const settings = { control: "enter-exit-tow", autoHoldStates: ["tow"] };
+
+        await action.onDialDown(fakeEvent("action-1", settings) as any);
+
+        expect(mockHoldBinding).toHaveBeenCalledWith("action-1", "carControlEnterExitTow");
+
+        await action.onDialUp(fakeEvent("action-1", settings) as any);
+
+        expect(mockReleaseBinding).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1500);
+
+        expect(mockReleaseBinding).toHaveBeenCalledWith("action-1");
+      });
+
+      it("should handle independent timers across action contexts", async () => {
+        primeTelemetry(action, "tow");
+        const settings = { control: "enter-exit-tow", autoHoldStates: ["tow"] };
+
+        await action.onKeyDown(fakeEvent("action-1", settings) as any);
+        await action.onKeyDown(fakeEvent("action-2", settings) as any);
+
+        expect(mockHoldBinding).toHaveBeenCalledTimes(2);
+
+        await action.onKeyDown(fakeEvent("action-1", settings) as any);
+
+        expect(mockReleaseBinding).toHaveBeenCalledWith("action-1");
+        expect(mockReleaseBinding).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(1500);
+
+        expect(mockReleaseBinding).toHaveBeenCalledWith("action-2");
+        expect(mockReleaseBinding).toHaveBeenCalledTimes(2);
+      });
+
+      it("should ignore auto-hold when state is enter-car (instant action)", async () => {
+        primeTelemetry(action, "enter-car");
+        const settings = {
+          control: "enter-exit-tow",
+          autoHoldStates: ["exit-car", "reset-to-pits", "tow"],
+        };
+
+        await action.onKeyDown(fakeEvent("action-1", settings) as any);
+
+        expect(mockHoldBinding).toHaveBeenCalledWith("action-1", "carControlEnterExitTow");
+        expect(action["autoHoldTimers"].has("action-1")).toBe(false);
+
+        await action.onKeyUp(fakeEvent("action-1", settings) as any);
+
+        expect(mockReleaseBinding).toHaveBeenCalledWith("action-1");
+      });
+
+      it("should ignore auto-hold when current state is not in autoHoldStates", async () => {
+        primeTelemetry(action, "exit-car");
+        // Only tow is selected; active state is exit-car
+        const settings = { control: "enter-exit-tow", autoHoldStates: ["tow"] };
+
+        await action.onKeyDown(fakeEvent("action-1", settings) as any);
+
+        expect(action["autoHoldTimers"].has("action-1")).toBe(false);
+
+        await action.onKeyUp(fakeEvent("action-1", settings) as any);
+
+        expect(mockReleaseBinding).toHaveBeenCalledWith("action-1");
+      });
+    });
+
+    describe("cleanup on disappear", () => {
+      let action: CarControl;
+
+      beforeEach(() => {
+        vi.useFakeTimers();
+        action = new CarControl();
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it("should clear timer and release binding on disappear", async () => {
+        primeTelemetry(action, "tow");
+        const settings = { control: "enter-exit-tow", autoHoldStates: ["tow"] };
+
+        await action.onKeyDown(fakeEvent("action-1", settings) as any);
+
+        expect(action["autoHoldTimers"].has("action-1")).toBe(true);
+
+        await action.onWillDisappear(fakeEvent("action-1", settings) as any);
+
+        expect(action["autoHoldTimers"].has("action-1")).toBe(false);
+        expect(mockReleaseBinding).toHaveBeenCalledWith("action-1");
+
+        mockReleaseBinding.mockClear();
+
+        await vi.advanceTimersByTimeAsync(2000);
+
+        expect(mockReleaseBinding).not.toHaveBeenCalled();
+      });
+    });
+  });
 });

--- a/packages/iracing-actions/src/actions/car-control/car-control.ts
+++ b/packages/iracing-actions/src/actions/car-control/car-control.ts
@@ -327,6 +327,10 @@ const CarControlSettings = CommonSettings.extend({
     .union([z.boolean(), z.string()])
     .transform((val) => val === true || val === "true")
     .default(false),
+  autoHoldStates: z
+    .array(z.enum(["exit-car", "reset-to-pits", "tow"]))
+    .default([])
+    .transform((arr) => [...new Set(arr)]),
 });
 
 type CarControlSettings = z.infer<typeof CarControlSettings>;
@@ -523,6 +527,9 @@ export class CarControl extends ConnectionStateAwareAction<CarControlSettings> {
     if (settings.control === "escape") {
       this.clearAutoHoldTimer(ev.action.id);
       await getKeyboard().releaseKeyCombination(ESC_KEY);
+    } else if (settings.control === "enter-exit-tow") {
+      this.clearAutoHoldTimer(ev.action.id);
+      await this.releaseBinding(ev.action.id);
     } else {
       await this.releaseBinding(ev.action.id);
     }
@@ -564,6 +571,15 @@ export class CarControl extends ConnectionStateAwareAction<CarControlSettings> {
       return;
     }
 
+    if (settings.control === "enter-exit-tow") {
+      // Auto-hold timer owns the release; skip when one is active
+      if (!this.autoHoldTimers.has(ev.action.id)) {
+        await this.releaseBinding(ev.action.id);
+      }
+
+      return;
+    }
+
     await this.releaseBinding(ev.action.id);
   }
 
@@ -585,6 +601,14 @@ export class CarControl extends ConnectionStateAwareAction<CarControlSettings> {
       return;
     }
 
+    if (settings.control === "enter-exit-tow") {
+      if (!this.autoHoldTimers.has(ev.action.id)) {
+        await this.releaseBinding(ev.action.id);
+      }
+
+      return;
+    }
+
     await this.releaseBinding(ev.action.id);
   }
 
@@ -601,6 +625,12 @@ export class CarControl extends ConnectionStateAwareAction<CarControlSettings> {
       return;
     }
 
+    if (settings.control === "enter-exit-tow") {
+      await this.executeEnterExitTow(actionId, settings);
+
+      return;
+    }
+
     const settingKey = CAR_CONTROL_GLOBAL_KEYS[settings.control];
 
     if (!settingKey) {
@@ -613,6 +643,59 @@ export class CarControl extends ConnectionStateAwareAction<CarControlSettings> {
       await this.holdBinding(actionId, settingKey);
     } else {
       await this.tapBinding(settingKey);
+    }
+  }
+
+  /**
+   * Resolves whether auto-hold should apply for the current Enter/Exit/Tow telemetry state.
+   * Enter-car is instant — never auto-holds regardless of settings.
+   */
+  private getEnterExitTowAutoHold(settings: CarControlSettings): boolean {
+    const telemetry = this.sdkController.getCurrentTelemetry();
+    const sessionInfo = this.sdkController.getSessionInfo();
+    const state = getEnterExitTowState(telemetry, sessionInfo);
+
+    if (state === "enter-car") return false;
+
+    return settings.autoHoldStates?.includes(state) ?? false;
+  }
+
+  private async executeEnterExitTow(actionId: string, settings: CarControlSettings): Promise<void> {
+    const settingKey = CAR_CONTROL_GLOBAL_KEYS["enter-exit-tow"];
+
+    if (!settingKey) {
+      this.logger.warn("No global key mapping for control: enter-exit-tow");
+
+      return;
+    }
+
+    const autoHold = this.getEnterExitTowAutoHold(settings);
+
+    if (autoHold) {
+      // Second press while timer running: cancel and release immediately
+      if (this.autoHoldTimers.has(actionId)) {
+        this.logger.info("Enter/Exit/Tow auto-hold cancelled");
+        this.clearAutoHoldTimer(actionId);
+        await this.releaseBinding(actionId);
+
+        return;
+      }
+
+      // First press: start hold, auto-release after timeout
+      this.logger.info("Enter/Exit/Tow auto-hold started");
+      await this.holdBinding(actionId, settingKey);
+      this.autoHoldTimers.set(
+        actionId,
+        setTimeout(() => {
+          this.logger.info("Enter/Exit/Tow auto-hold released");
+          void this.releaseBinding(actionId)
+            .catch((err) => this.logger.error(`Enter/Exit/Tow auto-hold release failed: ${err}`))
+            .finally(() => this.autoHoldTimers.delete(actionId));
+        }, AUTO_HOLD_DURATION),
+      );
+    } else {
+      // Manual hold: press on keyDown, release on keyUp
+      await this.holdBinding(actionId, settingKey);
     }
   }
 

--- a/packages/website/src/content/docs/docs/actions/driving/car-control.md
+++ b/packages/website/src/content/docs/docs/actions/driving/car-control.md
@@ -127,11 +127,11 @@ Engage the car starter. Hold the button to crank.
 
 ### Enter/Exit/Tow
 
-Context-aware car entry, exit, pit reset, or tow. The icon updates dynamically based on your current iRacing state, and the button uses a hold pattern — press and hold to confirm the action.
+Context-aware car entry, exit, pit reset, or tow. The icon updates dynamically based on your current iRacing state, and the button uses a hold pattern — press and hold to confirm the action. Enter Car is instant; Exit, Reset to Pits, and Tow each have an optional auto-hold checkbox that taps the button for you.
 
 #### Details
 
-- **Dial:** No rotation support; press and hold the dial to confirm, release to cancel
+- **Dial:** No rotation support; manual hold holds `Shift+R` while the button is pressed. When auto-hold is on for the active state, a single tap holds it for 1.5 seconds or until you press again
 - **Default binding:** `Shift+R`
 - **Telemetry-aware icon:** Yes — the icon switches between Enter Car, Exit Car, Reset to Pits, and Tow based on whether you are out of the car, in the pits, on track in a non-race session, or on track in a race
 
@@ -143,6 +143,13 @@ Enter/Exit/Tow automatically picks one of four display states based on live tele
 - **Exit Car** — In the pits; the icon shows a car with an outward arrow
 - **Reset to Pits** — On track in a non-race session; the icon shows a car with a reset arrow
 - **Tow** — On track in a race session; the icon shows a tow hook
+
+#### Setting: Auto-hold
+
+Three independent checkboxes pick which hold-based states use auto-hold. Each one applies only when the matching telemetry state is active, so you can mix manual and auto-hold per state (for example, auto-hold for tow but manual for exit). Enter Car is instant and has no checkbox.
+
+- **Off** (default) — Hold the button to hold `Shift+R`; release the button to release it
+- **On** — A single tap holds `Shift+R` for 1.5 seconds automatically; tap again during those 1.5 seconds to cancel early
 
 ---
 


### PR DESCRIPTION
## Related Issue

Fixes #212

## What changed?

Adds a per-state Auto-hold checkbox list to the Car Control action's Enter/Exit/Tow mode, mirroring the existing Escape auto-hold pattern from #189. Users opt in per telemetry-driven state:

- **Exit** (in pit stall)
- **Reset** (on track, non-race session)
- **Tow** (on track, race session)

Enter Car is instant and has no entry. The active auto-hold is resolved from live telemetry via `getEnterExitTowState()`, a single tap in an auto-hold state holds `Shift+R` for 1.5 s (shared `AUTO_HOLD_DURATION`), and a second tap cancels early. The shared `autoHoldTimers` map handles second-press cancellation, `onKeyUp`/`onDialUp` skip release while a timer is active, and `onWillDisappear` clears the timer before releasing the binding.

Implementation notes:
- Schema: `CarControlSettings.autoHoldStates` — `z.array` of `exit-car | reset-to-pits | tow` with a dedupe transform, mirroring the tire-service pattern.
- Routing: new `executeEnterExitTow()` mirrors `executeEscape()` but uses `holdBinding`/`releaseBinding` so SimHub routing still works.
- PI: single `sdpi-checkbox-list` (columns=1), shown only when Enter/Exit/Tow is selected in the Control dropdown.
- Tests, website docs, `docs/reference/actions.json`, and the `iracedeck-actions` skill updated.

## How to test

1. Build the repo (`pnpm build`) and reload the Stream Deck plugin (`streamdeck reload com.iracedeck.sd.core`).
2. Add a Car Control action, pick **Enter/Exit/Tow Car**. Confirm the **Auto-hold** row appears with three options (Exit / Reset / Tow) and disappears when you switch the control to anything else.
3. With all three unchecked: verify manual hold still works in each telemetry state (press-and-hold the button during each state — the key should be held while pressed and released on key up).
4. Check each option in isolation:
   - **Exit** in pit stall → single tap holds `Shift+R` for 1.5 s; a second tap during those 1.5 s cancels early.
   - **Reset** on track in a practice / qualifying session → same 1.5 s auto-hold behavior.
   - **Tow** on track in a race session → same 1.5 s auto-hold behavior.
5. In Enter Car state (out of car / replay / spectator), confirm auto-hold never engages even if all three options are checked.
6. Remove / re-add the action mid-hold to confirm `onWillDisappear` releases the binding cleanly.
7. Repeat on the Mirabox plugin (shared template, expected parity).

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added auto-hold functionality for Enter/Exit/Tow control, enabling single-tap activation with automatic 1.5-second release or re-press cancellation
  * Added configurable auto-hold per telemetry-driven state (Exit Car, Reset to Pits, Tow)

* **Documentation**
  * Updated Enter/Exit/Tow documentation with auto-hold behavior and configuration details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->