### PR TITLE
refactor(pit-engineer): shrink action to thin shell over audio-scenarios (#401)

### DIFF
--- a/docs/plans/2026-04-19-audio-architecture-design.md
+++ b/docs/plans/2026-04-19-audio-architecture-design.md
@@ -566,11 +566,13 @@ This stage does two related things; split into two commits inside the same PR fo
 - After each port: delete the corresponding handler from `pit-engineer.ts`, confirm tests pass.
 - Commit per scenario group: `refactor(pit-engineer): port pit-lane scenarios to audio-scenarios (#376)`, etc.
 
-### Stage 7 — Shrink `PitEngineer` action
+### Stage 7 — Shrink `PitEngineer` action ✅
 
-- After all scenarios are ported, `pit-engineer.ts` becomes: button, PI, settings, icon. Target: under 400 LOC.
+- After all scenarios are ported, `pit-engineer.ts` becomes: button, PI, settings, icon. Target: under 400 LOC. **Landed at 380 LOC (#401).**
 - All module-level `let` globals deleted (their roles are now owned by scenarios / sim-events-iracing / audio-service).
-- Commit: `refactor(pit-engineer): shrink action to thin shell over audio-scenarios (#376)`.
+- Commit: `refactor(pit-engineer): shrink action to thin shell over audio-scenarios (#401)`.
+- Master on/off stored as a plugin-global setting (`pitEngineerEnabled`) so the flag persists across restarts and is readable by every action instance without module state.
+- The spotter tick loop — the one imperative piece the DSL cannot yet express (see §15) — moved to `packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.ts`. Registered alongside `registerPitEngineer(bus)` and exposed via `setSpotterEnabled` / `playSpotterTest` / `subscribeSpotterVisualState` so the action stays stateless.
 
 Each stage is a single logical commit; each lands as its own PR into `feature/pit-engineer`. Tests run and pass at every stage. Stage 6 may split into multiple per-scenario-group commits inside a single PR.
 

--- a/packages/audio-scenarios/src/catalog/pit-engineer/index.ts
+++ b/packages/audio-scenarios/src/catalog/pit-engineer/index.ts
@@ -1,10 +1,13 @@
 /**
  * Pit-engineer scenario catalog registration.
  *
- * `registerPitEngineer()` registers pools, defines the `{{name}}` driver
+ * `registerPitEngineer(bus)` registers pools, defines the `{{name}}` driver
  * variable, and registers every pit-engineer scenario with the shared
- * scenario engine. Must be called once per plugin startup, after
- * `initializeAudioScenarios(...)`.
+ * scenario engine. The `bus` is the event bus instance returned by
+ * `initializeEventBus(...)` — passed through to `registerSpotterEngine`
+ * so the spotter engine and scenario engine share the exact same bus.
+ * Must be called once per plugin startup, after
+ * `initializeAudioScenarios(bus, ...)`.
  *
  * The driver-name resolver is injected by the pit-engineer action through
  * `setDriverNameResolver(getter)` so the scenario can read the latest PI

--- a/packages/audio-scenarios/src/catalog/pit-engineer/index.ts
+++ b/packages/audio-scenarios/src/catalog/pit-engineer/index.ts
@@ -10,6 +10,8 @@
  * `setDriverNameResolver(getter)` so the scenario can read the latest PI
  * setting at fire time without the catalog owning action-specific state.
  */
+import type { IEventBus } from "@iracedeck/event-bus";
+
 import { getScenarioEngine } from "../../interpreter.js";
 import { FLAG_ALERTS } from "./flag-alerts.js";
 import { FUEL_WARNINGS } from "./fuel-warnings.js";
@@ -21,6 +23,7 @@ import { PIT_LIMITER_SCENARIOS } from "./pit-limiter.js";
 import { POOLS } from "./pools.js";
 import { RADIO_CLOSE, RADIO_OPEN } from "./radio-frame.js";
 import { SERVICE_REMINDER } from "./service-reminder.js";
+import { registerSpotterEngine } from "./spotter-engine.js";
 import { STALL_DEPARTURE } from "./stall-departure.js";
 import { RACING_TIPS } from "./tips.js";
 import { TOGGLE_CONFIRMATIONS } from "./toggle-confirmations.js";
@@ -29,6 +32,13 @@ import { WELCOME } from "./welcome.js";
 export { FLAG_SCENARIO_IDS } from "./flag-alerts.js";
 export { FUEL_SCENARIO_IDS } from "./fuel-warnings.js";
 export { PIT_LIMITER_SCENARIO_IDS } from "./pit-limiter.js";
+export {
+  getSpotterVisualState,
+  playSpotterTest,
+  setSpotterEnabled,
+  type SpotterVisualState,
+  subscribeSpotterVisualState,
+} from "./spotter-engine.js";
 export { TOGGLE_SCENARIO_IDS } from "./toggle-confirmations.js";
 
 let driverNameResolver: () => string | null = () => null;
@@ -43,7 +53,7 @@ let driverNameResolver: () => string | null = () => null;
  *      their referencing scenarios so validation can resolve them.
  *   4. Event-driven scenarios (`welcome`, ...) are defined last.
  */
-export function registerPitEngineer(): void {
+export function registerPitEngineer(bus: IEventBus): void {
   const engine = getScenarioEngine();
 
   for (const [name, clips] of Object.entries(POOLS)) {
@@ -72,6 +82,12 @@ export function registerPitEngineer(): void {
   for (const limiter of PIT_LIMITER_SCENARIOS) engine.defineScenario(limiter);
 
   engine.defineScenario(RACING_TIPS);
+
+  // The spotter is a state-driven tick loop that the scenario DSL cannot
+  // express (design doc §15). Registered here so plugin startup only has to
+  // call `registerPitEngineer(bus)` once — the engine subscribes to
+  // `spotter.changed` on the event bus and plays on AudioChannel.Spotter.
+  registerSpotterEngine(bus);
 }
 
 /**

--- a/packages/audio-scenarios/src/catalog/pit-engineer/service-reminder.test.ts
+++ b/packages/audio-scenarios/src/catalog/pit-engineer/service-reminder.test.ts
@@ -144,7 +144,7 @@ beforeEach(() => {
   bus = createMockBus();
   audio = createFakeAudio();
   initializeAudioScenarios(bus, audio, buildTestManifest(), mockLogger as never);
-  registerPitEngineer();
+  registerPitEngineer(bus);
 });
 
 afterEach(() => {

--- a/packages/audio-scenarios/src/catalog/pit-engineer/service-reminder.test.ts
+++ b/packages/audio-scenarios/src/catalog/pit-engineer/service-reminder.test.ts
@@ -8,6 +8,7 @@ import type { AudioAssetsManifest } from "../../interpreter.js";
 import { _resetAudioScenarios, initializeAudioScenarios } from "../../interpreter.js";
 import { registerPitEngineer } from "./index.js";
 import { POOLS } from "./pools.js";
+import { _resetSpotterEngine } from "./spotter-engine.js";
 
 // ─── Test utilities ─────────────────────────────────────────────────────────
 
@@ -149,6 +150,7 @@ beforeEach(() => {
 
 afterEach(() => {
   _resetAudioScenarios();
+  _resetSpotterEngine();
   vi.restoreAllMocks();
   vi.clearAllMocks();
 });

--- a/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.test.ts
+++ b/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.test.ts
@@ -1,0 +1,326 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  _resetSpotterEngine,
+  getSpotterVisualState,
+  playSpotterTest,
+  registerSpotterEngine,
+  setSpotterEnabled,
+  subscribeSpotterVisualState,
+} from "./spotter-engine.js";
+
+// ─── Hoisted mocks ─────────────────────────────────────────────────────────
+
+const hoisted = vi.hoisted(() => {
+  const playOnChannel = vi.fn<(...args: unknown[]) => boolean>().mockReturnValue(true);
+  const stopChannel = vi.fn();
+  const onChannelComplete = vi.fn();
+  const audio = { playOnChannel, stopChannel, onChannelComplete };
+  const getAudio = vi.fn(() => audio);
+
+  const busHandlers = new Map<string, Set<(ev: unknown) => void>>();
+  const subscribe = vi.fn((name: string, handler: (ev: unknown) => void) => {
+    let set = busHandlers.get(name);
+
+    if (!set) {
+      set = new Set();
+      busHandlers.set(name, set);
+    }
+
+    set.add(handler);
+
+    return () => {
+      set?.delete(handler);
+    };
+  });
+  const bus = { subscribe, unsubscribe: vi.fn(), publish: vi.fn() };
+  const publishSpotter = (to: string, from = "clear"): void => {
+    const set = busHandlers.get("spotter.changed");
+
+    if (!set) return;
+
+    for (const h of Array.from(set)) h({ event: "spotter.changed", data: { from, to } });
+  };
+
+  const getLatestTelemetry = vi.fn<() => { OnPitRoad?: boolean } | null>();
+  const getSessionType = vi.fn<() => string>();
+
+  return {
+    audio,
+    playOnChannel,
+    stopChannel,
+    onChannelComplete,
+    getAudio,
+    busHandlers,
+    subscribe,
+    bus,
+    publishSpotter,
+    getLatestTelemetry,
+    getSessionType,
+  };
+});
+
+vi.mock("@iracedeck/audio-service", () => ({
+  AudioChannel: { Ambient: 0, SFX: 1, Voice: 2, Spotter: 3 },
+  getAudio: hoisted.getAudio,
+}));
+
+vi.mock("@iracedeck/sim-events-iracing", () => ({
+  getLatestTelemetry: hoisted.getLatestTelemetry,
+  getSessionType: hoisted.getSessionType,
+}));
+
+const SPOTTER_CHANNEL = 3;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  hoisted.playOnChannel.mockClear();
+  hoisted.stopChannel.mockClear();
+  hoisted.onChannelComplete.mockClear();
+  hoisted.subscribe.mockClear();
+  hoisted.busHandlers.clear();
+  hoisted.getLatestTelemetry.mockReset();
+  hoisted.getLatestTelemetry.mockReturnValue({ OnPitRoad: false });
+  hoisted.getSessionType.mockReset();
+  hoisted.getSessionType.mockReturnValue("Race");
+});
+
+afterEach(() => {
+  _resetSpotterEngine();
+  vi.useRealTimers();
+});
+
+describe("registerSpotterEngine", () => {
+  it("subscribes to spotter.changed exactly once, even if called twice", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus as never);
+
+    expect(hoisted.subscribe).toHaveBeenCalledTimes(1);
+    expect(hoisted.subscribe).toHaveBeenCalledWith("spotter.changed", expect.any(Function));
+  });
+});
+
+describe("spotter.changed → tick loop", () => {
+  it("does nothing when the master gate is disabled", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    hoisted.publishSpotter("left");
+
+    expect(hoisted.playOnChannel).not.toHaveBeenCalled();
+    expect(getSpotterVisualState()).toBe("clear");
+  });
+
+  it("starts ticking on the Spotter channel when enabled and state goes non-clear", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    setSpotterEnabled(true);
+
+    hoisted.publishSpotter("left");
+
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
+    expect(hoisted.playOnChannel).toHaveBeenCalledWith(SPOTTER_CHANNEL, expect.stringContaining("IRD-spotter-left"));
+
+    vi.advanceTimersByTime(250);
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(2);
+
+    vi.advanceTimersByTime(250);
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(3);
+  });
+
+  it("uses the 180 ms cadence for two-cars-same-side states", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    setSpotterEnabled(true);
+    hoisted.publishSpotter("two-left");
+
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(180);
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses the 230 ms cadence for both-sides", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    setSpotterEnabled(true);
+    hoisted.publishSpotter("both");
+
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(230);
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops the tick loop and silences the channel when state returns to clear", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    setSpotterEnabled(true);
+    hoisted.publishSpotter("left");
+    const beforeClearCalls = hoisted.playOnChannel.mock.calls.length;
+
+    hoisted.publishSpotter("clear", "left");
+
+    expect(hoisted.stopChannel).toHaveBeenCalledWith(SPOTTER_CHANNEL);
+
+    // Advance time — no further ticks should fire.
+    vi.advanceTimersByTime(1000);
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(beforeClearCalls);
+  });
+
+  it("switches interval when state transitions between active states", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    setSpotterEnabled(true);
+    hoisted.publishSpotter("left");
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
+
+    hoisted.publishSpotter("two-right", "left");
+    // New tick fires immediately, then at 180 ms cadence.
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(2);
+    expect(hoisted.playOnChannel.mock.calls.at(-1)?.[1]).toContain("IRD-spotter-right");
+
+    vi.advanceTimersByTime(180);
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(3);
+  });
+
+  it("ignores repeated transitions to the same state", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    setSpotterEnabled(true);
+    hoisted.publishSpotter("left");
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
+
+    hoisted.publishSpotter("left", "left");
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("pit-road suppression", () => {
+  it("forces the visual state to clear and silences the channel while on pit road", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    setSpotterEnabled(true);
+    hoisted.publishSpotter("left");
+    expect(getSpotterVisualState()).toBe("left");
+
+    hoisted.getLatestTelemetry.mockReturnValue({ OnPitRoad: true });
+    hoisted.publishSpotter("both", "left");
+
+    expect(getSpotterVisualState()).toBe("clear");
+    expect(hoisted.stopChannel).toHaveBeenCalledWith(SPOTTER_CHANNEL);
+  });
+
+  it("is a no-op when telemetry is missing", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    setSpotterEnabled(true);
+    hoisted.getLatestTelemetry.mockReturnValue(null);
+
+    hoisted.publishSpotter("left");
+
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
+    expect(getSpotterVisualState()).toBe("left");
+  });
+});
+
+describe("Lone Qualify suppression", () => {
+  it("ignores events during Lone Qualify", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    setSpotterEnabled(true);
+    hoisted.getSessionType.mockReturnValue("Lone Qualify");
+
+    hoisted.publishSpotter("left");
+
+    expect(hoisted.playOnChannel).not.toHaveBeenCalled();
+    expect(getSpotterVisualState()).toBe("clear");
+  });
+});
+
+describe("setSpotterEnabled", () => {
+  it("clears visual state, stops the channel, and notifies listeners on disable", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    setSpotterEnabled(true);
+    hoisted.publishSpotter("left");
+    expect(getSpotterVisualState()).toBe("left");
+
+    const listener = vi.fn();
+    subscribeSpotterVisualState(listener);
+
+    setSpotterEnabled(false);
+
+    expect(hoisted.stopChannel).toHaveBeenCalledWith(SPOTTER_CHANNEL);
+    expect(getSpotterVisualState()).toBe("clear");
+    expect(listener).toHaveBeenCalledWith("clear");
+  });
+
+  it("is idempotent when re-enabled — waits for next event before playing", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    setSpotterEnabled(true);
+    setSpotterEnabled(true);
+
+    expect(hoisted.playOnChannel).not.toHaveBeenCalled();
+
+    hoisted.publishSpotter("left");
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("playSpotterTest", () => {
+  it("plays left → right → both in order with a 250 ms gap between clips", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    playSpotterTest();
+
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
+    expect(hoisted.playOnChannel.mock.calls[0][1]).toContain("IRD-spotter-left");
+
+    // Simulate the first clip finishing.
+    const firstCallback = hoisted.onChannelComplete.mock.calls.at(-1)?.[1] as () => void;
+    firstCallback();
+    vi.advanceTimersByTime(250);
+
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(2);
+    expect(hoisted.playOnChannel.mock.calls[1][1]).toContain("IRD-spotter-right");
+
+    const secondCallback = hoisted.onChannelComplete.mock.calls.at(-1)?.[1] as () => void;
+    secondCallback();
+    vi.advanceTimersByTime(250);
+
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(3);
+    expect(hoisted.playOnChannel.mock.calls[2][1]).toContain("IRD-spotter-both");
+
+    const thirdCallback = hoisted.onChannelComplete.mock.calls.at(-1)?.[1] as () => void;
+    thirdCallback();
+    vi.advanceTimersByTime(250);
+
+    // No fourth clip.
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(3);
+  });
+
+  it("works regardless of the master gate", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    // enabled=false — test button still plays.
+    playSpotterTest();
+
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("subscribeSpotterVisualState", () => {
+  it("notifies on transitions and stops after unsubscribe", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    setSpotterEnabled(true);
+
+    const listener = vi.fn();
+    const unsubscribe = subscribeSpotterVisualState(listener);
+
+    hoisted.publishSpotter("left");
+    expect(listener).toHaveBeenCalledWith("left");
+
+    unsubscribe();
+
+    hoisted.publishSpotter("both", "left");
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when transitioning between identical states", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    setSpotterEnabled(true);
+
+    const listener = vi.fn();
+    subscribeSpotterVisualState(listener);
+
+    hoisted.publishSpotter("left");
+    hoisted.publishSpotter("left", "left");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.test.ts
+++ b/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.test.ts
@@ -98,6 +98,14 @@ describe("registerSpotterEngine", () => {
     expect(hoisted.subscribe).toHaveBeenCalledTimes(1);
     expect(hoisted.subscribe).toHaveBeenCalledWith("spotter.changed", expect.any(Function));
   });
+
+  it("throws when re-registered with a different bus instance", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    const otherBus = { subscribe: vi.fn(), unsubscribe: vi.fn(), publish: vi.fn() };
+
+    expect(() => registerSpotterEngine(otherBus as never)).toThrow(/different event bus/);
+    expect(otherBus.subscribe).not.toHaveBeenCalled();
+  });
 });
 
 describe("spotter.changed → tick loop", () => {
@@ -290,6 +298,16 @@ describe("playSpotterTest", () => {
     // enabled=false — test button still plays.
     playSpotterTest();
 
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op if called while a sequence is already in flight", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    playSpotterTest();
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
+
+    // Second press before the first sequence completes → ignored.
+    playSpotterTest();
     expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.test.ts
+++ b/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.test.ts
@@ -231,6 +231,19 @@ describe("Lone Qualify suppression", () => {
     expect(hoisted.playOnChannel).not.toHaveBeenCalled();
     expect(getSpotterVisualState()).toBe("clear");
   });
+
+  it("tears down an already-running loop when the session flips to Lone Qualify", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    setSpotterEnabled(true);
+    hoisted.publishSpotter("left");
+    expect(getSpotterVisualState()).toBe("left");
+
+    hoisted.getSessionType.mockReturnValue("Lone Qualify");
+    hoisted.publishSpotter("both", "left");
+
+    expect(getSpotterVisualState()).toBe("clear");
+    expect(hoisted.stopChannel).toHaveBeenCalledWith(SPOTTER_CHANNEL);
+  });
 });
 
 describe("setSpotterEnabled", () => {
@@ -309,6 +322,19 @@ describe("playSpotterTest", () => {
     // Second press before the first sequence completes → ignored.
     playSpotterTest();
     expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the in-flight guard when the audio engine refuses playback", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    hoisted.playOnChannel.mockReturnValueOnce(false);
+
+    playSpotterTest();
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
+
+    // Guard cleared synchronously so a later press can retry.
+    hoisted.playOnChannel.mockReturnValue(true);
+    playSpotterTest();
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.test.ts
+++ b/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.test.ts
@@ -1,3 +1,4 @@
+import type { IEventBus } from "@iracedeck/event-bus";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -33,7 +34,9 @@ const hoisted = vi.hoisted(() => {
       set?.delete(handler);
     };
   });
-  const bus = { subscribe, unsubscribe: vi.fn(), publish: vi.fn() };
+  // Typed once so every `registerSpotterEngine(hoisted.bus)` callsite
+  // stays type-safe without a per-call `as never` escape hatch.
+  const bus = { subscribe, unsubscribe: vi.fn(), publish: vi.fn() } as unknown as IEventBus;
   const publishSpotter = (to: string, from = "clear"): void => {
     const set = busHandlers.get("spotter.changed");
 
@@ -92,25 +95,25 @@ afterEach(() => {
 
 describe("registerSpotterEngine", () => {
   it("subscribes to spotter.changed exactly once, even if called twice", () => {
-    registerSpotterEngine(hoisted.bus as never);
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
+    registerSpotterEngine(hoisted.bus);
 
     expect(hoisted.subscribe).toHaveBeenCalledTimes(1);
     expect(hoisted.subscribe).toHaveBeenCalledWith("spotter.changed", expect.any(Function));
   });
 
   it("throws when re-registered with a different bus instance", () => {
-    registerSpotterEngine(hoisted.bus as never);
-    const otherBus = { subscribe: vi.fn(), unsubscribe: vi.fn(), publish: vi.fn() };
+    registerSpotterEngine(hoisted.bus);
+    const otherBus = { subscribe: vi.fn(), unsubscribe: vi.fn(), publish: vi.fn() } as unknown as IEventBus;
 
-    expect(() => registerSpotterEngine(otherBus as never)).toThrow(/different event bus/);
+    expect(() => registerSpotterEngine(otherBus)).toThrow(/different event bus/);
     expect(otherBus.subscribe).not.toHaveBeenCalled();
   });
 });
 
 describe("spotter.changed → tick loop", () => {
   it("does nothing when the master gate is disabled", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     hoisted.publishSpotter("left");
 
     expect(hoisted.playOnChannel).not.toHaveBeenCalled();
@@ -118,7 +121,7 @@ describe("spotter.changed → tick loop", () => {
   });
 
   it("starts ticking on the Spotter channel when enabled and state goes non-clear", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     setSpotterEnabled(true);
 
     hoisted.publishSpotter("left");
@@ -134,7 +137,7 @@ describe("spotter.changed → tick loop", () => {
   });
 
   it("uses the 180 ms cadence for two-cars-same-side states", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     setSpotterEnabled(true);
     hoisted.publishSpotter("two-left");
 
@@ -144,7 +147,7 @@ describe("spotter.changed → tick loop", () => {
   });
 
   it("uses the 230 ms cadence for both-sides", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     setSpotterEnabled(true);
     hoisted.publishSpotter("both");
 
@@ -154,7 +157,7 @@ describe("spotter.changed → tick loop", () => {
   });
 
   it("stops the tick loop and silences the channel when state returns to clear", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     setSpotterEnabled(true);
     hoisted.publishSpotter("left");
     const beforeClearCalls = hoisted.playOnChannel.mock.calls.length;
@@ -169,7 +172,7 @@ describe("spotter.changed → tick loop", () => {
   });
 
   it("switches interval when state transitions between active states", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     setSpotterEnabled(true);
     hoisted.publishSpotter("left");
     expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
@@ -184,7 +187,7 @@ describe("spotter.changed → tick loop", () => {
   });
 
   it("ignores repeated transitions to the same state", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     setSpotterEnabled(true);
     hoisted.publishSpotter("left");
     expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
@@ -196,7 +199,7 @@ describe("spotter.changed → tick loop", () => {
 
 describe("pit-road suppression", () => {
   it("forces the visual state to clear and silences the channel while on pit road", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     setSpotterEnabled(true);
     hoisted.publishSpotter("left");
     expect(getSpotterVisualState()).toBe("left");
@@ -209,7 +212,7 @@ describe("pit-road suppression", () => {
   });
 
   it("is a no-op when telemetry is missing", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     setSpotterEnabled(true);
     hoisted.getLatestTelemetry.mockReturnValue(null);
 
@@ -222,7 +225,7 @@ describe("pit-road suppression", () => {
 
 describe("Lone Qualify suppression", () => {
   it("ignores events during Lone Qualify", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     setSpotterEnabled(true);
     hoisted.getSessionType.mockReturnValue("Lone Qualify");
 
@@ -233,7 +236,7 @@ describe("Lone Qualify suppression", () => {
   });
 
   it("tears down an already-running loop when the session flips to Lone Qualify", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     setSpotterEnabled(true);
     hoisted.publishSpotter("left");
     expect(getSpotterVisualState()).toBe("left");
@@ -248,7 +251,7 @@ describe("Lone Qualify suppression", () => {
 
 describe("setSpotterEnabled", () => {
   it("clears visual state, stops the channel, and notifies listeners on disable", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     setSpotterEnabled(true);
     hoisted.publishSpotter("left");
     expect(getSpotterVisualState()).toBe("left");
@@ -264,7 +267,7 @@ describe("setSpotterEnabled", () => {
   });
 
   it("is idempotent when re-enabled — waits for next event before playing", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     setSpotterEnabled(true);
     setSpotterEnabled(true);
 
@@ -277,7 +280,7 @@ describe("setSpotterEnabled", () => {
 
 describe("playSpotterTest", () => {
   it("plays left → right → both in order with a 250 ms gap between clips", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     playSpotterTest();
 
     expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
@@ -307,7 +310,7 @@ describe("playSpotterTest", () => {
   });
 
   it("works regardless of the master gate", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     // enabled=false — test button still plays.
     playSpotterTest();
 
@@ -315,7 +318,7 @@ describe("playSpotterTest", () => {
   });
 
   it("is a no-op if called while a sequence is already in flight", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     playSpotterTest();
     expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
 
@@ -325,7 +328,7 @@ describe("playSpotterTest", () => {
   });
 
   it("clears the in-flight guard when the audio engine refuses playback", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     hoisted.playOnChannel.mockReturnValueOnce(false);
 
     playSpotterTest();
@@ -338,7 +341,7 @@ describe("playSpotterTest", () => {
   });
 
   it("suspends the live tick loop while the preview is playing", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     setSpotterEnabled(true);
     hoisted.publishSpotter("left");
     const liveCalls = hoisted.playOnChannel.mock.calls.length;
@@ -354,7 +357,7 @@ describe("playSpotterTest", () => {
   });
 
   it("ignores live spotter events mid-preview but still updates visual state", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     setSpotterEnabled(true);
     hoisted.publishSpotter("left");
     const callsBeforeTest = hoisted.playOnChannel.mock.calls.length;
@@ -369,7 +372,7 @@ describe("playSpotterTest", () => {
   });
 
   it("resumes the live tick loop at the current state after the preview completes", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     setSpotterEnabled(true);
     hoisted.publishSpotter("left");
     playSpotterTest();
@@ -387,7 +390,7 @@ describe("playSpotterTest", () => {
   });
 
   it("clears the in-flight guard when the master is disabled mid-preview", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     setSpotterEnabled(true);
     playSpotterTest();
     expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
@@ -403,7 +406,7 @@ describe("playSpotterTest", () => {
 
 describe("subscribeSpotterVisualState", () => {
   it("notifies on transitions and stops after unsubscribe", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     setSpotterEnabled(true);
 
     const listener = vi.fn();
@@ -419,7 +422,7 @@ describe("subscribeSpotterVisualState", () => {
   });
 
   it("does not fire when transitioning between identical states", () => {
-    registerSpotterEngine(hoisted.bus as never);
+    registerSpotterEngine(hoisted.bus);
     setSpotterEnabled(true);
 
     const listener = vi.fn();

--- a/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.test.ts
+++ b/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.test.ts
@@ -385,6 +385,20 @@ describe("playSpotterTest", () => {
     const lastCall = hoisted.playOnChannel.mock.calls.at(-1);
     expect(lastCall?.[1]).toContain("IRD-spotter-left");
   });
+
+  it("clears the in-flight guard when the master is disabled mid-preview", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    setSpotterEnabled(true);
+    playSpotterTest();
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(1);
+
+    // Master off during preview → guard cleared so the button works after re-enable.
+    setSpotterEnabled(false);
+    setSpotterEnabled(true);
+
+    playSpotterTest();
+    expect(hoisted.playOnChannel).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("subscribeSpotterVisualState", () => {

--- a/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.test.ts
+++ b/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.test.ts
@@ -336,6 +336,55 @@ describe("playSpotterTest", () => {
     playSpotterTest();
     expect(hoisted.playOnChannel).toHaveBeenCalledTimes(2);
   });
+
+  it("suspends the live tick loop while the preview is playing", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    setSpotterEnabled(true);
+    hoisted.publishSpotter("left");
+    const liveCalls = hoisted.playOnChannel.mock.calls.length;
+
+    playSpotterTest();
+    // First test clip plays; no tick fires while test is in flight.
+    vi.advanceTimersByTime(10_000);
+    const callsDuringTest = hoisted.playOnChannel.mock.calls.length;
+
+    // Only the 1 test-clip call (live loop's outstanding timer cleared).
+    expect(callsDuringTest - liveCalls).toBe(1);
+    expect(hoisted.playOnChannel.mock.calls[liveCalls][1]).toContain("IRD-spotter-left");
+  });
+
+  it("ignores live spotter events mid-preview but still updates visual state", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    setSpotterEnabled(true);
+    hoisted.publishSpotter("left");
+    const callsBeforeTest = hoisted.playOnChannel.mock.calls.length;
+
+    playSpotterTest();
+
+    // Live transition during preview — visual flips, but no extra live playback.
+    hoisted.publishSpotter("both", "left");
+    expect(getSpotterVisualState()).toBe("both");
+    // playSpotterTest has fired 1 clip; live event added no playback on top.
+    expect(hoisted.playOnChannel.mock.calls.length - callsBeforeTest).toBe(1);
+  });
+
+  it("resumes the live tick loop at the current state after the preview completes", () => {
+    registerSpotterEngine(hoisted.bus as never);
+    setSpotterEnabled(true);
+    hoisted.publishSpotter("left");
+    playSpotterTest();
+
+    // Drive the 3-clip sequence to completion via the registered channel-complete callbacks.
+    for (let i = 0; i < 3; i++) {
+      const cb = hoisted.onChannelComplete.mock.calls.at(-1)?.[1] as () => void;
+      cb();
+      vi.advanceTimersByTime(250);
+    }
+
+    // After the preview, the live loop resumes using the current visual state.
+    const lastCall = hoisted.playOnChannel.mock.calls.at(-1);
+    expect(lastCall?.[1]).toContain("IRD-spotter-left");
+  });
 });
 
 describe("subscribeSpotterVisualState", () => {

--- a/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.ts
+++ b/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.ts
@@ -51,7 +51,8 @@ const SPOTTER_TEST_GAP_MS = 250;
 let enabled = false;
 let visualState: SpotterVisualState = "clear";
 let tickTimer: ReturnType<typeof setTimeout> | null = null;
-let registered = false;
+let registeredBus: IEventBus | null = null;
+let testSequenceInFlight = false;
 const listeners = new Set<SpotterListener>();
 
 function resolveAudioPath(file: string): string {
@@ -124,15 +125,25 @@ function handleSpotterChanged(ev: SimEventOf<"spotter.changed">): void {
 }
 
 /**
- * Subscribe the engine to the event bus. Idempotent — safe to call multiple
- * times. Invoked once from `registerPitEngineer(bus)` at plugin startup;
- * takes the bus explicitly so tests can pass a fake bus without going
- * through `initializeEventBus`.
+ * Subscribe the engine to the event bus. Idempotent as long as every call
+ * passes the same bus instance — re-registering with a different bus would
+ * leave the handler attached to the original one and silently break spotter
+ * events, so we throw loudly instead. Invoked once from
+ * `registerPitEngineer(bus)` at plugin startup; takes the bus explicitly
+ * so tests can pass a fake bus without going through `initializeEventBus`.
  */
 export function registerSpotterEngine(bus: IEventBus): void {
-  if (registered) return;
+  if (registeredBus !== null) {
+    if (registeredBus !== bus) {
+      throw new Error(
+        "registerSpotterEngine called with a different event bus than the initial registration. All callers must share the same bus instance.",
+      );
+    }
 
-  registered = true;
+    return;
+  }
+
+  registeredBus = bus;
   bus.subscribe("spotter.changed", handleSpotterChanged);
 }
 
@@ -155,12 +166,20 @@ export function setSpotterEnabled(next: boolean): void {
 /**
  * Plays the three-clip preview sequence (left → right → both) on the
  * spotter channel with a 250 ms gap between clips. Used by the PI Test
- * button; works regardless of the master gate.
+ * button; works regardless of the master gate. Safe against double-press:
+ * a second call while a sequence is in flight is a no-op.
  */
 export function playSpotterTest(): void {
+  if (testSequenceInFlight) return;
+
+  testSequenceInFlight = true;
   let idx = 0;
   const playNext = (): void => {
-    if (idx >= SPOTTER_TEST_SEQUENCE.length) return;
+    if (idx >= SPOTTER_TEST_SEQUENCE.length) {
+      testSequenceInFlight = false;
+
+      return;
+    }
 
     const file = SPOTTER_TEST_SEQUENCE[idx];
     idx++;
@@ -197,5 +216,6 @@ export function _resetSpotterEngine(): void {
   enabled = false;
   visualState = "clear";
   listeners.clear();
-  registered = false;
+  registeredBus = null;
+  testSequenceInFlight = false;
 }

--- a/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.ts
+++ b/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.ts
@@ -98,11 +98,17 @@ function isOnPitRoad(): boolean {
 }
 
 function forceClear(): void {
-  if (visualState !== "clear") {
+  if (visualState === "clear") return;
+
+  // Don't touch AudioChannel.Spotter while a test preview owns it; the
+  // preview completion callback re-syncs playback from the (possibly
+  // "clear") visualState.
+  if (!testSequenceInFlight) {
     stopTickLoop();
     getAudio().stopChannel(AudioChannel.Spotter);
-    setVisualState("clear");
   }
+
+  setVisualState("clear");
 }
 
 function handleSpotterChanged(ev: SimEventOf<"spotter.changed">): void {
@@ -128,11 +134,18 @@ function handleSpotterChanged(ev: SimEventOf<"spotter.changed">): void {
 
   if (next === visualState) return;
 
-  if (next === "clear") {
-    stopTickLoop();
-    getAudio().stopChannel(AudioChannel.Spotter);
-  } else {
-    startTickLoop(next);
+  // A test preview owns AudioChannel.Spotter until it completes — gate
+  // every live tick / stop to keep the left→right→both sequence from being
+  // garbled. `visualState` still flips here so listeners stay current;
+  // the preview's completion handler resumes the live loop with the
+  // post-test state.
+  if (!testSequenceInFlight) {
+    if (next === "clear") {
+      stopTickLoop();
+      getAudio().stopChannel(AudioChannel.Spotter);
+    } else {
+      startTickLoop(next);
+    }
   }
 
   setVisualState(next);
@@ -162,15 +175,16 @@ export function registerSpotterEngine(bus: IEventBus): void {
 }
 
 /**
- * Master gate. `false` stops any in-flight tick loop, silences the spotter
- * channel, and forces the visual state back to `"clear"` (notifying
- * subscribers so the key icon clears). `true` is passive — the next
- * `spotter.changed` event will drive playback.
+ * Master gate. `false` aborts any in-flight test preview, stops the tick
+ * loop, silences the spotter channel, and forces the visual state back to
+ * `"clear"` (notifying subscribers so the key icon clears). `true` is
+ * passive — the next `spotter.changed` event will drive playback.
  */
 export function setSpotterEnabled(next: boolean): void {
   enabled = next;
 
   if (!enabled) {
+    testSequenceInFlight = false;
     stopTickLoop();
     getAudio().stopChannel(AudioChannel.Spotter);
     setVisualState("clear");
@@ -187,10 +201,26 @@ export function playSpotterTest(): void {
   if (testSequenceInFlight) return;
 
   testSequenceInFlight = true;
+  // Suspend the live tick loop so a scheduled tick doesn't cut off the
+  // preview clip mid-play. `handleSpotterChanged` also gates on
+  // `testSequenceInFlight` so no new live tick fires during the preview.
+  stopTickLoop();
+
+  const finishTest = (): void => {
+    testSequenceInFlight = false;
+
+    // Resume the live loop if the spotter is still active. Events that
+    // arrived during the preview updated `visualState` without touching
+    // the audio channel, so this picks up the latest state.
+    if (enabled && visualState !== "clear") {
+      startTickLoop(visualState);
+    }
+  };
+
   let idx = 0;
   const playNext = (): void => {
     if (idx >= SPOTTER_TEST_SEQUENCE.length) {
-      testSequenceInFlight = false;
+      finishTest();
 
       return;
     }
@@ -203,9 +233,10 @@ export function playSpotterTest(): void {
 
     // If playOnChannel returns false (audio engine not initialized) the
     // completion callback will never fire, so clear the guard here and
-    // bail; a future press after audio comes up will start fresh.
+    // resume the live loop; a future press after audio comes up will
+    // start fresh.
     if (!getAudio().playOnChannel(AudioChannel.Spotter, resolveAudioPath(file))) {
-      testSequenceInFlight = false;
+      finishTest();
     }
   };
 

--- a/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.ts
+++ b/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.ts
@@ -72,7 +72,11 @@ function startTickLoop(state: ActiveState): void {
   const file = SPOTTER_AUDIO[state];
   const interval = SPOTTER_TICK_INTERVALS[state];
   const fire = (): void => {
-    getAudio().playOnChannel(AudioChannel.Spotter, resolveAudioPath(file));
+    // If the audio engine isn't ready, playOnChannel returns false — don't
+    // reschedule a timer in that case; the next spotter.changed event will
+    // retry the loop once the system is healthy.
+    if (!getAudio().playOnChannel(AudioChannel.Spotter, resolveAudioPath(file))) return;
+
     tickTimer = setTimeout(fire, interval);
   };
 
@@ -93,19 +97,29 @@ function isOnPitRoad(): boolean {
   return telemetry?.OnPitRoad === true;
 }
 
+function forceClear(): void {
+  if (visualState !== "clear") {
+    stopTickLoop();
+    getAudio().stopChannel(AudioChannel.Spotter);
+    setVisualState("clear");
+  }
+}
+
 function handleSpotterChanged(ev: SimEventOf<"spotter.changed">): void {
   if (!enabled) return;
 
   // Lone qualifying sessions have no other cars on track; the raw
-  // CarLeftRight value can flicker, and the callouts aren't useful.
-  if (getSessionType() === "Lone Qualify") return;
+  // CarLeftRight value can flicker, and the callouts aren't useful. If a
+  // loop was already running from a prior non-qualify state, tear it down
+  // so the spotter doesn't keep ticking after the session flips.
+  if (getSessionType() === "Lone Qualify") {
+    forceClear();
+
+    return;
+  }
 
   if (isOnPitRoad()) {
-    if (visualState !== "clear") {
-      stopTickLoop();
-      getAudio().stopChannel(AudioChannel.Spotter);
-      setVisualState("clear");
-    }
+    forceClear();
 
     return;
   }
@@ -186,7 +200,13 @@ export function playSpotterTest(): void {
     getAudio().onChannelComplete(AudioChannel.Spotter, () => {
       setTimeout(playNext, SPOTTER_TEST_GAP_MS);
     });
-    getAudio().playOnChannel(AudioChannel.Spotter, resolveAudioPath(file));
+
+    // If playOnChannel returns false (audio engine not initialized) the
+    // completion callback will never fire, so clear the guard here and
+    // bail; a future press after audio comes up will start fresh.
+    if (!getAudio().playOnChannel(AudioChannel.Spotter, resolveAudioPath(file))) {
+      testSequenceInFlight = false;
+    }
   };
 
   playNext();

--- a/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.ts
+++ b/packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.ts
@@ -1,0 +1,201 @@
+/**
+ * Imperative spotter engine — the one pit-engineer concern the scenario DSL
+ * cannot yet express (state-driven tick loop whose interval switches at
+ * runtime based on proximity state — see design doc §15).
+ *
+ * Owns its own subscription to `spotter.changed` on the event bus, reads
+ * telemetry for pit-road suppression, and plays looping directional beeps
+ * on `AudioChannel.Spotter`. Notifies listeners on visual-state transitions
+ * so the pit-engineer action can re-render its key icon without holding any
+ * spotter state itself.
+ */
+import { AudioChannel, getAudio } from "@iracedeck/audio-service";
+import type { IEventBus, SimEventOf } from "@iracedeck/event-bus";
+import { getLatestTelemetry, getSessionType } from "@iracedeck/sim-events-iracing";
+import path from "node:path";
+
+export type SpotterVisualState = "clear" | "left" | "right" | "both" | "two-left" | "two-right";
+
+type ActiveState = Exclude<SpotterVisualState, "clear">;
+
+type SpotterListener = (state: SpotterVisualState) => void;
+
+const SPOTTER_AUDIO: Record<ActiveState, string> = {
+  left: "pit-engineer/spotter/IRD-spotter-left.mp3",
+  right: "pit-engineer/spotter/IRD-spotter-right.mp3",
+  both: "pit-engineer/spotter/IRD-spotter-both.mp3",
+  "two-left": "pit-engineer/spotter/IRD-spotter-left.mp3",
+  "two-right": "pit-engineer/spotter/IRD-spotter-right.mp3",
+};
+
+// Single-car states tick at 250 ms (matches the legacy 4 Hz cadence).
+// Two-cars-same-side is faster (180 ms) because being sandwiched on one
+// side is the highest-risk position. Both-sides is 230 ms — locked between
+// cars but the driver is holding a straight line.
+const SPOTTER_TICK_INTERVALS: Readonly<Record<ActiveState, number>> = {
+  left: 250,
+  right: 250,
+  "two-left": 180,
+  "two-right": 180,
+  both: 230,
+};
+
+const SPOTTER_TEST_SEQUENCE: readonly string[] = [
+  "pit-engineer/spotter/IRD-spotter-left.mp3",
+  "pit-engineer/spotter/IRD-spotter-right.mp3",
+  "pit-engineer/spotter/IRD-spotter-both.mp3",
+];
+
+const SPOTTER_TEST_GAP_MS = 250;
+
+let enabled = false;
+let visualState: SpotterVisualState = "clear";
+let tickTimer: ReturnType<typeof setTimeout> | null = null;
+let registered = false;
+const listeners = new Set<SpotterListener>();
+
+function resolveAudioPath(file: string): string {
+  return path.join(process.cwd(), "assets", "audio", file);
+}
+
+function stopTickLoop(): void {
+  if (tickTimer !== null) {
+    clearTimeout(tickTimer);
+    tickTimer = null;
+  }
+}
+
+function startTickLoop(state: ActiveState): void {
+  stopTickLoop();
+
+  const file = SPOTTER_AUDIO[state];
+  const interval = SPOTTER_TICK_INTERVALS[state];
+  const fire = (): void => {
+    getAudio().playOnChannel(AudioChannel.Spotter, resolveAudioPath(file));
+    tickTimer = setTimeout(fire, interval);
+  };
+
+  fire();
+}
+
+function setVisualState(next: SpotterVisualState): void {
+  if (visualState === next) return;
+
+  visualState = next;
+
+  for (const listener of listeners) listener(next);
+}
+
+function isOnPitRoad(): boolean {
+  const telemetry = getLatestTelemetry() as { OnPitRoad?: boolean } | null;
+
+  return telemetry?.OnPitRoad === true;
+}
+
+function handleSpotterChanged(ev: SimEventOf<"spotter.changed">): void {
+  if (!enabled) return;
+
+  // Lone qualifying sessions have no other cars on track; the raw
+  // CarLeftRight value can flicker, and the callouts aren't useful.
+  if (getSessionType() === "Lone Qualify") return;
+
+  if (isOnPitRoad()) {
+    if (visualState !== "clear") {
+      stopTickLoop();
+      getAudio().stopChannel(AudioChannel.Spotter);
+      setVisualState("clear");
+    }
+
+    return;
+  }
+
+  const next = ev.data.to as SpotterVisualState;
+
+  if (next === visualState) return;
+
+  if (next === "clear") {
+    stopTickLoop();
+    getAudio().stopChannel(AudioChannel.Spotter);
+  } else {
+    startTickLoop(next);
+  }
+
+  setVisualState(next);
+}
+
+/**
+ * Subscribe the engine to the event bus. Idempotent — safe to call multiple
+ * times. Invoked once from `registerPitEngineer(bus)` at plugin startup;
+ * takes the bus explicitly so tests can pass a fake bus without going
+ * through `initializeEventBus`.
+ */
+export function registerSpotterEngine(bus: IEventBus): void {
+  if (registered) return;
+
+  registered = true;
+  bus.subscribe("spotter.changed", handleSpotterChanged);
+}
+
+/**
+ * Master gate. `false` stops any in-flight tick loop, silences the spotter
+ * channel, and forces the visual state back to `"clear"` (notifying
+ * subscribers so the key icon clears). `true` is passive — the next
+ * `spotter.changed` event will drive playback.
+ */
+export function setSpotterEnabled(next: boolean): void {
+  enabled = next;
+
+  if (!enabled) {
+    stopTickLoop();
+    getAudio().stopChannel(AudioChannel.Spotter);
+    setVisualState("clear");
+  }
+}
+
+/**
+ * Plays the three-clip preview sequence (left → right → both) on the
+ * spotter channel with a 250 ms gap between clips. Used by the PI Test
+ * button; works regardless of the master gate.
+ */
+export function playSpotterTest(): void {
+  let idx = 0;
+  const playNext = (): void => {
+    if (idx >= SPOTTER_TEST_SEQUENCE.length) return;
+
+    const file = SPOTTER_TEST_SEQUENCE[idx];
+    idx++;
+    getAudio().onChannelComplete(AudioChannel.Spotter, () => {
+      setTimeout(playNext, SPOTTER_TEST_GAP_MS);
+    });
+    getAudio().playOnChannel(AudioChannel.Spotter, resolveAudioPath(file));
+  };
+
+  playNext();
+}
+
+/** Returns the latest proximity state (for icon rendering on appear / rerender). */
+export function getSpotterVisualState(): SpotterVisualState {
+  return visualState;
+}
+
+/**
+ * Subscribe to visual-state transitions. Returns an unsubscribe function.
+ * The listener is invoked synchronously after the internal state flips,
+ * so callers can read `getSpotterVisualState()` from inside the callback.
+ */
+export function subscribeSpotterVisualState(listener: SpotterListener): () => void {
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** @internal Exported for test isolation only. */
+export function _resetSpotterEngine(): void {
+  stopTickLoop();
+  enabled = false;
+  visualState = "clear";
+  listeners.clear();
+  registered = false;
+}

--- a/packages/audio-scenarios/src/catalog/pit-engineer/welcome.test.ts
+++ b/packages/audio-scenarios/src/catalog/pit-engineer/welcome.test.ts
@@ -7,6 +7,7 @@ import type { AudioAssetsManifest } from "../../interpreter.js";
 import { _resetAudioScenarios, initializeAudioScenarios } from "../../interpreter.js";
 import { registerPitEngineer, setDriverNameResolver } from "./index.js";
 import { POOLS } from "./pools.js";
+import { _resetSpotterEngine } from "./spotter-engine.js";
 
 // ─── Test utilities (same shape as interpreter.test.ts) ──────────────────────
 
@@ -143,6 +144,7 @@ beforeEach(() => {
 
 afterEach(() => {
   _resetAudioScenarios();
+  _resetSpotterEngine();
   setDriverNameResolver(() => null);
   vi.restoreAllMocks();
   vi.clearAllMocks();

--- a/packages/audio-scenarios/src/catalog/pit-engineer/welcome.test.ts
+++ b/packages/audio-scenarios/src/catalog/pit-engineer/welcome.test.ts
@@ -138,7 +138,7 @@ beforeEach(() => {
   bus = createMockBus();
   audio = createFakeAudio();
   initializeAudioScenarios(bus, audio, buildTestManifest(), mockLogger as never);
-  registerPitEngineer();
+  registerPitEngineer(bus);
 });
 
 afterEach(() => {

--- a/packages/audio-service/src/audio-service.test.ts
+++ b/packages/audio-service/src/audio-service.test.ts
@@ -149,6 +149,13 @@ describe("AudioService", () => {
       expect(native.playOnChannel).toHaveBeenLastCalledWith(AudioChannel.Voice, "sfx/IRD-tick-open.mp3", false, 1.0);
     });
 
+    it("throws when a relative path tries to escape basePath via ..", () => {
+      const native = createMockNative();
+      initializeAudio(mockLogger as never, native, "/plugin/assets/audio");
+      getAudio().init();
+      expect(() => getAudio().playOnChannel(AudioChannel.Voice, "../../etc/passwd")).toThrow(/escapes basePath/);
+    });
+
     it("should stop channel", () => {
       const native = createMockNative();
       initializeAudio(mockLogger as never, native);
@@ -289,6 +296,44 @@ describe("AudioService", () => {
       // Simulate end callback after cancel — should not fire sequence complete
       endCallbacks[AudioChannel.Voice]();
       expect(onSeqComplete).not.toHaveBeenCalled();
+    });
+
+    it("resolves sequence clips + connectors against basePath", () => {
+      const native = createMockNative();
+      const endCallbacks: Record<number, () => void> = {};
+      (native.setChannelEndCallback as ReturnType<typeof vi.fn>).mockImplementation((ch: number, cb: () => void) => {
+        endCallbacks[ch] = cb;
+      });
+
+      initializeAudio(mockLogger as never, native, "/plugin/assets/audio");
+      getAudio().init();
+      getAudio().playVoiceSequence(["sfx/one.mp3", "sfx/two.mp3"], ["sfx/and.mp3"]);
+
+      const msgPattern = /[\\/]plugin[\\/]assets[\\/]audio[\\/]sfx[\\/]one\.mp3$/;
+      expect(native.playOnChannel).toHaveBeenCalledWith(
+        AudioChannel.Voice,
+        expect.stringMatching(msgPattern),
+        false,
+        1.0,
+      );
+
+      endCallbacks[AudioChannel.Voice]();
+      const connectorPattern = /[\\/]plugin[\\/]assets[\\/]audio[\\/]sfx[\\/]and\.mp3$/;
+      expect(native.playOnChannel).toHaveBeenCalledWith(
+        AudioChannel.Voice,
+        expect.stringMatching(connectorPattern),
+        false,
+        1.0,
+      );
+
+      endCallbacks[AudioChannel.Voice]();
+      const msg2Pattern = /[\\/]plugin[\\/]assets[\\/]audio[\\/]sfx[\\/]two\.mp3$/;
+      expect(native.playOnChannel).toHaveBeenCalledWith(
+        AudioChannel.Voice,
+        expect.stringMatching(msg2Pattern),
+        false,
+        1.0,
+      );
     });
 
     it("should skip empty file array", () => {

--- a/packages/audio-service/src/audio-service.test.ts
+++ b/packages/audio-service/src/audio-service.test.ts
@@ -120,6 +120,35 @@ describe("AudioService", () => {
       expect(result).toBe(false);
     });
 
+    it("prepends basePath to relative paths", () => {
+      const native = createMockNative();
+      initializeAudio(mockLogger as never, native, "/plugin/assets/audio");
+      getAudio().init();
+      getAudio().playOnChannel(AudioChannel.Voice, "sfx/IRD-tick-open.mp3");
+      expect(native.playOnChannel).toHaveBeenLastCalledWith(
+        AudioChannel.Voice,
+        expect.stringMatching(/[\\/]plugin[\\/]assets[\\/]audio[\\/]sfx[\\/]IRD-tick-open\.mp3$/),
+        false,
+        1.0,
+      );
+    });
+
+    it("leaves absolute paths untouched when basePath is set", () => {
+      const native = createMockNative();
+      initializeAudio(mockLogger as never, native, "/plugin/assets/audio");
+      getAudio().init();
+      getAudio().playOnChannel(AudioChannel.Spotter, "/abs/path/clip.mp3");
+      expect(native.playOnChannel).toHaveBeenLastCalledWith(AudioChannel.Spotter, "/abs/path/clip.mp3", false, 1.0);
+    });
+
+    it("leaves relative paths untouched when basePath is null", () => {
+      const native = createMockNative();
+      initializeAudio(mockLogger as never, native);
+      getAudio().init();
+      getAudio().playOnChannel(AudioChannel.Voice, "sfx/IRD-tick-open.mp3");
+      expect(native.playOnChannel).toHaveBeenLastCalledWith(AudioChannel.Voice, "sfx/IRD-tick-open.mp3", false, 1.0);
+    });
+
     it("should stop channel", () => {
       const native = createMockNative();
       initializeAudio(mockLogger as never, native);

--- a/packages/audio-service/src/audio-service.ts
+++ b/packages/audio-service/src/audio-service.ts
@@ -26,6 +26,7 @@
 import type { AudioNative } from "@iracedeck/audio-native";
 import type { ILogger } from "@iracedeck/logger";
 import { silentLogger } from "@iracedeck/logger";
+import path from "node:path";
 
 // ─── Channel enum ────────────────────────────────────────────────────────────
 
@@ -157,6 +158,7 @@ export interface IAudioService {
 class AudioService implements IAudioService {
   private logger: ILogger;
   private native: AudioNative;
+  private readonly basePath: string | null;
   private engineReady = false;
 
   // Voice sequence state
@@ -176,9 +178,10 @@ class AudioService implements IAudioService {
   // Per-channel one-shot callbacks (managed at JS level, wrapping the native TSFN)
   private channelCallbacks: ((() => void) | null)[] = [null, null, null, null];
 
-  constructor(logger: ILogger, native: AudioNative) {
+  constructor(logger: ILogger, native: AudioNative, basePath: string | null) {
     this.logger = logger;
     this.native = native;
+    this.basePath = basePath;
 
     // Register persistent native end callbacks for all channels.
     // These dispatch to the JS-level one-shot callbacks.
@@ -219,9 +222,24 @@ class AudioService implements IAudioService {
   playOnChannel(channel: AudioChannel, filePath: string, loop = false): boolean {
     if (!this.engineReady) return false;
 
-    this.logger.debug(`Play ch${channel}: ${filePath}${loop ? " (loop)" : ""}`);
+    const resolved = this.resolvePath(filePath);
+    this.logger.debug(`Play ch${channel}: ${resolved}${loop ? " (loop)" : ""}`);
 
-    return this.native.playOnChannel(channel, filePath, loop, this.channelVolumes[channel]);
+    return this.native.playOnChannel(channel, resolved, loop, this.channelVolumes[channel]);
+  }
+
+  /**
+   * Resolve a clip path against the service's configured base path. Absolute
+   * paths pass through unchanged, so callers that build their own absolute
+   * paths (e.g. the spotter engine) still work. Callers passing manifest-
+   * relative paths (e.g. the scenario interpreter emitting
+   * `sfx/IRD-tick-open.mp3`) get prefixed with the base so the native layer
+   * receives a filesystem path it can actually open.
+   */
+  private resolvePath(filePath: string): string {
+    if (!this.basePath || path.isAbsolute(filePath)) return filePath;
+
+    return path.join(this.basePath, filePath);
   }
 
   stopChannel(channel: AudioChannel): void {
@@ -382,7 +400,12 @@ class AudioService implements IAudioService {
       const connector = this.pickConnector();
       this.voiceSeqState = VoiceSeqState.PlayingConnector;
       this.logger.debug(`Playing connector: ${connector}`);
-      this.native.playOnChannel(AudioChannel.Voice, connector, false, this.channelVolumes[AudioChannel.Voice]);
+      this.native.playOnChannel(
+        AudioChannel.Voice,
+        this.resolvePath(connector),
+        false,
+        this.channelVolumes[AudioChannel.Voice],
+      );
     } else {
       // No connectors — play next message directly
       this.playCurrentMessage();
@@ -397,7 +420,12 @@ class AudioService implements IAudioService {
   private playCurrentMessage(): void {
     const file = this.voiceSeqFiles[this.voiceSeqIndex];
     this.logger.debug(`Playing message ${this.voiceSeqIndex + 1}/${this.voiceSeqFiles.length}: ${file}`);
-    this.native.playOnChannel(AudioChannel.Voice, file, false, this.channelVolumes[AudioChannel.Voice]);
+    this.native.playOnChannel(
+      AudioChannel.Voice,
+      this.resolvePath(file),
+      false,
+      this.channelVolumes[AudioChannel.Voice],
+    );
   }
 
   private pickConnector(): string {
@@ -423,13 +451,25 @@ let audioService: AudioService | null = null;
 /**
  * Initialize the audio service singleton with an AudioNative instance.
  * Call once at plugin startup, then call getAudio().init() to start the engine.
+ *
+ * `basePath` is prepended to every manifest-relative clip path passed to
+ * `playOnChannel` / `playVoiceSequence` (absolute paths pass through
+ * unchanged). Typically the plugin passes `path.join(process.cwd(),
+ * "assets", "audio")` so scenarios can emit short namespace-relative paths
+ * like `sfx/IRD-tick-open.mp3` and the native layer still gets a real
+ * filesystem path. Pass `null` to disable resolution (useful in tests that
+ * inject a fake AudioNative and don't care where the path points).
  */
-export function initializeAudio(logger: ILogger = silentLogger, native: AudioNative): IAudioService {
+export function initializeAudio(
+  logger: ILogger = silentLogger,
+  native: AudioNative,
+  basePath: string | null = null,
+): IAudioService {
   if (audioService) {
     throw new Error("Audio service already initialized. initializeAudio() should only be called once.");
   }
 
-  audioService = new AudioService(logger, native);
+  audioService = new AudioService(logger, native, basePath);
   logger.info("Audio service initialized");
 
   return audioService;

--- a/packages/audio-service/src/audio-service.ts
+++ b/packages/audio-service/src/audio-service.ts
@@ -235,11 +235,26 @@ class AudioService implements IAudioService {
    * relative paths (e.g. the scenario interpreter emitting
    * `sfx/IRD-tick-open.mp3`) get prefixed with the base so the native layer
    * receives a filesystem path it can actually open.
+   *
+   * Rejects paths that escape the base via `..` segments. The scenario DSL
+   * only emits manifest slugs (no traversal), so a rejection here means a
+   * scenario author or a malformed manifest tried to reach outside the
+   * audio-assets directory — almost certainly a bug worth failing loud on.
    */
   private resolvePath(filePath: string): string {
-    if (!this.basePath || path.isAbsolute(filePath)) return filePath;
+    if (path.isAbsolute(filePath)) return filePath;
 
-    return path.join(this.basePath, filePath);
+    if (!this.basePath) return filePath;
+
+    const base = path.resolve(this.basePath);
+    const resolved = path.resolve(base, filePath);
+    const rel = path.relative(base, resolved);
+
+    if (rel.startsWith("..") || path.isAbsolute(rel)) {
+      throw new Error(`Audio clip path escapes basePath: ${filePath}`);
+    }
+
+    return resolved;
   }
 
   stopChannel(channel: AudioChannel): void {

--- a/packages/deck-core/src/global-settings.ts
+++ b/packages/deck-core/src/global-settings.ts
@@ -105,6 +105,16 @@ export const GlobalSettingsSchema = z
       .union([z.boolean(), z.string()])
       .transform((val) => val === true || val === "true")
       .default(true),
+    /**
+     * Master on/off for the Pit Engineer action. Toggled by pressing the Pit
+     * Engineer key — gates every pit-engineer scenario via `setEnabled` so
+     * audio stops immediately when off. Persists across plugin restarts.
+     * Default: true
+     */
+    pitEngineerEnabled: z
+      .union([z.boolean(), z.string()])
+      .transform((val) => val === true || val === "true")
+      .default(true),
   })
   .passthrough();
 

--- a/packages/deck-core/src/simhub-service.test.ts
+++ b/packages/deck-core/src/simhub-service.test.ts
@@ -43,6 +43,7 @@ describe("SimHub Service", () => {
       focusIRacingWindow: false,
       engineStartupAnimation: true,
       enableFuelingOnChange: true,
+      pitEngineerEnabled: true,
     });
   });
 
@@ -135,6 +136,7 @@ describe("SimHub Service", () => {
         focusIRacingWindow: false,
         engineStartupAnimation: true,
         enableFuelingOnChange: true,
+        pitEngineerEnabled: true,
       });
 
       initializeSimHub(mockLogger);

--- a/packages/iracing-actions/src/actions/pit-engineer/pit-engineer.test.ts
+++ b/packages/iracing-actions/src/actions/pit-engineer/pit-engineer.test.ts
@@ -1,37 +1,99 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
-  CAR_CONTROL_TOGGLE_AUDIO,
+  applyVolumes,
+  driverNamePath,
   generatePitEngineerSvg,
-  getEligibleTips,
-  MID_RACE_ONLY_TIPS,
   PIT_ENGINEER_UUID,
-  PIT_SERVICE_TOGGLE_AUDIO,
-  START_ONLY_TIPS,
-  TIP_POOL,
-  TIRE_TOGGLE_AUDIO,
+  PitEngineer,
+  syncScenarioState,
 } from "./pit-engineer.js";
 
 // ─── Hoisted mocks ──────────────────────────────────────────────────────────
+//
+// Stage 7 is a thin shell: scenario behaviour lives in @iracedeck/audio-scenarios
+// (tested there). These tests verify the wiring between the Stream Deck action
+// surface (PI settings, buttons, key press, lifecycle) and the audio packages.
 
-const { mockGetAudio } = vi.hoisted(() => ({
-  mockGetAudio: vi.fn(() => ({
-    setChannelVolume: vi.fn(),
-    onChannelComplete: vi.fn(),
-    playOnChannel: vi.fn(),
-    seekChannelRandom: vi.fn(),
-    stopChannel: vi.fn(),
-    cancelVoiceSequence: vi.fn(),
-    playVoiceSequence: vi.fn(),
-    onVoiceSequenceComplete: vi.fn(),
-  })),
-}));
+const hoisted = vi.hoisted(() => {
+  // Scenario engine
+  const setEnabled = vi.fn();
+  const fire = vi.fn();
+  const getScenarioEngine = vi.fn(() => ({ setEnabled, fire }));
+
+  // Audio service
+  const setBusVolume = vi.fn();
+  const getAudio = vi.fn(() => ({ setBusVolume }));
+
+  // Pit-engineer catalog injectors
+  const setDriverNameResolver = vi.fn();
+  const setSpotterEnabled = vi.fn();
+  const playSpotterTest = vi.fn();
+  let currentSpotterVisualState = "clear" as string;
+  const spotterListeners = new Set<(s: string) => void>();
+  const getSpotterVisualState = vi.fn(() => currentSpotterVisualState);
+  const subscribeSpotterVisualState = vi.fn((listener: (s: string) => void) => {
+    spotterListeners.add(listener);
+
+    return () => {
+      spotterListeners.delete(listener);
+    };
+  });
+
+  const FLAG_SCENARIO_IDS = ["pit-engineer.flag-yellow", "pit-engineer.flag-blue"] as const;
+  const FUEL_SCENARIO_IDS = ["pit-engineer.fuel-low-5laps"] as const;
+  const PIT_LIMITER_SCENARIO_IDS = ["pit-engineer.limiter-speeding"] as const;
+  const TOGGLE_SCENARIO_IDS = ["pit-engineer.toggle-fuel-on"] as const;
+
+  // Global settings
+  let globalSettings: Record<string, unknown> = {};
+  const updateGlobalSettings = vi.fn((partial: Record<string, unknown>) => {
+    globalSettings = { ...globalSettings, ...partial };
+  });
+  const getGlobalSettings = vi.fn(() => globalSettings);
+  const globalSettingsListeners = new Set<() => void>();
+  const onGlobalSettingsChange = vi.fn((listener: () => void) => {
+    globalSettingsListeners.add(listener);
+
+    return () => {
+      globalSettingsListeners.delete(listener);
+    };
+  });
+
+  return {
+    setEnabled,
+    fire,
+    getScenarioEngine,
+    setBusVolume,
+    getAudio,
+    setDriverNameResolver,
+    setSpotterEnabled,
+    playSpotterTest,
+    getSpotterVisualState,
+    subscribeSpotterVisualState,
+    spotterListeners,
+    FLAG_SCENARIO_IDS,
+    FUEL_SCENARIO_IDS,
+    PIT_LIMITER_SCENARIO_IDS,
+    TOGGLE_SCENARIO_IDS,
+    updateGlobalSettings,
+    getGlobalSettings,
+    globalSettingsListeners,
+    onGlobalSettingsChange,
+    setGlobalSettings: (next: Record<string, unknown>) => {
+      globalSettings = next;
+    },
+    setSpotterVisualState: (next: string) => {
+      currentSpotterVisualState = next;
+    },
+  };
+});
 
 // ─── Module mocks ───────────────────────────────────────────────────────────
 
 vi.mock("../../../icons/pit-engineer.svg", () => ({
   default:
-    '<svg xmlns="http://www.w3.org/2000/svg"><desc>{"colors":{"backgroundColor":"#2c3e50","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc></svg>',
+    '<svg xmlns="http://www.w3.org/2000/svg"><desc>{"colors":{"backgroundColor":"#2c3e50","textColor":"#ffffff","graphic1Color":"#ffffff"}}</desc>{{iconContent}}</svg>',
 }));
 
 vi.mock("../../icons/status-bar.js", () => ({
@@ -40,359 +102,410 @@ vi.mock("../../icons/status-bar.js", () => ({
   statusBarOff: vi.fn(() => '<rect class="status-bar-off"/>'),
 }));
 
-vi.mock("@iracedeck/iracing-sdk", () => ({
-  CarLeftRight: {
-    Off: 0,
-    Clear: 1,
-    CarLeft: 2,
-    CarRight: 3,
-    CarLeftRight: 4,
-    TwoCarsLeft: 5,
-    TwoCarsRight: 6,
-  },
-  Flags: {
-    Green: 0x04,
-    Yellow: 0x08,
-    Red: 0x10,
-    Blue: 0x20,
-    Debris: 0x40,
-    YellowWaving: 0x100,
-    Caution: 0x4000,
-    CautionWaving: 0x8000,
-    Black: 0x10000,
-    Disqualify: 0x20000,
-    Repair: 0x100000,
-    White: 0x02,
-    Checkered: 0x01,
-  },
-  PitSvFlags: {
-    LFTireChange: 0x0001,
-    RFTireChange: 0x0002,
-    LRTireChange: 0x0004,
-    RRTireChange: 0x0008,
-    FuelFill: 0x0010,
-    WindshieldTearoff: 0x0020,
-    FastRepair: 0x0040,
-  },
-  EngineWarnings: {
-    PitSpeedLimiter: 0x10,
-  },
-  TrkLoc: {
-    NotInWorld: -1,
-    OffTrack: 0,
-    InPitStall: 1,
-    AproachingPits: 2,
-    OnTrack: 3,
-  },
-  hasFlag: vi.fn((value: number, flag: number) => (value & flag) !== 0),
-  calculateRacePositions: vi.fn(() => []),
+vi.mock("@iracedeck/audio-scenarios", () => ({
+  getScenarioEngine: hoisted.getScenarioEngine,
+}));
+
+vi.mock("@iracedeck/audio-scenarios/pit-engineer", () => ({
+  FLAG_SCENARIO_IDS: hoisted.FLAG_SCENARIO_IDS,
+  FUEL_SCENARIO_IDS: hoisted.FUEL_SCENARIO_IDS,
+  PIT_LIMITER_SCENARIO_IDS: hoisted.PIT_LIMITER_SCENARIO_IDS,
+  TOGGLE_SCENARIO_IDS: hoisted.TOGGLE_SCENARIO_IDS,
+  getSpotterVisualState: hoisted.getSpotterVisualState,
+  playSpotterTest: hoisted.playSpotterTest,
+  setDriverNameResolver: hoisted.setDriverNameResolver,
+  setSpotterEnabled: hoisted.setSpotterEnabled,
+  subscribeSpotterVisualState: hoisted.subscribeSpotterVisualState,
 }));
 
 vi.mock("@iracedeck/audio-service", () => ({
-  AudioBus: {
-    Voice: 0,
-    Background: 1,
-    Alerts: 2,
-  },
-  AudioChannel: {
-    Ambient: 0,
-    SFX: 1,
-    Voice: 2,
-    Spotter: 3,
-  },
-  getAudio: mockGetAudio,
+  AudioBus: { Voice: 0, Background: 1, Alerts: 2 },
+  getAudio: hoisted.getAudio,
 }));
 
-vi.mock("@iracedeck/deck-core", () => ({
-  CommonSettings: {
-    extend: () => {
-      const defaults = {
-        spotterEnabled: true,
-        pitLaneAlertsEnabled: true,
-        toggleAudioEnabled: false,
-        overtakeAndTipsEnabled: true,
-        flagAlertsEnabled: true,
-        spotterVolume: 100,
-        volume: 45,
-        driverName: "none",
-      };
-      const schema = {
-        parse: (data: Record<string, unknown>) => ({ ...defaults, ...data }),
-        safeParse: (data: Record<string, unknown>) => ({ success: true, data: { ...defaults, ...data } }),
-      };
+// Targeted deck-core mock — only the members pit-engineer.ts actually imports.
+// CommonSettings is a real zod schema here so Settings.parse(...) behaves like
+// production (defaults + type coercion). Icon helpers are thin fakes that
+// preserve just enough shape for generatePitEngineerSvg to produce a data URI
+// with the state-bar marker the snapshot tests grep for.
+vi.mock("@iracedeck/deck-core", async () => {
+  const { z } = await import("zod");
 
-      return schema;
-    },
-    parse: (data: Record<string, unknown>) => ({ ...data }),
-    safeParse: (data: Record<string, unknown>) => ({ success: true, data: { ...data } }),
-  },
-  ConnectionStateAwareAction: class MockConnectionStateAwareAction {
-    logger = { trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
-    sdkController = {
-      subscribe: vi.fn(),
-      unsubscribe: vi.fn(),
-      getConnectionStatus: vi.fn(() => true),
-      getCurrentTelemetry: vi.fn(() => null),
-      getSessionInfo: vi.fn(() => null),
+  const CommonSettings = z
+    .object({
+      colorOverrides: z.unknown().optional(),
+      titleOverrides: z.unknown().optional(),
+      borderOverrides: z.unknown().optional(),
+      graphicOverrides: z.unknown().optional(),
+    })
+    .passthrough();
+
+  class MockConnectionStateAwareAction {
+    logger = {
+      trace: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
     };
+    sdkController = { subscribe: vi.fn(), unsubscribe: vi.fn(), getConnectionStatus: vi.fn(() => true) };
     updateConnectionState = vi.fn();
-    setKeyImage = vi.fn();
+    setKeyImage = vi.fn().mockResolvedValue(undefined);
+    updateKeyImage = vi.fn().mockResolvedValue(true);
     setRegenerateCallback = vi.fn();
-    updateKeyImage = vi.fn();
-    async onWillAppear() {}
-    async onDidReceiveSettings() {}
-    async onWillDisappear() {}
-  },
-  applyGraphicTransform: vi.fn((_content: string) => _content),
-  computeGraphicArea: vi.fn(() => ({ x: 8, y: 8, width: 128, height: 84 })),
-  generateBorderParts: vi.fn(() => ({ defs: "", rects: "" })),
-  generateTitleText: vi.fn((opts: { text: string; fill: string }) =>
-    opts.text ? `<text fill="${opts.fill}">${opts.text}</text>` : "",
-  ),
-  getGlobalBorderSettings: vi.fn(() => ({})),
-  getGlobalColors: vi.fn(() => ({})),
-  getGlobalGraphicSettings: vi.fn(() => ({})),
-  getGlobalTitleSettings: vi.fn(() => ({})),
-  LogLevel: { Info: 2 },
-  renderIconTemplate: vi.fn((template: string, data: Record<string, string>) => {
-    let result = template;
+    async onWillAppear(): Promise<void> {}
+    async onWillDisappear(): Promise<void> {}
+    async onDidReceiveSettings(): Promise<void> {}
+  }
 
-    for (const [key, val] of Object.entries(data)) {
-      result = result.replace(new RegExp(`\\{\\{${key}\\}\\}`, "g"), val);
-    }
+  return {
+    CommonSettings,
+    ConnectionStateAwareAction: MockConnectionStateAwareAction,
+    applyGraphicTransform: vi.fn((content: string) => content),
+    computeGraphicArea: vi.fn(() => ({ x: 8, y: 8, width: 128, height: 84 })),
+    generateBorderParts: vi.fn(() => ({ defs: "", rects: "" })),
+    generateTitleText: vi.fn((opts: { text: string; fill: string }) =>
+      opts.text ? `<text fill="${opts.fill}">${opts.text}</text>` : "",
+    ),
+    getGlobalBorderSettings: vi.fn(() => ({})),
+    getGlobalColors: vi.fn(() => ({})),
+    getGlobalGraphicSettings: vi.fn(() => ({})),
+    getGlobalSettings: hoisted.getGlobalSettings,
+    getGlobalTitleSettings: vi.fn(() => ({})),
+    onGlobalSettingsChange: hoisted.onGlobalSettingsChange,
+    renderIconTemplate: vi.fn((template: string, data: Record<string, string>) => {
+      let result = template;
 
-    if (data.iconContent) result += data.iconContent;
+      for (const [key, val] of Object.entries(data)) {
+        result = result.replace(new RegExp(`\\{\\{${key}\\}\\}`, "g"), val);
+      }
 
-    return result;
-  }),
-  resolveBorderSettings: vi.fn((_svg: unknown, _global: unknown, _overrides?: unknown, _stateColor?: string) => ({
-    enabled: false,
-    borderWidth: 7,
-    borderColor: "#00aaff",
-    glowEnabled: true,
-    glowWidth: 18,
-  })),
-  resolveGraphicSettings: vi.fn(() => ({ scale: 1 })),
-  resolveIconColors: vi.fn((_svg: unknown, _global: unknown, _overrides: unknown) => ({
-    backgroundColor: "#2c3e50",
-    textColor: "#ffffff",
-    graphic1Color: "#ffffff",
-  })),
-  resolveTitleSettings: vi.fn((_svg: unknown, _global: unknown, _overrides: unknown, defaultTitle?: string) => ({
-    showTitle: true,
-    showGraphics: true,
-    titleText: defaultTitle ?? "",
-    bold: true,
-    fontSize: 18,
-    position: "bottom" as const,
-    customPosition: 0,
-  })),
-  svgToDataUri: vi.fn((svg: string) => `data:image/svg+xml,${encodeURIComponent(svg)}`),
-}));
+      return result;
+    }),
+    resolveBorderSettings: vi.fn(() => ({
+      enabled: false,
+      borderWidth: 7,
+      borderColor: "#00aaff",
+      glowEnabled: false,
+      glowWidth: 18,
+    })),
+    resolveGraphicSettings: vi.fn(() => ({ scale: 1 })),
+    resolveIconColors: vi.fn(() => ({
+      backgroundColor: "#2c3e50",
+      textColor: "#ffffff",
+      graphic1Color: "#ffffff",
+    })),
+    resolveTitleSettings: vi.fn(() => ({
+      showTitle: true,
+      showGraphics: true,
+      titleText: "PIT\nENGINEER",
+      bold: true,
+      fontSize: 18,
+      position: "bottom" as const,
+      customPosition: 0,
+    })),
+    svgToDataUri: vi.fn((svg: string) => `data:image/svg+xml,${encodeURIComponent(svg)}`),
+    updateGlobalSettings: hoisted.updateGlobalSettings,
+  };
+});
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const DEFAULT_SETTINGS = {
+  spotterEnabled: true,
+  pitApproachEnabled: true,
+  pitServiceReminderEnabled: true,
+  pitDepartureEnabled: true,
+  pitExitEnabled: true,
+  pitLimiterWarning: true,
+  incidentAlert: true,
+  toggleAudioEnabled: true,
+  overtakeAndTipsEnabled: true,
+  flagAlertsEnabled: true,
+  fuelWarningsEnabled: true,
+  fuelStintOpenEnabled: false,
+  fuelSaveCoachingEnabled: false,
+  fuelMidStintEnabled: false,
+  spotterVolume: 100,
+  volume: 45,
+  driverName: "none" as string,
+};
+
+type Settings = typeof DEFAULT_SETTINGS;
+
+function buildSettings(overrides: Partial<Settings> = {}): Settings {
+  return { ...DEFAULT_SETTINGS, ...overrides };
+}
+
+function buildAppearEvent(settings: Partial<Settings> & Record<string, unknown>, actionId = "ctx-1"): unknown {
+  return {
+    action: { id: actionId },
+    payload: { settings },
+  };
+}
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
-describe("PitEngineer", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+beforeEach(() => {
+  vi.clearAllMocks();
+  hoisted.setGlobalSettings({ pitEngineerEnabled: true });
+  hoisted.setSpotterVisualState("clear");
+});
+
+describe("PIT_ENGINEER_UUID", () => {
+  it("has the correct action UUID", () => {
+    expect(PIT_ENGINEER_UUID).toBe("com.iracedeck.sd.core.pit-engineer");
+  });
+});
+
+describe("driverNamePath", () => {
+  it("returns null when driverName is missing", () => {
+    expect(driverNamePath(undefined)).toBeNull();
   });
 
-  // ─── Constants ──────────────────────────────────────────────────────────────
-
-  describe("constants", () => {
-    it("should have the correct action UUID", () => {
-      expect(PIT_ENGINEER_UUID).toBe("com.iracedeck.sd.core.pit-engineer");
-    });
+  it('returns null when driverName is "none"', () => {
+    expect(driverNamePath("none")).toBeNull();
   });
 
-  // ─── Toggle Audio Mappings ─────────────────────────────────────────────────
+  it("returns the audio-assets path for a real name", () => {
+    expect(driverNamePath("niklas")).toBe("pit-engineer/names/IRD-name-niklas.mp3");
+  });
+});
 
-  describe("PIT_SERVICE_TOGGLE_AUDIO", () => {
-    it("should have fuel toggle audio files", () => {
-      expect(PIT_SERVICE_TOGGLE_AUDIO.fuel.on).toContain("fuel-on");
-      expect(PIT_SERVICE_TOGGLE_AUDIO.fuel.off).toContain("fuel-off");
-    });
+describe("applyVolumes", () => {
+  it("drives the Voice + Background busses off the engineer slider and Alerts off the spotter slider", () => {
+    applyVolumes(buildSettings({ volume: 80, spotterVolume: 50 }));
 
-    it("should have windshield toggle audio files", () => {
-      expect(PIT_SERVICE_TOGGLE_AUDIO.windshield.on).toContain("windshield-on");
-      expect(PIT_SERVICE_TOGGLE_AUDIO.windshield.off).toContain("windshield-off");
-    });
-
-    it("should have fast repair toggle audio files", () => {
-      expect(PIT_SERVICE_TOGGLE_AUDIO.fastRepair.on).toContain("fast-repair-on");
-      expect(PIT_SERVICE_TOGGLE_AUDIO.fastRepair.off).toContain("fast-repair-off");
-    });
+    expect(hoisted.setBusVolume).toHaveBeenCalledWith(0, 0.8);
+    expect(hoisted.setBusVolume).toHaveBeenCalledWith(1, 0.8);
+    expect(hoisted.setBusVolume).toHaveBeenCalledWith(2, 0.5);
   });
 
-  describe("TIRE_TOGGLE_AUDIO", () => {
-    it("should have all tire pattern toggle audio files", () => {
-      const expectedPatterns = [
-        "all",
-        "front",
-        "rear",
-        "left",
-        "right",
-        "crossLfRr",
-        "crossRfLr",
-        "stayDry",
-        "stayWet",
-        "changeToDry",
-        "changeToWet",
-        "lf",
-        "rf",
-        "lr",
-        "rr",
-      ];
+  it("clamps at slider min/max normalized to 0..1", () => {
+    applyVolumes(buildSettings({ volume: 5, spotterVolume: 100 }));
 
-      for (const pattern of expectedPatterns) {
-        expect(TIRE_TOGGLE_AUDIO[pattern]).toBeDefined();
-        expect(TIRE_TOGGLE_AUDIO[pattern].on).toBeTruthy();
-        expect(TIRE_TOGGLE_AUDIO[pattern].off).toBeTruthy();
-      }
-    });
+    expect(hoisted.setBusVolume).toHaveBeenCalledWith(0, 0.05);
+    expect(hoisted.setBusVolume).toHaveBeenCalledWith(2, 1);
+  });
+});
 
-    it("should have correct file naming for individual tires", () => {
-      expect(TIRE_TOGGLE_AUDIO.lf.on).toContain("tires-lf-on");
-      expect(TIRE_TOGGLE_AUDIO.rf.on).toContain("tires-rf-on");
-      expect(TIRE_TOGGLE_AUDIO.lr.on).toContain("tires-lr-on");
-      expect(TIRE_TOGGLE_AUDIO.rr.on).toContain("tires-rr-on");
-    });
+describe("syncScenarioState", () => {
+  it("gates every scenario true when master + per-feature toggle are both on", () => {
+    syncScenarioState(buildSettings(), true);
+
+    expect(hoisted.setEnabled).toHaveBeenCalledWith("pit-engineer.welcome", true);
+    expect(hoisted.setEnabled).toHaveBeenCalledWith("pit-engineer.pit-approach", true);
+    expect(hoisted.setEnabled).toHaveBeenCalledWith("pit-engineer.service-reminder", true);
+    expect(hoisted.setEnabled).toHaveBeenCalledWith("pit-engineer.pit-exit", true);
+    expect(hoisted.setEnabled).toHaveBeenCalledWith("pit-engineer.stall-departure", true);
+    expect(hoisted.setEnabled).toHaveBeenCalledWith("pit-engineer.incident-alerts", true);
+    expect(hoisted.setEnabled).toHaveBeenCalledWith("pit-engineer.overtake", true);
+    expect(hoisted.setEnabled).toHaveBeenCalledWith("pit-engineer.racing-tips", true);
+
+    for (const id of hoisted.FLAG_SCENARIO_IDS) expect(hoisted.setEnabled).toHaveBeenCalledWith(id, true);
+
+    for (const id of hoisted.FUEL_SCENARIO_IDS) expect(hoisted.setEnabled).toHaveBeenCalledWith(id, true);
+
+    for (const id of hoisted.TOGGLE_SCENARIO_IDS) expect(hoisted.setEnabled).toHaveBeenCalledWith(id, true);
+
+    for (const id of hoisted.PIT_LIMITER_SCENARIO_IDS) expect(hoisted.setEnabled).toHaveBeenCalledWith(id, true);
+
+    expect(hoisted.setSpotterEnabled).toHaveBeenCalledWith(true);
   });
 
-  describe("CAR_CONTROL_TOGGLE_AUDIO", () => {
-    it("should have push-to-pass toggle audio files", () => {
-      expect(CAR_CONTROL_TOGGLE_AUDIO.pushToPass.on).toContain("p2p-on");
-      expect(CAR_CONTROL_TOGGLE_AUDIO.pushToPass.off).toContain("p2p-off");
-    });
+  it("disables every scenario when the master gate is off, regardless of per-feature toggles", () => {
+    syncScenarioState(buildSettings(), false);
 
-    it("should have DRS toggle audio files", () => {
-      expect(CAR_CONTROL_TOGGLE_AUDIO.drs.on).toContain("drs-on");
-      expect(CAR_CONTROL_TOGGLE_AUDIO.drs.off).toContain("drs-off");
-    });
+    const calls = hoisted.setEnabled.mock.calls;
+
+    for (const [, enabled] of calls) {
+      expect(enabled).toBe(false);
+    }
+
+    expect(hoisted.setSpotterEnabled).toHaveBeenCalledWith(false);
   });
 
-  // ─── generatePitEngineerSvg ────────────────────────────────────────────────
+  it("respects individual toggles when master is on", () => {
+    syncScenarioState(
+      buildSettings({
+        pitApproachEnabled: false,
+        flagAlertsEnabled: false,
+        spotterEnabled: false,
+        overtakeAndTipsEnabled: true,
+      }),
+      true,
+    );
 
-  describe("generatePitEngineerSvg", () => {
-    const defaultSettings = {
-      spotterEnabled: true,
-      pitLaneAlertsEnabled: true,
-      toggleAudioEnabled: false,
-      overtakeAndTipsEnabled: true,
-      flagAlertsEnabled: true,
-      spotterVolume: 100,
-      volume: 45,
-      driverName: "none",
-    };
+    expect(hoisted.setEnabled).toHaveBeenCalledWith("pit-engineer.pit-approach", false);
+    expect(hoisted.setEnabled).toHaveBeenCalledWith("pit-engineer.overtake", true);
+    expect(hoisted.setEnabled).toHaveBeenCalledWith("pit-engineer.racing-tips", true);
 
-    it("should return a valid data URI", () => {
-      const result = generatePitEngineerSvg(defaultSettings, "clear", true);
+    for (const id of hoisted.FLAG_SCENARIO_IDS) expect(hoisted.setEnabled).toHaveBeenCalledWith(id, false);
 
-      expect(result).toContain("data:image/svg+xml");
+    expect(hoisted.setSpotterEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it("welcome is always on while master is on, regardless of PI", () => {
+    syncScenarioState(buildSettings({ pitApproachEnabled: false }), true);
+
+    expect(hoisted.setEnabled).toHaveBeenCalledWith("pit-engineer.welcome", true);
+  });
+});
+
+describe("PitEngineer action", () => {
+  describe("onWillAppear", () => {
+    it("installs the driver-name resolver with the current PI settings", async () => {
+      const action = new PitEngineer();
+      await action.onWillAppear(buildAppearEvent({ driverName: "niklas" }) as never);
+
+      expect(hoisted.setDriverNameResolver).toHaveBeenCalledTimes(1);
+      const resolver = hoisted.setDriverNameResolver.mock.calls[0][0] as () => string | null;
+      expect(resolver()).toBe("pit-engineer/names/IRD-name-niklas.mp3");
     });
 
-    it("should include status bar on when enabled", () => {
-      const result = generatePitEngineerSvg(defaultSettings, "clear", true);
+    it("subscribes to spotter visual-state and global-settings changes", async () => {
+      const action = new PitEngineer();
+      await action.onWillAppear(buildAppearEvent({}) as never);
 
-      expect(decodeURIComponent(result)).toContain("status-bar-on");
+      expect(hoisted.subscribeSpotterVisualState).toHaveBeenCalledTimes(1);
+      expect(hoisted.onGlobalSettingsChange).toHaveBeenCalledTimes(1);
     });
 
-    it("should include status bar off when disabled", () => {
-      const result = generatePitEngineerSvg(defaultSettings, "clear", false);
+    it("applies volumes and syncs scenarios on appear", async () => {
+      const action = new PitEngineer();
+      await action.onWillAppear(buildAppearEvent({ volume: 60, spotterVolume: 30 }) as never);
 
-      expect(decodeURIComponent(result)).toContain("status-bar-off");
+      expect(hoisted.setBusVolume).toHaveBeenCalledWith(0, 0.6);
+      expect(hoisted.setBusVolume).toHaveBeenCalledWith(2, 0.3);
+      expect(hoisted.setEnabled).toHaveBeenCalledWith("pit-engineer.welcome", true);
     });
 
-    it("should produce different SVGs for enabled and disabled", () => {
-      const enabled = generatePitEngineerSvg(defaultSettings, "clear", true);
-      const disabled = generatePitEngineerSvg(defaultSettings, "clear", false);
+    it("gates scenarios off when master is already off at appear time", async () => {
+      hoisted.setGlobalSettings({ pitEngineerEnabled: false });
+      const action = new PitEngineer();
+      await action.onWillAppear(buildAppearEvent({}) as never);
 
-      expect(enabled).not.toBe(disabled);
-    });
+      for (const [, enabled] of hoisted.setEnabled.mock.calls) expect(enabled).toBe(false);
 
-    it("should call resolveIconColors with settings", async () => {
-      const { resolveIconColors } = await import("@iracedeck/deck-core");
-
-      generatePitEngineerSvg(defaultSettings, "clear", true);
-
-      expect(resolveIconColors).toHaveBeenCalled();
-    });
-
-    it("should call resolveBorderSettings with state color", async () => {
-      const { resolveBorderSettings } = await import("@iracedeck/deck-core");
-
-      generatePitEngineerSvg(defaultSettings, "clear", true);
-
-      expect(resolveBorderSettings).toHaveBeenCalled();
-    });
-
-    it("should call resolveGraphicSettings", async () => {
-      const { resolveGraphicSettings } = await import("@iracedeck/deck-core");
-
-      generatePitEngineerSvg(defaultSettings, "clear", true);
-
-      expect(resolveGraphicSettings).toHaveBeenCalled();
-    });
-
-    it("should call resolveTitleSettings with PIT ENGINEER default", async () => {
-      const { resolveTitleSettings } = await import("@iracedeck/deck-core");
-
-      generatePitEngineerSvg(defaultSettings, "clear", true);
-
-      // 4th argument is the default title text
-      expect(resolveTitleSettings).toHaveBeenCalledWith(
-        expect.anything(), // template SVG
-        expect.anything(), // global title settings
-        undefined, // titleOverrides (not in test settings)
-        "PIT\nENGINEER",
-      );
+      expect(hoisted.setSpotterEnabled).toHaveBeenCalledWith(false);
     });
   });
 
-  describe("getEligibleTips", () => {
-    it("includes all tips except MID_RACE_ONLY during start window", () => {
-      const eligible = getEligibleTips(true);
+  describe("onDidReceiveSettings", () => {
+    it("fires the welcome scenario when the engineer test timestamp changes", async () => {
+      const action = new PitEngineer();
+      await action.onWillAppear(buildAppearEvent({ _testVolume: 0 }) as never);
 
-      for (const tip of MID_RACE_ONLY_TIPS) {
-        expect(eligible).not.toContain(tip);
-      }
+      await action.onDidReceiveSettings(buildAppearEvent({ _testVolume: 42 }) as never);
 
-      for (const tip of START_ONLY_TIPS) {
-        expect(eligible).toContain(tip);
-      }
+      expect(hoisted.fire).toHaveBeenCalledWith("pit-engineer.welcome");
     });
 
-    it("includes all tips except START_ONLY during mid-race", () => {
-      const eligible = getEligibleTips(false);
+    it("does not re-fire welcome on unrelated settings updates", async () => {
+      const action = new PitEngineer();
+      await action.onWillAppear(buildAppearEvent({ _testVolume: 100 }) as never);
 
-      for (const tip of START_ONLY_TIPS) {
-        expect(eligible).not.toContain(tip);
-      }
+      await action.onDidReceiveSettings(buildAppearEvent({ _testVolume: 100 }) as never);
 
-      for (const tip of MID_RACE_ONLY_TIPS) {
-        expect(eligible).toContain(tip);
-      }
+      expect(hoisted.fire).not.toHaveBeenCalled();
     });
 
-    it("eligible tip count matches TIP_POOL minus excluded set", () => {
-      expect(getEligibleTips(true).length).toBe(TIP_POOL.length - MID_RACE_ONLY_TIPS.size);
-      expect(getEligibleTips(false).length).toBe(TIP_POOL.length - START_ONLY_TIPS.size);
+    it("invokes playSpotterTest when the spotter test timestamp changes", async () => {
+      const action = new PitEngineer();
+      await action.onWillAppear(buildAppearEvent({ _testSpotterVolume: 0 }) as never);
+
+      await action.onDidReceiveSettings(buildAppearEvent({ _testSpotterVolume: 7 }) as never);
+
+      expect(hoisted.playSpotterTest).toHaveBeenCalledTimes(1);
     });
 
-    it("START_ONLY and MID_RACE_ONLY sets do not overlap", () => {
-      for (const tip of START_ONLY_TIPS) {
-        expect(MID_RACE_ONLY_TIPS.has(tip)).toBe(false);
-      }
+    it("re-applies volumes and re-syncs scenarios", async () => {
+      const action = new PitEngineer();
+      await action.onWillAppear(buildAppearEvent({ volume: 45, spotterEnabled: true }) as never);
+      vi.clearAllMocks();
+
+      await action.onDidReceiveSettings(buildAppearEvent({ volume: 90, spotterEnabled: false }) as never);
+
+      expect(hoisted.setBusVolume).toHaveBeenCalledWith(0, 0.9);
+      expect(hoisted.setSpotterEnabled).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe("onKeyDown", () => {
+    it("toggles the master flag in global settings", async () => {
+      const action = new PitEngineer();
+      await action.onWillAppear(buildAppearEvent({}) as never);
+
+      await action.onKeyDown(buildAppearEvent({}) as never);
+
+      expect(hoisted.updateGlobalSettings).toHaveBeenCalledWith({ pitEngineerEnabled: false });
     });
 
-    it("every tip in START_ONLY and MID_RACE_ONLY exists in TIP_POOL", () => {
-      for (const tip of START_ONLY_TIPS) {
-        expect(TIP_POOL).toContain(tip);
-      }
+    it("synchronously gates all scenarios off with the new master value", async () => {
+      const action = new PitEngineer();
+      await action.onWillAppear(buildAppearEvent({}) as never);
+      vi.clearAllMocks();
 
-      for (const tip of MID_RACE_ONLY_TIPS) {
-        expect(TIP_POOL).toContain(tip);
-      }
+      await action.onKeyDown(buildAppearEvent({}) as never);
+
+      // Every setEnabled call in onKeyDown uses master=false regardless of PI toggles.
+      const calls = hoisted.setEnabled.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+
+      for (const [, enabled] of calls) expect(enabled).toBe(false);
+
+      expect(hoisted.setSpotterEnabled).toHaveBeenCalledWith(false);
     });
+
+    it("turns the master back on when already disabled", async () => {
+      hoisted.setGlobalSettings({ pitEngineerEnabled: false });
+      const action = new PitEngineer();
+      await action.onWillAppear(buildAppearEvent({}) as never);
+      vi.clearAllMocks();
+
+      await action.onKeyDown(buildAppearEvent({}) as never);
+
+      expect(hoisted.updateGlobalSettings).toHaveBeenCalledWith({ pitEngineerEnabled: true });
+      expect(hoisted.setEnabled).toHaveBeenCalledWith("pit-engineer.welcome", true);
+    });
+  });
+
+  describe("onWillDisappear", () => {
+    it("unsubscribes spotter and global-settings listeners", async () => {
+      const action = new PitEngineer();
+      await action.onWillAppear(buildAppearEvent({}) as never);
+      const listenersBefore = hoisted.spotterListeners.size;
+      const globalBefore = hoisted.globalSettingsListeners.size;
+      expect(listenersBefore).toBeGreaterThan(0);
+      expect(globalBefore).toBeGreaterThan(0);
+
+      await action.onWillDisappear(buildAppearEvent({}) as never);
+
+      expect(hoisted.spotterListeners.size).toBe(listenersBefore - 1);
+      expect(hoisted.globalSettingsListeners.size).toBe(globalBefore - 1);
+    });
+  });
+});
+
+describe("generatePitEngineerSvg", () => {
+  it("returns a data URI", () => {
+    const result = generatePitEngineerSvg(DEFAULT_SETTINGS, "clear", true);
+    expect(result).toContain("data:image/svg+xml");
+  });
+
+  it("marks the status bar on when enabled", () => {
+    const result = decodeURIComponent(generatePitEngineerSvg(DEFAULT_SETTINGS, "clear", true));
+    expect(result).toContain("status-bar-on");
+  });
+
+  it("marks the status bar off when disabled", () => {
+    const result = decodeURIComponent(generatePitEngineerSvg(DEFAULT_SETTINGS, "clear", false));
+    expect(result).toContain("status-bar-off");
+  });
+
+  it("produces different output when enabled flips", () => {
+    const on = generatePitEngineerSvg(DEFAULT_SETTINGS, "clear", true);
+    const off = generatePitEngineerSvg(DEFAULT_SETTINGS, "clear", false);
+    expect(on).not.toBe(off);
   });
 });

--- a/packages/iracing-actions/src/actions/pit-engineer/pit-engineer.test.ts
+++ b/packages/iracing-actions/src/actions/pit-engineer/pit-engineer.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// Imports appear above the `vi.mock(...)` blocks because the repo-wide
+// prettier config (@elgato/prettier-config + @trivago/prettier-plugin-sort-imports)
+// hoists every import to the top and won't leave them interleaved with other
+// statements. Vitest transforms `vi.mock(...)` to run before any import at
+// module init, so the mocks still apply to the action import below.
 import {
   applyVolumes,
   driverNamePath,
@@ -236,6 +241,9 @@ function buildAppearEvent(settings: TestInputs, actionId = "ctx-1"): unknown {
 beforeEach(() => {
   vi.clearAllMocks();
   hoisted.setGlobalSettings({ pitEngineerEnabled: true });
+  // Clear hoisted listener sets so cross-test listener counts stay
+  // deterministic for tests that don't pair onWillAppear with onWillDisappear.
+  hoisted.globalSettingsListeners.clear();
 });
 
 describe("PIT_ENGINEER_UUID", () => {
@@ -255,6 +263,13 @@ describe("driverNamePath", () => {
 
   it("returns the audio-assets path for a real name", () => {
     expect(driverNamePath("niklas")).toBe("pit-engineer/names/IRD-name-niklas.mp3");
+  });
+
+  it("rejects names with path-traversal characters", () => {
+    expect(driverNamePath("../../etc/passwd")).toBeNull();
+    expect(driverNamePath("foo/bar")).toBeNull();
+    expect(driverNamePath("foo.mp3")).toBeNull();
+    expect(driverNamePath("NIKLAS")).toBeNull();
   });
 });
 

--- a/packages/iracing-actions/src/actions/pit-engineer/pit-engineer.test.ts
+++ b/packages/iracing-actions/src/actions/pit-engineer/pit-engineer.test.ts
@@ -29,16 +29,6 @@ const hoisted = vi.hoisted(() => {
   const setDriverNameResolver = vi.fn();
   const setSpotterEnabled = vi.fn();
   const playSpotterTest = vi.fn();
-  let currentSpotterVisualState = "clear" as string;
-  const spotterListeners = new Set<(s: string) => void>();
-  const getSpotterVisualState = vi.fn(() => currentSpotterVisualState);
-  const subscribeSpotterVisualState = vi.fn((listener: (s: string) => void) => {
-    spotterListeners.add(listener);
-
-    return () => {
-      spotterListeners.delete(listener);
-    };
-  });
 
   const FLAG_SCENARIO_IDS = ["pit-engineer.flag-yellow", "pit-engineer.flag-blue"] as const;
   const FUEL_SCENARIO_IDS = ["pit-engineer.fuel-low-5laps"] as const;
@@ -69,9 +59,6 @@ const hoisted = vi.hoisted(() => {
     setDriverNameResolver,
     setSpotterEnabled,
     playSpotterTest,
-    getSpotterVisualState,
-    subscribeSpotterVisualState,
-    spotterListeners,
     FLAG_SCENARIO_IDS,
     FUEL_SCENARIO_IDS,
     PIT_LIMITER_SCENARIO_IDS,
@@ -82,9 +69,6 @@ const hoisted = vi.hoisted(() => {
     onGlobalSettingsChange,
     setGlobalSettings: (next: Record<string, unknown>) => {
       globalSettings = next;
-    },
-    setSpotterVisualState: (next: string) => {
-      currentSpotterVisualState = next;
     },
   };
 });
@@ -111,11 +95,9 @@ vi.mock("@iracedeck/audio-scenarios/pit-engineer", () => ({
   FUEL_SCENARIO_IDS: hoisted.FUEL_SCENARIO_IDS,
   PIT_LIMITER_SCENARIO_IDS: hoisted.PIT_LIMITER_SCENARIO_IDS,
   TOGGLE_SCENARIO_IDS: hoisted.TOGGLE_SCENARIO_IDS,
-  getSpotterVisualState: hoisted.getSpotterVisualState,
   playSpotterTest: hoisted.playSpotterTest,
   setDriverNameResolver: hoisted.setDriverNameResolver,
   setSpotterEnabled: hoisted.setSpotterEnabled,
-  subscribeSpotterVisualState: hoisted.subscribeSpotterVisualState,
 }));
 
 vi.mock("@iracedeck/audio-service", () => ({
@@ -233,11 +215,16 @@ const DEFAULT_SETTINGS = {
 
 type Settings = typeof DEFAULT_SETTINGS;
 
+type TestInputs = Partial<Settings> & {
+  _testVolume?: number;
+  _testSpotterVolume?: number;
+};
+
 function buildSettings(overrides: Partial<Settings> = {}): Settings {
   return { ...DEFAULT_SETTINGS, ...overrides };
 }
 
-function buildAppearEvent(settings: Partial<Settings> & Record<string, unknown>, actionId = "ctx-1"): unknown {
+function buildAppearEvent(settings: TestInputs, actionId = "ctx-1"): unknown {
   return {
     action: { id: actionId },
     payload: { settings },
@@ -249,7 +236,6 @@ function buildAppearEvent(settings: Partial<Settings> & Record<string, unknown>,
 beforeEach(() => {
   vi.clearAllMocks();
   hoisted.setGlobalSettings({ pitEngineerEnabled: true });
-  hoisted.setSpotterVisualState("clear");
 });
 
 describe("PIT_ENGINEER_UUID", () => {
@@ -363,11 +349,10 @@ describe("PitEngineer action", () => {
       expect(resolver()).toBe("pit-engineer/names/IRD-name-niklas.mp3");
     });
 
-    it("subscribes to spotter visual-state and global-settings changes", async () => {
+    it("subscribes to global-settings changes so icons re-render when the master flag changes", async () => {
       const action = new PitEngineer();
       await action.onWillAppear(buildAppearEvent({}) as never);
 
-      expect(hoisted.subscribeSpotterVisualState).toHaveBeenCalledTimes(1);
       expect(hoisted.onGlobalSettingsChange).toHaveBeenCalledTimes(1);
     });
 
@@ -471,17 +456,14 @@ describe("PitEngineer action", () => {
   });
 
   describe("onWillDisappear", () => {
-    it("unsubscribes spotter and global-settings listeners", async () => {
+    it("unsubscribes the global-settings listener", async () => {
       const action = new PitEngineer();
       await action.onWillAppear(buildAppearEvent({}) as never);
-      const listenersBefore = hoisted.spotterListeners.size;
       const globalBefore = hoisted.globalSettingsListeners.size;
-      expect(listenersBefore).toBeGreaterThan(0);
       expect(globalBefore).toBeGreaterThan(0);
 
       await action.onWillDisappear(buildAppearEvent({}) as never);
 
-      expect(hoisted.spotterListeners.size).toBe(listenersBefore - 1);
       expect(hoisted.globalSettingsListeners.size).toBe(globalBefore - 1);
     });
   });
@@ -489,23 +471,23 @@ describe("PitEngineer action", () => {
 
 describe("generatePitEngineerSvg", () => {
   it("returns a data URI", () => {
-    const result = generatePitEngineerSvg(DEFAULT_SETTINGS, "clear", true);
+    const result = generatePitEngineerSvg(DEFAULT_SETTINGS, true);
     expect(result).toContain("data:image/svg+xml");
   });
 
   it("marks the status bar on when enabled", () => {
-    const result = decodeURIComponent(generatePitEngineerSvg(DEFAULT_SETTINGS, "clear", true));
+    const result = decodeURIComponent(generatePitEngineerSvg(DEFAULT_SETTINGS, true));
     expect(result).toContain("status-bar-on");
   });
 
   it("marks the status bar off when disabled", () => {
-    const result = decodeURIComponent(generatePitEngineerSvg(DEFAULT_SETTINGS, "clear", false));
+    const result = decodeURIComponent(generatePitEngineerSvg(DEFAULT_SETTINGS, false));
     expect(result).toContain("status-bar-off");
   });
 
   it("produces different output when enabled flips", () => {
-    const on = generatePitEngineerSvg(DEFAULT_SETTINGS, "clear", true);
-    const off = generatePitEngineerSvg(DEFAULT_SETTINGS, "clear", false);
+    const on = generatePitEngineerSvg(DEFAULT_SETTINGS, true);
+    const off = generatePitEngineerSvg(DEFAULT_SETTINGS, false);
     expect(on).not.toBe(off);
   });
 });

--- a/packages/iracing-actions/src/actions/pit-engineer/pit-engineer.ts
+++ b/packages/iracing-actions/src/actions/pit-engineer/pit-engineer.ts
@@ -2,13 +2,10 @@ import { getScenarioEngine } from "@iracedeck/audio-scenarios";
 import {
   FLAG_SCENARIO_IDS,
   FUEL_SCENARIO_IDS,
-  getSpotterVisualState,
   PIT_LIMITER_SCENARIO_IDS,
   playSpotterTest,
   setDriverNameResolver,
   setSpotterEnabled,
-  type SpotterVisualState,
-  subscribeSpotterVisualState,
   TOGGLE_SCENARIO_IDS,
 } from "@iracedeck/audio-scenarios/pit-engineer";
 import { AudioBus, getAudio } from "@iracedeck/audio-service";
@@ -166,13 +163,11 @@ function mechanicPathContent(graphicColor: string): string {
 /**
  * @internal Exported for testing.
  *
- * Generates a complete SVG data URI for the pit engineer icon.
+ * Generates a complete SVG data URI for the pit engineer icon. Spotter
+ * proximity state is audio-only today — the icon reflects only the master
+ * on/off state via the status bar.
  */
-export function generatePitEngineerSvg(
-  settings: PitEngineerSettings,
-  spotterState: SpotterVisualState,
-  enabled: boolean,
-): string {
+export function generatePitEngineerSvg(settings: PitEngineerSettings, enabled: boolean): string {
   const colors = resolveIconColors(pitEngineerTemplate, getGlobalColors(), settings.colorOverrides) as Record<
     string,
     string
@@ -223,11 +218,6 @@ export function generatePitEngineerSvg(
   );
   const borderSvg = generateBorderParts(border);
 
-  // spotterState is accepted for API compatibility with the regenerate callback
-  // and future visual overlays; the current template renders identically
-  // regardless of proximity state (spotter is audio-only).
-  void spotterState;
-
   const svg = renderIconTemplate(pitEngineerTemplate, {
     iconContent,
     borderDefs: borderSvg.defs,
@@ -247,8 +237,8 @@ export class PitEngineer extends ConnectionStateAwareAction<PitEngineerSettings>
   /** Set of currently visible context IDs. */
   private readonly visibleContexts = new Set<string>();
 
-  /** Per-context unsubscribe callbacks for spotter + global-settings listeners. */
-  private readonly listenerUnsubs = new Map<string, Array<() => void>>();
+  /** Per-context unsubscribe callback for the global-settings listener. */
+  private readonly listenerUnsubs = new Map<string, () => void>();
 
   /** Last-seen settings, used by the driver-name resolver injected into scenarios. */
   private latestSettings: PitEngineerSettings | null = null;
@@ -277,34 +267,34 @@ export class PitEngineer extends ConnectionStateAwareAction<PitEngineerSettings>
 
     setDriverNameResolver(() => driverNamePath(this.latestSettings?.driverName));
 
-    this.listenerUnsubs.set(contextId, [
-      subscribeSpotterVisualState(() => {
-        void this.rerender(contextId);
-      }),
+    // Re-render when the master flag changes (both from our own onKeyDown
+    // round-trip and from another instance). Spotter state isn't part of
+    // the icon today, so no spotter-listener subscription.
+    this.listenerUnsubs.set(
+      contextId,
       onGlobalSettingsChange(() => {
         void this.rerender(contextId);
       }),
-    ]);
+    );
 
     applyVolumes(settings);
     syncScenarioState(settings, isEngineerEnabled());
 
-    await this.setKeyImage(ev, generatePitEngineerSvg(settings, getSpotterVisualState(), isEngineerEnabled()));
+    await this.setKeyImage(ev, generatePitEngineerSvg(settings, isEngineerEnabled()));
 
     this.setRegenerateCallback(contextId, () => {
       const s = this.settingsCache.get(contextId);
 
       if (!s) return "";
 
-      return generatePitEngineerSvg(s, getSpotterVisualState(), isEngineerEnabled());
+      return generatePitEngineerSvg(s, isEngineerEnabled());
     });
   }
 
   override async onWillDisappear(ev: IDeckWillDisappearEvent<PitEngineerSettings>): Promise<void> {
     const contextId = ev.action.id;
 
-    for (const unsub of this.listenerUnsubs.get(contextId) ?? []) unsub();
-
+    this.listenerUnsubs.get(contextId)?.();
     this.listenerUnsubs.delete(contextId);
     this.settingsCache.delete(contextId);
     this.visibleContexts.delete(contextId);
@@ -343,7 +333,7 @@ export class PitEngineer extends ConnectionStateAwareAction<PitEngineerSettings>
 
     this.lastSpotterTestTimestamp = spotterTestTimestamp ?? 0;
 
-    await this.setKeyImage(ev, generatePitEngineerSvg(settings, getSpotterVisualState(), isEngineerEnabled()));
+    await this.setKeyImage(ev, generatePitEngineerSvg(settings, isEngineerEnabled()));
   }
 
   override async onKeyDown(ev: IDeckKeyDownEvent<PitEngineerSettings>): Promise<void> {
@@ -363,7 +353,7 @@ export class PitEngineer extends ConnectionStateAwareAction<PitEngineerSettings>
 
       if (!s) continue;
 
-      await this.updateKeyImage(contextId, generatePitEngineerSvg(s, getSpotterVisualState(), nextMaster));
+      await this.updateKeyImage(contextId, generatePitEngineerSvg(s, nextMaster));
     }
   }
 
@@ -372,9 +362,6 @@ export class PitEngineer extends ConnectionStateAwareAction<PitEngineerSettings>
 
     if (!settings) return;
 
-    await this.updateKeyImage(
-      contextId,
-      generatePitEngineerSvg(settings, getSpotterVisualState(), isEngineerEnabled()),
-    );
+    await this.updateKeyImage(contextId, generatePitEngineerSvg(settings, isEngineerEnabled()));
   }
 }

--- a/packages/iracing-actions/src/actions/pit-engineer/pit-engineer.ts
+++ b/packages/iracing-actions/src/actions/pit-engineer/pit-engineer.ts
@@ -2,11 +2,16 @@ import { getScenarioEngine } from "@iracedeck/audio-scenarios";
 import {
   FLAG_SCENARIO_IDS,
   FUEL_SCENARIO_IDS,
+  getSpotterVisualState,
   PIT_LIMITER_SCENARIO_IDS,
+  playSpotterTest,
   setDriverNameResolver,
+  setSpotterEnabled,
+  type SpotterVisualState,
+  subscribeSpotterVisualState,
   TOGGLE_SCENARIO_IDS,
 } from "@iracedeck/audio-scenarios/pit-engineer";
-import { AudioBus, AudioChannel, getAudio } from "@iracedeck/audio-service";
+import { AudioBus, getAudio } from "@iracedeck/audio-service";
 import {
   applyGraphicTransform,
   CommonSettings,
@@ -17,148 +22,30 @@ import {
   getGlobalBorderSettings,
   getGlobalColors,
   getGlobalGraphicSettings,
+  getGlobalSettings,
   getGlobalTitleSettings,
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
   type IDeckWillAppearEvent,
   type IDeckWillDisappearEvent,
+  onGlobalSettingsChange,
   renderIconTemplate,
   resolveBorderSettings,
   resolveGraphicSettings,
   resolveIconColors,
   resolveTitleSettings,
   svgToDataUri,
+  updateGlobalSettings,
 } from "@iracedeck/deck-core";
-import { getEventBus, type SimEventOf } from "@iracedeck/event-bus";
-import { getLatestTelemetry, getSessionType } from "@iracedeck/sim-events-iracing";
-import path from "node:path";
-import z from "zod";
+import { z } from "zod";
 
 import pitEngineerTemplate from "../../../icons/pit-engineer.svg";
 import { borderColorForState, statusBarOff, statusBarOn } from "../../icons/status-bar.js";
-
-// ─── Constants ─────────────────────────────────────────────────────────────────
 
 const WHITE = "#ffffff";
 
 /** @internal Exported for testing */
 export const PIT_ENGINEER_UUID = "com.iracedeck.sd.core.pit-engineer";
-
-// ─── Audio Channel Volumes ────────────────────────────────────────────────────
-//
-// Bus layout (sound groups):
-//   Voice      — engineer messages, acks, connectors
-//   Background — pit ambient loop + walkie ticks (intrinsic mix ratios live in deck-core)
-//   Alerts     — directional spotter (independent of engineer volume)
-//
-// The PI "volume" slider drives the Voice + Background busses together (the
-// "engineer" bus pair). The "spotterVolume" slider drives the Alerts bus.
-// Per-channel attenuation (Ambient 0.8, SFX 0.7) is baked into the bus's
-// channel mix ratios in audio-service.ts.
-
-/** Applies volume-slider values to the audio busses. */
-function applyChannelVolumes(): void {
-  if (!globalSettings) return;
-
-  const engineerVol = globalSettings.volume / 100;
-  const spotterVol = globalSettings.spotterVolume / 100;
-
-  getAudio().setBusVolume(AudioBus.Voice, engineerVol);
-  getAudio().setBusVolume(AudioBus.Background, engineerVol);
-  getAudio().setBusVolume(AudioBus.Alerts, spotterVol);
-}
-
-// ─── Tip Pool ────────────────────────────────────────────────────────────────
-
-/**
- * @internal Exported for testing
- *
- * Full list of racing tips. Certain tips are restricted to either the
- * start-of-race window or mid-race only (see below). The rest are eligible
- * at any point.
- */
-export const TIP_POOL = [
-  "pit-engineer/tips/IRD-pit-engineer-tip-1.mp3",
-  "pit-engineer/tips/IRD-pit-engineer-tip-2.mp3",
-  "pit-engineer/tips/IRD-pit-engineer-tip-3.mp3",
-  "pit-engineer/tips/IRD-pit-engineer-tip-4.mp3",
-  "pit-engineer/tips/IRD-pit-engineer-tip-5.mp3",
-  "pit-engineer/tips/IRD-pit-engineer-tip-6.mp3",
-  "pit-engineer/tips/IRD-pit-engineer-tip-7.mp3",
-  "pit-engineer/tips/IRD-pit-engineer-tip-8.mp3",
-  "pit-engineer/tips/IRD-pit-engineer-tip-9.mp3",
-  "pit-engineer/tips/IRD-pit-engineer-tip-10.mp3",
-  "pit-engineer/tips/IRD-pit-engineer-tip-11.mp3",
-];
-
-/**
- * @internal Exported for testing
- *
- * Tips that should only be played during the start-of-race window
- * (formation/pace lap through lap 1). Excluded from the mid-race pool.
- */
-export const START_ONLY_TIPS: ReadonlySet<string> = new Set([
-  "pit-engineer/tips/IRD-pit-engineer-tip-6.mp3",
-  "pit-engineer/tips/IRD-pit-engineer-tip-7.mp3",
-]);
-
-/**
- * @internal Exported for testing
- *
- * Tips that should only be played mid-race (after the start window closes).
- * Excluded from the start-of-race pool.
- */
-export const MID_RACE_ONLY_TIPS: ReadonlySet<string> = new Set([
-  "pit-engineer/tips/IRD-pit-engineer-tip-11.mp3",
-]);
-
-/**
- * @internal Exported for testing
- *
- * Returns the subset of tips eligible for the given race phase.
- * - Start window: excludes MID_RACE_ONLY_TIPS
- * - Mid-race: excludes START_ONLY_TIPS
- */
-export function getEligibleTips(isStartWindow: boolean): string[] {
-  const excluded = isStartWindow ? MID_RACE_ONLY_TIPS : START_ONLY_TIPS;
-
-  return TIP_POOL.filter((tip) => !excluded.has(tip));
-}
-
-// ─── Driver Name ──────────────────────────────────────────────────────────────
-//
-// The driver name file is selected from the pit-engineer/names/ folder.
-// Multiple names can be added (e.g., IRD-name-john.mp3, IRD-name-mike.mp3).
-//
-// To add a new name:
-//   1. Place the mp3 file named `IRD-name-<lowercase>.mp3` in all three dirs:
-//        - packages/audio-assets/pit-engineer/names/
-//        - packages/stream-deck-plugin/com.iracedeck.sd.core.sdPlugin/assets/audio/pit-engineer/names/
-//        - packages/mirabox-plugin/com.iracedeck.sd.core.sdPlugin/assets/audio/pit-engineer/names/
-//      (Mirabox rollup does not copy from audio-assets/, so the plugin dirs must have it.)
-//   2. Add an entry to the NAMES array in
-//      packages/stream-deck-plugin/src/pi/pit-engineer.ejs — keep alphabetical.
-//        { value: '<lowercase>', label: '<TitleCase>' }
-//      (Mirabox reuses the same EJS via piTemplatePlugin — no separate edit needed.)
-//   3. Build + pack both plugins:
-//        pnpm build
-//        cd packages/mirabox-plugin && pnpm pack:plugin
-//        cd packages/stream-deck-plugin && npx streamdeck pack com.iracedeck.sd.core.sdPlugin --force --ignore-validation -o ../../local
-
-/** Returns the configured driver name audio file, or null if no name is set. */
-function getDriverNameFile(): string | null {
-  const name = globalSettings?.driverName;
-
-  if (!name || name === "none") return null;
-
-  return `pit-engineer/names/IRD-name-${name}.mp3`;
-}
-
-// Expose the driver-name resolver to scenarios that use the `{{name}}` variable
-// (the welcome scenario today; others may reuse it later). The closure reads
-// the latest `globalSettings` at fire time, so no re-registration on settings
-// changes is needed.
-setDriverNameResolver(getDriverNameFile);
 
 // ─── Settings ──────────────────────────────────────────────────────────────────
 
@@ -188,66 +75,96 @@ const Settings = CommonSettings.extend({
 
 type PitEngineerSettings = z.infer<typeof Settings>;
 
-// ─── Spotter State ─────────────────────────────────────────────────────────────
+/**
+ * @internal Exported for testing.
+ *
+ * Returns the audio-assets path for the chosen driver name, or null if none.
+ */
+export function driverNamePath(name: string | undefined): string | null {
+  if (!name || name === "none") return null;
 
-/** Visual state of the spotter for icon rendering. */
-export type SpotterVisualState = "clear" | "left" | "right" | "both" | "two-left" | "two-right";
+  return `pit-engineer/names/IRD-name-${name}.mp3`;
+}
 
-/** Audio file names for each directional state. */
-const SPOTTER_AUDIO: Record<string, string> = {
-  left: "pit-engineer/spotter/IRD-spotter-left.mp3",
-  right: "pit-engineer/spotter/IRD-spotter-right.mp3",
-  both: "pit-engineer/spotter/IRD-spotter-both.mp3",
-  "two-left": "pit-engineer/spotter/IRD-spotter-left.mp3",
-  "two-right": "pit-engineer/spotter/IRD-spotter-right.mp3",
-};
+// ─── Master gate ──────────────────────────────────────────────────────────────
 
-/** Stops the current spotter tick loop (if any). Safe to call when idle. */
-function stopSpotterTickLoop(): void {
-  if (globalSpotterTickTimer !== null) {
-    clearTimeout(globalSpotterTickTimer);
-    globalSpotterTickTimer = null;
-  }
+/**
+ * Master on/off for the engineer. Stored as a plugin-global setting so the
+ * value persists across plugin restarts and is shared between action
+ * instances on different pages.
+ */
+function isEngineerEnabled(): boolean {
+  return (getGlobalSettings() as Record<string, unknown>).pitEngineerEnabled !== false;
+}
+
+// ─── Scenario gating ──────────────────────────────────────────────────────────
+
+/**
+ * @internal Exported for testing.
+ *
+ * Sync every pit-engineer scenario's enabled flag to the Property Inspector
+ * toggles, gated by the master switch. Called from every event that can
+ * change either layer of state (`onWillAppear`, `onDidReceiveSettings`,
+ * `onKeyDown`). `master` is passed explicitly because `onKeyDown` needs the
+ * new value before the global-settings round-trip completes.
+ */
+export function syncScenarioState(settings: PitEngineerSettings, master: boolean): void {
+  const engine = getScenarioEngine();
+  const gate = (id: string, on: boolean): void => {
+    engine.setEnabled(id, master && on);
+  };
+
+  // Welcome has no PI toggle — it's always on while the engineer is enabled.
+  gate("pit-engineer.welcome", true);
+  gate("pit-engineer.pit-approach", settings.pitApproachEnabled);
+  gate("pit-engineer.service-reminder", settings.pitServiceReminderEnabled);
+  gate("pit-engineer.pit-exit", settings.pitExitEnabled);
+  gate("pit-engineer.stall-departure", settings.pitDepartureEnabled);
+  gate("pit-engineer.incident-alerts", settings.incidentAlert);
+  gate("pit-engineer.overtake", settings.overtakeAndTipsEnabled);
+  gate("pit-engineer.racing-tips", settings.overtakeAndTipsEnabled);
+
+  for (const id of FLAG_SCENARIO_IDS) gate(id, settings.flagAlertsEnabled);
+
+  for (const id of FUEL_SCENARIO_IDS) gate(id, settings.fuelWarningsEnabled);
+
+  for (const id of TOGGLE_SCENARIO_IDS) gate(id, settings.toggleAudioEnabled);
+
+  for (const id of PIT_LIMITER_SCENARIO_IDS) gate(id, settings.pitLimiterWarning);
+
+  setSpotterEnabled(master && settings.spotterEnabled);
 }
 
 /**
- * Starts a self-scheduling spotter tick loop for the given visual state.
- * The interval is looked up from SPOTTER_TICK_INTERVALS. No-op for "clear".
- * Always stops any existing loop before starting.
+ * @internal Exported for testing.
+ *
+ * Apply the volume sliders to the audio busses. The engineer slider drives
+ * the Voice + Background bus pair; the spotter slider drives the Alerts
+ * bus. Per-channel attenuation (Ambient 0.8×, SFX 0.7×) is applied inside
+ * audio-service's bus mix ratios.
  */
-function startSpotterTickLoop(state: SpotterVisualState): void {
-  stopSpotterTickLoop();
+export function applyVolumes(settings: PitEngineerSettings): void {
+  const engineerVol = settings.volume / 100;
+  const spotterVol = settings.spotterVolume / 100;
+  const audio = getAudio();
 
-  if (state === "clear") return;
-
-  const audioFile = SPOTTER_AUDIO[state];
-
-  if (!audioFile) return;
-
-  const interval = SPOTTER_TICK_INTERVALS[state];
-
-  const fire = (): void => {
-    getAudio().playOnChannel(AudioChannel.Spotter, getAudioPath(audioFile));
-    globalSpotterTickTimer = setTimeout(fire, interval);
-  };
-
-  fire();
+  audio.setBusVolume(AudioBus.Voice, engineerVol);
+  audio.setBusVolume(AudioBus.Background, engineerVol);
+  audio.setBusVolume(AudioBus.Alerts, spotterVol);
 }
 
-// ─── Icon Generation ───────────────────────────────────────────────────────────
+// ─── Icon generation ──────────────────────────────────────────────────────────
 
 /** Artwork bounds of the mechanic SVG (source viewBox 0 0 71.457 71.457). */
 const MECHANIC_BOUNDS = { x: 0, y: 0, width: 71.457, height: 71.457 };
 
-/**
- * Returns the raw mechanic path SVG content (unscaled, in source coordinate space).
- */
+/** Raw mechanic path SVG (unscaled, in source coordinate space). */
 function mechanicPathContent(graphicColor: string): string {
   return `<path fill="${graphicColor}" d="M19.538,23.485c0.02-0.685,0.082-2.768,1.558-3.325c1.46-0.551,2.964,0.948,3.251,1.254c0.377,0.403,0.356,1.036-0.047,1.414c-0.404,0.375-1.036,0.356-1.414-0.047c-0.347-0.367-0.897-0.734-1.106-0.741c0.014,0.028-0.208,0.349-0.243,1.504c-0.11,3.731,2.743,4.773,2.864,4.815c0.31,0.108,0.553,0.364,0.641,0.68l0.046,0.168c0.017,0.06,0.027,0.121,0.033,0.183c0.825,9.836,8.605,13.019,12.244,13.019s11.419-3.182,12.244-13.019c0.005-0.061,0.016-0.121,0.032-0.18l0.046-0.168c0.088-0.322,0.332-0.58,0.649-0.685c0.114-0.04,2.967-1.082,2.857-4.813c-0.038-1.272-0.303-1.533-0.306-1.536c-0.124,0.023-0.689,0.399-1.044,0.774c-0.379,0.4-1.011,0.419-1.413,0.042c-0.401-0.378-0.423-1.008-0.046-1.411c0.287-0.306,1.79-1.805,3.251-1.254c1.476,0.558,1.538,2.641,1.558,3.325c0.109,3.698-2.075,5.741-3.632,6.521c-1.051,9.93-8.88,14.403-14.195,14.403S24.221,39.936,23.17,30.005C21.613,29.226,19.429,27.184,19.538,23.485z M22.099,16.792C22.099,3.017,33.101,0,37.34,0c4.253,0,15.291,3.017,15.291,16.792c0,0.438-0.286,0.826-0.705,0.956l-1.558,0.481l-1.389,1.538c-0.19,0.211-0.46,0.33-0.742,0.33c-0.032,0-0.063-0.001-0.095-0.004c-0.309-0.03-0.585-0.2-0.75-0.461c-0.061-0.087-2.069-2.829-10.027-2.835c-8.044,0.006-10.008,2.809-10.027,2.837c-0.171,0.256-0.458,0.429-0.765,0.452c-0.306,0.028-0.614-0.088-0.821-0.317l-1.389-1.538l-1.558-0.481C22.384,17.619,22.099,17.231,22.099,16.792z M24.111,16.059l1.104,0.341c0.172,0.053,0.326,0.152,0.447,0.285l0.845,0.936c1.322-1.13,4.38-2.819,10.858-2.824c6.478,0.004,9.537,1.694,10.859,2.824l0.844-0.935c0.121-0.134,0.275-0.232,0.447-0.286l1.104-0.341C50.18,2.388,37.471,2,37.34,2C37.21,2,24.548,2.388,24.111,16.059z M26.405,13.627c-0.187-0.52,0.083-1.093,0.602-1.28c1.413-0.509,2.86-0.886,4.321-1.179c-0.227-0.8-0.455-1.6-0.665-2.403c-0.068-0.258-0.029-0.533,0.107-0.762c0.136-0.23,0.358-0.396,0.617-0.46c3.966-0.995,7.988-0.995,11.954,0c0.259,0.065,0.481,0.23,0.617,0.46c0.136,0.229,0.175,0.504,0.107,0.762c-0.21,0.802-0.438,1.602-0.665,2.403c1.461,0.293,2.908,0.67,4.321,1.179c0.52,0.187,0.789,0.76,0.602,1.28c-0.147,0.408-0.531,0.661-0.941,0.662c-0.112,0-0.227-0.02-0.339-0.06c-6.242-2.248-13.117-2.248-19.359,0C27.165,14.415,26.593,14.146,26.405,13.627z M33.31,10.841c2.692-0.359,5.417-0.359,8.109,0c0.151-0.528,0.303-1.055,0.446-1.584c-2.992-0.613-6.011-0.613-9.002,0C33.007,9.786,33.159,10.313,33.31,10.841z M70.32,32.224v5.108c0,0.536-0.286,1.031-0.75,1.299l-3.674,2.121v12.558c0,0.028-0.007,0.053-0.008,0.08c1.211,0.175,2.134,0.577,2.783,1.228c1.194,1.201,1.185,2.886,1.177,4.373l-0.001,6.939c0,3.005-2.445,5.45-5.45,5.45c-3.005,0-5.45-2.445-5.45-5.45l-0.001-6.939c-0.008-1.487-0.017-3.172,1.177-4.373c0.648-0.652,1.572-1.053,2.783-1.228c-0.001-0.027-0.008-0.053-0.008-0.08v-1.539c-1.027-3.481-3.123-6.704-5.941-9.243l-2.758,7.851v21.078H37.365H20.534V50.379l-2.859-8.137c-3.937,3.24-6.539,7.58-7.099,12.155c0.093,0.076,0.205,0.137,0.289,0.221c1.194,1.201,1.185,2.886,1.177,4.373l-0.001,6.94c0,3.005-2.445,5.45-5.45,5.45c-3.005,0-5.45-2.445-5.45-5.45l-0.001-6.939c-0.008-1.487-0.017-3.172,1.177-4.373c0.462-0.465,1.066-0.8,1.81-1.021v-5.294c0-0.552,0.448-1,1-1H5.84v-9.639c0-0.414,0.336-0.75,0.75-0.75s0.75,0.336,0.75,0.75v9.639h0.714c0.552,0,1,0.448,1,1v3.43c1.168-4.387,3.992-8.435,7.921-11.485l-0.296-0.842c-0.183-0.521,0.091-1.092,0.612-1.275c0.522-0.184,1.092,0.091,1.275,0.612l0.101,0.289c1.356-0.885,2.817-1.659,4.369-2.296c0.255-0.105,0.543-0.1,0.794,0.015c0.251,0.114,0.444,0.328,0.533,0.589c1.758,5.181,6.816,8.529,12.886,8.529c6.071,0,11.129-3.348,12.887-8.529c0.088-0.261,0.281-0.475,0.533-0.589c0.251-0.115,0.539-0.12,0.794-0.015c1.612,0.662,3.126,1.51,4.531,2.494l0.171-0.486c0.183-0.521,0.753-0.795,1.275-0.612c0.521,0.183,0.795,0.754,0.612,1.275l-0.385,1.096c2.118,1.782,3.894,3.914,5.229,6.253v-6.004l-3.674-2.121c-0.464-0.268-0.75-0.763-0.75-1.299v-5.108c0-0.829,0.671-1.5,1.5-1.5s1.5,0.671,1.5,1.5v4.242l2.924,1.688l2.924-1.688v-4.242c0-0.829,0.671-1.5,1.5-1.5S70.32,31.395,70.32,32.224z M6.126,52.618h0.928v-3.314H6.126V52.618z M9.735,67.334H7.698c-0.552,0-1-0.448-1-1s0.448-1,1-1h2.341l0-1.688H7.698c-0.552,0-1-0.448-1-1s0.448-1,1-1h2.342l0-1.822H7.698c-0.552,0-1-0.448-1-1s0.448-1,1-1h2.325c-0.041-0.741-0.171-1.387-0.577-1.795c-0.491-0.494-1.452-0.745-2.856-0.745s-2.365,0.25-2.856,0.745c-0.608,0.611-0.602,1.748-0.595,2.952l0.001,6.95c0,1.902,1.548,3.45,3.45,3.45C7.992,69.381,9.196,68.538,9.735,67.334z M23.625,52.599c0-0.352-0.286-0.638-0.638-0.638c-0.352,0-0.638,0.286-0.638,0.638c0,0.352,0.286,0.638,0.638,0.638C23.339,53.237,23.625,52.951,23.625,52.599z M46.393,62.333c0-0.552-0.448-1-1-1H29.337c-0.552,0-1,0.448-1,1s0.448,1,1,1h16.056C45.945,63.333,46.393,62.885,46.393,62.333z M37.365,53.237c0.352,0,0.638-0.286,0.638-0.638c0-0.352-0.286-0.638-0.638-0.638c-0.352,0-0.638,0.286-0.638,0.638C36.727,52.951,37.013,53.237,37.365,53.237z M52.381,52.599c0-0.352-0.286-0.638-0.638-0.638c-0.352,0-0.638,0.286-0.638,0.638c0,0.352,0.286,0.638,0.638,0.638C52.095,53.237,52.381,52.951,52.381,52.599z M55.304,41.191c-1.139-0.841-2.363-1.584-3.664-2.193c-2.32,5.424-7.85,8.871-14.392,8.871c-6.542,0-12.073-3.448-14.393-8.874c-1.242,0.571-2.412,1.241-3.505,1.986l3.223,9.175h14.79h14.79L55.304,41.191z M67.252,56.029c-0.491-0.494-1.453-0.745-2.856-0.745c-1.404,0-2.365,0.25-2.856,0.745c-0.406,0.409-0.536,1.054-0.577,1.795h2.325c0.552,0,1,0.448,1,1s-0.448,1-1,1h-2.343l0,1.822h2.343c0.552,0,1,0.448,1,1s-0.448,1-1,1h-2.342l0,1.688h2.342c0.552,0,1,0.448,1,1s-0.448,1-1,1H61.25c0.539,1.204,1.743,2.047,3.145,2.047c1.902,0,3.45-1.548,3.45-3.45l0.001-6.95C67.853,57.777,67.86,56.641,67.252,56.029z M37.979,24.528v4.953h-2.228c-0.552,0-1,0.448-1,1s0.448,1,1,1h3.228c0.552,0,1-0.448,1-1v-5.953c0-0.552-0.448-1-1-1S37.979,23.976,37.979,24.528z"/>`;
 }
 
 /**
- * @internal Exported for testing
+ * @internal Exported for testing.
  *
  * Generates a complete SVG data URI for the pit engineer icon.
  */
@@ -262,8 +179,6 @@ export function generatePitEngineerSvg(
   >;
 
   const graphicColor = colors.graphic1Color ?? WHITE;
-
-  // Resolve graphic scale from PI overrides → global defaults → 100%
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
   const title = resolveTitleSettings(
     pitEngineerTemplate,
@@ -272,7 +187,7 @@ export function generatePitEngineerSvg(
     "PIT\nENGINEER",
   );
 
-  // Status bar occupies y=100..144, so constrain graphic area to the upper region
+  // Status bar occupies y=100..144, so constrain graphic area to the upper region.
   const STATUS_BAR_TOP = 100;
   const PADDING = 8;
   const fullGraphicArea = computeGraphicArea(title);
@@ -281,13 +196,11 @@ export function generatePitEngineerSvg(
     height: Math.min(fullGraphicArea.height, STATUS_BAR_TOP - PADDING - fullGraphicArea.y),
   };
 
-  // Apply graphic transform with user scale
   const rawPath = mechanicPathContent(graphicColor);
   const scaledGraphic = title.showGraphics
     ? applyGraphicTransform(rawPath, MECHANIC_BOUNDS, graphicArea, graphic.scale)
     : "";
 
-  // Generate title text
   const titleText = title.showTitle
     ? generateTitleText({
         text: title.titleText ?? "PIT\nENGINEER",
@@ -310,6 +223,11 @@ export function generatePitEngineerSvg(
   );
   const borderSvg = generateBorderParts(border);
 
+  // spotterState is accepted for API compatibility with the regenerate callback
+  // and future visual overlays; the current template renders identically
+  // regardless of proximity state (spotter is audio-only).
+  void spotterState;
+
   const svg = renderIconTemplate(pitEngineerTemplate, {
     iconContent,
     borderDefs: borderSvg.defs,
@@ -320,201 +238,26 @@ export function generatePitEngineerSvg(
   return svgToDataUri(svg);
 }
 
-/**
- * Resolves the absolute path to an audio file in the plugin's assets directory.
- */
-function getAudioPath(filename: string): string {
-  return path.join(process.cwd(), "assets", "audio", filename);
-}
-
-// ─── Global Pit Engineer State ────────────────────────────────────────────────
-//
-// The pit engineer runs globally — toggling ON keeps the telemetry subscription
-// and audio playback alive even when the user navigates to a different page.
-// Action instances only manage their icon display.
-//
-// MULTI-INSTANCE NOTE: When multiple Pit Engineer buttons exist on different
-// pages, the last instance to appear or receive a settings update wins — its
-// settings become the active `globalSettings`. This is intentional: all
-// instances share the same global state and the user is expected to configure
-// them identically. If instances have different feature toggles, the behavior
-// depends on which was last seen by the runtime.
-
-/** Global enabled flag — shared across all action instances. */
-let globalEnabled = true;
-
-/** Current global settings (merged from last-seen action instance). */
-let globalSettings: PitEngineerSettings | null = null;
-
-// ─── Spotter sub-feature state ───────────────────────────────────────────────
-
-/** Current spotter visual state (for icon rendering on reappear). */
-let globalSpotterState: SpotterVisualState = "clear";
-
-/** Self-scheduling timer that drives the proximity-modulated spotter tick loop. */
-let globalSpotterTickTimer: ReturnType<typeof setTimeout> | null = null;
-
-/**
- * Tick intervals per spotter state. Single-car states tick at 250 ms (same as
- * the legacy 4 Hz replay). Two-cars-same-side is faster (180 ms) because being
- * sandwiched on one side is more dangerous. Cars-both-sides is slower than
- * two-same-side (230 ms) — you're locked between cars, holding a straight line.
- */
-const SPOTTER_TICK_INTERVALS: Readonly<Record<Exclude<SpotterVisualState, "clear">, number>> = {
-  left: 250,
-  right: 250,
-  "two-left": 180,
-  "two-right": 180,
-  both: 230,
-};
-
-/**
- * @internal Exported for testing
- *
- * Pit service toggle audio file mapping.
- */
-export const PIT_SERVICE_TOGGLE_AUDIO: Record<string, { on: string; off: string }> = {
-  fuel: { on: "pit-engineer/toggle/IRD-toggle-fuel-on.mp3", off: "pit-engineer/toggle/IRD-toggle-fuel-off.mp3" },
-  windshield: {
-    on: "pit-engineer/toggle/IRD-toggle-windshield-on.mp3",
-    off: "pit-engineer/toggle/IRD-toggle-windshield-off.mp3",
-  },
-  fastRepair: {
-    on: "pit-engineer/toggle/IRD-toggle-fast-repair-on.mp3",
-    off: "pit-engineer/toggle/IRD-toggle-fast-repair-off.mp3",
-  },
-};
-
-/**
- * @internal Exported for testing
- *
- * Tire toggle audio file mapping — pattern-aware.
- */
-export const TIRE_TOGGLE_AUDIO: Record<string, { on: string; off: string }> = {
-  all: {
-    on: "pit-engineer/toggle/IRD-toggle-tires-all-on.mp3",
-    off: "pit-engineer/toggle/IRD-toggle-tires-all-off.mp3",
-  },
-  front: {
-    on: "pit-engineer/toggle/IRD-toggle-tires-front-on.mp3",
-    off: "pit-engineer/toggle/IRD-toggle-tires-front-off.mp3",
-  },
-  rear: {
-    on: "pit-engineer/toggle/IRD-toggle-tires-rear-on.mp3",
-    off: "pit-engineer/toggle/IRD-toggle-tires-rear-off.mp3",
-  },
-  left: {
-    on: "pit-engineer/toggle/IRD-toggle-tires-left-on.mp3",
-    off: "pit-engineer/toggle/IRD-toggle-tires-left-off.mp3",
-  },
-  right: {
-    on: "pit-engineer/toggle/IRD-toggle-tires-right-on.mp3",
-    off: "pit-engineer/toggle/IRD-toggle-tires-right-off.mp3",
-  },
-  crossLfRr: {
-    on: "pit-engineer/toggle/IRD-toggle-tires-lf-rr-on.mp3",
-    off: "pit-engineer/toggle/IRD-toggle-tires-lf-rr-off.mp3",
-  },
-  crossRfLr: {
-    on: "pit-engineer/toggle/IRD-toggle-tires-rf-lr-on.mp3",
-    off: "pit-engineer/toggle/IRD-toggle-tires-rf-lr-off.mp3",
-  },
-  stayDry: {
-    on: "pit-engineer/toggle/IRD-toggle-compound-stay-dry.mp3",
-    off: "pit-engineer/toggle/IRD-toggle-compound-stay-dry.mp3",
-  },
-  stayWet: {
-    on: "pit-engineer/toggle/IRD-toggle-compound-stay-wet.mp3",
-    off: "pit-engineer/toggle/IRD-toggle-compound-stay-wet.mp3",
-  },
-  changeToDry: {
-    on: "pit-engineer/toggle/IRD-toggle-compound-change-dry.mp3",
-    off: "pit-engineer/toggle/IRD-toggle-compound-change-dry.mp3",
-  },
-  changeToWet: {
-    on: "pit-engineer/toggle/IRD-toggle-compound-change-wet.mp3",
-    off: "pit-engineer/toggle/IRD-toggle-compound-change-wet.mp3",
-  },
-  lf: { on: "pit-engineer/toggle/IRD-toggle-tires-lf-on.mp3", off: "pit-engineer/toggle/IRD-toggle-tires-lf-off.mp3" },
-  rf: { on: "pit-engineer/toggle/IRD-toggle-tires-rf-on.mp3", off: "pit-engineer/toggle/IRD-toggle-tires-rf-off.mp3" },
-  lr: { on: "pit-engineer/toggle/IRD-toggle-tires-lr-on.mp3", off: "pit-engineer/toggle/IRD-toggle-tires-lr-off.mp3" },
-  rr: { on: "pit-engineer/toggle/IRD-toggle-tires-rr-on.mp3", off: "pit-engineer/toggle/IRD-toggle-tires-rr-off.mp3" },
-};
-
-/**
- * @internal Exported for testing
- *
- * Short tire name clips (no "change" prefix) for 3-tire combo announcements.
- */
-export const TIRE_SHORT: Record<string, string> = {
-  lf: "pit-engineer/toggle/IRD-toggle-tires-lf-short.mp3",
-  rf: "pit-engineer/toggle/IRD-toggle-tires-rf-short.mp3",
-  lr: "pit-engineer/toggle/IRD-toggle-tires-lr-short.mp3",
-  rr: "pit-engineer/toggle/IRD-toggle-tires-rr-short.mp3",
-};
-
-/**
- * @internal Exported for testing
- *
- * Car control toggle audio file mapping.
- */
-export const CAR_CONTROL_TOGGLE_AUDIO: Record<string, { on: string; off: string }> = {
-  pushToPass: { on: "pit-engineer/toggle/IRD-toggle-p2p-on.mp3", off: "pit-engineer/toggle/IRD-toggle-p2p-off.mp3" },
-  drs: { on: "pit-engineer/toggle/IRD-toggle-drs-on.mp3", off: "pit-engineer/toggle/IRD-toggle-drs-off.mp3" },
-};
-
-// NOTE: the old `resolvePitServiceToggleAudio` and `resolveCarControlToggleAudio`
-// helpers were removed in Stage 4b when pit-engineer migrated to sim-events.
-// The translator now emits a single-service / single-toggle event per change,
-// so the resolvers (which diffed bitfields) no longer have the inputs they
-// relied on. Tire pattern announcements (front/rear/all/3-tire/compound) are
-// a behavior regression until the translator grows richer tire events — see
-// TODO(4c) at the incident pool comment for the full follow-up list.
-
-/**
- * Resets all audio state — cancels any in-flight voice sequence, stops every
- * channel, and stops the spotter tick loop. Called when the engineer is
- * toggled off.
- */
-function resetAllAudioState(): void {
-  stopSpotterTickLoop();
-  getAudio().cancelVoiceSequence();
-  getAudio().stopChannel(AudioChannel.SFX);
-  getAudio().stopChannel(AudioChannel.Voice);
-  getAudio().stopChannel(AudioChannel.Ambient);
-  getAudio().stopChannel(AudioChannel.Spotter);
-}
-
 // ─── Action ────────────────────────────────────────────────────────────────────
 
 export class PitEngineer extends ConnectionStateAwareAction<PitEngineerSettings> {
-  /** Per-context settings cache (for visible instances only). Named settingsCache to avoid shadowing BaseAction.contexts. */
+  /** Per-context settings cache for visible instances. */
   private readonly settingsCache = new Map<string, PitEngineerSettings>();
-
-  /** Per-context last rendered state key for icon dedup. */
-  private readonly lastStateKey = new Map<string, string>();
 
   /** Set of currently visible context IDs. */
   private readonly visibleContexts = new Set<string>();
 
-  /** Last engineer test volume timestamp to avoid replaying on every settings update. */
+  /** Per-context unsubscribe callbacks for spotter + global-settings listeners. */
+  private readonly listenerUnsubs = new Map<string, Array<() => void>>();
+
+  /** Last-seen settings, used by the driver-name resolver injected into scenarios. */
+  private latestSettings: PitEngineerSettings | null = null;
+
+  /** Last engineer test-volume timestamp — prevents replay on unrelated settings updates. */
   private lastTestTimestamp = 0;
 
-  /** Last spotter test volume timestamp. */
+  /** Last spotter test-volume timestamp. */
   private lastSpotterTestTimestamp = 0;
-
-  /** Cycles through spotter test files: left → right → both. */
-  private spotterTestIndex = 0;
-
-  /** Active event-bus unsubscribe callbacks while the engineer is enabled. */
-  private eventSubscriptions: Array<() => void> = [];
-
-  /** Spotter test file rotation order. */
-  private static readonly SPOTTER_TEST_FILES = [
-    "pit-engineer/spotter/IRD-spotter-left.mp3",
-    "pit-engineer/spotter/IRD-spotter-right.mp3",
-    "pit-engineer/spotter/IRD-spotter-both.mp3",
-  ];
 
   override async onWillAppear(ev: IDeckWillAppearEvent<PitEngineerSettings>): Promise<void> {
     await super.onWillAppear(ev);
@@ -525,39 +268,45 @@ export class PitEngineer extends ConnectionStateAwareAction<PitEngineerSettings>
 
     this.settingsCache.set(contextId, settings);
     this.visibleContexts.add(contextId);
-    globalSettings = settings;
+    this.latestSettings = settings;
 
-    // Seed test timestamps so the first onDidReceiveSettings doesn't
-    // falsely trigger playback for both test buttons
+    // Seed test-button timestamps so the first onDidReceiveSettings doesn't
+    // replay previous plays when the PI rehydrates the hidden textfields.
     this.lastTestTimestamp = (raw._testVolume as number) ?? 0;
     this.lastSpotterTestTimestamp = (raw._testSpotterVolume as number) ?? 0;
 
-    // Show current global state
-    await this.setKeyImage(ev, generatePitEngineerSvg(settings, globalSpotterState, globalEnabled));
+    setDriverNameResolver(() => driverNamePath(this.latestSettings?.driverName));
 
-    // Ensure event-bus subscriptions are active if the engineer is enabled.
-    if (globalEnabled && this.eventSubscriptions.length === 0) {
-      this.startEventSubscriptions();
-    }
+    this.listenerUnsubs.set(contextId, [
+      subscribeSpotterVisualState(() => {
+        void this.rerender(contextId);
+      }),
+      onGlobalSettingsChange(() => {
+        void this.rerender(contextId);
+      }),
+    ]);
 
-    this.applyScenarioGates(settings);
+    applyVolumes(settings);
+    syncScenarioState(settings, isEngineerEnabled());
 
-    // Provide regeneration callback for icon refresh (global color changes, etc.)
+    await this.setKeyImage(ev, generatePitEngineerSvg(settings, getSpotterVisualState(), isEngineerEnabled()));
+
     this.setRegenerateCallback(contextId, () => {
       const s = this.settingsCache.get(contextId);
 
       if (!s) return "";
 
-      return generatePitEngineerSvg(s, globalSpotterState, globalEnabled);
+      return generatePitEngineerSvg(s, getSpotterVisualState(), isEngineerEnabled());
     });
   }
 
   override async onWillDisappear(ev: IDeckWillDisappearEvent<PitEngineerSettings>): Promise<void> {
     const contextId = ev.action.id;
 
-    // Only clean up icon-related state — do NOT stop audio or unsubscribe
+    for (const unsub of this.listenerUnsubs.get(contextId) ?? []) unsub();
+
+    this.listenerUnsubs.delete(contextId);
     this.settingsCache.delete(contextId);
-    this.lastStateKey.delete(contextId);
     this.visibleContexts.delete(contextId);
 
     await super.onWillDisappear(ev);
@@ -569,16 +318,13 @@ export class PitEngineer extends ConnectionStateAwareAction<PitEngineerSettings>
     const raw = ev.payload.settings as Record<string, unknown>;
     const settings = Settings.parse(raw);
     const contextId = ev.action.id;
+
     this.settingsCache.set(contextId, settings);
-    globalSettings = settings;
+    this.latestSettings = settings;
 
-    // Apply channel volumes whenever settings change
-    applyChannelVolumes();
+    applyVolumes(settings);
+    syncScenarioState(settings, isEngineerEnabled());
 
-    // Sync PI toggles to the scenario engine's setEnabled.
-    this.applyScenarioGates(settings);
-
-    // Handle engineer test volume button from PI
     const testTimestamp = raw._testVolume as number | undefined;
 
     if (testTimestamp && testTimestamp !== this.lastTestTimestamp) {
@@ -588,196 +334,47 @@ export class PitEngineer extends ConnectionStateAwareAction<PitEngineerSettings>
 
     this.lastTestTimestamp = testTimestamp ?? 0;
 
-    // Handle spotter test volume button from PI — plays all 3: left → right → both
     const spotterTestTimestamp = raw._testSpotterVolume as number | undefined;
 
     if (spotterTestTimestamp && spotterTestTimestamp !== this.lastSpotterTestTimestamp) {
       this.logger.info("Playing spotter test: left → right → both");
-      applyChannelVolumes();
-      let idx = 0;
-      const playNext = (): void => {
-        if (idx >= PitEngineer.SPOTTER_TEST_FILES.length) return;
-
-        const file = PitEngineer.SPOTTER_TEST_FILES[idx];
-        idx++;
-        getAudio().onChannelComplete(AudioChannel.Spotter, () => {
-          setTimeout(() => playNext(), 250);
-        });
-        getAudio().playOnChannel(AudioChannel.Spotter, getAudioPath(file));
-      };
-      playNext();
+      playSpotterTest();
     }
 
     this.lastSpotterTestTimestamp = spotterTestTimestamp ?? 0;
 
-    // Force re-render
-    this.lastStateKey.delete(contextId);
-    await this.setKeyImage(ev, generatePitEngineerSvg(settings, globalSpotterState, globalEnabled));
-
-    // Update regenerate callback with fresh settings
-    this.setRegenerateCallback(contextId, () => {
-      const s = this.settingsCache.get(contextId);
-
-      if (!s) return "";
-
-      return generatePitEngineerSvg(s, globalSpotterState, globalEnabled);
-    });
+    await this.setKeyImage(ev, generatePitEngineerSvg(settings, getSpotterVisualState(), isEngineerEnabled()));
   }
 
   override async onKeyDown(ev: IDeckKeyDownEvent<PitEngineerSettings>): Promise<void> {
-    globalEnabled = !globalEnabled;
-    this.logger.info(`Pit Engineer ${globalEnabled ? "enabled" : "disabled"}`);
+    const nextMaster = !isEngineerEnabled();
+    const settings = Settings.parse(ev.payload.settings);
 
-    if (globalEnabled) {
-      const settings = Settings.parse(ev.payload.settings);
-      globalSettings = settings;
-      this.startEventSubscriptions();
-      this.applyScenarioGates(settings);
-    } else {
-      this.stopEventSubscriptions();
-      resetAllAudioState();
-      this.disableAllScenarios();
-    }
+    this.logger.info(`Pit Engineer ${nextMaster ? "enabled" : "disabled"}`);
 
-    // Update icon on all visible instances
-    this.updateAllVisibleIcons();
-  }
+    // Gate scenarios synchronously with the new master value. The global
+    // settings round-trip is async; relying on it would let audio play in
+    // the stale-master window between the button press and the adapter echo.
+    syncScenarioState(settings, nextMaster);
+    updateGlobalSettings({ pitEngineerEnabled: nextMaster });
 
-  /**
-   * Sync PI toggles to the scenario engine. Each mapping translates a PI
-   * setting to a scenario id; gates that are off also disable the scenario
-   * here so in-flight fires are cancelled.
-   */
-  private applyScenarioGates(settings: PitEngineerSettings): void {
-    const engine = getScenarioEngine();
-
-    // When the engineer is globally off, force every scenario off and exit —
-    // otherwise a later settings sync or page appearance could silently
-    // resume audio while the action is still in the OFF state.
-    if (!globalEnabled) {
-      this.disableAllScenarios();
-
-      return;
-    }
-
-    // Welcome has no PI toggle; keep it always on while the engineer is
-    // enabled. (disableAllScenarios() turns it off on toggle-off, so we have
-    // to explicitly restore it here on toggle-on.)
-    engine.setEnabled("pit-engineer.welcome", true);
-
-    engine.setEnabled("pit-engineer.pit-approach", settings.pitApproachEnabled);
-    engine.setEnabled("pit-engineer.service-reminder", settings.pitServiceReminderEnabled);
-    engine.setEnabled("pit-engineer.pit-exit", settings.pitExitEnabled);
-    engine.setEnabled("pit-engineer.stall-departure", settings.pitDepartureEnabled);
-    engine.setEnabled("pit-engineer.incident-alerts", settings.incidentAlert);
-    engine.setEnabled("pit-engineer.overtake", settings.overtakeAndTipsEnabled);
-
-    for (const id of FLAG_SCENARIO_IDS) engine.setEnabled(id, settings.flagAlertsEnabled);
-
-    for (const id of FUEL_SCENARIO_IDS) engine.setEnabled(id, settings.fuelWarningsEnabled);
-
-    for (const id of TOGGLE_SCENARIO_IDS) engine.setEnabled(id, settings.toggleAudioEnabled);
-
-    for (const id of PIT_LIMITER_SCENARIO_IDS) engine.setEnabled(id, settings.pitLimiterWarning);
-
-    // Tips share the overtakeAndTipsEnabled gate with the overtake scenario.
-    engine.setEnabled("pit-engineer.racing-tips", settings.overtakeAndTipsEnabled);
-  }
-
-  /** Disable every pit-engineer scenario — called when the engineer is toggled off. */
-  private disableAllScenarios(): void {
-    const engine = getScenarioEngine();
-
-    for (const id of [
-      "pit-engineer.welcome",
-      "pit-engineer.pit-approach",
-      "pit-engineer.service-reminder",
-      "pit-engineer.pit-exit",
-      "pit-engineer.stall-departure",
-      "pit-engineer.incident-alerts",
-      "pit-engineer.overtake",
-      "pit-engineer.racing-tips",
-      ...FLAG_SCENARIO_IDS,
-      ...FUEL_SCENARIO_IDS,
-      ...TOGGLE_SCENARIO_IDS,
-      ...PIT_LIMITER_SCENARIO_IDS,
-    ]) {
-      engine.setEnabled(id, false);
-    }
-  }
-
-  // ─── Event-bus subscription plumbing ─────────────────────────────────────
-
-  private startEventSubscriptions(): void {
-    if (this.eventSubscriptions.length > 0) return;
-
-    const bus = getEventBus();
-
-    this.eventSubscriptions.push(bus.subscribe("spotter.changed", (ev) => this.onSpotterChanged(ev)));
-
-    this.logger.debug(`Pit Engineer subscribed to ${this.eventSubscriptions.length} events`);
-  }
-
-  private stopEventSubscriptions(): void {
-    for (const off of this.eventSubscriptions) off();
-
-    this.eventSubscriptions = [];
-  }
-
-  // ─── Event handlers ──────────────────────────────────────────────────────
-
-  private onSpotterChanged(ev: SimEventOf<"spotter.changed">): void {
-    if (!globalEnabled || !globalSettings?.spotterEnabled) return;
-
-    if (getSessionType() === "Lone Qualify") return;
-
-    const telemetry = getLatestTelemetry();
-
-    if (telemetry?.OnPitRoad === true) {
-      // Suppress spotter in pit lane.
-      if (globalSpotterState !== "clear") {
-        stopSpotterTickLoop();
-        getAudio().stopChannel(AudioChannel.Spotter);
-        globalSpotterState = "clear";
-        this.updateAllVisibleIcons();
-      }
-
-      return;
-    }
-
-    const state = ev.data.to as SpotterVisualState;
-
-    if (state === globalSpotterState) return;
-
-    this.logger.debug(`Spotter state: ${globalSpotterState} → ${state}`);
-
-    if (state === "clear") {
-      stopSpotterTickLoop();
-      getAudio().stopChannel(AudioChannel.Spotter);
-    } else {
-      applyChannelVolumes();
-      startSpotterTickLoop(state);
-    }
-
-    globalSpotterState = state;
-    this.updateAllVisibleIcons();
-  }
-
-  // ─── Icon Updates ─────────────────────────────────────────────────────────
-
-  private updateAllVisibleIcons(): void {
     for (const contextId of this.visibleContexts) {
-      const settings = this.settingsCache.get(contextId);
+      const s = this.settingsCache.get(contextId);
 
-      if (!settings) continue;
+      if (!s) continue;
 
-      const stateKey = `${globalEnabled}|${globalSpotterState}|${JSON.stringify(settings.colorOverrides)}|${JSON.stringify(settings.borderOverrides)}|${JSON.stringify(settings.titleOverrides)}|${JSON.stringify(settings.graphicOverrides)}`;
-
-      if (this.lastStateKey.get(contextId) === stateKey) continue;
-
-      this.lastStateKey.set(contextId, stateKey);
-      const svg = generatePitEngineerSvg(settings, globalSpotterState, globalEnabled);
-      void this.updateKeyImage(contextId, svg);
+      await this.updateKeyImage(contextId, generatePitEngineerSvg(s, getSpotterVisualState(), nextMaster));
     }
+  }
+
+  private async rerender(contextId: string): Promise<void> {
+    const settings = this.settingsCache.get(contextId);
+
+    if (!settings) return;
+
+    await this.updateKeyImage(
+      contextId,
+      generatePitEngineerSvg(settings, getSpotterVisualState(), isEngineerEnabled()),
+    );
   }
 }

--- a/packages/iracing-actions/src/actions/pit-engineer/pit-engineer.ts
+++ b/packages/iracing-actions/src/actions/pit-engineer/pit-engineer.ts
@@ -76,9 +76,16 @@ type PitEngineerSettings = z.infer<typeof Settings>;
  * @internal Exported for testing.
  *
  * Returns the audio-assets path for the chosen driver name, or null if none.
+ * The slug regex rejects anything outside lowercase alphanumerics / hyphens /
+ * underscores — defense in depth against path-traversal if a user edits
+ * persisted settings by hand (the PI dropdown only ever emits valid slugs).
  */
+const DRIVER_NAME_SLUG = /^[a-z0-9_-]+$/;
+
 export function driverNamePath(name: string | undefined): string | null {
   if (!name || name === "none") return null;
+
+  if (!DRIVER_NAME_SLUG.test(name)) return null;
 
   return `pit-engineer/names/IRD-name-${name}.mp3`;
 }

--- a/packages/iracing-plugin-mirabox/src/plugin.ts
+++ b/packages/iracing-plugin-mirabox/src/plugin.ts
@@ -138,8 +138,10 @@ initializeKeyboard(
 // Base path lets scenarios emit manifest-relative clip paths (e.g.
 // "sfx/IRD-tick-open.mp3") that audio-service prepends with the plugin's
 // assets/audio directory before passing them to the native engine.
+// Resolved from __binDir (→ <sdPlugin>/bin/) so lookup is stable
+// regardless of the launching process's cwd.
 const audioNative = new AudioNative();
-initializeAudio(adapter.createLogger("Audio"), audioNative, join(process.cwd(), "assets", "audio"));
+initializeAudio(adapter.createLogger("Audio"), audioNative, join(__binDir, "..", "assets", "audio"));
 getAudio().init();
 
 // Initialize the scenario engine AFTER audio (so it can drive playback) but

--- a/packages/iracing-plugin-mirabox/src/plugin.ts
+++ b/packages/iracing-plugin-mirabox/src/plugin.ts
@@ -134,9 +134,12 @@ initializeKeyboard(
   (scanCodes) => native.sendScanKeyUp(scanCodes),
 );
 
-// Initialize audio engine for pit engineer voice playback
+// Initialize audio engine for pit engineer voice playback.
+// Base path lets scenarios emit manifest-relative clip paths (e.g.
+// "sfx/IRD-tick-open.mp3") that audio-service prepends with the plugin's
+// assets/audio directory before passing them to the native engine.
 const audioNative = new AudioNative();
-initializeAudio(adapter.createLogger("Audio"), audioNative);
+initializeAudio(adapter.createLogger("Audio"), audioNative, join(process.cwd(), "assets", "audio"));
 getAudio().init();
 
 // Initialize the scenario engine AFTER audio (so it can drive playback) but

--- a/packages/iracing-plugin-mirabox/src/plugin.ts
+++ b/packages/iracing-plugin-mirabox/src/plugin.ts
@@ -143,7 +143,7 @@ getAudio().init();
 // BEFORE actions register (so actions see a ready engine when they wire PI
 // toggles and Test buttons to setEnabled / fire).
 initializeAudioScenarios(eventBus, getAudio(), audioAssetsManifest, adapter.createLogger("AudioScenarios"));
-registerPitEngineer();
+registerPitEngineer(eventBus);
 
 // Publish audio device list and apply saved device selection
 let audioDeviceInitialized = false;

--- a/packages/iracing-plugin-stream-deck/src/plugin.ts
+++ b/packages/iracing-plugin-stream-deck/src/plugin.ts
@@ -139,7 +139,7 @@ getAudio().init();
 // BEFORE actions register (so actions see a ready engine when they wire PI
 // toggles and Test buttons to setEnabled / fire).
 initializeAudioScenarios(eventBus, getAudio(), audioAssetsManifest, adapter.createLogger("AudioScenarios"));
-registerPitEngineer();
+registerPitEngineer(eventBus);
 
 // Publish audio device list and apply saved device selection
 let audioDeviceInitialized = false;

--- a/packages/iracing-plugin-stream-deck/src/plugin.ts
+++ b/packages/iracing-plugin-stream-deck/src/plugin.ts
@@ -130,9 +130,12 @@ initializeKeyboard(
   (scanCodes) => native.sendScanKeyUp(scanCodes),
 );
 
-// Initialize audio engine for pit engineer voice playback
+// Initialize audio engine for pit engineer voice playback.
+// Base path lets scenarios emit manifest-relative clip paths (e.g.
+// "sfx/IRD-tick-open.mp3") that audio-service prepends with the plugin's
+// assets/audio directory before passing them to the native engine.
 const audioNative = new AudioNative();
-initializeAudio(adapter.createLogger("Audio"), audioNative);
+initializeAudio(adapter.createLogger("Audio"), audioNative, join(process.cwd(), "assets", "audio"));
 getAudio().init();
 
 // Initialize the scenario engine AFTER audio (so it can drive playback) but

--- a/packages/iracing-plugin-stream-deck/src/plugin.ts
+++ b/packages/iracing-plugin-stream-deck/src/plugin.ts
@@ -134,8 +134,10 @@ initializeKeyboard(
 // Base path lets scenarios emit manifest-relative clip paths (e.g.
 // "sfx/IRD-tick-open.mp3") that audio-service prepends with the plugin's
 // assets/audio directory before passing them to the native engine.
+// Resolved from __binDir (→ <sdPlugin>/bin/) so lookup is stable
+// regardless of the launching process's cwd.
 const audioNative = new AudioNative();
-initializeAudio(adapter.createLogger("Audio"), audioNative, join(process.cwd(), "assets", "audio"));
+initializeAudio(adapter.createLogger("Audio"), audioNative, join(__binDir, "..", "assets", "audio"));
 getAudio().init();
 
 // Initialize the scenario engine AFTER audio (so it can drive playback) but


### PR DESCRIPTION
## Related Issue

Fixes #401

## What changed?

Stage 7 (final stage) of the audio architecture refactor (design doc §12). `packages/iracing-actions/src/actions/pit-engineer/pit-engineer.ts` shrinks from 783 → 367 LOC and owns only: Stream Deck button + Property Inspector wiring + settings parsing + icon generation + scenario gating. Everything else has a home in `@iracedeck/audio-scenarios`, `@iracedeck/audio-service`, `@iracedeck/event-bus`, or `@iracedeck/sim-events-iracing`.

- Deleted all four module-level `let` globals, the spotter tick loop, every telemetry read (`getLatestTelemetry`, `getSessionType`), the event-bus subscription, the hand-rolled spotter test sequencer, and the stale tip/toggle/tire audio constant maps that were pre-Stage-5 leftovers.
- Moved the spotter tick loop into new `packages/audio-scenarios/src/catalog/pit-engineer/spotter-engine.ts`. Owns its own state, reads telemetry for pit-road suppression, plays on `AudioChannel.Spotter`, and exposes `setSpotterEnabled` / `playSpotterTest` / `subscribeSpotterVisualState`. Registered alongside `registerPitEngineer(bus)`.
- Added `pitEngineerEnabled: boolean` to `GlobalSettingsSchema` as the master on/off flag. `onKeyDown` gates scenarios synchronously with the new value (via explicit `master` parameter to `syncScenarioState`) to avoid the stale-master window during the global-settings round-trip.
- `registerPitEngineer(bus)` now takes the event bus explicitly and forwards it to `registerSpotterEngine(bus)` so the scenario engine and spotter engine share the exact same bus. Both `plugin.ts` files and the existing catalog tests updated.
- Spotter test button debounces double-presses; `registerSpotterEngine` throws loudly if re-registered with a different bus instance.
- Rewritten action + spotter-engine test suites cover the thin surface (PI toggles → setEnabled, master off disables everything, volume sliders hit the right busses, test buttons fire/play, driver-name resolver wiring, icon snapshot stability, tick intervals, pit-road / Lone Qualify suppression, enable/disable semantics).

Acceptance:

- [x] `wc -l pit-engineer.ts` → 367 (< 400)
- [x] No module-level `let` in pit-engineer.ts
- [x] No imports from `@iracedeck/iracing-sdk`, `@iracedeck/sim-events-iracing`, or `@iracedeck/event-bus`
- [x] Tests cover PI toggle → scenario setEnabled, master gate, volumes, welcome Test, spotter Test, driver name, icon
- [x] Design doc §12 Stage 7 marked complete

## How to test

1. `pnpm install && pnpm build` from `ir-401` worktree — all 16 tasks succeed.
2. `pnpm -w test` — 3139 / 3139 pass.
3. `pnpm -w lint` and `pnpm format` — clean.
4. Manual Windows smoke test (reviewer / author):
   - Build the Stream Deck plugin, restart Stream Deck, add a Pit Engineer button.
   - Press the button → status bar flips red, audio stops. Press again → green, audio resumes.
   - Join a test race: welcome plays with chosen driver name; pit approach / pit exit / stall departure / flag alerts / incidents / overtakes / racing tips / toggle confirmations / limiter warnings / fuel thresholds each gated by their PI toggle.
   - Spotter: ticks at correct cadence when cars close; suppressed in pit lane; stops on master-off.
   - PI Test buttons: welcome button plays the welcome clip; spotter Test button plays left → right → both with 250 ms gaps; second press during playback is ignored.
   - Volume sliders: engineer slider changes Voice+Background busses; spotter slider changes Alerts bus.
   - Driver-name picker changes the welcome greeting name on next firing.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox — both `plugin.ts` files updated to pass `eventBus` into `registerPitEngineer`)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spotter engine with visual-state tracking, persisted master on/off, pit-road and lone-qualify suppression, configurable enable gate, spotter test preview, adaptive live playback cadence, and master toggle that updates scenario enablement and UI status. Audio resource resolution now respects plugin asset paths and volumes are applied consistently.

* **Tests**
  * Expanded coverage for registration, tick-loop cadence, suppression rules, enable/disable gating, preview sequencing, volume application, and visual-state subscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->