### PR TITLE
improve(pit-crew): radar volume min 0 default 100 (#418)

### DIFF
--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -67,7 +67,7 @@ Mode counts reflect the PI Mode/Setting dropdown choices documented in each acti
 | Black Box Selector | 3 | direct (with 11 Black Box options), next, previous |
 | Look Direction | 4 | look-left, look-right, look-up, look-down (all hold pattern) |
 | Car Control | 10 | pit-speed-limiter (telemetry-aware), push-to-pass (telemetry-aware), drs (telemetry-aware), headlight-flash (hold), tear-off-visor, ignition, starter (hold), enter-exit-tow (hold, telemetry-aware, per-state auto-hold options for exit/reset/tow), escape (hardcoded ESC, auto-hold option), pause-sim |
-| Pit Crew | 2 | radar (toggles the directional proximity tick loop), radar-volume (with Direction up/down; steps global radarVolume by ±5, clamped 5–100). A Race Engineer voice mode is planned for a follow-up release and will return to the Mode dropdown alongside its voice scenarios. |
+| Pit Crew | 2 | radar (toggles the directional proximity tick loop), radar-volume (with Direction up/down; steps global radarVolume by ±5, clamped 0–100). A Race Engineer voice mode is planned for a follow-up release and will return to the Mode dropdown alongside its voice scenarios. |
 
 ### Cockpit & Interface
 

--- a/docs/plugins/core/actions/pit-crew.md
+++ b/docs/plugins/core/actions/pit-crew.md
@@ -15,7 +15,7 @@ Multi-mode action covering the iRaceDeck pit-side audio framework. The initial r
 
 ### Button Press
 - **Radar mode**: Flips the plugin-global `radarEnabled` and stops/starts the directional proximity tick loop synchronously. Used by Radar alongside the per-instance Radar Test button.
-- **Radar Volume mode**: Steps the plugin-global `radarVolume` by ±5, clamped to 5–100. Takes effect immediately on `AudioBus.Alerts`. Direction is configured per button (Up or Down).
+- **Radar Volume mode**: Steps the plugin-global `radarVolume` by ±5, clamped to 0–100. Takes effect immediately on `AudioBus.Alerts`. Direction is configured per button (Up or Down). Stepping to 0 mutes the radar without toggling the feature off.
 
 ## Settings
 
@@ -30,10 +30,10 @@ Multi-mode action covering the iRaceDeck pit-side audio framework. The initial r
 
 ### Direction Options
 - **Up** - Bumps Radar volume by 5 (max 100)
-- **Down** - Reduces Radar volume by 5 (min 5)
+- **Down** - Reduces Radar volume by 5 (min 0)
 
 ### Plugin-global Audio Settings (in the Pit Crew accordion, not under Global Settings)
-- **Radar Volume** (range 5–100, default 100) - slider + Test button. Shared across every Pit Crew instance.
+- **Radar Volume** (range 0–100, default 100) - slider + Test button. Shared across every Pit Crew instance.
 - **Output Device** - audio device used for the iRaceDeck audio engine; shared globally across the plugin.
 
 ## Keyboard Simulation

--- a/docs/reference/actions.json
+++ b/docs/reference/actions.json
@@ -145,7 +145,7 @@
               "mode": "radar-volume",
               "direction": "down",
               "label": "Radar Volume Down",
-              "description": "Reduces the global Radar volume by 5 (min 5)"
+              "description": "Reduces the global Radar volume by 5 (min 0)"
             }
           ]
         }

--- a/packages/deck-core/src/global-settings.ts
+++ b/packages/deck-core/src/global-settings.ts
@@ -119,11 +119,12 @@ export const GlobalSettingsSchema = z
       .transform((val) => val === true || val === "true")
       .default(true),
     /**
-     * Volume for the directional Radar ticks, 5–100 (mapped to 0.05–1.0 on
+     * Volume for the directional Radar ticks, 0–100 (mapped to 0.0–1.0 on
      * `AudioBus.Alerts`). Stepped by the Radar Volume Up/Down modes of the
-     * Pit Crew action. Default: 100.
+     * Pit Crew action; sliding to 0 mutes the radar without toggling the
+     * feature off. Default: 100.
      */
-    radarVolume: z.coerce.number().min(5).max(100).default(100),
+    radarVolume: z.coerce.number().min(0).max(100).default(100),
   })
   .passthrough();
 

--- a/packages/iracing-actions/src/actions/pit-crew/pit-crew.ejs
+++ b/packages/iracing-actions/src/actions/pit-crew/pit-crew.ejs
@@ -27,7 +27,7 @@
 			content:
 				'<sdpi-item label="Radar Volume">' +
 					'<div style="display:flex;align-items:center;gap:8px;">' +
-						'<ird-range-input setting="radarVolume" global min="5" max="100" step="1" default="100" style="flex:1;"></ird-range-input>' +
+						'<ird-range-input setting="radarVolume" global min="0" max="100" step="1" default="100" style="flex:1;"></ird-range-input>' +
 						'<ird-audio-test target="test-radar-field" label="Test"></ird-audio-test>' +
 					'</div>' +
 				'</sdpi-item>' +

--- a/packages/iracing-actions/src/actions/pit-crew/pit-crew.test.ts
+++ b/packages/iracing-actions/src/actions/pit-crew/pit-crew.test.ts
@@ -453,8 +453,8 @@ describe("PitCrew action", () => {
       expect(hoisted.updateGlobalSettings).not.toHaveBeenCalled();
     });
 
-    it("clamps at 5 (no-op when already at min)", async () => {
-      hoisted.setGlobalSettings({ raceEngineerEnabled: true, radarEnabled: true, radarVolume: 5 });
+    it("clamps at 0 (no-op when already at min)", async () => {
+      hoisted.setGlobalSettings({ raceEngineerEnabled: true, radarEnabled: true, radarVolume: 0 });
       const action = new PitCrew();
       await action.onWillAppear(buildAppearEvent({ mode: "radar-volume", direction: "down" }) as never);
       vi.clearAllMocks();
@@ -462,6 +462,17 @@ describe("PitCrew action", () => {
       await action.onKeyDown(buildAppearEvent({ mode: "radar-volume", direction: "down" }) as never);
 
       expect(hoisted.updateGlobalSettings).not.toHaveBeenCalled();
+    });
+
+    it("steps to 0 on direction=down when current volume is VOLUME_STEP", async () => {
+      hoisted.setGlobalSettings({ raceEngineerEnabled: true, radarEnabled: true, radarVolume: 5 });
+      const action = new PitCrew();
+      await action.onWillAppear(buildAppearEvent({ mode: "radar-volume", direction: "down" }) as never);
+      vi.clearAllMocks();
+
+      await action.onKeyDown(buildAppearEvent({ mode: "radar-volume", direction: "down" }) as never);
+
+      expect(hoisted.updateGlobalSettings).toHaveBeenCalledWith({ radarVolume: 0 });
     });
   });
 

--- a/packages/iracing-actions/src/actions/pit-crew/pit-crew.test.ts
+++ b/packages/iracing-actions/src/actions/pit-crew/pit-crew.test.ts
@@ -462,6 +462,7 @@ describe("PitCrew action", () => {
       await action.onKeyDown(buildAppearEvent({ mode: "radar-volume", direction: "down" }) as never);
 
       expect(hoisted.updateGlobalSettings).not.toHaveBeenCalled();
+      expect(hoisted.setBusVolume).not.toHaveBeenCalled();
     });
 
     it("steps to 0 on direction=down when current volume is VOLUME_STEP", async () => {
@@ -473,6 +474,7 @@ describe("PitCrew action", () => {
       await action.onKeyDown(buildAppearEvent({ mode: "radar-volume", direction: "down" }) as never);
 
       expect(hoisted.updateGlobalSettings).toHaveBeenCalledWith({ radarVolume: 0 });
+      expect(hoisted.setBusVolume).toHaveBeenCalledWith(2, 0);
     });
   });
 

--- a/packages/iracing-actions/src/actions/pit-crew/pit-crew.ts
+++ b/packages/iracing-actions/src/actions/pit-crew/pit-crew.ts
@@ -32,7 +32,7 @@ import { borderColorForState, statusBarOff, statusBarOn } from "../../icons/stat
 
 const WHITE = "#ffffff";
 const VOLUME_STEP = 5;
-const VOLUME_MIN = 5;
+const VOLUME_MIN = 0;
 const VOLUME_MAX = 100;
 
 /** @internal Exported for testing */

--- a/packages/website/src/content/docs/docs/actions/driving/pit-crew.md
+++ b/packages/website/src/content/docs/docs/actions/driving/pit-crew.md
@@ -25,12 +25,12 @@ Toggles the directional proximity tick loop on/off. Pressing the button flips `r
 
 ### Radar Volume
 
-Steps the global Radar volume up or down. Takes effect immediately on `AudioBus.Alerts` so the next tick plays at the new level. Clamps at 5 (minimum) and 100 (maximum). The key shows the current percentage in its title.
+Steps the global Radar volume up or down. Takes effect immediately on `AudioBus.Alerts` so the next tick plays at the new level. Clamps at 0 (minimum, fully muted) and 100 (maximum). The key shows the current percentage in its title.
 
 #### Setting: Direction
 
 - **Up** — Bumps `radarVolume` by 5 (max 100)
-- **Down** — Reduces `radarVolume` by 5 (min 5)
+- **Down** — Reduces `radarVolume` by 5 (min 0)
 
 #### Details
 
@@ -42,7 +42,7 @@ Steps the global Radar volume up or down. Takes effect immediately on `AudioBus.
 
 The Pit Crew accordion in the Property Inspector exposes these plugin-global settings alongside the Mode selector (not under the generic Global Settings section):
 
-- **Radar Volume** (5–100, default 100) — slider + Test button. Shared across every Pit Crew instance; the button lets you preview the left → right → both sequence without waiting for a live proximity event.
+- **Radar Volume** (0–100, default 100) — slider + Test button. Shared across every Pit Crew instance; the button lets you preview the left → right → both sequence without waiting for a live proximity event. Sliding to 0 mutes the radar without toggling the feature off.
 - **Output Device** — the audio device used for the iRaceDeck audio engine; shared globally across the plugin.
 
 ## Notes


### PR DESCRIPTION
## Related Issue

Fixes #418.

## What changed?

Lower the radar-volume minimum from 5 to 0 so the slider alone can mute the radar without toggling the feature off. Supersedes the "clamps at 5 and 100" acceptance clause in #413.

- `packages/iracing-actions/src/actions/pit-crew/pit-crew.ts`: `VOLUME_MIN = 5` → `0`. `readRadarVolume()` already clamps via the constant.
- `packages/iracing-actions/src/actions/pit-crew/pit-crew.ejs`: `ird-range-input` `min="5"` → `min="0"`. Default stays at 100.
- `packages/deck-core/src/global-settings.ts`: `GlobalSettingsSchema.radarVolume: z.coerce.number().min(5).max(100)` → `.min(0)`. JSDoc updated.
- `pit-crew.test.ts`: "clamps at 5" → "clamps at 0"; added regression for step-down from 5 → 0.
- Docs sync: `docs/plugins/core/actions/pit-crew.md`, `docs/reference/actions.json`, `packages/website/.../pit-crew.md`, `.claude/skills/iracedeck-actions/SKILL.md`.

`VOLUME_STEP = 5` is deliberately preserved — stepping granularity is independent of the range.

## How to test

- [ ] PI: radar volume slider accepts 0–100. Default on a new button is 100.
- [ ] Radar Volume Down mode: stepping from 5 lands at 0 (no-op at 0).
- [ ] Live session: radarVolume=0 produces no ticks; 100 produces full-volume ticks.
- [ ] Existing configurations (typically 100) are unaffected.
- [ ] `pnpm -w build`, `pnpm -w lint`, `pnpm -w test`, `pnpm format` all green (3168 tests).

## Checklist

- [x] Linked to an approved issue (#418, sub-issue of #375)
- [x] New code has unit tests (new step-to-0 regression)
- [x] Changes registered in all applicable plugins (Stream Deck rebuilds from shared EJS; Mirabox doesn't ship this action)
- [x] No unrelated changes included

Stacks on top of #422 (#417) which stacks on #421 (#416) which stacks on #420 (#415). Bases auto-retarget to `feature/pit-engineer` as the stack merges.

Sub-issue of #375.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Radar volume now accepts 0 as the minimum (0–100), allowing complete muting without disabling the radar; down-step behavior updated to reach 0.
* **Documentation**
  * Updated UI and help text to show the 0–100 range and clarify that 0 mutes but does not toggle off radar.
* **Tests**
  * Boundary tests updated/added to verify 0-volume behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->