### PR TITLE
chore(pit-crew): remove redundant mode-selector paragraph (#416)

### DIFF
--- a/packages/iracing-actions/src/actions/pit-crew/pit-crew.ejs
+++ b/packages/iracing-actions/src/actions/pit-crew/pit-crew.ejs
@@ -6,11 +6,6 @@
 	<body>
 		<%- include('section-header', { title: 'Action Settings' }) %>
 
-		<p style="padding: 0 16px; color: #999; font-size: 12px;">
-			Pick what pressing this button does. Race Engineer and Radar have independent
-			on/off switches so silencing the voice engineer doesn't kill the proximity alerts.
-		</p>
-
 		<sdpi-item label="Mode">
 			<sdpi-select id="mode-select" setting="mode" default="radar">
 				<option value="radar">Radar</option>


### PR DESCRIPTION
## Related Issue

Fixes #416.

## What changed?

Deletes the introductory `<p>` block above the Mode selector in `packages/iracing-actions/src/actions/pit-crew/pit-crew.ejs`. No other multi-mode action (force-feedback, cockpit-misc, camera-focus, session-info, black-box-selector) has an equivalent preamble — the Mode label is self-explanatory.

## How to test

- [ ] Open a Pit Crew button's PI. The section header flows directly into the Mode selector, matching the structure of other multi-mode actions.
- [ ] `pnpm -w build`, `pnpm -w lint`, `pnpm -w test`, `pnpm format` all green.

## Checklist

- [x] Linked to an approved issue (#416, sub-issue of #375)
- [x] New code has unit tests (no new code; existing 3150 tests still pass)
- [x] Changes registered in all applicable plugins (shared EJS regenerates Stream Deck `ui/pit-crew.html`; Mirabox doesn't ship this action)
- [x] No unrelated changes included

Stacks on top of #420 (#415). Base will auto-retarget to `feature/pit-engineer` once #420 merges.

Sub-issue of #375.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed explanatory guidance text from pit crew action settings regarding voice engineer and radar proximity alerts behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->