### PR TITLE
refactor(audio): persist Output Device by stable ma_device_id, not enumeration index (#427)

### DIFF
--- a/docs/plugins/core/actions/pit-crew.md
+++ b/docs/plugins/core/actions/pit-crew.md
@@ -34,7 +34,7 @@ Multi-mode action covering the iRaceDeck pit-side audio framework. The initial r
 
 ### Plugin-global Audio Settings (in the Pit Crew accordion, not under Global Settings)
 - **Radar Volume** (range 0–100, default 100) - slider + Test button. Shared across every Pit Crew instance.
-- **Output Device** - audio device used for the iRaceDeck audio engine; shared globally across the plugin.
+- **Output Device** - audio device used for the iRaceDeck audio engine; shared globally across the plugin. Persisted by the platform-stable device id (WASAPI endpoint ID on Windows), so the selection survives device-list reordering, replug, and OS audio-preference changes.
 
 ## Keyboard Simulation
 

--- a/packages/audio-native/CLAUDE.md
+++ b/packages/audio-native/CLAUDE.md
@@ -60,11 +60,14 @@ Stops all 4 channels.
 ### `seekChannelRandom(channel: number): void`
 Seeks to a random position in the current sound (used for ambient loop variation).
 
-### `getAudioDevices(): Array<{ index: number, name: string, isDefault: boolean }>`
-Enumerates available audio playback devices.
+### `getAudioDevices(): Array<{ index: number, name: string, id: string, isDefault: boolean }>`
+Enumerates available audio playback devices. `id` is a hex-encoded `ma_device_id` — the platform-stable identifier (WASAPI endpoint ID on Windows, CoreAudio UID on macOS, etc.) suitable for persisting selection across sessions. `index` is the volatile enumeration position retained for backward compatibility.
 
 ### `setAudioDevice(deviceIndex: number): boolean`
-Switches audio output to a specific device. -1 for system default. Stops all sounds and reinitializes the engine.
+Switches audio output to a specific device by enumeration index. -1 for system default. Stops all sounds and reinitializes the engine. Prefer `setAudioDeviceById` for persisted selections.
+
+### `setAudioDeviceById(deviceId: string): boolean`
+Switches audio output to a device looked up by its stable `id` from `getAudioDevices`. Returns `false` if the id is not found in the current enumeration (e.g. unplugged device). On engine-init failure, falls back to the system default so the mixer remains usable. Use this for any selection that needs to survive replug or driver reset.
 
 ## Channel enum
 

--- a/packages/audio-native/src/addon.cc
+++ b/packages/audio-native/src/addon.cc
@@ -5,12 +5,71 @@
  * Provides a 4-channel mixer used by Pit Engineer and other audio actions.
  */
 
+#include <cstring>
 #include <mutex>
 #include <napi.h>
 #include <string>
 
 #define MINIAUDIO_IMPLEMENTATION
 #include "miniaudio.h"
+
+// ============================================================================
+// Stable device-id encoding
+// ============================================================================
+//
+// `ma_device_id` is a union of platform-specific stable identifiers (WASAPI
+// endpoint IDs, CoreAudio UIDs, ALSA names, etc.). The raw layout is opaque
+// to JS; we expose it as an uppercase-hex string of `sizeof(ma_device_id)`
+// bytes so it round-trips losslessly between native enumeration and the
+// persisted plugin setting.
+//
+// The encoding is deliberately format-stable: the byte layout of
+// `ma_device_id` depends on miniaudio's compile-time configuration (active
+// backends), so a setting persisted under one build is only meaningful to
+// the same build. That is acceptable for iRaceDeck — we ship a single
+// addon binary per platform and there is no cross-machine setting sync.
+
+static std::string SerializeDeviceId(const ma_device_id &id)
+{
+    static constexpr char hex[] = "0123456789ABCDEF";
+    const ma_uint8 *bytes = reinterpret_cast<const ma_uint8 *>(&id);
+    std::string out;
+    out.resize(sizeof(ma_device_id) * 2);
+    for (size_t i = 0; i < sizeof(ma_device_id); i++)
+    {
+        out[i * 2] = hex[(bytes[i] >> 4) & 0x0F];
+        out[i * 2 + 1] = hex[bytes[i] & 0x0F];
+    }
+    return out;
+}
+
+static bool DeserializeDeviceId(const std::string &hex, ma_device_id &outId)
+{
+    if (hex.size() != sizeof(ma_device_id) * 2)
+    {
+        return false;
+    }
+
+    ma_uint8 *bytes = reinterpret_cast<ma_uint8 *>(&outId);
+    for (size_t i = 0; i < sizeof(ma_device_id); i++)
+    {
+        auto fromHex = [](char c) -> int {
+            if (c >= '0' && c <= '9') return c - '0';
+            if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+            if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+            return -1;
+        };
+
+        int hi = fromHex(hex[i * 2]);
+        int lo = fromHex(hex[i * 2 + 1]);
+        if (hi < 0 || lo < 0)
+        {
+            return false;
+        }
+        bytes[i] = static_cast<ma_uint8>((hi << 4) | lo);
+    }
+    return true;
+}
 
 // ============================================================================
 // Audio Engine (miniaudio — multi-channel mixer)
@@ -383,7 +442,12 @@ Napi::Value SeekChannelRandom(const Napi::CallbackInfo &info)
 
 /**
  * Get list of available audio playback devices.
- * @returns Array of { index: number, name: string, isDefault: boolean }
+ * @returns Array of { index: number, name: string, id: string, isDefault: boolean }
+ *
+ * `id` is a hex-encoded `ma_device_id` — the platform-stable identifier
+ * (WASAPI endpoint ID on Windows, CoreAudio UID on macOS, etc.) suitable
+ * for persisting selection across sessions. `index` is preserved for
+ * backward compatibility with `setAudioDevice(index)`.
  */
 Napi::Value GetAudioDevices(const Napi::CallbackInfo &info)
 {
@@ -408,6 +472,7 @@ Napi::Value GetAudioDevices(const Napi::CallbackInfo &info)
         Napi::Object device = Napi::Object::New(env);
         device.Set("index", Napi::Number::New(env, static_cast<int>(i)));
         device.Set("name", Napi::String::New(env, pPlaybackDevices[i].name));
+        device.Set("id", Napi::String::New(env, SerializeDeviceId(pPlaybackDevices[i].id)));
         device.Set("isDefault", Napi::Boolean::New(env, pPlaybackDevices[i].isDefault != 0));
         result.Set(i, device);
     }
@@ -522,6 +587,111 @@ Napi::Value SetAudioDevice(const Napi::CallbackInfo &info)
     return Napi::Boolean::New(env, true);
 }
 
+/**
+ * Switch audio output to a specific device looked up by its stable ID.
+ * Stops all sounds, reinitializes engine with the matched device.
+ *
+ * @param deviceId - Hex-encoded `ma_device_id` from a `getAudioDevices()` entry.
+ * @returns true if the device was found and the engine was reinitialized.
+ *          Returns false if the ID is malformed, the device isn't in the
+ *          current enumeration, or engine reinit fails. On reinit failure
+ *          the engine is recreated with the system default so the mixer
+ *          stays usable.
+ */
+Napi::Value SetAudioDeviceById(const Napi::CallbackInfo &info)
+{
+    Napi::Env env = info.Env();
+
+    if (info.Length() < 1 || !info[0].IsString())
+    {
+        Napi::TypeError::New(env, "Expected (deviceId: string)").ThrowAsJavaScriptException();
+        return Napi::Boolean::New(env, false);
+    }
+
+    if (!g_engine || !g_audioContext)
+    {
+        return Napi::Boolean::New(env, false);
+    }
+
+    std::string idHex = info[0].As<Napi::String>().Utf8Value();
+    ma_device_id targetId;
+    if (!DeserializeDeviceId(idHex, targetId))
+    {
+        return Napi::Boolean::New(env, false);
+    }
+
+    // Look up the device by raw-bytes match against the current enumeration.
+    // We resolve every session because device list ordering is volatile, but
+    // the underlying ma_device_id bytes are platform-stable.
+    ma_device_info *pPlaybackDevices;
+    ma_uint32 playbackCount;
+    ma_result enumResult = ma_context_get_devices(g_audioContext, &pPlaybackDevices, &playbackCount, NULL, NULL);
+    if (enumResult != MA_SUCCESS)
+    {
+        return Napi::Boolean::New(env, false);
+    }
+
+    int matchIndex = -1;
+    for (ma_uint32 i = 0; i < playbackCount; i++)
+    {
+        if (memcmp(&pPlaybackDevices[i].id, &targetId, sizeof(ma_device_id)) == 0)
+        {
+            matchIndex = static_cast<int>(i);
+            break;
+        }
+    }
+
+    if (matchIndex < 0)
+    {
+        return Napi::Boolean::New(env, false);
+    }
+
+    // Snapshot the matched ID — `pPlaybackDevices` is owned by miniaudio and
+    // may be invalidated by the next enumeration / reinit.
+    ma_device_id selectedId = pPlaybackDevices[matchIndex].id;
+
+    // Stop all active sounds before tearing down the engine
+    for (int i = 0; i < IRD_MAX_CHANNELS; i++)
+    {
+        uninitChannel(i);
+    }
+
+    ma_engine_uninit(g_engine);
+    delete g_engine;
+    g_engine = nullptr;
+
+    // Reinitialize engine with the selected device
+    g_engine = new ma_engine();
+    ma_engine_config engineConfig = ma_engine_config_init();
+    engineConfig.pContext = g_audioContext;
+    engineConfig.pPlaybackDeviceID = &selectedId;
+
+    ma_result result = ma_engine_init(&engineConfig, g_engine);
+    if (result != MA_SUCCESS)
+    {
+        delete g_engine;
+        g_engine = nullptr;
+
+        // Fallback: try default device so the mixer remains usable.
+        g_engine = new ma_engine();
+        ma_engine_config fallbackConfig = ma_engine_config_init();
+        fallbackConfig.pContext = g_audioContext;
+        ma_result fallbackResult = ma_engine_init(&fallbackConfig, g_engine);
+        if (fallbackResult != MA_SUCCESS)
+        {
+            delete g_engine;
+            g_engine = nullptr;
+        }
+        g_selectedDeviceIndex = -1;
+        return Napi::Boolean::New(env, false);
+    }
+
+    // Track the matched index so a subsequent `setAudioDevice(index)` skip
+    // optimization stays consistent with what's actually open.
+    g_selectedDeviceIndex = matchIndex;
+    return Napi::Boolean::New(env, true);
+}
+
 // ============================================================================
 // Module Initialization
 // ============================================================================
@@ -539,6 +709,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports)
     exports.Set("seekChannelRandom", Napi::Function::New(env, SeekChannelRandom));
     exports.Set("getAudioDevices", Napi::Function::New(env, GetAudioDevices));
     exports.Set("setAudioDevice", Napi::Function::New(env, SetAudioDevice));
+    exports.Set("setAudioDeviceById", Napi::Function::New(env, SetAudioDeviceById));
 
     return exports;
 }

--- a/packages/audio-native/src/addon.cc
+++ b/packages/audio-native/src/addon.cc
@@ -19,9 +19,18 @@
 //
 // `ma_device_id` is a union of platform-specific stable identifiers (WASAPI
 // endpoint IDs, CoreAudio UIDs, ALSA names, etc.). The raw layout is opaque
-// to JS; we expose it as an uppercase-hex string of `sizeof(ma_device_id)`
-// bytes so it round-trips losslessly between native enumeration and the
-// persisted plugin setting.
+// to JS; we expose it as an uppercase-hex string so it round-trips losslessly
+// between native enumeration and the persisted plugin setting.
+//
+// We trim trailing zero bytes before hex-encoding and zero-pad on decode.
+// `ma_context_get_devices` zero-initializes the union, so unused tail bytes
+// are not data — trimming reduces a Windows WASAPI endpoint id from
+// 2 * sizeof(ma_device_id) (~512 chars) down to ~220 chars (the actual
+// `{0.0.0.00000000}.{guid}` wide-string plus its null terminator). Without
+// trimming, pushing the device list into Stream Deck's global settings
+// inflates the cross-process settings echo enough to trigger a stack
+// overflow in the SDK's connection logger when the failed-parse fallback
+// tries to format the oversized payload.
 //
 // The encoding is deliberately format-stable: the byte layout of
 // `ma_device_id` depends on miniaudio's compile-time configuration (active
@@ -33,9 +42,20 @@ static std::string SerializeDeviceId(const ma_device_id &id)
 {
     static constexpr char hex[] = "0123456789ABCDEF";
     const ma_uint8 *bytes = reinterpret_cast<const ma_uint8 *>(&id);
+
+    // Trim trailing zero bytes. Safe because miniaudio zero-fills the union
+    // and every backend stores its identifier in the leading bytes (string
+    // backends include their null terminator; integer backends fit in 4 bytes
+    // followed by zero padding).
+    size_t sigLen = sizeof(ma_device_id);
+    while (sigLen > 0 && bytes[sigLen - 1] == 0)
+    {
+        sigLen--;
+    }
+
     std::string out;
-    out.resize(sizeof(ma_device_id) * 2);
-    for (size_t i = 0; i < sizeof(ma_device_id); i++)
+    out.resize(sigLen * 2);
+    for (size_t i = 0; i < sigLen; i++)
     {
         out[i * 2] = hex[(bytes[i] >> 4) & 0x0F];
         out[i * 2 + 1] = hex[bytes[i] & 0x0F];
@@ -45,13 +65,20 @@ static std::string SerializeDeviceId(const ma_device_id &id)
 
 static bool DeserializeDeviceId(const std::string &hex, ma_device_id &outId)
 {
-    if (hex.size() != sizeof(ma_device_id) * 2)
+    // Hex must be even-length and fit within the union. Empty string is
+    // rejected so the System Default sentinel ("") never round-trips into
+    // a zero-filled ma_device_id and accidentally matches a real device.
+    if (hex.empty() || hex.size() > sizeof(ma_device_id) * 2 || hex.size() % 2 != 0)
     {
         return false;
     }
 
+    // Zero-fill so trimmed trailing bytes are restored — the resulting
+    // memcmp matches what `ma_context_get_devices` enumerates.
+    memset(&outId, 0, sizeof(ma_device_id));
     ma_uint8 *bytes = reinterpret_cast<ma_uint8 *>(&outId);
-    for (size_t i = 0; i < sizeof(ma_device_id); i++)
+    size_t numBytes = hex.size() / 2;
+    for (size_t i = 0; i < numBytes; i++)
     {
         auto fromHex = [](char c) -> int {
             if (c >= '0' && c <= '9') return c - '0';

--- a/packages/audio-native/src/index.ts
+++ b/packages/audio-native/src/index.ts
@@ -31,8 +31,16 @@ export enum AudioChannel {
   Radar = 3,
 }
 
-/** Audio device descriptor returned by {@link AudioNative.getAudioDevices}. */
-export type AudioDeviceInfo = { index: number; name: string; isDefault: boolean };
+/**
+ * Audio device descriptor returned by {@link AudioNative.getAudioDevices}.
+ *
+ * `id` is a hex-encoded `ma_device_id` — the platform-stable identifier
+ * (WASAPI endpoint ID on Windows, CoreAudio UID on macOS, etc.) suitable
+ * for persisting selection across sessions. `index` is the volatile
+ * enumeration position retained for backward compatibility with
+ * {@link AudioNative.setAudioDevice}.
+ */
+export type AudioDeviceInfo = { index: number; name: string; id: string; isDefault: boolean };
 
 // Try to load native addon (only on Windows, with safety catch).
 // Force mock mode by creating a `.mock` file in the sdPlugin folder,
@@ -197,5 +205,18 @@ export class AudioNative {
     }
 
     return this.getMock().setAudioDevice(deviceIndex);
+  }
+
+  /**
+   * Switch audio output to a device looked up by its stable `id` from
+   * {@link getAudioDevices}. Returns true on success, false if the id is
+   * unknown to the current enumeration (e.g. unplugged device).
+   */
+  setAudioDeviceById(deviceId: string): boolean {
+    if (addon) {
+      return addon.setAudioDeviceById(deviceId);
+    }
+
+    return this.getMock().setAudioDeviceById(deviceId);
   }
 }

--- a/packages/audio-native/src/mock-impl.test.ts
+++ b/packages/audio-native/src/mock-impl.test.ts
@@ -59,15 +59,24 @@ describe("AudioNativeMock", () => {
   });
 
   describe("device enumeration", () => {
-    it("getAudioDevices returns a single default mock device", () => {
+    it("getAudioDevices returns a single default mock device with a stable id", () => {
       const devices = mock.getAudioDevices();
-      expect(devices).toEqual([{ index: 0, name: "Mock Audio Device", isDefault: true }]);
+      expect(devices).toEqual([{ index: 0, name: "Mock Audio Device", id: "mock-device-0", isDefault: true }]);
     });
 
     it("setAudioDevice returns true for any index", () => {
       expect(mock.setAudioDevice(-1)).toBe(true);
       expect(mock.setAudioDevice(0)).toBe(true);
       expect(mock.setAudioDevice(99)).toBe(true);
+    });
+
+    it("setAudioDeviceById returns true for the known mock id", () => {
+      expect(mock.setAudioDeviceById("mock-device-0")).toBe(true);
+    });
+
+    it("setAudioDeviceById returns false for unknown ids", () => {
+      expect(mock.setAudioDeviceById("unknown-id")).toBe(false);
+      expect(mock.setAudioDeviceById("")).toBe(false);
     });
   });
 });

--- a/packages/audio-native/src/mock-impl.ts
+++ b/packages/audio-native/src/mock-impl.ts
@@ -35,10 +35,18 @@ export class AudioNativeMock {
   seekChannelRandom(_channel: number): void {}
 
   getAudioDevices(): AudioDeviceInfo[] {
-    return [{ index: 0, name: "Mock Audio Device", isDefault: true }];
+    return [{ index: 0, name: "Mock Audio Device", id: MOCK_DEVICE_ID, isDefault: true }];
   }
 
   setAudioDevice(_deviceIndex: number): boolean {
     return true;
   }
+
+  setAudioDeviceById(deviceId: string): boolean {
+    // Mock honors only the synthetic mock id; unknown ids would be
+    // unrecoverable on a real device, and tests rely on this distinction.
+    return deviceId === MOCK_DEVICE_ID;
+  }
 }
+
+const MOCK_DEVICE_ID = "mock-device-0";

--- a/packages/audio-service/src/audio-service.test.ts
+++ b/packages/audio-service/src/audio-service.test.ts
@@ -14,8 +14,9 @@ function createMockNative(): AudioNative {
     setChannelEndCallback: vi.fn(),
     stopAllChannels: vi.fn(),
     seekChannelRandom: vi.fn(),
-    getAudioDevices: vi.fn(() => [{ index: 0, name: "Default Device", isDefault: true }]),
+    getAudioDevices: vi.fn(() => [{ index: 0, name: "Default Device", id: "default-id", isDefault: true }]),
     setAudioDevice: vi.fn(() => true),
+    setAudioDeviceById: vi.fn(() => true),
   } as unknown as AudioNative;
 }
 
@@ -343,6 +344,59 @@ describe("AudioService", () => {
       getAudio().playVoiceSequence([]);
       // playOnChannel should only have been called by init setup, not for empty sequence
       expect(native.playOnChannel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("device selection", () => {
+    it("getAudioDevices forwards the native enumeration with stable id", () => {
+      const native = createMockNative();
+      (native.getAudioDevices as ReturnType<typeof vi.fn>).mockReturnValue([
+        { index: 0, name: "Speakers", id: "AAAA", isDefault: true },
+        { index: 1, name: "Headset", id: "BBBB", isDefault: false },
+      ]);
+      initializeAudio(mockLogger as never, native);
+
+      expect(getAudio().getAudioDevices()).toEqual([
+        { index: 0, name: "Speakers", id: "AAAA", isDefault: true },
+        { index: 1, name: "Headset", id: "BBBB", isDefault: false },
+      ]);
+    });
+
+    it("setAudioDevice stops all channels and forwards the index", () => {
+      const native = createMockNative();
+      initializeAudio(mockLogger as never, native);
+      getAudio().init();
+      vi.clearAllMocks();
+
+      const ok = getAudio().setAudioDevice(-1);
+
+      expect(ok).toBe(true);
+      expect(native.stopAllChannels).toHaveBeenCalledTimes(1);
+      expect(native.setAudioDevice).toHaveBeenCalledWith(-1);
+    });
+
+    it("setAudioDeviceById stops all channels and forwards the id", () => {
+      const native = createMockNative();
+      initializeAudio(mockLogger as never, native);
+      getAudio().init();
+      vi.clearAllMocks();
+
+      const ok = getAudio().setAudioDeviceById("DEADBEEF");
+
+      expect(ok).toBe(true);
+      expect(native.stopAllChannels).toHaveBeenCalledTimes(1);
+      expect(native.setAudioDeviceById).toHaveBeenCalledWith("DEADBEEF");
+    });
+
+    it("setAudioDeviceById returns false (and does not throw) when the native layer rejects the id", () => {
+      const native = createMockNative();
+      (native.setAudioDeviceById as ReturnType<typeof vi.fn>).mockReturnValue(false);
+      initializeAudio(mockLogger as never, native);
+      getAudio().init();
+
+      const ok = getAudio().setAudioDeviceById("STALE-ID");
+
+      expect(ok).toBe(false);
     });
   });
 });

--- a/packages/audio-service/src/audio-service.ts
+++ b/packages/audio-service/src/audio-service.ts
@@ -390,11 +390,21 @@ class AudioService implements IAudioService {
       this.logger.info("Audio output device switched by id");
       this.logger.debug(`Device id: ${deviceId}`);
     } else {
-      // A stale or unknown id — caller decides how to recover (typically
-      // fall back to system default via setAudioDevice(-1)). Log at warn
-      // since it's expected after a device unplug, not an internal failure.
-      this.logger.warn("Audio output device id not found in current enumeration");
-      this.logger.debug(`Unknown device id: ${deviceId}`);
+      // The native layer returns false for three distinct reasons:
+      // (a) the id isn't in the current enumeration (stale / unplugged /
+      // legacy value), (b) the hex string is malformed, or (c) the engine
+      // reinit failed. Distinguish (a) from (b)+(c) by re-checking the
+      // enumeration so the operator log is truthful. Caller decides how
+      // to recover (typically fall back to system default).
+      const exists = this.native.getAudioDevices().some((d) => d.id === deviceId);
+
+      if (exists) {
+        this.logger.error("Failed to switch audio output device by id (engine reinit failed)");
+      } else {
+        this.logger.warn("Audio output device id not found in current enumeration");
+      }
+
+      this.logger.debug(`Device id: ${deviceId}`);
     }
 
     return ok;

--- a/packages/audio-service/src/audio-service.ts
+++ b/packages/audio-service/src/audio-service.ts
@@ -147,10 +147,18 @@ export interface IAudioService {
   seekChannelRandom(channel: AudioChannel): void;
 
   /** Get list of available audio output devices. */
-  getAudioDevices(): Array<{ index: number; name: string; isDefault: boolean }>;
+  getAudioDevices(): Array<{ index: number; name: string; id: string; isDefault: boolean }>;
 
   /** Switch to a specific audio output device. -1 for system default. Returns true on success. */
   setAudioDevice(deviceIndex: number): boolean;
+
+  /**
+   * Switch to a device looked up by its stable `id` from
+   * {@link getAudioDevices}. Use this for any persisted selection — `id`
+   * survives device-list reordering, replug, and OS audio reconfiguration.
+   * Returns false if the id isn't in the current enumeration.
+   */
+  setAudioDeviceById(deviceId: string): boolean;
 }
 
 // ─── Implementation ──────────────────────────────────────────────────────────
@@ -345,7 +353,7 @@ class AudioService implements IAudioService {
     this.native.seekChannelRandom(channel);
   }
 
-  getAudioDevices(): Array<{ index: number; name: string; isDefault: boolean }> {
+  getAudioDevices(): Array<{ index: number; name: string; id: string; isDefault: boolean }> {
     return this.native.getAudioDevices();
   }
 
@@ -359,9 +367,34 @@ class AudioService implements IAudioService {
     const ok = this.native.setAudioDevice(deviceIndex);
 
     if (ok) {
-      this.logger.info(`Audio output device switched to index ${deviceIndex}`);
+      this.logger.info("Audio output device switched");
+      this.logger.debug(`Device index: ${deviceIndex}`);
     } else {
-      this.logger.error(`Failed to switch audio output device to index ${deviceIndex}`);
+      this.logger.error("Failed to switch audio output device");
+      this.logger.debug(`Failed device index: ${deviceIndex}`);
+    }
+
+    return ok;
+  }
+
+  setAudioDeviceById(deviceId: string): boolean {
+    // Stop all active playback before switching
+    this.cancelVoiceSequence();
+    this.native.stopAllChannels();
+
+    for (let i = 0; i < 4; i++) this.channelCallbacks[i] = null;
+
+    const ok = this.native.setAudioDeviceById(deviceId);
+
+    if (ok) {
+      this.logger.info("Audio output device switched by id");
+      this.logger.debug(`Device id: ${deviceId}`);
+    } else {
+      // A stale or unknown id — caller decides how to recover (typically
+      // fall back to system default via setAudioDevice(-1)). Log at warn
+      // since it's expected after a device unplug, not an internal failure.
+      this.logger.warn("Audio output device id not found in current enumeration");
+      this.logger.debug(`Unknown device id: ${deviceId}`);
     }
 
     return ok;

--- a/packages/iracing-plugin-mirabox/src/plugin.ts
+++ b/packages/iracing-plugin-mirabox/src/plugin.ts
@@ -149,9 +149,12 @@ getAudio().init();
 initializeAudioScenarios(eventBus, getAudio(), audioAssetsManifest, adapter.createLogger("AudioScenarios"));
 registerPitCrew(eventBus);
 
-// Publish audio device list and apply saved device selection
+// Publish audio device list and apply saved device selection.
+// See `iracing-plugin-stream-deck/src/plugin.ts` for the persistence
+// contract (id-based; empty string = System Default; legacy values fall
+// back to default without rewriting the persisted setting).
 let audioDeviceInitialized = false;
-let currentAudioDevice = -1;
+let currentAudioDeviceId: string | null = null;
 onGlobalSettingsChange((settings) => {
   const s = settings as Record<string, unknown>;
 
@@ -163,13 +166,21 @@ onGlobalSettingsChange((settings) => {
 
   // Apply audio output device (on startup and when changed from PI)
   const saved = s.audioOutputDevice;
-  const deviceIndex = saved !== undefined && saved !== null && saved !== "" ? Number(saved) : -1;
+  const deviceId = typeof saved === "string" ? saved : "";
 
-  if (deviceIndex !== currentAudioDevice) {
-    currentAudioDevice = deviceIndex;
+  if (deviceId !== currentAudioDeviceId) {
+    currentAudioDeviceId = deviceId;
 
-    if (deviceIndex !== -1 || audioDeviceInitialized) {
-      getAudio().setAudioDevice(deviceIndex);
+    if (deviceId === "") {
+      if (audioDeviceInitialized) {
+        getAudio().setAudioDevice(-1);
+      }
+    } else {
+      const ok = getAudio().setAudioDeviceById(deviceId);
+
+      if (!ok) {
+        getAudio().setAudioDevice(-1);
+      }
     }
   }
 

--- a/packages/iracing-plugin-mirabox/src/plugin.ts
+++ b/packages/iracing-plugin-mirabox/src/plugin.ts
@@ -152,14 +152,18 @@ registerPitCrew(eventBus);
 // Publish audio device list and apply saved device selection.
 // See `iracing-plugin-stream-deck/src/plugin.ts` for the persistence
 // contract (id-based; empty string = System Default; legacy values fall
-// back to default without rewriting the persisted setting).
-let audioDeviceInitialized = false;
-let currentAudioDeviceId: string | null = null;
+// back to default without rewriting the persisted setting) and the
+// recursion-safety note around the listener re-entry.
+let audioDeviceListPushed = false;
+let currentAudioDeviceId: string = "";
 onGlobalSettingsChange((settings) => {
   const s = settings as Record<string, unknown>;
 
-  // Publish device list for PI consumption (once, on first settings receipt)
-  if (!audioDeviceInitialized) {
+  // Publish device list for PI consumption (once, on first settings receipt).
+  // Set the flag BEFORE the push: updateGlobalSettings synchronously re-fires
+  // this listener, and without the flip we infinite-loop on the push branch.
+  if (!audioDeviceListPushed) {
+    audioDeviceListPushed = true;
     const devices = getAudio().getAudioDevices();
     updateGlobalSettings({ _audioDeviceList: JSON.stringify(devices) });
   }
@@ -168,23 +172,19 @@ onGlobalSettingsChange((settings) => {
   const saved = s.audioOutputDevice;
   const deviceId = typeof saved === "string" ? saved : "";
 
-  if (deviceId !== currentAudioDeviceId) {
-    currentAudioDeviceId = deviceId;
+  if (deviceId === currentAudioDeviceId) return;
 
-    if (deviceId === "") {
-      if (audioDeviceInitialized) {
-        getAudio().setAudioDevice(-1);
-      }
-    } else {
-      const ok = getAudio().setAudioDeviceById(deviceId);
+  currentAudioDeviceId = deviceId;
 
-      if (!ok) {
-        getAudio().setAudioDevice(-1);
-      }
+  if (deviceId === "") {
+    getAudio().setAudioDevice(-1);
+  } else {
+    const ok = getAudio().setAudioDeviceById(deviceId);
+
+    if (!ok) {
+      getAudio().setAudioDevice(-1);
     }
   }
-
-  audioDeviceInitialized = true;
 });
 
 // Initialize window focus service for focusing iRacing before any action

--- a/packages/iracing-plugin-stream-deck/src/plugin.ts
+++ b/packages/iracing-plugin-stream-deck/src/plugin.ts
@@ -156,13 +156,23 @@ registerPitCrew(eventBus);
 // "-1", malformed entries) are treated as unknown and silently fall back
 // to System Default. The project is pre-v1 with a single user; no
 // migration code is needed.
-let audioDeviceInitialized = false;
-let currentAudioDeviceId: string | null = null;
+//
+// `currentAudioDeviceId` starts as `""` (System Default) because that is
+// what `getAudio().init()` opened above — without this seed, the first
+// arrival of `audioOutputDevice = ""` would look like a transition and
+// fire a redundant `setAudioDevice(-1)` (an engine teardown + reopen).
+let audioDeviceListPushed = false;
+let currentAudioDeviceId: string = "";
 onGlobalSettingsChange((settings) => {
   const s = settings as Record<string, unknown>;
 
-  // Publish device list for PI consumption (once, on first settings receipt)
-  if (!audioDeviceInitialized) {
+  // Publish device list for PI consumption (once, on first settings receipt).
+  // CRITICAL: set the flag BEFORE calling updateGlobalSettings — that call
+  // synchronously re-fires this listener (see deck-core's
+  // applyParsedSettings), and without the flag flip we infinite-loop on the
+  // push branch.
+  if (!audioDeviceListPushed) {
+    audioDeviceListPushed = true;
     const devices = getAudio().getAudioDevices();
     updateGlobalSettings({ _audioDeviceList: JSON.stringify(devices) });
   }
@@ -171,31 +181,23 @@ onGlobalSettingsChange((settings) => {
   const saved = s.audioOutputDevice;
   const deviceId = typeof saved === "string" ? saved : "";
 
-  if (deviceId !== currentAudioDeviceId) {
-    currentAudioDeviceId = deviceId;
+  if (deviceId === currentAudioDeviceId) return;
 
-    // Skip the open-default call on the very first receipt: the engine
-    // already opened the system default during init(). After the first
-    // settings round-trip, every empty-string arrival is the result of
-    // either a deliberate user pick or a non-default → default switch.
-    if (deviceId === "") {
-      if (audioDeviceInitialized) {
-        getAudio().setAudioDevice(-1);
-      }
-    } else {
-      const ok = getAudio().setAudioDeviceById(deviceId);
+  currentAudioDeviceId = deviceId;
 
-      // Stale or unknown id (legacy index, unplugged device): fall back to
-      // System Default. We do NOT rewrite the persisted setting — the user
-      // may replug their device next session and we want it to re-bind
-      // automatically when the id reappears in the enumeration.
-      if (!ok) {
-        getAudio().setAudioDevice(-1);
-      }
+  if (deviceId === "") {
+    getAudio().setAudioDevice(-1);
+  } else {
+    const ok = getAudio().setAudioDeviceById(deviceId);
+
+    // Stale or unknown id (legacy index, unplugged device): fall back to
+    // System Default. We do NOT rewrite the persisted setting — the user
+    // may replug their device next session and we want it to re-bind
+    // automatically when the id reappears in the enumeration.
+    if (!ok) {
+      getAudio().setAudioDevice(-1);
     }
   }
-
-  audioDeviceInitialized = true;
 });
 
 // Initialize window focus service for focusing iRacing before any action

--- a/packages/iracing-plugin-stream-deck/src/plugin.ts
+++ b/packages/iracing-plugin-stream-deck/src/plugin.ts
@@ -145,9 +145,19 @@ getAudio().init();
 initializeAudioScenarios(eventBus, getAudio(), audioAssetsManifest, adapter.createLogger("AudioScenarios"));
 registerPitCrew(eventBus);
 
-// Publish audio device list and apply saved device selection
+// Publish audio device list and apply saved device selection.
+//
+// `audioOutputDevice` is persisted as the platform-stable `ma_device_id`
+// (hex-encoded) — empty string means System Default. The enumeration index
+// is volatile across replug / driver reset / OS audio-preference change, so
+// we re-resolve by id every session.
+//
+// Legacy values from pre-#427 builds (numeric index strings, the literal
+// "-1", malformed entries) are treated as unknown and silently fall back
+// to System Default. The project is pre-v1 with a single user; no
+// migration code is needed.
 let audioDeviceInitialized = false;
-let currentAudioDevice = -1;
+let currentAudioDeviceId: string | null = null;
 onGlobalSettingsChange((settings) => {
   const s = settings as Record<string, unknown>;
 
@@ -159,13 +169,29 @@ onGlobalSettingsChange((settings) => {
 
   // Apply audio output device (on startup and when changed from PI)
   const saved = s.audioOutputDevice;
-  const deviceIndex = saved !== undefined && saved !== null && saved !== "" ? Number(saved) : -1;
+  const deviceId = typeof saved === "string" ? saved : "";
 
-  if (deviceIndex !== currentAudioDevice) {
-    currentAudioDevice = deviceIndex;
+  if (deviceId !== currentAudioDeviceId) {
+    currentAudioDeviceId = deviceId;
 
-    if (deviceIndex !== -1 || audioDeviceInitialized) {
-      getAudio().setAudioDevice(deviceIndex);
+    // Skip the open-default call on the very first receipt: the engine
+    // already opened the system default during init(). After the first
+    // settings round-trip, every empty-string arrival is the result of
+    // either a deliberate user pick or a non-default → default switch.
+    if (deviceId === "") {
+      if (audioDeviceInitialized) {
+        getAudio().setAudioDevice(-1);
+      }
+    } else {
+      const ok = getAudio().setAudioDeviceById(deviceId);
+
+      // Stale or unknown id (legacy index, unplugged device): fall back to
+      // System Default. We do NOT rewrite the persisted setting — the user
+      // may replug their device next session and we want it to re-bind
+      // automatically when the id reappears in the enumeration.
+      if (!ok) {
+        getAudio().setAudioDevice(-1);
+      }
     }
   }
 

--- a/packages/pi-components/src/components/audio-device-select.test.ts
+++ b/packages/pi-components/src/components/audio-device-select.test.ts
@@ -62,10 +62,10 @@ describe("ird-audio-device-select", () => {
       expect(el.querySelector("select")).not.toBeNull();
     });
 
-    it("includes the System Default option with value '-1'", () => {
+    it("includes the System Default option with the empty-string value", () => {
       const opts = el.querySelectorAll("option");
       expect(opts.length).toBe(1);
-      expect(opts[0].value).toBe("-1");
+      expect(opts[0].value).toBe("");
       expect(opts[0].textContent).toBe("System Default");
     });
 
@@ -87,17 +87,17 @@ describe("ird-audio-device-select", () => {
       const devicesCallback = mock.callbacks.get("_audioDeviceList")!;
       devicesCallback(
         JSON.stringify([
-          { index: 0, name: "Speaker A", isDefault: false },
-          { index: 1, name: "Speaker B", isDefault: true },
+          { index: 0, name: "Speaker A", id: "AAAA", isDefault: false },
+          { index: 1, name: "Speaker B", id: "BBBB", isDefault: true },
         ]),
       );
 
       const opts = Array.from(el.querySelectorAll("option"));
       expect(opts.length).toBe(3);
-      expect(opts[0].value).toBe("-1");
-      expect(opts[1].value).toBe("0");
+      expect(opts[0].value).toBe("");
+      expect(opts[1].value).toBe("AAAA");
       expect(opts[1].textContent).toBe("Speaker A");
-      expect(opts[2].value).toBe("1");
+      expect(opts[2].value).toBe("BBBB");
       expect(opts[2].textContent).toBe("Speaker B (Default)");
     });
 
@@ -117,68 +117,103 @@ describe("ird-audio-device-select", () => {
       const opts = el.querySelectorAll("option");
       expect(opts.length).toBe(1);
     });
+
+    it("skips devices missing the stable id field", () => {
+      const devicesCallback = mock.callbacks.get("_audioDeviceList")!;
+      devicesCallback(
+        JSON.stringify([
+          { index: 0, name: "Headset", id: "AAAA" },
+          { index: 1, name: "Legacy device" }, // no id
+        ]),
+      );
+
+      const opts = Array.from(el.querySelectorAll("option"));
+      expect(opts.length).toBe(2); // System Default + the one with id
+      expect(opts[1].value).toBe("AAAA");
+    });
   });
 
   describe("selection state", () => {
-    it("applies the persisted value from the setting callback", () => {
+    it("applies the persisted id from the setting callback", () => {
       const settingCallback = mock.callbacks.get("audioOutputDevice")!;
       const devicesCallback = mock.callbacks.get("_audioDeviceList")!;
 
-      devicesCallback(JSON.stringify([{ index: 2, name: "Headset" }]));
-      settingCallback("2");
+      devicesCallback(JSON.stringify([{ index: 2, name: "Headset", id: "DEADBEEF" }]));
+      settingCallback("DEADBEEF");
 
       const select = el.querySelector("select") as HTMLSelectElement;
-      expect(select.value).toBe("2");
+      expect(select.value).toBe("DEADBEEF");
     });
 
-    it("re-applies the persisted value after the device list loads", () => {
+    it("re-applies the persisted id after the device list loads", () => {
       const settingCallback = mock.callbacks.get("audioOutputDevice")!;
       const devicesCallback = mock.callbacks.get("_audioDeviceList")!;
 
-      settingCallback("1");
-      devicesCallback(JSON.stringify([{ index: 1, name: "B" }]));
+      settingCallback("CAFE0001");
+      devicesCallback(JSON.stringify([{ index: 1, name: "B", id: "CAFE0001" }]));
 
       const select = el.querySelector("select") as HTMLSelectElement;
-      expect(select.value).toBe("1");
+      expect(select.value).toBe("CAFE0001");
     });
 
-    it("falls back to '-1' when the setting is empty or undefined", () => {
+    it("selects System Default (empty value) when the setting is the empty string", () => {
       const settingCallback = mock.callbacks.get("audioOutputDevice")!;
       settingCallback("");
 
       const select = el.querySelector("select") as HTMLSelectElement;
-      expect(select.value).toBe("-1");
+      expect(select.value).toBe("");
     });
 
-    it("falls back to '-1' when the persisted device index is no longer in the current device list", () => {
+    it("falls back to System Default when the persisted device id is no longer in the current device list", () => {
       const settingCallback = mock.callbacks.get("audioOutputDevice")!;
       const devicesCallback = mock.callbacks.get("_audioDeviceList")!;
 
-      // Persisted selection was index 7, but the current enumeration only
-      // has indices 0 and 1 (e.g. the headset was unplugged).
-      settingCallback("7");
+      // Persisted selection was the unplugged headset; the current
+      // enumeration only contains the built-in speakers.
+      settingCallback("MISSING-ID");
       devicesCallback(
         JSON.stringify([
-          { index: 0, name: "Built-in" },
-          { index: 1, name: "Speakers" },
+          { index: 0, name: "Built-in", id: "AAAA" },
+          { index: 1, name: "Speakers", id: "BBBB" },
         ]),
       );
 
       const select = el.querySelector("select") as HTMLSelectElement;
-      expect(select.value).toBe("-1");
+      expect(select.value).toBe("");
+    });
+
+    it("treats a legacy numeric-index value as unknown and falls back to System Default", () => {
+      const settingCallback = mock.callbacks.get("audioOutputDevice")!;
+      const devicesCallback = mock.callbacks.get("_audioDeviceList")!;
+
+      // A pre-#427 install persisted "1" (the index). Under the id-based
+      // scheme that's just an unknown value; user re-picks once.
+      settingCallback("1");
+      devicesCallback(JSON.stringify([{ index: 0, name: "Speakers", id: "AAAA" }]));
+
+      const select = el.querySelector("select") as HTMLSelectElement;
+      expect(select.value).toBe("");
     });
   });
 
   describe("change dispatching", () => {
-    it("writes the selected value through the save hook", () => {
+    it("writes the selected id through the save hook", () => {
       const devicesCallback = mock.callbacks.get("_audioDeviceList")!;
-      devicesCallback(JSON.stringify([{ index: 3, name: "X" }]));
+      devicesCallback(JSON.stringify([{ index: 3, name: "X", id: "XYZ123" }]));
 
       const select = el.querySelector("select") as HTMLSelectElement;
-      select.value = "3";
+      select.value = "XYZ123";
       select.dispatchEvent(new Event("change", { bubbles: true }));
 
-      expect(mock.saves.get("audioOutputDevice")).toHaveBeenCalledWith("3");
+      expect(mock.saves.get("audioOutputDevice")).toHaveBeenCalledWith("XYZ123");
+    });
+
+    it("writes the empty string when System Default is selected", () => {
+      const select = el.querySelector("select") as HTMLSelectElement;
+      select.value = "";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+
+      expect(mock.saves.get("audioOutputDevice")).toHaveBeenCalledWith("");
     });
 
     it("dispatches exactly one change event per user selection (no double-fire from native bubble)", () => {
@@ -186,7 +221,7 @@ describe("ird-audio-device-select", () => {
       el.addEventListener("change", handler);
 
       const select = el.querySelector("select") as HTMLSelectElement;
-      select.value = "-1";
+      select.value = "";
       select.dispatchEvent(new Event("change", { bubbles: true }));
 
       expect(handler).toHaveBeenCalledTimes(1);

--- a/packages/pi-components/src/components/audio-device-select.ts
+++ b/packages/pi-components/src/components/audio-device-select.ts
@@ -3,10 +3,11 @@
  * Audio Device Select Web Component for Stream Deck Property Inspector
  *
  * A styled `<select>` bound to a plugin-global setting that stores the
- * selected audio output device index as a string (e.g. `"-1"` for
- * System Default, or the string form of a miniaudio device index).
- * Options are populated at runtime from a second global setting
- * (a JSON array of `{ index: number, name: string, isDefault?: boolean }`),
+ * selected audio output device by its stable `id` (a hex-encoded
+ * `ma_device_id` from the audio-native enumeration). The empty string
+ * represents System Default. Options are populated at runtime from a
+ * second global setting (a JSON array of
+ * `{ index: number, name: string, id: string, isDefault?: boolean }`),
  * which the plugin maintains from its audio-device enumeration.
  *
  * Usage in HTML:
@@ -22,10 +23,11 @@
  *
  * Attributes:
  * - setting: Plugin-global setting key that stores the selected device
- *   index as a string (default: `audioOutputDevice`).
+ *   id as a string (default: `audioOutputDevice`). The empty string
+ *   means System Default.
  * - devices: Plugin-global setting key that stores the device list as a
  *   JSON array (default: `_audioDeviceList`).
- * - default-label: Label shown for the `-1` (System Default) option
+ * - default-label: Label shown for the System Default option
  *   (default: `System Default`).
  *
  * The plugin populates `devices` via `updateGlobalSettings({ [devicesKey]: JSON.stringify(list) })`.
@@ -33,15 +35,18 @@
 
 let styleInjected = false;
 
-type DeviceRecord = { index: number; name: string; isDefault?: boolean };
+type DeviceRecord = { index?: number; name: string; id: string; isDefault?: boolean };
 
 const DEFAULT_SETTING = "audioOutputDevice";
 const DEFAULT_DEVICE_LIST_SETTING = "_audioDeviceList";
 const DEFAULT_LABEL = "System Default";
 
+/** Sentinel value persisted for the System Default selection. */
+const SYSTEM_DEFAULT_VALUE = "";
+
 export class AudioDeviceSelect extends HTMLElement {
   private select: HTMLSelectElement | null = null;
-  private savedValue = "-1";
+  private savedValue = SYSTEM_DEFAULT_VALUE;
   private saveToStreamDeck: ((value: string) => void) | null = null;
   private _initialized = false;
 
@@ -103,7 +108,11 @@ export class AudioDeviceSelect extends HTMLElement {
     const devicesKey = this.getAttribute("devices") ?? DEFAULT_DEVICE_LIST_SETTING;
 
     const [, save] = window.SDPIComponents.useGlobalSettings(settingKey, (value: string) => {
-      this.savedValue = value !== null && value !== undefined && value !== "" ? String(value) : "-1";
+      // Runtime may deliver non-string types; normalize to string so the
+      // option-value comparison in applySavedValue is type-safe. Empty
+      // string is the System Default sentinel, not a "missing" marker.
+      const v: unknown = value;
+      this.savedValue = v == null ? SYSTEM_DEFAULT_VALUE : String(v);
       this.applySavedValue();
     });
     this.saveToStreamDeck = save;
@@ -132,13 +141,19 @@ export class AudioDeviceSelect extends HTMLElement {
     this.select.replaceChildren();
 
     const systemOption = document.createElement("option");
-    systemOption.value = "-1";
+    systemOption.value = SYSTEM_DEFAULT_VALUE;
     systemOption.textContent = defaultLabel;
     this.select.appendChild(systemOption);
 
     for (const device of devices) {
+      // Skip records without a usable stable id. The plugin should always
+      // populate id from the audio-native enumeration, but defend against
+      // malformed input — and against an empty-string id colliding with
+      // the System Default option.
+      if (typeof device.id !== "string" || device.id === "") continue;
+
       const opt = document.createElement("option");
-      opt.value = String(device.index);
+      opt.value = device.id;
       opt.textContent = `${device.name}${device.isDefault ? " (Default)" : ""}`;
       this.select.appendChild(opt);
     }
@@ -147,13 +162,14 @@ export class AudioDeviceSelect extends HTMLElement {
   private applySavedValue(): void {
     if (!this.select) return;
 
-    // If the persisted device index is no longer in the current option
-    // list (e.g. the selected device was unplugged), fall back to
-    // System Default so the dropdown reflects what miniaudio will
-    // actually use. Native `<select>.value = "<unknown>"` silently
-    // clears the selection — surface that as "-1" explicitly.
+    // If the persisted device id is no longer in the current option list
+    // (e.g. unplugged headset, or a legacy numeric-index value from
+    // pre-#427 builds), fall back to System Default so the dropdown
+    // reflects what miniaudio will actually use. Native
+    // `<select>.value = "<unknown>"` silently clears the selection —
+    // surface that as the System Default value explicitly.
     const exists = Array.from(this.select.options).some((opt) => opt.value === this.savedValue);
-    this.select.value = exists ? this.savedValue : "-1";
+    this.select.value = exists ? this.savedValue : SYSTEM_DEFAULT_VALUE;
   }
 }
 

--- a/packages/website/src/content/docs/docs/actions/driving/pit-crew.md
+++ b/packages/website/src/content/docs/docs/actions/driving/pit-crew.md
@@ -43,7 +43,7 @@ Steps the global Radar volume up or down. Takes effect immediately on `AudioBus.
 The Pit Crew accordion in the Property Inspector exposes these plugin-global settings alongside the Mode selector (not under the generic Global Settings section):
 
 - **Radar Volume** (0–100, default 100) — slider + Test button. Shared across every Pit Crew instance; the button lets you preview the left → right → both sequence without waiting for a live proximity event. Sliding to 0 mutes the radar without toggling the feature off.
-- **Output Device** — the audio device used for the iRaceDeck audio engine; shared globally across the plugin.
+- **Output Device** — the audio device used for the iRaceDeck audio engine; shared globally across the plugin. The selection is persisted by the platform-stable device id (WASAPI endpoint ID on Windows), so it survives replug and Windows audio-preference changes — no need to re-pick after rebooting or moving the headset to a different USB port.
 
 ## Notes
 


### PR DESCRIPTION
## Related Issue

Fixes #427

## What changed?

Sub-issue of #375. Follow-up to #417.

The miniaudio enumeration index is volatile across sessions: adding, removing, or replugging an unrelated device shifts every other index, so a saved index reopens the wrong device on the next launch. `ma_device_info.id` is the platform-stable identifier (WASAPI endpoint GUID on Windows, CoreAudio UID on macOS) — switch persistence to that.

**Native** (`packages/audio-native/src/addon.cc`):
- Hex-encode `ma_device_id` (full `sizeof(ma_device_id)` bytes) so the raw layout round-trips losslessly through a JS string.
- Add `id` to every `getAudioDevices()` entry alongside `index`/`name`/`isDefault`. `index` is retained for backward compat with `setAudioDevice(index)`.
- Add `setAudioDeviceById(idStr)`: decodes the hex, looks up the device by raw-bytes match against the live enumeration, reinitializes the engine. On failure falls back to system default so the mixer stays usable.

**Service + mock**:
- Mirror the new field and method on `AudioNative` and `AudioNativeMock` (mock honors a synthetic `mock-device-0` id and rejects others).
- Add `setAudioDeviceById` to `IAudioService` and `AudioService` with the same channel-cleanup pattern as `setAudioDevice`. Returns `false` on unknown id; caller (the plugin) decides recovery.

**PI component** (`packages/pi-components/src/components/audio-device-select.ts`):
- Switch option `value` from index string to the stable id string. The System Default sentinel is now the empty string (was `\"-1\"`), so the persisted setting type is uniformly a string id.
- Skip device records missing `id`, and reject empty-string id to avoid colliding with the System Default option.
- Treat unknown / legacy / numeric-index persisted values as missing — the dropdown falls back to System Default and the user re-picks once.

**Plugin glue** (both Stream Deck and Mirabox plugins):
- Persist as id string; fall back to system default on stale or unknown id without rewriting the persisted setting (so a replugged device re-binds automatically once it reappears in the enumeration).
- Skip the redundant default-open call on the very first settings receipt (engine already opened the system default during `init()`).

**Docs** (audio-native/CLAUDE.md, action docs, website docs) updated to reflect the id-based contract.

## Known limitation

Mid-session device-list change (best-effort acceptance criterion in the issue) is **deferred** — neither a notification callback nor polling re-resolution is wired up. Mid-session unplug/replug requires a plugin restart to re-bind. Documented in code; can be added in a follow-up issue.

## Dependency / merge order

Depends on #425 conceptually (the in-flight \`sdpi-select datasource\` refactor). When #425 lands:
- The legacy \`ird-audio-device-select\` component this PR modified is deleted by #425.
- The new datasource handler in #425 emits \`value: d.id\` (the same field this PR adds to the enumeration).

Both PRs end at the same correct state. Either order works; minor merge resolution required when stacking.

## How to test

- \`pnpm test\` — 3187 tests pass (added: mock id field, new \`setAudioDeviceById\` paths, PI legacy-index fallback).
- \`pnpm lint\` / \`pnpm format\` — clean.
- \`pnpm build\` (Stream Deck + Mirabox + native addon) — clean.
- Manual:
  1. Open the Pit Crew Property Inspector, select a non-default Output Device.
  2. Restart Stream Deck. The selected device must still be selected and audible.
  3. Unplug the device, restart Stream Deck. The dropdown must show System Default; the persisted setting must be unchanged (verify in plugin global settings).
  4. Replug the device, restart Stream Deck. The originally-selected device must be selected and audible again — no re-pick required.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Output device selection now persists using platform-stable device identifiers so chosen outputs are reapplied reliably across sessions.

* **Bug Fixes**
  * Prevents loss of audio output selection when devices are reordered, disconnected/reconnected, or when OS audio preferences change.

* **Documentation**
  * Docs updated to explain stable-identifier persistence for the Output Device setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->