### PR TITLE
fix(pi-components): ird-range-input treats 0 as a valid value (not empty) (#426)

### DIFF
--- a/packages/iracing-actions/src/actions/pit-crew/pit-crew.test.ts
+++ b/packages/iracing-actions/src/actions/pit-crew/pit-crew.test.ts
@@ -473,6 +473,7 @@ describe("PitCrew action", () => {
       await action.onKeyDown(buildAppearEvent({ mode: "radar-volume", direction: "up" }) as never);
 
       expect(hoisted.updateGlobalSettings).not.toHaveBeenCalled();
+      expect(hoisted.setBusVolume).not.toHaveBeenCalled();
     });
 
     it("clamps at 0 (no-op when already at min)", async () => {
@@ -482,6 +483,34 @@ describe("PitCrew action", () => {
       vi.clearAllMocks();
 
       await action.onKeyDown(buildAppearEvent({ mode: "radar-volume", direction: "down" }) as never);
+
+      expect(hoisted.updateGlobalSettings).not.toHaveBeenCalled();
+      expect(hoisted.setBusVolume).not.toHaveBeenCalled();
+    });
+
+    it("auto-repeat at upper boundary (5x onKeyDown at 100) is fully a no-op", async () => {
+      hoisted.setGlobalSettings({ raceEngineerEnabled: true, radarEnabled: true, radarVolume: 100 });
+      const action = new PitCrew();
+      await action.onWillAppear(buildAppearEvent({ mode: "radar-volume", direction: "up" }) as never);
+      vi.clearAllMocks();
+
+      for (let i = 0; i < 5; i += 1) {
+        await action.onKeyDown(buildAppearEvent({ mode: "radar-volume", direction: "up" }) as never);
+      }
+
+      expect(hoisted.updateGlobalSettings).not.toHaveBeenCalled();
+      expect(hoisted.setBusVolume).not.toHaveBeenCalled();
+    });
+
+    it("auto-repeat at lower boundary (5x onKeyDown at 0) is fully a no-op", async () => {
+      hoisted.setGlobalSettings({ raceEngineerEnabled: true, radarEnabled: true, radarVolume: 0 });
+      const action = new PitCrew();
+      await action.onWillAppear(buildAppearEvent({ mode: "radar-volume", direction: "down" }) as never);
+      vi.clearAllMocks();
+
+      for (let i = 0; i < 5; i += 1) {
+        await action.onKeyDown(buildAppearEvent({ mode: "radar-volume", direction: "down" }) as never);
+      }
 
       expect(hoisted.updateGlobalSettings).not.toHaveBeenCalled();
       expect(hoisted.setBusVolume).not.toHaveBeenCalled();

--- a/packages/pi-components/src/components/range-input.test.ts
+++ b/packages/pi-components/src/components/range-input.test.ts
@@ -279,4 +279,125 @@ describe("ird-range-input", () => {
       expect((withDefault as HTMLInputElement).value).toBe("");
     });
   });
+
+  describe("settings hook value coercion", () => {
+    /**
+     * Test stub for window.SDPIComponents that exposes the value listener so
+     * tests can simulate the host delivering different value types (number,
+     * string, null, undefined, "") to the persistence callback.
+     */
+    function installSDPIStub(): { emit: (value: unknown) => void } {
+      let listener: ((value: string) => void) | null = null;
+      const makeHook = (_key: string, callback: (value: string) => void) => {
+        listener = callback;
+
+        return [() => Promise.resolve(""), () => undefined];
+      };
+
+      (window as unknown as Record<string, unknown>).SDPIComponents = {
+        useSettings: makeHook,
+        useGlobalSettings: makeHook,
+      };
+
+      return {
+        emit: (value) => {
+          // The runtime can deliver non-string types even though the type
+          // annotation in key-binding-utils.ts says (value: string).
+          listener?.(value as string);
+        },
+      };
+    }
+
+    function createWithSetting(defaultAttr = "100"): {
+      el: HTMLElement;
+      rangeInput: HTMLInputElement;
+      numberInput: HTMLInputElement;
+    } {
+      while (document.body.firstChild) {
+        document.body.removeChild(document.body.firstChild);
+      }
+
+      const el = document.createElement("ird-range-input");
+      el.setAttribute("min", "0");
+      el.setAttribute("max", "100");
+      el.setAttribute("default", defaultAttr);
+      el.setAttribute("setting", "radarVolume");
+      document.body.appendChild(el);
+
+      return {
+        el,
+        rangeInput: el.querySelector('input[type="range"]') as HTMLInputElement,
+        numberInput: el.querySelector('input[type="number"]') as HTMLInputElement,
+      };
+    }
+
+    it("displays 0 when callback fires with the number 0 (not the default)", () => {
+      const stub = installSDPIStub();
+      const { el, rangeInput, numberInput } = createWithSetting("100");
+
+      stub.emit(0);
+
+      expect((el as HTMLInputElement).value).toBe("0");
+      expect(rangeInput.value).toBe("0");
+      expect(numberInput.value).toBe("0");
+    });
+
+    it('displays 0 when callback fires with the string "0"', () => {
+      const stub = installSDPIStub();
+      const { el, rangeInput, numberInput } = createWithSetting("100");
+
+      stub.emit("0");
+
+      expect((el as HTMLInputElement).value).toBe("0");
+      expect(rangeInput.value).toBe("0");
+      expect(numberInput.value).toBe("0");
+    });
+
+    it("falls back to default attribute when callback fires with empty string", () => {
+      const stub = installSDPIStub();
+      const { el, rangeInput, numberInput } = createWithSetting("75");
+
+      stub.emit("");
+
+      expect((el as HTMLInputElement).value).toBe("");
+      expect(rangeInput.value).toBe("75");
+      expect(numberInput.value).toBe("75");
+    });
+
+    it("falls back to default attribute when callback fires with null", () => {
+      const stub = installSDPIStub();
+      const { el, rangeInput, numberInput } = createWithSetting("75");
+
+      stub.emit(null);
+
+      expect((el as HTMLInputElement).value).toBe("");
+      expect(rangeInput.value).toBe("75");
+      expect(numberInput.value).toBe("75");
+    });
+
+    it("falls back to default attribute when callback fires with undefined", () => {
+      const stub = installSDPIStub();
+      const { el, rangeInput, numberInput } = createWithSetting("75");
+
+      stub.emit(undefined);
+
+      expect((el as HTMLInputElement).value).toBe("");
+      expect(rangeInput.value).toBe("75");
+      expect(numberInput.value).toBe("75");
+    });
+
+    it("displays the value after host echoes back a real 0 (regression: radar volume snap-to-100)", () => {
+      const stub = installSDPIStub();
+      const { el, rangeInput, numberInput } = createWithSetting("100");
+
+      // Simulate a sequence: user has 5, presses Down, host echoes 0
+      stub.emit(5);
+      expect((el as HTMLInputElement).value).toBe("5");
+
+      stub.emit(0);
+      expect((el as HTMLInputElement).value).toBe("0");
+      expect(rangeInput.value).toBe("0");
+      expect(numberInput.value).toBe("0");
+    });
+  });
 });

--- a/packages/pi-components/src/components/range-input.ts
+++ b/packages/pi-components/src/components/range-input.ts
@@ -247,7 +247,12 @@ export class RangeInput extends HTMLElement {
       const [, save] = useSettingsHook(
         settingName,
         (value: string) => {
-          this.currentValue = value || "";
+          // Runtime may deliver number/null/undefined despite the string type
+          // annotation. Treat only null/undefined/empty-string as cleared so
+          // the numeric value 0 (e.g., radarVolume) doesn't fall through to
+          // the default-display branch via JS truthiness.
+          const v: unknown = value;
+          this.currentValue = v == null || v === "" ? "" : String(v);
           this.updateDisplay();
         },
         null,


### PR DESCRIPTION
## Related Issue

Fixes #426

## What changed?

Sub-issue of #375. Regression from #418 / #423.

The `ird-range-input` `hookSettings` callback used `value || ""` to coerce the value the host delivered, which collapses the number `0` (a JS-falsy value but a valid persisted setting like `radarVolume`) into the empty-string "cleared" branch. `updateDisplay()` then paints the slider's `default` attribute on both inputs.

**Symptom:** Radar Volume Down at 5 wrote 0 to global settings; the host echoed 0 back; the PI snapped the slider to 100 (`default="100"`).

**Fix:** Replace the falsy coercion with an explicit `null` / `undefined` / empty-string check so 0 round-trips correctly:

```ts
const v: unknown = value;
this.currentValue = v == null || v === "" ? "" : String(v);
```

Audited the other zero-valued paths in `range-input.ts` (`clampValue`, `commitNumberInput`, `updateDisplay`, slider `input` listener) — all use string comparisons against DOM values or explicit `=== ""` checks; none have the falsy-zero problem. The numeric input's `=== ""` short-circuit (allow user typing empty) is intentional and stays.

Also tightened the pit-crew radar-volume boundary tests:
- "clamps at 100" now also asserts `setBusVolume.not.toHaveBeenCalled()` (matching the lower-bound test added in #423).
- Two new auto-repeat tests fire `onKeyDown` 5× at each boundary and assert zero side-effects across the full burst.

## How to test

- `pnpm test` — 3186 tests pass.
- `pnpm lint` / `pnpm format` — clean.
- `pnpm build` — clean.
- Manual: open the Pit Crew Radar Volume PI, set to 5, press Down — the slider must show **0** (not snap to 100). Press Down again — no-op. Set to 100, press Up repeatedly — no-op.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — N/A, `ird-range-input` is shared via `@iracedeck/pi-components`
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed range input component to correctly display zero values instead of reverting to defaults.

* **Tests**
  * Enhanced test coverage for boundary condition handling and value coercion edge cases, including zero values, null/undefined inputs, and repeated boundary interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->