### PR TITLE
ci: pin pnpm@10.0.0 on pnpm/action-setup@v6 (#386)

### DIFF
--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
+        with:
+          version: 10.0.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
+        with:
+          version: 10.0.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
+        with:
+          version: 10.0.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/firebase-hosting-release.yml
+++ b/.github/workflows/firebase-hosting-release.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
+        with:
+          version: 10.0.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release-pack-mirabox.yml
+++ b/.github/workflows/release-pack-mirabox.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
+        with:
+          version: 10.0.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release-pack-streamdeck.yml
+++ b/.github/workflows/release-pack-streamdeck.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
+        with:
+          version: 10.0.0
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Related Issue

Fixes #386

## What changed?

Added `with: { version: 10.0.0 }` to every `pnpm/action-setup@v6` step across all six workflows.

`pnpm/action-setup@v6` bootstraps with a bundled **pnpm v11.0.0-rc.x**. When `packageManager` is set in `package.json` (we have `pnpm@10.0.0`), the action's own `readTargetVersion` returns `undefined`, the `self-update` step is skipped, and the action defers to pnpm 11 RC's auto-switch feature. That path writes `pnpm-lock.yaml` with two YAML documents, which pnpm 10 then refuses to read under `--frozen-lockfile`:

```text
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at "...pnpm-lock.yaml" is broken: expected a single document in the stream, but found more
```

This is the bug tracked upstream in [pnpm/action-setup#228](https://github.com/pnpm/action-setup/issues/228) (still open against v6.0.2).

When `version` is passed as an input, v6 runs `pnpm self-update <version>` and the v11 RC bootstrap is replaced with real pnpm 10 before any user command runs — no auto-switch, no lockfile corruption. v6 throws on mismatch between `version` and the `packageManager` field, so `10.0.0` is kept on both sides to match what master already has.

Only the Release workflow was hitting this in practice (Windows + `--frozen-lockfile`), but the same pin is applied to Format / Lint / Tests / Firebase so all workflows use identical pnpm setup and no one is one `--frozen-lockfile` rename away from a rerun of this bug.

## How to test

1. Wait for the Format / Lint / Tests workflows on this PR to finish green — that proves the pinned `version: 10.0.0` input is accepted by v6 and doesn't regress the Ubuntu path.
2. After merge, the v1.14.0 tag will be deleted and re-cut at the new master HEAD so the Release workflow runs on a commit that contains this fix. Both Windows release jobs (`build-streamdeck` and `build-mirabox`) should pass on the re-cut tag.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests <!-- N/A: CI workflow-only change -->
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) <!-- N/A: workflow-only -->
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configurations to standardize build environment tooling across all continuous integration and deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->