### PR TITLE
chore(pit-crew): hide Race Engineer mode until voice scenarios return (#415)

### DIFF
--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -67,7 +67,7 @@ Mode counts reflect the PI Mode/Setting dropdown choices documented in each acti
 | Black Box Selector | 3 | direct (with 11 Black Box options), next, previous |
 | Look Direction | 4 | look-left, look-right, look-up, look-down (all hold pattern) |
 | Car Control | 10 | pit-speed-limiter (telemetry-aware), push-to-pass (telemetry-aware), drs (telemetry-aware), headlight-flash (hold), tear-off-visor, ignition, starter (hold), enter-exit-tow (hold, telemetry-aware, per-state auto-hold options for exit/reset/tow), escape (hardcoded ESC, auto-hold option), pause-sim |
-| Pit Crew | 3 | race-engineer (toggles the Race Engineer voice global), radar (toggles the directional proximity tick loop), radar-volume (with Direction up/down; steps global radarVolume by ±5, clamped 5–100). Race Engineer and Radar have independent globals so silencing the voice doesn't kill the ticks. |
+| Pit Crew | 2 | radar (toggles the directional proximity tick loop), radar-volume (with Direction up/down; steps global radarVolume by ±5, clamped 5–100). A Race Engineer voice mode is planned for a follow-up release and will return to the Mode dropdown alongside its voice scenarios. |
 
 ### Cockpit & Interface
 

--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -38,7 +38,7 @@ When asked about actions or controls:
 | Category | Actions | Modes | Description |
 |----------|---------|-------|-------------|
 | Display & Session | 2 | 7 | Live session data: incidents, laps, position, fuel, flags |
-| Driving Controls | 6 | 30 | AI spotter, audio, black boxes, look direction, car control, pit crew (race engineer + radar) |
+| Driving Controls | 6 | 30 | AI spotter, audio, black boxes, look direction, car control, pit crew (radar + radar-volume; Race Engineer voice mode planned) |
 | Cockpit & Interface | 5 | 33 | Wipers, force feedback, splits & reference, telemetry, UI toggles |
 | View & Camera | 5 | 87 | FOV, replay, camera controls, broadcast tools |
 | Media | 1 | 7 | Video recording, screenshots, texture management |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 **Key highlights:**
 
 - Live telemetry at 4 Hz with automatic iRacing connection/reconnection
-- **Pit Crew** action with two independent features: **Race Engineer** voice (scenarios land in follow-up releases) and **Radar** directional proximity ticks via multi-channel audio mixer (miniaudio)
+- **Pit Crew** action with **Radar** directional proximity ticks via multi-channel audio mixer (miniaudio); a voice **Race Engineer** feature is planned for a follow-up release
 - All keyboard shortcuts are user-configurable via the Property Inspector
 - SDK-first design: uses iRacing broadcast commands where possible, keyboard simulation only as fallback
 - Native C++ addon for low-latency Win32 API access (iRacing SDK, keyboard input, audio engine)

--- a/docs/plugins/core/actions/pit-crew.md
+++ b/docs/plugins/core/actions/pit-crew.md
@@ -1,6 +1,6 @@
 # Pit Crew
 
-Multi-mode action covering the iRaceDeck pit-side audio framework: Race Engineer voice scenarios and the directional Radar proximity ticks. Race Engineer and Radar have independent on/off globals so silencing one does not affect the other.
+Multi-mode action covering the iRaceDeck pit-side audio framework. The initial release exposes only the directional Radar proximity ticks. A Race Engineer voice feature is planned and will return to the Mode dropdown in a follow-up release alongside its voice scenarios.
 
 ## Properties
 
@@ -14,7 +14,6 @@ Multi-mode action covering the iRaceDeck pit-side audio framework: Race Engineer
 ## Behavior
 
 ### Button Press
-- **Race Engineer mode**: Flips the plugin-global `raceEngineerEnabled`. Voice scenarios (welcome, pit-lane callouts, flag alerts, fuel warnings, etc.) ship disabled until their follow-up PRs re-register them; this toggle flips the gate they will read. Today the only observable effect is the status-bar icon state.
 - **Radar mode**: Flips the plugin-global `radarEnabled` and stops/starts the directional proximity tick loop synchronously. Used by Radar alongside the per-instance Radar Test button.
 - **Radar Volume mode**: Steps the plugin-global `radarVolume` by ±5, clamped to 5–100. Takes effect immediately on `AudioBus.Alerts`. Direction is configured per button (Up or Down).
 
@@ -22,11 +21,10 @@ Multi-mode action covering the iRaceDeck pit-side audio framework: Race Engineer
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| Mode | Dropdown | Race Engineer | Selects what the key press does |
+| Mode | Dropdown | Radar | Selects what the key press does |
 | Direction | Dropdown | Up | Up / Down step, visible only when Mode = Radar Volume |
 
 ### Mode Options
-- **Race Engineer** - Toggles the Race Engineer voice on/off
 - **Radar** - Toggles the directional proximity ticks on/off
 - **Radar Volume** - Steps the global Radar volume up or down
 
@@ -44,12 +42,10 @@ None. Pit Crew drives its own audio framework; it does not emit keyboard events.
 
 ## Icon States
 
-Race Engineer and Radar modes paint a status bar on the lower third of the key (green when the feature is on, red when off). Radar Volume modes paint no status bar — the current volume shows as a percentage in the title.
+Radar mode paints a status bar on the lower third of the key (green when the feature is on, red when off). Radar Volume modes paint no status bar — the current volume shows as a percentage in the title.
 
 | Mode / State | Icon |
 |--------------|------|
-| Race Engineer — on | Headset / mic glyph, status bar green |
-| Race Engineer — off | Headset / mic glyph, status bar red |
 | Radar — on | Radar-sweep glyph, status bar green |
 | Radar — off | Radar-sweep glyph, status bar red |
 | Radar Volume Up | Radar glyph + up arrow, title shows `VOL +` and current % |

--- a/docs/reference/actions.json
+++ b/docs/reference/actions.json
@@ -132,13 +132,8 @@
           "file": "pit-crew.ts",
           "encoder": false,
           "settingsKeys": ["mode", "direction"],
-          "description": "Multi-mode action for the iRaceDeck audio framework. Race Engineer and Radar have independent on/off globals so silencing the voice engineer doesn't kill the proximity ticks. Voice-engineer scenarios (welcome, pit-lane callouts, flag alerts, etc.) land in follow-up PRs — Race Engineer today only flips a global flag.",
+          "description": "Multi-mode action for the iRaceDeck audio framework. The initial release exposes only the directional Radar proximity ticks; a Race Engineer voice feature is planned for a follow-up release and will return to the Mode dropdown alongside its voice scenarios.",
           "modes": [
-            {
-              "mode": "race-engineer",
-              "label": "Race Engineer",
-              "description": "Toggles the Race Engineer voice on/off"
-            },
             { "mode": "radar", "label": "Radar", "description": "Toggles the directional proximity tick loop on/off" },
             {
               "mode": "radar-volume",

--- a/packages/iracing-actions/src/actions/pit-crew/pit-crew.ejs
+++ b/packages/iracing-actions/src/actions/pit-crew/pit-crew.ejs
@@ -12,8 +12,7 @@
 		</p>
 
 		<sdpi-item label="Mode">
-			<sdpi-select id="mode-select" setting="mode" default="race-engineer">
-				<option value="race-engineer">Race Engineer</option>
+			<sdpi-select id="mode-select" setting="mode" default="radar">
 				<option value="radar">Radar</option>
 				<option value="radar-volume">Radar Volume</option>
 			</sdpi-select>
@@ -109,11 +108,11 @@
 					else directionItem.classList.add("hidden");
 				};
 
-				update(modeSelect.value || "race-engineer");
+				update(modeSelect.value || "radar");
 				modeSelect.addEventListener("change", (ev) => update(ev.target.value));
 				modeSelect.addEventListener("input", (ev) => update(ev.target.value));
 
-				let last = modeSelect.value || "race-engineer";
+				let last = modeSelect.value || "radar";
 				setInterval(() => {
 					const current = modeSelect.value;
 					if (current && current !== last) {

--- a/packages/iracing-actions/src/actions/pit-crew/pit-crew.test.ts
+++ b/packages/iracing-actions/src/actions/pit-crew/pit-crew.test.ts
@@ -191,11 +191,17 @@ describe("PIT_CREW_UUID", () => {
 });
 
 describe("Settings (persisted legacy field stripping)", () => {
-  it("defaults mode to race-engineer and direction to up", () => {
+  it("defaults mode to radar and direction to up", () => {
     const parsed = Settings.parse({});
 
-    expect(parsed.mode).toBe("race-engineer");
+    expect(parsed.mode).toBe("radar");
     expect(parsed.direction).toBe("up");
+  });
+
+  it("still accepts persisted race-engineer mode for backward compat", () => {
+    const parsed = Settings.parse({ mode: "race-engineer" });
+
+    expect(parsed.mode).toBe("race-engineer");
   });
 
   it("silently drops pre-#413 action-level fields via Zod's default strip mode", () => {

--- a/packages/iracing-actions/src/actions/pit-crew/pit-crew.ts
+++ b/packages/iracing-actions/src/actions/pit-crew/pit-crew.ts
@@ -59,7 +59,7 @@ export const PIT_CREW_UUID = "com.iracedeck.sd.core.pit-crew";
  */
 /** @internal Exported for testing. */
 export const Settings = CommonSettings.extend({
-  mode: z.enum(["race-engineer", "radar", "radar-volume"]).default("race-engineer"),
+  mode: z.enum(["race-engineer", "radar", "radar-volume"]).default("radar"),
   direction: z.enum(["up", "down"]).default("up"),
 });
 

--- a/packages/website/src/content/docs/docs/actions/driving/pit-crew.md
+++ b/packages/website/src/content/docs/docs/actions/driving/pit-crew.md
@@ -1,27 +1,17 @@
 ---
 title: Pit Crew
-description: Voice engineer + directional proximity radar, driven by the iRaceDeck audio framework.
+description: Directional proximity radar driven by the iRaceDeck audio framework.
 sidebar:
   badge:
-    text: "3 modes"
+    text: "2 modes"
     variant: tip
 ---
 
-Pit Crew bundles iRaceDeck's pit-side audio into one Stream Deck action. A **Race Engineer** voice (welcome / pit-lane callouts / flag alerts / incidents / fuel warnings — all coming back in follow-up releases) and a **Radar** (directional proximity ticks on the audio bus when a car pulls alongside) share the action's Mode dropdown. The two features have independent on/off globals, so muting the voice engineer to talk to teammates on Discord doesn't kill the proximity alerts.
+Pit Crew bundles iRaceDeck's pit-side audio into one Stream Deck action. In the initial release, only the **Radar** mode (directional proximity ticks on the audio bus when a car pulls alongside) is exposed. A **Race Engineer** voice (welcome / pit-lane callouts / flag alerts / incidents / fuel warnings) is planned to return in follow-up releases and will be re-added to the Mode dropdown alongside its voice scenarios.
 
 ## Modes
 
 Select the mode from the **Mode** dropdown in the Property Inspector. For the Radar Volume mode, also pick **Up** or **Down** from the **Direction** dropdown.
-
-### Race Engineer
-
-Toggles the Race Engineer voice on/off for every Pit Crew instance across the plugin. Pressing the button flips `raceEngineerEnabled` in plugin-global settings; the status bar at the bottom of the key flips green ↔ red. Voice scenarios (welcome, pit-lane, flag alerts, fuel warnings, etc.) are deferred to follow-up releases — the toggle today only flips the global flag that those scenarios will read once they return.
-
-#### Details
-
-- **Dial:** Not supported
-- **Default binding:** None — button-driven feature, no keyboard binding
-- **Telemetry-aware icon:** Yes — the status bar reflects the current global flag
 
 ### Radar
 

--- a/packages/website/src/content/docs/docs/actions/driving/pit-crew.md
+++ b/packages/website/src/content/docs/docs/actions/driving/pit-crew.md
@@ -7,7 +7,7 @@ sidebar:
     variant: tip
 ---
 
-Pit Crew bundles iRaceDeck's pit-side audio into one Stream Deck action. In the initial release, only the **Radar** mode (directional proximity ticks on the audio bus when a car pulls alongside) is exposed. A **Race Engineer** voice (welcome / pit-lane callouts / flag alerts / incidents / fuel warnings) is planned to return in follow-up releases and will be re-added to the Mode dropdown alongside its voice scenarios.
+Pit Crew bundles iRaceDeck's pit-side audio into one Stream Deck action. The initial release exposes **Radar** (directional proximity ticks on the audio bus when a car pulls alongside) and **Radar Volume** (a dedicated Up/Down mode for stepping the radar volume from the key). A **Race Engineer** voice (welcome / pit-lane callouts / flag alerts / incidents / fuel warnings) is planned to return in follow-up releases and will be re-added to the Mode dropdown alongside its voice scenarios.
 
 ## Modes
 


### PR DESCRIPTION
## Related Issue

Fixes #415.

## What changed?

- Removed the `<option value="race-engineer">` from the Pit Crew Mode dropdown (`pit-crew.ejs`).
- Changed the Mode select default and the Zod `Settings.mode` default from `"race-engineer"` to `"radar"`.
- Kept `"race-engineer"` in the Zod enum so persisted button configurations (from the `feature/pit-engineer` preview) still parse without error.
- Updated the direction-visibility polling fallback seed from `"race-engineer"` to `"radar"`.
- Synced downstream docs per `.claude/rules/build-and-commit.md`:
  - `packages/website/.../pit-crew.md` — removed the Race Engineer section, badge count 3 → 2 modes.
  - `docs/plugins/core/actions/pit-crew.md` — removed the Race Engineer behaviour/mode/icon-state entries; default mode now Radar.
  - `docs/reference/actions.json` — dropped the `"race-engineer"` mode entry; rewrote description.
  - `.claude/skills/iracedeck-actions/SKILL.md` — Pit Crew modes 3 → 2.
  - `README.md` — reworded Pit Crew highlight.

Note: the "Pick what pressing this button does…" paragraph above the Mode selector is unchanged here — #416 deletes it.

## How to test

- [ ] Load the built `com.iracedeck.sd.core.sdPlugin` in Stream Deck. Open a Pit Crew button's PI: Mode dropdown shows only **Radar** and **Radar Volume**; Radar is pre-selected on a new action.
- [ ] Configure a button in Radar mode — proximity ticks toggle on/off during a live session (existing behaviour).
- [ ] Legacy test: manually edit the button's `settings.json` to set `"mode": "race-engineer"`; the PI loads without a parse error, mode still flips the `raceEngineerEnabled` global flag, no audio plays (expected — voice scenarios are unregistered).
- [ ] `pnpm -w build`, `pnpm -w lint`, `pnpm -w test`, `pnpm format` all green.

## Checklist

- [x] Linked to an approved issue (#415, sub-issue of #375)
- [x] New code has unit tests (new backward-compat `Settings.parse({ mode: "race-engineer" })` case + existing default-mode test updated to `radar`)
- [x] Changes registered in all applicable plugins (Stream Deck generates `ui/pit-crew.html` from the shared EJS; Mirabox does not ship the audio action — platform feature flag)
- [x] No unrelated changes included

Sub-issue of #375.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Pit Crew now defaults to Radar mode; Radar directional proximity ticks and volume are the active features.
  * Race Engineer voice is deferred to a planned follow-up release; mode will be returned later.

* **Documentation**
  * All Pit Crew docs and README updated to reflect Radar-first release and Race Engineer as a future enhancement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->