### PR TITLE
refactor(audio): extract audio-service package (#396)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,9 +7,10 @@ Packages
 - `@iracedeck/logger`
 - `@iracedeck/iracing-native` — has its own `CLAUDE.md` documenting native keyboard functions
 - `@iracedeck/audio-native` — native miniaudio-backed 4-channel mixer; has its own `CLAUDE.md`
+- `@iracedeck/audio-service` — TypeScript multi-channel audio mixer singleton over `@iracedeck/audio-native`. Exports `AudioChannel`, `AudioBus`, `initializeAudio`, `getAudio`, `IAudioService`. Owns bus routing, per-channel volumes, voice-sequence engine, and device selection.
 - `@iracedeck/iracing-sdk`
 - `@iracedeck/icon-composer` — Standalone SVG icon assembly with zero dependencies. Contains all pure assembly functions (assembleIcon, resolveIconColors, resolveTitleSettings, resolveBorderSettings, resolveGraphicSettings, etc.). Re-exported by deck-core for backward compatibility.
-- `@iracedeck/deck-core` — Platform-agnostic base classes, types, and shared utilities (base actions, keyboard service, audio service, global settings, icon templates, etc.). Re-exports icon-composer and adds global settings readers.
+- `@iracedeck/deck-core` — Platform-agnostic base classes, types, and shared utilities (base actions, keyboard service, global settings, icon templates, etc.). Re-exports icon-composer and adds global settings readers.
 - `@iracedeck/deck-adapter-elgato` — Elgato Stream Deck adapter bridging the Elgato SDK to deck-core's `IDeckPlatformAdapter` interface; also provides `createSDLogger`
 - `@iracedeck/deck-adapter-mirabox` — Mirabox adapter bridging the VSD Craft WebSocket protocol to deck-core's `IDeckPlatformAdapter` interface
 - `@iracedeck/iracing-actions` — All action implementations; import from `@iracedeck/deck-core` (not `@elgato/streamdeck`). Each action lives in its own folder under `src/actions/<name>/` containing `<name>.ts`, `<name>.test.ts`, `<name>.ejs` (PI template), and `icon.svg`/`key.svg` (static icons). Shared template data lives in `src/actions/data/`. Plugin-global PI templates (e.g., `settings.ejs`) live in `src/actions/settings/`.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,7 +7,7 @@ Packages
 - `@iracedeck/logger`
 - `@iracedeck/iracing-native` — has its own `CLAUDE.md` documenting native keyboard functions
 - `@iracedeck/audio-native` — native miniaudio-backed 4-channel mixer; has its own `CLAUDE.md`
-- `@iracedeck/audio-service` — TypeScript multi-channel audio mixer singleton over `@iracedeck/audio-native`. Exports `AudioChannel`, `AudioBus`, `initializeAudio`, `getAudio`, `IAudioService`. Owns bus routing, per-channel volumes, voice-sequence engine, and device selection.
+- `@iracedeck/audio-service` — TypeScript multi-channel audio mixer singleton over `@iracedeck/audio-native`. Exports `AudioChannel`, `AudioBus`, `initializeAudio`, `getAudio`, `isAudioInitialized`, `IAudioService`. Owns bus routing, per-channel volumes, voice-sequence engine, and device selection.
 - `@iracedeck/iracing-sdk`
 - `@iracedeck/icon-composer` — Standalone SVG icon assembly with zero dependencies. Contains all pure assembly functions (assembleIcon, resolveIconColors, resolveTitleSettings, resolveBorderSettings, resolveGraphicSettings, etc.). Re-exported by deck-core for backward compatibility.
 - `@iracedeck/deck-core` — Platform-agnostic base classes, types, and shared utilities (base actions, keyboard service, global settings, icon templates, etc.). Re-exports icon-composer and adds global settings readers.

--- a/packages/audio-native/src/index.ts
+++ b/packages/audio-native/src/index.ts
@@ -57,7 +57,7 @@ if (platform() === "win32" && !forceMock) {
  * native addon is unavailable), delegates to {@link AudioNativeMock} which
  * returns success for every call but produces no audio.
  *
- * The method surface is the one consumed by `@iracedeck/deck-core`'s
+ * The method surface is the one consumed by `@iracedeck/audio-service`'s
  * `initializeAudio(logger, native)` — any shape-compatible object can be
  * passed in its place for testing.
  */

--- a/packages/audio-service/package.json
+++ b/packages/audio-service/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@iracedeck/audio-service",
+  "version": "1.14.0",
+  "description": "Multi-channel audio mixer singleton over @iracedeck/audio-native",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf dist",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@iracedeck/audio-native": "workspace:*",
+    "@iracedeck/logger": "workspace:*"
+  },
+  "devDependencies": {
+    "@tsconfig/node22": "22.0.5",
+    "@types/node": "25.6.0",
+    "rimraf": "6.1.3",
+    "typescript": "5.9.3",
+    "vitest": "4.1.4"
+  }
+}

--- a/packages/audio-service/src/audio-service.test.ts
+++ b/packages/audio-service/src/audio-service.test.ts
@@ -1,15 +1,9 @@
+import type { AudioNative } from "@iracedeck/audio-native";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import {
-  _resetAudio,
-  AudioChannel,
-  type AudioEngineCallbacks,
-  getAudio,
-  initializeAudio,
-  isAudioInitialized,
-} from "./audio-service.js";
+import { _resetAudio, AudioChannel, getAudio, initializeAudio, isAudioInitialized } from "./audio-service.js";
 
-function createMockNative(): AudioEngineCallbacks {
+function createMockNative(): AudioNative {
   return {
     initAudioEngine: vi.fn(() => true),
     destroyAudioEngine: vi.fn(),
@@ -22,7 +16,7 @@ function createMockNative(): AudioEngineCallbacks {
     seekChannelRandom: vi.fn(),
     getAudioDevices: vi.fn(() => [{ index: 0, name: "Default Device", isDefault: true }]),
     setAudioDevice: vi.fn(() => true),
-  };
+  } as unknown as AudioNative;
 }
 
 const mockLogger = {

--- a/packages/audio-service/src/audio-service.ts
+++ b/packages/audio-service/src/audio-service.ts
@@ -12,29 +12,22 @@
  * random connector words ("and", "also", "plus") between them.
  *
  * Usage:
- * 1. Call initializeAudio() once at plugin startup with native callbacks
+ * 1. Call initializeAudio() once at plugin startup with an AudioNative instance
  * 2. Call getAudio().init() to start the engine
  * 3. Use getAudio() in actions to play sounds on channels
  *
  * @example
- * import { initializeAudio, getAudio, AudioChannel } from "@iracedeck/deck-core";
- * const native = new IRacingNative();
- * initializeAudio(logger, {
- *   initAudioEngine: () => native.initAudioEngine(),
- *   destroyAudioEngine: () => native.destroyAudioEngine(),
- *   playOnChannel: (ch, path, loop, vol) => native.playOnChannel(ch, path, loop, vol),
- *   stopChannel: (ch) => native.stopChannel(ch),
- *   setChannelVolume: (ch, vol) => native.setChannelVolume(ch, vol),
- *   isChannelPlaying: (ch) => native.isChannelPlaying(ch),
- *   setChannelEndCallback: (ch, cb) => native.setChannelEndCallback(ch, cb),
- *   stopAllChannels: () => native.stopAllChannels(),
- * });
+ * import { AudioNative } from "@iracedeck/audio-native";
+ * import { initializeAudio, getAudio } from "@iracedeck/audio-service";
+ * const native = new AudioNative();
+ * initializeAudio(logger, native);
  * getAudio().init();
  */
+import type { AudioNative } from "@iracedeck/audio-native";
 import type { ILogger } from "@iracedeck/logger";
 import { silentLogger } from "@iracedeck/logger";
 
-// ─── Channel enum (re-exported from iracing-native for convenience) ──────────
+// ─── Channel enum ────────────────────────────────────────────────────────────
 
 export enum AudioChannel {
   Ambient = 0,
@@ -81,23 +74,6 @@ const CHANNEL_MIX_RATIO: Readonly<Record<AudioChannel, number>> = {
   [AudioChannel.Voice]: 1.0,
   [AudioChannel.Spotter]: 1.0,
 };
-
-// ─── Native callback interface ───────────────────────────────────────────────
-
-/** Callbacks provided by the native addon for the miniaudio engine. */
-export interface AudioEngineCallbacks {
-  initAudioEngine: () => boolean;
-  destroyAudioEngine: () => void;
-  playOnChannel: (channel: number, filePath: string, loop: boolean, volume: number) => boolean;
-  stopChannel: (channel: number) => void;
-  setChannelVolume: (channel: number, volume: number) => void;
-  isChannelPlaying: (channel: number) => boolean;
-  setChannelEndCallback: (channel: number, callback: () => void) => void;
-  stopAllChannels: () => void;
-  seekChannelRandom: (channel: number) => void;
-  getAudioDevices: () => Array<{ index: number; name: string; isDefault: boolean }>;
-  setAudioDevice: (deviceIndex: number) => boolean;
-}
 
 // ─── Voice sequence state ────────────────────────────────────────────────────
 
@@ -180,7 +156,7 @@ export interface IAudioService {
 
 class AudioService implements IAudioService {
   private logger: ILogger;
-  private native: AudioEngineCallbacks;
+  private native: AudioNative;
   private engineReady = false;
 
   // Voice sequence state
@@ -200,7 +176,7 @@ class AudioService implements IAudioService {
   // Per-channel one-shot callbacks (managed at JS level, wrapping the native TSFN)
   private channelCallbacks: ((() => void) | null)[] = [null, null, null, null];
 
-  constructor(logger: ILogger, native: AudioEngineCallbacks) {
+  constructor(logger: ILogger, native: AudioNative) {
     this.logger = logger;
     this.native = native;
 
@@ -445,10 +421,10 @@ class AudioService implements IAudioService {
 let audioService: AudioService | null = null;
 
 /**
- * Initialize the audio service singleton with the miniaudio engine callbacks.
+ * Initialize the audio service singleton with an AudioNative instance.
  * Call once at plugin startup, then call getAudio().init() to start the engine.
  */
-export function initializeAudio(logger: ILogger = silentLogger, native: AudioEngineCallbacks): IAudioService {
+export function initializeAudio(logger: ILogger = silentLogger, native: AudioNative): IAudioService {
   if (audioService) {
     throw new Error("Audio service already initialized. initializeAudio() should only be called once.");
   }

--- a/packages/audio-service/src/index.ts
+++ b/packages/audio-service/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @iracedeck/audio-service
+ *
+ * Multi-channel audio mixer singleton layered over `@iracedeck/audio-native`.
+ * Provides bus routing, a voice-sequence engine, and device selection on top
+ * of the raw miniaudio bindings.
+ */
+export {
+  _resetAudio,
+  AudioBus,
+  AudioChannel,
+  getAudio,
+  type IAudioService,
+  initializeAudio,
+  isAudioInitialized,
+} from "./audio-service.js";

--- a/packages/audio-service/tsconfig.json
+++ b/packages/audio-service/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "customConditions": [
+      "node"
+    ],
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "noImplicitOverride": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/deck-core/CLAUDE.md
+++ b/packages/deck-core/CLAUDE.md
@@ -39,7 +39,6 @@ deck-core adds global settings readers on top of the pure functions:
 - `scan-code-map.ts` — PS/2 scan code mapping
 - `iracing-hotkeys.ts` — iRacing hotkey presets
 - `unit-conversion.ts` — Fuel unit conversion utilities
-- `audio-service.ts` — Multi-channel audio mixer singleton (miniaudio). Provides `initializeAudio()`, `getAudio()`, `AudioChannel` enum, `IAudioService` interface. Four independent channels (Ambient, SFX, Voice, Spotter) with per-channel volume, looping, completion callbacks, and a voice sequence engine for chaining clips with connector words.
 
 ## Build
 

--- a/packages/deck-core/src/index.ts
+++ b/packages/deck-core/src/index.ts
@@ -209,18 +209,6 @@ export {
 // Key binding utilities
 export { formatKeyBinding, parseKeyBinding, parseBinding } from "./key-binding-utils.js";
 
-// Audio service singleton (miniaudio multi-channel mixer)
-export {
-  AudioBus,
-  AudioChannel,
-  initializeAudio,
-  getAudio,
-  isAudioInitialized,
-  _resetAudio,
-  type AudioEngineCallbacks,
-  type IAudioService,
-} from "./audio-service.js";
-
 // Plugin config singleton
 export {
   initPluginConfig,

--- a/packages/iracing-actions/package.json
+++ b/packages/iracing-actions/package.json
@@ -12,6 +12,7 @@
     }
   },
   "dependencies": {
+    "@iracedeck/audio-service": "workspace:*",
     "@iracedeck/deck-core": "workspace:*",
     "@iracedeck/icons": "workspace:*",
     "@iracedeck/iracing-sdk": "workspace:*",

--- a/packages/iracing-actions/src/actions/pit-engineer/pit-engineer.test.ts
+++ b/packages/iracing-actions/src/actions/pit-engineer/pit-engineer.test.ts
@@ -111,6 +111,21 @@ vi.mock("@iracedeck/iracing-sdk", () => ({
   calculateRacePositions: vi.fn(() => []),
 }));
 
+vi.mock("@iracedeck/audio-service", () => ({
+  AudioBus: {
+    Voice: 0,
+    Background: 1,
+    Alerts: 2,
+  },
+  AudioChannel: {
+    Ambient: 0,
+    SFX: 1,
+    Voice: 2,
+    Spotter: 3,
+  },
+  getAudio: mockGetAudio,
+}));
+
 vi.mock("@iracedeck/deck-core", () => ({
   CommonSettings: {
     extend: () => {
@@ -133,12 +148,6 @@ vi.mock("@iracedeck/deck-core", () => ({
     },
     parse: (data: Record<string, unknown>) => ({ ...data }),
     safeParse: (data: Record<string, unknown>) => ({ success: true, data: { ...data } }),
-  },
-  AudioChannel: {
-    Ambient: 0,
-    SFX: 1,
-    Voice: 2,
-    Spotter: 3,
   },
   ConnectionStateAwareAction: class MockConnectionStateAwareAction {
     logger = { trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
@@ -163,7 +172,6 @@ vi.mock("@iracedeck/deck-core", () => ({
   generateTitleText: vi.fn((opts: { text: string; fill: string }) =>
     opts.text ? `<text fill="${opts.fill}">${opts.text}</text>` : "",
   ),
-  getAudio: mockGetAudio,
   getGlobalBorderSettings: vi.fn(() => ({})),
   getGlobalColors: vi.fn(() => ({})),
   getGlobalGraphicSettings: vi.fn(() => ({})),

--- a/packages/iracing-actions/src/actions/pit-engineer/pit-engineer.ts
+++ b/packages/iracing-actions/src/actions/pit-engineer/pit-engineer.ts
@@ -1,13 +1,11 @@
+import { AudioBus, AudioChannel, getAudio } from "@iracedeck/audio-service";
 import {
   applyGraphicTransform,
-  AudioBus,
-  AudioChannel,
   CommonSettings,
   computeGraphicArea,
   ConnectionStateAwareAction,
   generateBorderParts,
   generateTitleText,
-  getAudio,
   getGlobalBorderSettings,
   getGlobalColors,
   getGlobalGraphicSettings,

--- a/packages/iracing-plugin-mirabox/package.json
+++ b/packages/iracing-plugin-mirabox/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@iracedeck/audio-native": "workspace:*",
+    "@iracedeck/audio-service": "workspace:*",
     "@iracedeck/deck-adapter-mirabox": "workspace:*",
     "@iracedeck/deck-core": "workspace:*",
     "@iracedeck/iracing-actions": "workspace:*",

--- a/packages/iracing-plugin-mirabox/rollup.config.mjs
+++ b/packages/iracing-plugin-mirabox/rollup.config.mjs
@@ -236,7 +236,7 @@ const config = {
 		},
 		inlineDynamicImports: true
 	},
-	external: ["@iracedeck/audio-native", "@iracedeck/iracing-native", "yaml", "keysender", "ws"],
+	external: ["@iracedeck/audio-native", "@iracedeck/audio-service", "@iracedeck/iracing-native", "yaml", "keysender", "ws"],
 	plugins: [
 		// Resolve .js imports to .ts files for the raw-TypeScript actions package.
 		// Only applies to relative imports (starting with ".") within the actions package.
@@ -323,6 +323,7 @@ const config = {
 					type: "module",
 					dependencies: {
 						"@iracedeck/audio-native": "file:../../../audio-native",
+						"@iracedeck/audio-service": "file:../../../audio-service",
 						"@iracedeck/iracing-native": "file:../../../iracing-native",
 						ws: "8.18.2",
 						yaml: "2.8.2",

--- a/packages/iracing-plugin-mirabox/src/plugin.ts
+++ b/packages/iracing-plugin-mirabox/src/plugin.ts
@@ -7,13 +7,12 @@
  * Mirrors the Elgato Stream Deck plugin initialization order.
  */
 import { AudioNative } from "@iracedeck/audio-native";
+import { getAudio, initializeAudio } from "@iracedeck/audio-service";
 import { VSDPlatformAdapter } from "@iracedeck/deck-adapter-mirabox";
 import {
-  getAudio,
   initAppMonitor,
   initEngineStartupAnimation,
   initGlobalSettings,
-  initializeAudio,
   initializeBindingDispatcher,
   initializeKeyboard,
   initializeSDK,

--- a/packages/iracing-plugin-stream-deck/package.json
+++ b/packages/iracing-plugin-stream-deck/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@elgato/streamdeck": "2.1.0",
     "@iracedeck/audio-native": "workspace:*",
+    "@iracedeck/audio-service": "workspace:*",
     "@iracedeck/deck-adapter-elgato": "workspace:*",
     "@iracedeck/deck-core": "workspace:*",
     "@iracedeck/iracing-actions": "workspace:*",

--- a/packages/iracing-plugin-stream-deck/rollup.config.mjs
+++ b/packages/iracing-plugin-stream-deck/rollup.config.mjs
@@ -162,7 +162,7 @@ const config = {
 		},
 		inlineDynamicImports: true
 	},
-	external: ["@iracedeck/audio-native", "@iracedeck/iracing-native", "yaml", "keysender"],
+	external: ["@iracedeck/audio-native", "@iracedeck/audio-service", "@iracedeck/iracing-native", "yaml", "keysender"],
 	plugins: [
 		// Resolve .js imports to .ts files for the raw-TypeScript actions package.
 		// Only applies to relative imports (starting with ".") within the actions package.
@@ -279,6 +279,7 @@ const config = {
 					type: "module",
 					dependencies: {
 						"@iracedeck/audio-native": "file:../../../audio-native",
+						"@iracedeck/audio-service": "file:../../../audio-service",
 						"@iracedeck/iracing-native": "file:../../../iracing-native",
 						yaml: "2.8.2",
 					},

--- a/packages/iracing-plugin-stream-deck/src/plugin.ts
+++ b/packages/iracing-plugin-stream-deck/src/plugin.ts
@@ -1,12 +1,11 @@
 import streamDeck from "@elgato/streamdeck";
 import { AudioNative } from "@iracedeck/audio-native";
+import { getAudio, initializeAudio } from "@iracedeck/audio-service";
 import { ElgatoPlatformAdapter } from "@iracedeck/deck-adapter-elgato";
 import {
-  getAudio,
   initAppMonitor,
   initEngineStartupAnimation,
   initGlobalSettings,
-  initializeAudio,
   initializeBindingDispatcher,
   initializeKeyboard,
   initializeSDK,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,31 @@ importers:
         specifier: 4.1.4
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.0.2)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
+  packages/audio-service:
+    dependencies:
+      '@iracedeck/audio-native':
+        specifier: workspace:*
+        version: link:../audio-native
+      '@iracedeck/logger':
+        specifier: workspace:*
+        version: link:../logger
+    devDependencies:
+      '@tsconfig/node22':
+        specifier: 22.0.5
+        version: 22.0.5
+      '@types/node':
+        specifier: 25.6.0
+        version: 25.6.0
+      rimraf:
+        specifier: 6.1.3
+        version: 6.1.3
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.4
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.0.2)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+
   packages/deck-adapter-elgato:
     dependencies:
       '@elgato/streamdeck':
@@ -214,6 +239,9 @@ importers:
 
   packages/iracing-actions:
     dependencies:
+      '@iracedeck/audio-service':
+        specifier: workspace:*
+        version: link:../audio-service
       '@iracedeck/deck-core':
         specifier: workspace:*
         version: link:../deck-core
@@ -270,6 +298,9 @@ importers:
       '@iracedeck/audio-native':
         specifier: workspace:*
         version: link:../audio-native
+      '@iracedeck/audio-service':
+        specifier: workspace:*
+        version: link:../audio-service
       '@iracedeck/deck-adapter-mirabox':
         specifier: workspace:*
         version: link:../deck-adapter-mirabox
@@ -346,6 +377,9 @@ importers:
       '@iracedeck/audio-native':
         specifier: workspace:*
         version: link:../audio-native
+      '@iracedeck/audio-service':
+        specifier: workspace:*
+        version: link:../audio-service
       '@iracedeck/deck-adapter-elgato':
         specifier: workspace:*
         version: link:../deck-adapter-elgato

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,6 +38,8 @@ export default defineConfig({
   plugins: [svgPlugin()],
   resolve: {
     alias: {
+      "@iracedeck/audio-native": resolve(__dirname, "packages/audio-native/src/index.ts"),
+      "@iracedeck/audio-service": resolve(__dirname, "packages/audio-service/src/index.ts"),
       "@iracedeck/deck-core": resolve(__dirname, "packages/deck-core/src/index.ts"),
       "@iracedeck/icon-composer": resolve(__dirname, "packages/icon-composer/src/index.ts"),
       "@iracedeck/iracing-sdk": resolve(__dirname, "packages/iracing-sdk/src/index.ts"),


### PR DESCRIPTION
## Related Issue

Fixes #396

## What changed?

Stage 2 of the audio architecture rollout (see `docs/plans/2026-04-19-audio-architecture-design.md` §4.4 and §12). Moves the multi-channel audio mixer singleton from `@iracedeck/deck-core` into a new standalone `@iracedeck/audio-service` package that depends on `@iracedeck/audio-native` directly.

- New package `packages/audio-service/` with `package.json`, `tsconfig.json`, `src/index.ts`, `src/audio-service.ts` (moved from deck-core), `src/audio-service.test.ts` (moved, 22 tests).
- `initializeAudio(logger, native)` now takes an `AudioNative` instance instead of the ad-hoc `AudioEngineCallbacks` callback bag. The interface is gone — `AudioNative` from `@iracedeck/audio-native` is the direct dependency.
- `@iracedeck/deck-core` no longer re-exports audio symbols. Per the design plan, `master` never sees an intermediate state, so consumers swap imports in this same commit — no compatibility shim.
- Consumers updated: `pit-engineer.ts`, both plugins' `plugin.ts`, both plugins' `rollup.config.mjs` (external + emitted `bin/package.json`), and the three `package.json` files (`iracing-actions`, `iracing-plugin-stream-deck`, `iracing-plugin-mirabox`) gain `@iracedeck/audio-service` as a workspace dep.
- `pit-engineer.test.ts` mock split: `AudioChannel`, `AudioBus`, and `getAudio` moved into a new `vi.mock("@iracedeck/audio-service", …)` block; deck-core mock trimmed.
- Root `vitest.config.ts` gains `@iracedeck/audio-service` and `@iracedeck/audio-native` alias entries (matches the pattern for every other shared package, so tests resolve to `src/` not built `dist/`).
- Docs updated in lockstep: root `.claude/CLAUDE.md` (packages list), `packages/deck-core/CLAUDE.md` (audio-service bullet removed), and the JSDoc on `AudioNative` in `packages/audio-native/src/index.ts` (now references audio-service).

## How to test

```bash
pnpm install
pnpm build
pnpm test     # 88 files / 3132 tests green
pnpm lint
```

Grep check for acceptance: no `@iracedeck/deck-core` imports of `AudioChannel` / `AudioBus` / `initializeAudio` / `getAudio` / `IAudioService` remain.

Runtime smoke test (Windows): `pnpm --filter @iracedeck/iracing-plugin-stream-deck build` then restart the plugin; Pit Engineer button still plays the welcome sequence and responds to the PI volume sliders and device dropdown.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces a standalone audio service package providing multi-channel mixing, per-channel volumes, bus routing, voice sequencing, and device selection.

* **Refactor**
  * Core and plugin packages now import and use the dedicated audio service instead of the prior bundled surface.

* **Tests & Chores**
  * Tests, build configs, and tooling updated to reference the new package and its public entry points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->