### PR TITLE
fix(deck-core): update global-settings cache synchronously on local writes (#419)

### DIFF
--- a/packages/deck-core/src/global-settings.test.ts
+++ b/packages/deck-core/src/global-settings.test.ts
@@ -142,14 +142,11 @@ describe("global-settings cache (synchronous update on local writes)", () => {
 
   it("no-ops when the adapter is not initialized", () => {
     _resetGlobalSettings();
-    const logger = createMockLogger();
     // Not calling initGlobalSettings — adapterRef stays null.
 
     updateGlobalSettings({ radarEnabled: false });
 
-    // Nothing to assert on the adapter (we didn't create one); just
-    // verify no throw and that subsequent reads stay at the default.
+    // No throw; cache stays at the schema default.
     expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(true);
-    expect(logger.warn).not.toHaveBeenCalled(); // logger isn't wired when init never ran
   });
 });

--- a/packages/deck-core/src/global-settings.test.ts
+++ b/packages/deck-core/src/global-settings.test.ts
@@ -1,0 +1,155 @@
+import type { ILogger } from "@iracedeck/logger";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  _resetGlobalSettings,
+  getGlobalSettings,
+  initGlobalSettings,
+  onGlobalSettingsChange,
+  updateGlobalSettings,
+} from "./global-settings.js";
+import type { IDeckPlatformAdapter } from "./types.js";
+
+type EchoCallback = (settings: unknown) => void;
+
+function createMockLogger(): ILogger {
+  return {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  } as unknown as ILogger;
+}
+
+interface MockAdapter {
+  adapter: IDeckPlatformAdapter;
+  echo: EchoCallback | null;
+  setGlobalSettings: ReturnType<typeof vi.fn<(settings: Record<string, unknown>) => void>>;
+  getGlobalSettings: ReturnType<typeof vi.fn<() => void>>;
+}
+
+function createMockAdapter(): MockAdapter {
+  const echoHolder: { echo: EchoCallback | null } = { echo: null };
+  const setGlobalSettings = vi.fn<(settings: Record<string, unknown>) => void>();
+  const getGlobalSettings = vi.fn<() => void>();
+
+  const adapter = {
+    onDidReceiveGlobalSettings: (cb: EchoCallback) => {
+      echoHolder.echo = cb;
+    },
+    setGlobalSettings,
+    getGlobalSettings,
+  } as unknown as IDeckPlatformAdapter;
+
+  return {
+    adapter,
+    get echo() {
+      return echoHolder.echo;
+    },
+    setGlobalSettings,
+    getGlobalSettings,
+  };
+}
+
+describe("global-settings cache (synchronous update on local writes)", () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    _resetGlobalSettings();
+    mock = createMockAdapter();
+    initGlobalSettings(mock.adapter, createMockLogger());
+  });
+
+  it("updateGlobalSettings reflects the new value on the very next getGlobalSettings call", () => {
+    updateGlobalSettings({ radarEnabled: false });
+
+    expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(false);
+  });
+
+  it("alternates radarEnabled across consecutive local writes without any host echo", () => {
+    updateGlobalSettings({ radarEnabled: false });
+    expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(false);
+
+    updateGlobalSettings({ radarEnabled: true });
+    expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(true);
+
+    updateGlobalSettings({ radarEnabled: false });
+    expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(false);
+
+    // No echo has fired yet — the adapter's echo callback was captured
+    // but never invoked.
+    expect(mock.echo).not.toBeNull();
+  });
+
+  it("matches the toggle pattern used by Pit Crew (read → flip → write → read)", () => {
+    // Simulates toggleRadar: reads isRadarEnabled(), flips, writes.
+    const readFlipWrite = () => {
+      const current = (getGlobalSettings() as Record<string, unknown>).radarEnabled !== false;
+      updateGlobalSettings({ radarEnabled: !current });
+    };
+
+    readFlipWrite();
+    expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(false);
+
+    readFlipWrite();
+    expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(true);
+
+    readFlipWrite();
+    expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(false);
+  });
+
+  it("applies the same behaviour to raceEngineerEnabled (same toggle code path)", () => {
+    updateGlobalSettings({ raceEngineerEnabled: false });
+    expect((getGlobalSettings() as Record<string, unknown>).raceEngineerEnabled).toBe(false);
+
+    updateGlobalSettings({ raceEngineerEnabled: true });
+    expect((getGlobalSettings() as Record<string, unknown>).raceEngineerEnabled).toBe(true);
+  });
+
+  it("notifies listeners on every local write, not just on host echoes", () => {
+    const listener = vi.fn();
+    onGlobalSettingsChange(listener);
+
+    updateGlobalSettings({ radarVolume: 80 });
+    updateGlobalSettings({ radarVolume: 75 });
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener.mock.calls[0][0].radarVolume).toBe(80);
+    expect(listener.mock.calls[1][0].radarVolume).toBe(75);
+  });
+
+  it("forwards the merged (parsed) settings to the adapter", () => {
+    updateGlobalSettings({ radarEnabled: false });
+
+    expect(mock.setGlobalSettings).toHaveBeenCalledTimes(1);
+    const sent = mock.setGlobalSettings.mock.calls[0][0] as Record<string, unknown>;
+    expect(sent.radarEnabled).toBe(false);
+  });
+
+  it("reconciles on host echo without losing later local writes' semantics", () => {
+    updateGlobalSettings({ radarEnabled: false });
+    expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(false);
+
+    // Host finally echoes the earlier write — cache stays false.
+    mock.echo?.({ radarEnabled: false });
+    expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(false);
+
+    // New local write still flips immediately.
+    updateGlobalSettings({ radarEnabled: true });
+    expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(true);
+  });
+
+  it("no-ops when the adapter is not initialized", () => {
+    _resetGlobalSettings();
+    const logger = createMockLogger();
+    // Not calling initGlobalSettings — adapterRef stays null.
+
+    updateGlobalSettings({ radarEnabled: false });
+
+    // Nothing to assert on the adapter (we didn't create one); just
+    // verify no throw and that subsequent reads stay at the default.
+    expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(true);
+    expect(logger.warn).not.toHaveBeenCalled(); // logger isn't wired when init never ran
+  });
+});

--- a/packages/deck-core/src/global-settings.test.ts
+++ b/packages/deck-core/src/global-settings.test.ts
@@ -119,12 +119,24 @@ describe("global-settings cache (synchronous update on local writes)", () => {
     expect(listener.mock.calls[1][0].radarVolume).toBe(75);
   });
 
-  it("forwards the merged (parsed) settings to the adapter", () => {
+  it("forwards the full merged+parsed settings payload to the adapter", () => {
     updateGlobalSettings({ radarEnabled: false });
 
     expect(mock.setGlobalSettings).toHaveBeenCalledTimes(1);
     const sent = mock.setGlobalSettings.mock.calls[0][0] as Record<string, unknown>;
-    expect(sent.radarEnabled).toBe(false);
+    // Assert both the partial override and the Zod-produced defaults are
+    // all present — this proves the adapter receives the parsed result,
+    // not just the caller's bare partial.
+    expect(sent).toMatchObject({
+      radarEnabled: false,
+      raceEngineerEnabled: true,
+      radarVolume: 100,
+      disableWhenDisconnected: true,
+      focusIRacingWindow: false,
+      enableFuelingOnChange: true,
+      simHubHost: "127.0.0.1",
+      simHubPort: 8888,
+    });
   });
 
   it("reconciles on host echo without losing later local writes' semantics", () => {

--- a/packages/deck-core/src/global-settings.test.ts
+++ b/packages/deck-core/src/global-settings.test.ts
@@ -143,8 +143,12 @@ describe("global-settings cache (synchronous update on local writes)", () => {
     updateGlobalSettings({ radarEnabled: false });
     expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(false);
 
+    // initGlobalSettings must register an echo callback; fail loudly if
+    // not, otherwise the reconciliation step below silently skips.
+    expect(mock.echo).not.toBeNull();
+
     // Host finally echoes the earlier write — cache stays false.
-    mock.echo?.({ radarEnabled: false });
+    mock.echo!({ radarEnabled: false });
     expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(false);
 
     // New local write still flips immediately.

--- a/packages/deck-core/src/global-settings.ts
+++ b/packages/deck-core/src/global-settings.ts
@@ -183,12 +183,7 @@ export function initGlobalSettings(adapter: IDeckPlatformAdapter, log: ILogger):
     logger?.debug(`Raw settings: ${JSON.stringify(settings)}`);
     const newSettings = GlobalSettingsSchema.parse(settings);
     logger?.debug(`Parsed focusIRacingWindow: ${newSettings.focusIRacingWindow}`);
-    currentSettings = newSettings;
-
-    // Notify all listeners
-    for (const listener of listeners) {
-      listener(newSettings);
-    }
+    applyParsedSettings(newSettings);
   });
 
   initialized = true;
@@ -226,7 +221,14 @@ export function onGlobalSettingsChange(listener: GlobalSettingsListener): () => 
 
 /**
  * Update global settings by merging partial values into current settings.
- * Writes the merged result back to the platform adapter.
+ * Writes the merged result back to the platform adapter **and** updates the
+ * in-memory cache synchronously so subsequent reads in the same task see the
+ * new value. The host's `onDidReceiveGlobalSettings` echo is not guaranteed to
+ * fire promptly — in observed Stream Deck sessions the echo has arrived
+ * minutes after the write — and without the synchronous cache update every
+ * read-modify-write toggle (Pit Crew Radar, Race Engineer) gets stuck because
+ * subsequent presses re-read the stale value and compute the same "next"
+ * again. See #419.
  *
  * @param partial - Partial settings to merge into current settings
  */
@@ -240,7 +242,27 @@ export function updateGlobalSettings(partial: Record<string, unknown>): void {
   const merged = { ...currentSettings, ...partial };
   logger?.info("Updating global settings");
   logger?.debug(`Partial update: ${JSON.stringify(partial)}`);
-  adapterRef.setGlobalSettings(merged);
+
+  // Parse + apply synchronously so the cache and listeners reflect the
+  // new value immediately. The later `onDidReceiveGlobalSettings` echo
+  // re-parses the same payload and reconciles as a no-op.
+  const applied = applyParsedSettings(GlobalSettingsSchema.parse(merged));
+  adapterRef.setGlobalSettings(applied);
+}
+
+/**
+ * Apply a parsed settings object: update the cache and notify listeners.
+ * Shared between the host-echo path (`onDidReceiveGlobalSettings`) and the
+ * local-write path (`updateGlobalSettings`) so both stay in sync.
+ */
+function applyParsedSettings(parsed: GlobalSettings): GlobalSettings {
+  currentSettings = parsed;
+
+  for (const listener of listeners) {
+    listener(parsed);
+  }
+
+  return parsed;
 }
 
 /**

--- a/packages/iracing-actions/src/actions/pit-crew/pit-crew.test.ts
+++ b/packages/iracing-actions/src/actions/pit-crew/pit-crew.test.ts
@@ -415,6 +415,28 @@ describe("PitCrew action", () => {
       const updates = hoisted.updateGlobalSettings.mock.calls.flatMap(([partial]) => Object.keys(partial));
       expect(updates).not.toContain("raceEngineerEnabled");
     });
+
+    it("alternates radarEnabled across three consecutive presses without a host echo (#419)", async () => {
+      hoisted.setGlobalSettings({ raceEngineerEnabled: true, radarEnabled: true, radarVolume: 100 });
+      const action = new PitCrew();
+      const event = buildAppearEvent({ mode: "radar" }) as never;
+      await action.onWillAppear(event);
+
+      // Press 1 — on → off
+      await action.onKeyDown(event);
+      expect(hoisted.updateGlobalSettings).toHaveBeenLastCalledWith({ radarEnabled: false });
+      expect(hoisted.setRadarEnabled).toHaveBeenLastCalledWith(false);
+
+      // Press 2 — off → on (the #419 bug: previously stayed at false)
+      await action.onKeyDown(event);
+      expect(hoisted.updateGlobalSettings).toHaveBeenLastCalledWith({ radarEnabled: true });
+      expect(hoisted.setRadarEnabled).toHaveBeenLastCalledWith(true);
+
+      // Press 3 — on → off
+      await action.onKeyDown(event);
+      expect(hoisted.updateGlobalSettings).toHaveBeenLastCalledWith({ radarEnabled: false });
+      expect(hoisted.setRadarEnabled).toHaveBeenLastCalledWith(false);
+    });
   });
 
   describe("onKeyDown — radar-volume mode", () => {


### PR DESCRIPTION
## Related Issue

Fixes #419.

## What changed?

`updateGlobalSettings()` used to hand the merged payload to the adapter and rely on the host's `onDidReceiveGlobalSettings` echo to refresh the in-memory cache. The Stream Deck host does **not** guarantee a prompt echo — in the session log that prompted this issue, the echo arrived **~6 minutes** after the write. Between the write and the echo, `getGlobalSettings()` returned stale state, so every read-modify-write toggle got stuck computing the same "next" value repeatedly.

This PR:

- Parses the merged partial via Zod and updates `currentSettings` + notifies listeners **synchronously** in `updateGlobalSettings`, before dispatching to the adapter.
- Extracts `applyParsedSettings(parsed)` as the single cache-mutation point; both the echo path and the local-write path funnel through it. No duplicate notifications; the later echo re-parses the same payload and reconciles as a no-op.
- Forwards the **parsed** (coerced) payload to `adapterRef.setGlobalSettings` so host and cache stay consistent.

Tests:
- **New** `packages/deck-core/src/global-settings.test.ts` — 8 cases covering single-write visibility, 3× alternation without echo, the Pit Crew read-flip-write shape, `raceEngineerEnabled` (same latent bug fixed), listener notification on local writes, parsed payload forwarding to the adapter, echo reconciliation after stale local writes, and uninitialised no-op guard.
- `pit-crew.test.ts` regression for the reported symptom: 3 consecutive Radar-mode presses alternate `radarEnabled` without a host echo (expected `true` → `false` → `true` → `false`).

## How to test

Live session:
- [ ] Connect to iRacing with radar ticks active.
- [ ] Press the Pit Crew Radar button once — ticks stop, key flips red.
- [ ] Press again immediately — ticks resume, key flips green.
- [ ] Alternate 4+ times without waiting for a PI round-trip; behaviour holds.
- [ ] Race Engineer toggle also alternates (status bar flips) across consecutive presses.

Automated:
- [ ] `pnpm -w build`, `pnpm -w lint`, `pnpm -w test`, `pnpm format` all green. Test count 3168 → 3177 (+9: eight new global-settings cases + one Pit Crew regression).

## Checklist

- [x] Linked to an approved issue (#419, sub-issue of #375)
- [x] New code has unit tests (new `global-settings.test.ts`, new Pit Crew regression)
- [x] Changes registered in all applicable plugins (fix is in `@iracedeck/deck-core`; both plugins consume the updated behaviour automatically)
- [x] No unrelated changes included

Stacks on top of #423 (#418) → #422 (#417) → #421 (#416) → #420 (#415). Bases auto-retarget to `feature/pit-engineer` as the stack merges.

Sub-issue of #375.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Global settings now apply immediately in-memory and notify listeners synchronously on local changes, then reconcile with later host echoes to avoid stale or stuck states (fixes radar toggle flakiness).

* **Tests**
  * Added tests verifying immediate local-write behavior, listener notifications on every local change, host-echo reconciliation, and correct radar-mode toggle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->