### PR TITLE
improve(pit-crew): replace raw HTML inputs with ird-* components (#417)

### DIFF
--- a/.claude/rules/stream-deck-actions.md
+++ b/.claude/rules/stream-deck-actions.md
@@ -179,6 +179,26 @@ Always include both scripts in PI HTML files:
 - Keyboard mode stores: `{"type":"keyboard","key":"f1","modifiers":[]}`
 - SimHub mode stores: `{"type":"simhub","role":"My Role Name"}`
 
+**`ird-audio-test`** - Preview-playback trigger button. Writes `Date.now()` into a hidden `sdpi-textfield` so the action's `onDidReceiveSettings` handler detects the bump and plays the preview.
+```html
+<div style="display:none;"><sdpi-textfield id="test-radar-field" setting="_testRadarVolume"></sdpi-textfield></div>
+<ird-audio-test target="test-radar-field" label="Test"></ird-audio-test>
+```
+- `target` - DOM id of the hidden `sdpi-textfield` to bump
+- `label` - Button text (default "Test")
+
+**`ird-audio-device-select`** - Plugin-global audio output device dropdown. Binds to a global setting storing the selected device index, and populates its options from a second global setting that holds the device-list JSON (maintained by the plugin at runtime).
+```html
+<sdpi-item label="Output Device">
+  <ird-audio-device-select setting="audioOutputDevice" devices="_audioDeviceList" default-label="System Default"></ird-audio-device-select>
+</sdpi-item>
+```
+- `setting` - Global setting key holding the selected device index (default: `audioOutputDevice`)
+- `devices` - Global setting key holding the device-list JSON (default: `_audioDeviceList`). Payload: `[{ "index": number, "name": string, "isDefault"?: boolean }, …]`
+- `default-label` - Label for the `-1` (System Default) option (default: `System Default`)
+
+**Never** use raw `<button>`, `<select>`, `<input>`, or `<textarea>` in a PI `.ejs`. Use an `sdpi-*` component or introduce a new `ird-*` component in `packages/pi-components/src/components/` if no suitable one exists.
+
 ### sdpi-components Library
 
 See `@.claude/rules/sdpi-components.md` for the full component reference (attributes, value types, helpers, communication).

--- a/packages/iracing-actions/src/actions/pit-crew/pit-crew.ejs
+++ b/packages/iracing-actions/src/actions/pit-crew/pit-crew.ejs
@@ -28,13 +28,11 @@
 				'<sdpi-item label="Radar Volume">' +
 					'<div style="display:flex;align-items:center;gap:8px;">' +
 						'<ird-range-input setting="radarVolume" global min="5" max="100" step="1" default="100" style="flex:1;"></ird-range-input>' +
-						'<button id="test-radar-btn" style="padding:2px 10px;border:1px solid #555;border-radius:4px;cursor:pointer;font-size:11px;background:#2a2a2a;color:#808080;flex-shrink:0;height:26px;box-sizing:border-box;">Test</button>' +
+						'<ird-audio-test target="test-radar-field" label="Test"></ird-audio-test>' +
 					'</div>' +
 				'</sdpi-item>' +
 				'<sdpi-item label="Output Device">' +
-					'<select id="audio-device-select" global setting="audioOutputDevice" style="width:100%;padding:4px;background:#2a2a2a;color:#c8c8c8;border:1px solid #555;border-radius:4px;">' +
-						'<option value="-1">System Default</option>' +
-					'</select>' +
+					'<ird-audio-device-select setting="audioOutputDevice" devices="_audioDeviceList" default-label="System Default"></ird-audio-device-select>' +
 				'</sdpi-item>'
 		}) %>
 
@@ -44,51 +42,6 @@
 
 		<script>
 		(function() {
-			// Test button — bumps the hidden _testRadarVolume timestamp, which the
-			// action reads in onDidReceiveSettings to trigger playRadarTest().
-			const radarBtn = document.getElementById('test-radar-btn');
-			if (radarBtn) {
-				radarBtn.addEventListener('click', () => {
-					const field = document.getElementById('test-radar-field');
-					if (field) {
-						field.value = String(Date.now());
-						field.dispatchEvent(new Event('change', { bubbles: true }));
-					}
-				});
-			}
-
-			// Audio output device dropdown — populated from global settings.
-			const deviceSelect = document.getElementById('audio-device-select');
-			if (deviceSelect && window.SDPIComponents) {
-				let savedDevice = '-1';
-				let setDevice = null;
-
-				const deviceHook = window.SDPIComponents.useGlobalSettings('audioOutputDevice', function(value) {
-					savedDevice = value !== null && value !== undefined ? String(value) : '-1';
-					deviceSelect.value = savedDevice;
-				});
-				setDevice = deviceHook[1];
-
-				window.SDPIComponents.useGlobalSettings('_audioDeviceList', function(value) {
-					if (!value) return;
-					try {
-						const devices = JSON.parse(value);
-						deviceSelect.innerHTML = '<option value="-1">System Default</option>';
-						devices.forEach(function(d) {
-							const opt = document.createElement('option');
-							opt.value = String(d.index);
-							opt.textContent = d.name + (d.isDefault ? ' (Default)' : '');
-							deviceSelect.appendChild(opt);
-						});
-						deviceSelect.value = savedDevice;
-					} catch(e) { /* ignore parse errors */ }
-				});
-
-				deviceSelect.addEventListener('change', function() {
-					if (setDevice) setDevice(deviceSelect.value);
-				});
-			}
-
 			// Direction visibility — hide unless Mode = radar-volume. sdpi-select
 			// events can be flaky (see session-info.ejs precedent), so combine
 			// change/input listeners with a polling fallback.

--- a/packages/pi-components/src/components/audio-device-select.test.ts
+++ b/packages/pi-components/src/components/audio-device-select.test.ts
@@ -149,6 +149,24 @@ describe("ird-audio-device-select", () => {
       const select = el.querySelector("select") as HTMLSelectElement;
       expect(select.value).toBe("-1");
     });
+
+    it("falls back to '-1' when the persisted device index is no longer in the current device list", () => {
+      const settingCallback = mock.callbacks.get("audioOutputDevice")!;
+      const devicesCallback = mock.callbacks.get("_audioDeviceList")!;
+
+      // Persisted selection was index 7, but the current enumeration only
+      // has indices 0 and 1 (e.g. the headset was unplugged).
+      settingCallback("7");
+      devicesCallback(
+        JSON.stringify([
+          { index: 0, name: "Built-in" },
+          { index: 1, name: "Speakers" },
+        ]),
+      );
+
+      const select = el.querySelector("select") as HTMLSelectElement;
+      expect(select.value).toBe("-1");
+    });
   });
 
   describe("change dispatching", () => {

--- a/packages/pi-components/src/components/audio-device-select.test.ts
+++ b/packages/pi-components/src/components/audio-device-select.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Import the module to trigger custom element registration
+import "./audio-device-select.js";
+
+type SettingsCallback = (value: string) => void;
+type SettingsHook = [() => Promise<string>, (value: string) => void];
+
+interface MockSDPI {
+  useGlobalSettings: (key: string, callback: SettingsCallback, debounceMs?: number | null) => SettingsHook;
+}
+
+interface MockSDPIState {
+  callbacks: Map<string, SettingsCallback>;
+  saves: Map<string, ReturnType<typeof vi.fn>>;
+}
+
+function installMockSDPI(): MockSDPIState {
+  const state: MockSDPIState = {
+    callbacks: new Map(),
+    saves: new Map(),
+  };
+
+  const useGlobalSettings = (key: string, callback: SettingsCallback): SettingsHook => {
+    state.callbacks.set(key, callback);
+    const save = vi.fn((_value: string) => undefined);
+    state.saves.set(key, save);
+
+    return [async () => "", save];
+  };
+
+  const sdpi: MockSDPI = { useGlobalSettings };
+  (window as unknown as Record<string, unknown>).SDPIComponents = sdpi;
+
+  return state;
+}
+
+describe("ird-audio-device-select", () => {
+  let el: HTMLElement;
+  let mock: MockSDPIState;
+
+  beforeEach(() => {
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+
+    mock = installMockSDPI();
+
+    el = document.createElement("ird-audio-device-select");
+    el.setAttribute("setting", "audioOutputDevice");
+    el.setAttribute("devices", "_audioDeviceList");
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    (window as unknown as Record<string, unknown>).SDPIComponents = undefined;
+  });
+
+  describe("DOM structure", () => {
+    it("renders a native <select>", () => {
+      expect(el.querySelector("select")).not.toBeNull();
+    });
+
+    it("includes the System Default option with value '-1'", () => {
+      const opts = el.querySelectorAll("option");
+      expect(opts.length).toBe(1);
+      expect(opts[0].value).toBe("-1");
+      expect(opts[0].textContent).toBe("System Default");
+    });
+
+    it("respects the default-label attribute", () => {
+      while (document.body.firstChild) {
+        document.body.removeChild(document.body.firstChild);
+      }
+
+      const custom = document.createElement("ird-audio-device-select");
+      custom.setAttribute("default-label", "Default output");
+      document.body.appendChild(custom);
+
+      expect(custom.querySelector("option")!.textContent).toBe("Default output");
+    });
+  });
+
+  describe("device-list population", () => {
+    it("replaces options with devices from the _audioDeviceList global, keeping System Default first", () => {
+      const devicesCallback = mock.callbacks.get("_audioDeviceList")!;
+      devicesCallback(
+        JSON.stringify([
+          { index: 0, name: "Speaker A", isDefault: false },
+          { index: 1, name: "Speaker B", isDefault: true },
+        ]),
+      );
+
+      const opts = Array.from(el.querySelectorAll("option"));
+      expect(opts.length).toBe(3);
+      expect(opts[0].value).toBe("-1");
+      expect(opts[1].value).toBe("0");
+      expect(opts[1].textContent).toBe("Speaker A");
+      expect(opts[2].value).toBe("1");
+      expect(opts[2].textContent).toBe("Speaker B (Default)");
+    });
+
+    it("ignores malformed JSON without throwing", () => {
+      const devicesCallback = mock.callbacks.get("_audioDeviceList")!;
+      expect(() => devicesCallback("{not json}")).not.toThrow();
+
+      // Still has just the System Default option
+      const opts = el.querySelectorAll("option");
+      expect(opts.length).toBe(1);
+    });
+
+    it("ignores non-array payloads", () => {
+      const devicesCallback = mock.callbacks.get("_audioDeviceList")!;
+      devicesCallback(JSON.stringify({ not: "an array" }));
+
+      const opts = el.querySelectorAll("option");
+      expect(opts.length).toBe(1);
+    });
+  });
+
+  describe("selection state", () => {
+    it("applies the persisted value from the setting callback", () => {
+      const settingCallback = mock.callbacks.get("audioOutputDevice")!;
+      const devicesCallback = mock.callbacks.get("_audioDeviceList")!;
+
+      devicesCallback(JSON.stringify([{ index: 2, name: "Headset" }]));
+      settingCallback("2");
+
+      const select = el.querySelector("select") as HTMLSelectElement;
+      expect(select.value).toBe("2");
+    });
+
+    it("re-applies the persisted value after the device list loads", () => {
+      const settingCallback = mock.callbacks.get("audioOutputDevice")!;
+      const devicesCallback = mock.callbacks.get("_audioDeviceList")!;
+
+      settingCallback("1");
+      devicesCallback(JSON.stringify([{ index: 1, name: "B" }]));
+
+      const select = el.querySelector("select") as HTMLSelectElement;
+      expect(select.value).toBe("1");
+    });
+
+    it("falls back to '-1' when the setting is empty or undefined", () => {
+      const settingCallback = mock.callbacks.get("audioOutputDevice")!;
+      settingCallback("");
+
+      const select = el.querySelector("select") as HTMLSelectElement;
+      expect(select.value).toBe("-1");
+    });
+  });
+
+  describe("change dispatching", () => {
+    it("writes the selected value through the save hook", () => {
+      const devicesCallback = mock.callbacks.get("_audioDeviceList")!;
+      devicesCallback(JSON.stringify([{ index: 3, name: "X" }]));
+
+      const select = el.querySelector("select") as HTMLSelectElement;
+      select.value = "3";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+
+      expect(mock.saves.get("audioOutputDevice")).toHaveBeenCalledWith("3");
+    });
+
+    it("bubbles a change event from the custom element", () => {
+      const handler = vi.fn();
+      el.addEventListener("change", handler);
+
+      const select = el.querySelector("select") as HTMLSelectElement;
+      select.value = "-1";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+
+      expect(handler).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/pi-components/src/components/audio-device-select.test.ts
+++ b/packages/pi-components/src/components/audio-device-select.test.ts
@@ -181,7 +181,7 @@ describe("ird-audio-device-select", () => {
       expect(mock.saves.get("audioOutputDevice")).toHaveBeenCalledWith("3");
     });
 
-    it("bubbles a change event from the custom element", () => {
+    it("dispatches exactly one change event per user selection (no double-fire from native bubble)", () => {
       const handler = vi.fn();
       el.addEventListener("change", handler);
 
@@ -189,7 +189,7 @@ describe("ird-audio-device-select", () => {
       select.value = "-1";
       select.dispatchEvent(new Event("change", { bubbles: true }));
 
-      expect(handler).toHaveBeenCalled();
+      expect(handler).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/pi-components/src/components/audio-device-select.ts
+++ b/packages/pi-components/src/components/audio-device-select.ts
@@ -1,0 +1,152 @@
+/// <reference lib="dom" />
+/**
+ * Audio Device Select Web Component for Stream Deck Property Inspector
+ *
+ * A styled `<select>` bound to a plugin-global setting that stores the
+ * selected audio output device index as a string (e.g. `"-1"` for
+ * System Default, or the string form of a miniaudio device index).
+ * Options are populated at runtime from a second global setting
+ * (a JSON array of `{ index: number, name: string, isDefault?: boolean }`),
+ * which the plugin maintains from its audio-device enumeration.
+ *
+ * Usage in HTML:
+ * ```html
+ * <sdpi-item label="Output Device">
+ *   <ird-audio-device-select
+ *     setting="audioOutputDevice"
+ *     devices="_audioDeviceList"
+ *     default-label="System Default"
+ *   ></ird-audio-device-select>
+ * </sdpi-item>
+ * ```
+ *
+ * Attributes:
+ * - setting: Plugin-global setting key that stores the selected device
+ *   index as a string (default: `audioOutputDevice`).
+ * - devices: Plugin-global setting key that stores the device list as a
+ *   JSON array (default: `_audioDeviceList`).
+ * - default-label: Label shown for the `-1` (System Default) option
+ *   (default: `System Default`).
+ *
+ * The plugin populates `devices` via `updateGlobalSettings({ [devicesKey]: JSON.stringify(list) })`.
+ */
+
+let styleInjected = false;
+
+type DeviceRecord = { index: number; name: string; isDefault?: boolean };
+
+const DEFAULT_SETTING = "audioOutputDevice";
+const DEFAULT_DEVICE_LIST_SETTING = "_audioDeviceList";
+const DEFAULT_LABEL = "System Default";
+
+export class AudioDeviceSelect extends HTMLElement {
+  private select: HTMLSelectElement | null = null;
+  private savedValue = "-1";
+  private saveToStreamDeck: ((value: string) => void) | null = null;
+  private _initialized = false;
+
+  connectedCallback(): void {
+    if (this._initialized) return;
+
+    this._initialized = true;
+
+    this.injectStyle();
+    this.buildDOM();
+    this.attachListeners();
+    this.hookSettings();
+  }
+
+  private injectStyle(): void {
+    if (styleInjected || typeof document === "undefined") return;
+
+    const style = document.createElement("style");
+    style.textContent = `
+      ird-audio-device-select select {
+        width: 100%;
+        padding: 4px;
+        background: #2a2a2a;
+        color: #c8c8c8;
+        border: 1px solid #555;
+        border-radius: 4px;
+      }
+    `;
+    document.head.appendChild(style);
+    styleInjected = true;
+  }
+
+  private buildDOM(): void {
+    this.select = document.createElement("select");
+    this.renderOptions([]);
+    this.appendChild(this.select);
+  }
+
+  private attachListeners(): void {
+    this.select?.addEventListener("change", () => {
+      if (!this.select) return;
+
+      this.savedValue = this.select.value;
+      this.saveToStreamDeck?.(this.savedValue);
+      this.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+  }
+
+  private hookSettings(): void {
+    if (!window.SDPIComponents) return;
+
+    const settingKey = this.getAttribute("setting") ?? DEFAULT_SETTING;
+    const devicesKey = this.getAttribute("devices") ?? DEFAULT_DEVICE_LIST_SETTING;
+
+    const [, save] = window.SDPIComponents.useGlobalSettings(settingKey, (value: string) => {
+      this.savedValue = value !== null && value !== undefined && value !== "" ? String(value) : "-1";
+      this.applySavedValue();
+    });
+    this.saveToStreamDeck = save;
+
+    window.SDPIComponents.useGlobalSettings(devicesKey, (value: string) => {
+      if (!value) return;
+
+      try {
+        const devices = JSON.parse(value) as DeviceRecord[];
+
+        if (!Array.isArray(devices)) return;
+
+        this.renderOptions(devices);
+        this.applySavedValue();
+      } catch {
+        // ignore parse errors; dropdown keeps its prior options
+      }
+    });
+  }
+
+  private renderOptions(devices: DeviceRecord[]): void {
+    if (!this.select) return;
+
+    const defaultLabel = this.getAttribute("default-label") ?? DEFAULT_LABEL;
+
+    this.select.innerHTML = "";
+
+    const systemOption = document.createElement("option");
+    systemOption.value = "-1";
+    systemOption.textContent = defaultLabel;
+    this.select.appendChild(systemOption);
+
+    for (const device of devices) {
+      const opt = document.createElement("option");
+      opt.value = String(device.index);
+      opt.textContent = `${device.name}${device.isDefault ? " (Default)" : ""}`;
+      this.select.appendChild(opt);
+    }
+  }
+
+  private applySavedValue(): void {
+    if (!this.select) return;
+
+    this.select.value = this.savedValue;
+  }
+}
+
+if (typeof customElements !== "undefined") {
+  if (!customElements.get("ird-audio-device-select")) {
+    customElements.define("ird-audio-device-select", AudioDeviceSelect);
+  }
+}

--- a/packages/pi-components/src/components/audio-device-select.ts
+++ b/packages/pi-components/src/components/audio-device-select.ts
@@ -81,8 +81,14 @@ export class AudioDeviceSelect extends HTMLElement {
   }
 
   private attachListeners(): void {
-    this.select?.addEventListener("change", () => {
+    this.select?.addEventListener("change", (ev: Event) => {
       if (!this.select) return;
+
+      // Native `change` on `<select>` bubbles through the host custom
+      // element. Without `stopPropagation` the consumer would see two
+      // events per user selection — once from the native bubble and
+      // once from the host dispatch below.
+      ev.stopPropagation();
 
       this.savedValue = this.select.value;
       this.saveToStreamDeck?.(this.savedValue);

--- a/packages/pi-components/src/components/audio-device-select.ts
+++ b/packages/pi-components/src/components/audio-device-select.ts
@@ -129,7 +129,7 @@ export class AudioDeviceSelect extends HTMLElement {
 
     const defaultLabel = this.getAttribute("default-label") ?? DEFAULT_LABEL;
 
-    this.select.innerHTML = "";
+    this.select.replaceChildren();
 
     const systemOption = document.createElement("option");
     systemOption.value = "-1";

--- a/packages/pi-components/src/components/audio-device-select.ts
+++ b/packages/pi-components/src/components/audio-device-select.ts
@@ -141,7 +141,13 @@ export class AudioDeviceSelect extends HTMLElement {
   private applySavedValue(): void {
     if (!this.select) return;
 
-    this.select.value = this.savedValue;
+    // If the persisted device index is no longer in the current option
+    // list (e.g. the selected device was unplugged), fall back to
+    // System Default so the dropdown reflects what miniaudio will
+    // actually use. Native `<select>.value = "<unknown>"` silently
+    // clears the selection — surface that as "-1" explicitly.
+    const exists = Array.from(this.select.options).some((opt) => opt.value === this.savedValue);
+    this.select.value = exists ? this.savedValue : "-1";
   }
 }
 

--- a/packages/pi-components/src/components/audio-test.test.ts
+++ b/packages/pi-components/src/components/audio-test.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Import the module to trigger custom element registration
+import "./audio-test.js";
+
+describe("ird-audio-test", () => {
+  let button: HTMLElement;
+  let field: HTMLInputElement;
+
+  beforeEach(() => {
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+
+    field = document.createElement("input");
+    field.id = "target-field";
+    document.body.appendChild(field);
+
+    button = document.createElement("ird-audio-test");
+    button.setAttribute("target", "target-field");
+    document.body.appendChild(button);
+  });
+
+  describe("DOM structure", () => {
+    it("creates a native <button> inside the element", () => {
+      const inner = button.querySelector("button");
+      expect(inner).not.toBeNull();
+      expect(inner!.type).toBe("button");
+    });
+
+    it("uses the label attribute for button text", () => {
+      while (document.body.firstChild) {
+        document.body.removeChild(document.body.firstChild);
+      }
+
+      const labeled = document.createElement("ird-audio-test");
+      labeled.setAttribute("target", "x");
+      labeled.setAttribute("label", "Play preview");
+      document.body.appendChild(labeled);
+
+      expect(labeled.querySelector("button")!.textContent).toBe("Play preview");
+    });
+
+    it("defaults the label to 'Test' when no label attribute is set", () => {
+      expect(button.querySelector("button")!.textContent).toBe("Test");
+    });
+  });
+
+  describe("click behaviour", () => {
+    it("writes a timestamp into the target field and dispatches a change event", () => {
+      const before = Date.now();
+      const handler = vi.fn();
+      field.addEventListener("change", handler);
+
+      button.querySelector("button")!.click();
+
+      const written = Number(field.value);
+      expect(Number.isFinite(written)).toBe(true);
+      expect(written).toBeGreaterThanOrEqual(before);
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it("does nothing when the target id does not resolve to a field", () => {
+      while (document.body.firstChild) {
+        document.body.removeChild(document.body.firstChild);
+      }
+
+      const orphan = document.createElement("ird-audio-test");
+      orphan.setAttribute("target", "does-not-exist");
+      document.body.appendChild(orphan);
+
+      expect(() => orphan.querySelector("button")!.click()).not.toThrow();
+    });
+
+    it("does nothing when the target attribute is missing", () => {
+      while (document.body.firstChild) {
+        document.body.removeChild(document.body.firstChild);
+      }
+
+      const untargeted = document.createElement("ird-audio-test");
+      document.body.appendChild(untargeted);
+
+      expect(() => untargeted.querySelector("button")!.click()).not.toThrow();
+    });
+  });
+});

--- a/packages/pi-components/src/components/audio-test.ts
+++ b/packages/pi-components/src/components/audio-test.ts
@@ -1,0 +1,95 @@
+/// <reference lib="dom" />
+/**
+ * Audio Test Button Web Component for Stream Deck Property Inspector
+ *
+ * A styled button that, when clicked, writes a timestamp into a hidden
+ * per-action setting (an `sdpi-textfield`) so the action's
+ * `onDidReceiveSettings` handler can detect the bump and trigger a
+ * preview. Used by Pit Crew to call `playRadarTest()` without adding a
+ * richer RPC surface.
+ *
+ * Usage in HTML:
+ * ```html
+ * <div style="display:none;">
+ *   <sdpi-textfield id="test-radar-field" setting="_testRadarVolume"></sdpi-textfield>
+ * </div>
+ * <ird-audio-test target="test-radar-field" label="Test"></ird-audio-test>
+ * ```
+ *
+ * Attributes:
+ * - target: DOM id of the hidden `sdpi-textfield` whose value should be
+ *   bumped to `Date.now()` on click.
+ * - label: Button text (default "Test").
+ */
+
+let styleInjected = false;
+
+export class AudioTest extends HTMLElement {
+  private button: HTMLButtonElement | null = null;
+  private _initialized = false;
+
+  connectedCallback(): void {
+    if (this._initialized) return;
+
+    this._initialized = true;
+
+    this.injectStyle();
+    this.buildDOM();
+    this.attachListeners();
+  }
+
+  private injectStyle(): void {
+    if (styleInjected || typeof document === "undefined") return;
+
+    const style = document.createElement("style");
+    style.textContent = `
+      ird-audio-test button {
+        padding: 2px 10px;
+        border: 1px solid #555;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 11px;
+        background: #2a2a2a;
+        color: #808080;
+        flex-shrink: 0;
+        height: 26px;
+        box-sizing: border-box;
+      }
+      ird-audio-test button:hover {
+        color: #d8d8d8;
+        border-color: #777;
+      }
+    `;
+    document.head.appendChild(style);
+    styleInjected = true;
+  }
+
+  private buildDOM(): void {
+    const label = this.getAttribute("label") ?? "Test";
+    this.button = document.createElement("button");
+    this.button.type = "button";
+    this.button.textContent = label;
+    this.appendChild(this.button);
+  }
+
+  private attachListeners(): void {
+    this.button?.addEventListener("click", () => {
+      const targetId = this.getAttribute("target");
+
+      if (!targetId) return;
+
+      const field = document.getElementById(targetId) as HTMLInputElement | null;
+
+      if (!field) return;
+
+      field.value = String(Date.now());
+      field.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+  }
+}
+
+if (typeof customElements !== "undefined") {
+  if (!customElements.get("ird-audio-test")) {
+    customElements.define("ird-audio-test", AudioTest);
+  }
+}

--- a/packages/pi-components/src/components/index.ts
+++ b/packages/pi-components/src/components/index.ts
@@ -13,6 +13,12 @@
 // Autocomplete Input - text input with dropdown suggestions
 export { AutocompleteInput } from "./autocomplete-input.js";
 
+// Audio Device Select - global audio output device dropdown populated from a device-list global
+export { AudioDeviceSelect } from "./audio-device-select.js";
+
+// Audio Test - button that bumps a hidden per-action timestamp to trigger preview playback
+export { AudioTest } from "./audio-test.js";
+
 // Color Picker - custom color picker with "not set" state and inline hex display
 export { ColorPicker } from "./color-picker.js";
 


### PR DESCRIPTION
## Related Issue

Fixes #417.

## What changed?

Pit Crew shipped two raw HTML inputs with hand-written JS wiring, violating `.claude/rules/stream-deck-actions.md` ("PI inputs must be `sdpi-*` or `ird-*`"). This PR replaces them with cohesive custom components and deletes the wiring.

New components in `packages/pi-components/src/components/`:

- **`ird-audio-test`** — styled button that writes `Date.now()` into a targetable `sdpi-textfield`, letting the action's `onDidReceiveSettings` detect the bump and fire `playRadarTest()`. Attributes: `target`, `label`.
- **`ird-audio-device-select`** — plugin-global device dropdown. Binds to the `audioOutputDevice` global and dynamically repopulates from `_audioDeviceList` (JSON) maintained by the plugin. Attributes: `setting`, `devices`, `default-label`.

Both follow existing `ird-range-input` / `ird-color-picker` / `ird-key-binding` patterns (once-guarded `connectedCallback`, shared style injection, `useGlobalSettings` hook, SSR-safe registration).

Updated:
- `pit-crew.ejs` accordion content: rewrites Radar Volume and Output Device rows to use the new components. The in-file `<script>` only keeps the Direction-visibility polling fallback.
- `stream-deck-actions.md`: documents both new components and adds a "never use raw `<button>/<select>/<input>/<textarea>`" clause to the Custom Components section.

## How to test

- [ ] Build succeeds; `pi-components.js` contains the two new class definitions; `ui/pit-crew.html` contains `<ird-audio-test target="test-radar-field" label="Test">` and `<ird-audio-device-select …>`.
- [ ] In Stream Deck, open a Pit Crew button's PI. The Test button plays the left → right → both sweep. Selecting an output device persists across PI reopens and is shared across every Pit Crew instance (global setting).
- [ ] `grep -n "<button\|<select\|<input\|<textarea" packages/iracing-actions/src/actions/pit-crew/pit-crew.ejs` returns zero hits.
- [ ] `pnpm -w build`, `pnpm -w lint`, `pnpm -w test`, `pnpm format` all green. Test count grew from 3150 → 3167 (17 new cases covering DOM structure, late-arriving device list, malformed payload tolerance, settings persistence, and event bubbling).

## Checklist

- [x] Linked to an approved issue (#417, sub-issue of #375)
- [x] New code has unit tests (`audio-test.test.ts`, `audio-device-select.test.ts`)
- [x] Changes registered in all applicable plugins (Stream Deck rebuilds PI from shared EJS; Mirabox doesn't ship this action)
- [x] No unrelated changes included

Stacks on top of #421 (#416) which stacks on #420 (#415). Bases auto-retarget to `feature/pit-engineer` as the stack merges.

Sub-issue of #375. Related to #395 (broader sdpi-component audit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Audio Test button component for triggering preview playback.
  * Added an Audio Device selector dropdown with persistent selection and “System Default” support.

* **UI Improvements**
  * Pit Crew Audio interface now uses the new custom controls for audio settings.

* **Documentation**
  * Expanded Property Inspector guidance to require sanctioned PI controls and documented new audio PI usages.

* **Tests**
  * Added unit tests for device-list handling, selection persistence, and test-button behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->