### PR TITLE
fix(plugins): refresh audio device list on every PI open (#431)

### DIFF
--- a/packages/deck-adapter-elgato/src/adapter.ts
+++ b/packages/deck-adapter-elgato/src/adapter.ts
@@ -168,6 +168,15 @@ export class ElgatoPlatformAdapter implements IDeckPlatformAdapter {
     });
   }
 
+  onPropertyInspectorDidAppear(callback: () => void): void {
+    // streamDeck.ui.onDidAppear fires once per PI becoming visible, regardless
+    // of which action opens it. The payload carries action/context info; we
+    // only care that *some* PI opened, so the callback is parameterless.
+    this.sd.ui.onDidAppear(() => {
+      callback();
+    });
+  }
+
   createLogger(scope: string): ILogger {
     return createSDLogger(this.sd.logger.createScope(scope));
   }

--- a/packages/deck-adapter-mirabox/src/adapter.test.ts
+++ b/packages/deck-adapter-mirabox/src/adapter.test.ts
@@ -104,6 +104,26 @@ describe("VSDPlatformAdapter", () => {
     });
   });
 
+  describe("onPropertyInspectorDidAppear", () => {
+    it("should register a global event handler for propertyInspectorDidAppear", () => {
+      const callback = vi.fn();
+      adapter.onPropertyInspectorDidAppear(callback);
+
+      expect(client.onGlobalEvent).toHaveBeenCalledWith("propertyInspectorDidAppear", expect.any(Function));
+    });
+
+    it("should invoke the callback (parameterless) when the PI-appear event arrives", () => {
+      const callback = vi.fn();
+      adapter.onPropertyInspectorDidAppear(callback);
+
+      const handler = client.onGlobalEvent.mock.calls[0][1];
+      handler({ event: "propertyInspectorDidAppear", action: "com.iracedeck.sd.core.pit-crew", context: "abc" });
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith();
+    });
+  });
+
   describe("createLogger", () => {
     it("should create a logger with the given scope", () => {
       const logger = adapter.createLogger("TestScope");

--- a/packages/deck-adapter-mirabox/src/adapter.ts
+++ b/packages/deck-adapter-mirabox/src/adapter.ts
@@ -162,6 +162,17 @@ export class VSDPlatformAdapter implements IDeckPlatformAdapter {
     });
   }
 
+  onPropertyInspectorDidAppear(callback: () => void): void {
+    // VSD Craft mimics the Elgato protocol; `propertyInspectorDidAppear`
+    // carries an `action` field, but `routeEvent` also fans it out to
+    // global handlers, so a single generic subscription here is enough.
+    // Callback is parameterless because consumers today only need the
+    // "some PI opened" signal, not per-action identity.
+    this.client.onGlobalEvent("propertyInspectorDidAppear", () => {
+      callback();
+    });
+  }
+
   createLogger(scope: string): ILogger {
     return createConsoleLogger(scope);
   }

--- a/packages/deck-core/src/types.ts
+++ b/packages/deck-core/src/types.ts
@@ -87,6 +87,13 @@ export interface IDeckPlatformAdapter {
   onApplicationDidLaunch(callback: (application: string) => void): void;
   /** Subscribe to application termination events */
   onApplicationDidTerminate(callback: (application: string) => void): void;
+  /**
+   * Subscribe to Property Inspector appear events (fires each time any
+   * action's PI becomes visible). Used to refresh dynamic PI state that
+   * only makes sense while the PI is open — e.g. re-enumerating audio
+   * output devices so a headset plugged in after plugin startup appears.
+   */
+  onPropertyInspectorDidAppear(callback: () => void): void;
   /** Create a scoped logger for a component */
   createLogger(scope: string): ILogger;
   /** Register an action handler for a UUID */

--- a/packages/iracing-plugin-mirabox/src/plugin.ts
+++ b/packages/iracing-plugin-mirabox/src/plugin.ts
@@ -154,18 +154,33 @@ registerPitCrew(eventBus);
 // contract (id-based; empty string = System Default; legacy values fall
 // back to default without rewriting the persisted setting) and the
 // recursion-safety note around the listener re-entry.
-let audioDeviceListPushed = false;
+let initialDevicePushDone = false;
 let currentAudioDeviceId: string = "";
+// Cache the last pushed payload so identical re-enumerations (the common
+// case on repeated PI re-opens with no hardware change) don't churn the
+// sdpi-components data source and force a full dropdown re-render.
+let lastPushedDeviceListJson = "";
+
+function pushAudioDevicesIfChanged(): void {
+  const devices = getAudio().getAudioDevices();
+  const json = JSON.stringify(devices);
+
+  if (json === lastPushedDeviceListJson) return;
+
+  lastPushedDeviceListJson = json;
+  updateGlobalSettings({ _audioDeviceList: json });
+}
+
 onGlobalSettingsChange((settings) => {
   const s = settings as Record<string, unknown>;
 
-  // Publish device list for PI consumption (once, on first settings receipt).
-  // Set the flag BEFORE the push: updateGlobalSettings synchronously re-fires
-  // this listener, and without the flip we infinite-loop on the push branch.
-  if (!audioDeviceListPushed) {
-    audioDeviceListPushed = true;
-    const devices = getAudio().getAudioDevices();
-    updateGlobalSettings({ _audioDeviceList: JSON.stringify(devices) });
+  // First time settings arrive, seed the device list so the PI sees the
+  // initial enumeration without needing to be opened first. After this
+  // the PI-appear hook drives refreshes — `initialDevicePushDone` is just
+  // a one-shot gate, not a "never refresh" latch.
+  if (!initialDevicePushDone) {
+    initialDevicePushDone = true;
+    pushAudioDevicesIfChanged();
   }
 
   // Apply audio output device (on startup and when changed from PI)
@@ -185,6 +200,15 @@ onGlobalSettingsChange((settings) => {
       getAudio().setAudioDevice(-1);
     }
   }
+});
+
+// Re-enumerate audio devices on every PI open so a headset plugged in
+// after Stream Deck booted appears without a full restart. The
+// `pushAudioDevicesIfChanged` guard short-circuits the common case (PI
+// reopened, no hardware changed) so the sdpi-components data source
+// doesn't churn.
+adapter.onPropertyInspectorDidAppear(() => {
+  pushAudioDevicesIfChanged();
 });
 
 // Initialize window focus service for focusing iRacing before any action

--- a/packages/iracing-plugin-mirabox/src/plugin.ts
+++ b/packages/iracing-plugin-mirabox/src/plugin.ts
@@ -203,7 +203,7 @@ onGlobalSettingsChange((settings) => {
 });
 
 // Re-enumerate audio devices on every PI open so a headset plugged in
-// after Stream Deck booted appears without a full restart. The
+// after VSD Craft booted appears without a full restart. The
 // `pushAudioDevicesIfChanged` guard short-circuits the common case (PI
 // reopened, no hardware changed) so the sdpi-components data source
 // doesn't churn.

--- a/packages/iracing-plugin-stream-deck/src/plugin.ts
+++ b/packages/iracing-plugin-stream-deck/src/plugin.ts
@@ -161,20 +161,33 @@ registerPitCrew(eventBus);
 // what `getAudio().init()` opened above — without this seed, the first
 // arrival of `audioOutputDevice = ""` would look like a transition and
 // fire a redundant `setAudioDevice(-1)` (an engine teardown + reopen).
-let audioDeviceListPushed = false;
+let initialDevicePushDone = false;
 let currentAudioDeviceId: string = "";
+// Cache the last pushed payload so identical re-enumerations (the common
+// case on repeated PI re-opens with no hardware change) don't churn the
+// sdpi-components data source and force a full dropdown re-render.
+let lastPushedDeviceListJson = "";
+
+function pushAudioDevicesIfChanged(): void {
+  const devices = getAudio().getAudioDevices();
+  const json = JSON.stringify(devices);
+
+  if (json === lastPushedDeviceListJson) return;
+
+  lastPushedDeviceListJson = json;
+  updateGlobalSettings({ _audioDeviceList: json });
+}
+
 onGlobalSettingsChange((settings) => {
   const s = settings as Record<string, unknown>;
 
-  // Publish device list for PI consumption (once, on first settings receipt).
-  // CRITICAL: set the flag BEFORE calling updateGlobalSettings — that call
-  // synchronously re-fires this listener (see deck-core's
-  // applyParsedSettings), and without the flag flip we infinite-loop on the
-  // push branch.
-  if (!audioDeviceListPushed) {
-    audioDeviceListPushed = true;
-    const devices = getAudio().getAudioDevices();
-    updateGlobalSettings({ _audioDeviceList: JSON.stringify(devices) });
+  // First time settings arrive, seed the device list so the PI sees the
+  // initial enumeration without needing to be opened first. After this
+  // the PI-appear hook drives refreshes — `initialDevicePushDone` is just
+  // a one-shot gate, not a "never refresh" latch.
+  if (!initialDevicePushDone) {
+    initialDevicePushDone = true;
+    pushAudioDevicesIfChanged();
   }
 
   // Apply audio output device (on startup and when changed from PI)
@@ -198,6 +211,15 @@ onGlobalSettingsChange((settings) => {
       getAudio().setAudioDevice(-1);
     }
   }
+});
+
+// Re-enumerate audio devices on every PI open so a headset plugged in
+// after Stream Deck booted appears without a full restart. The
+// `pushAudioDevicesIfChanged` guard short-circuits the common case (PI
+// reopened, no hardware changed) so the sdpi-components data source
+// doesn't churn.
+adapter.onPropertyInspectorDidAppear(() => {
+  pushAudioDevicesIfChanged();
 });
 
 // Initialize window focus service for focusing iRacing before any action

--- a/packages/iracing-plugin-stream-deck/src/shared/app-monitor.test.ts
+++ b/packages/iracing-plugin-stream-deck/src/shared/app-monitor.test.ts
@@ -46,6 +46,7 @@ function createMockAdapter() {
     onApplicationDidTerminate: vi.fn((cb: (application: string) => void) => {
       terminateCallbacks.push(cb);
     }),
+    onPropertyInspectorDidAppear: vi.fn(),
     createLogger: vi.fn(() => createMockLogger()),
     registerAction: vi.fn(),
     onKeyDown: vi.fn(),


### PR DESCRIPTION
## Related Issue

Closes #431

## What changed?

- Added `onPropertyInspectorDidAppear(callback)` to `IDeckPlatformAdapter`. Elgato implementation uses `streamDeck.ui.onDidAppear()`; Mirabox implementation subscribes via `VSDClient.onGlobalEvent("propertyInspectorDidAppear")`.
- Both plugins (`iracing-plugin-stream-deck`, `iracing-plugin-mirabox`) now refresh `_audioDeviceList` on every PI open. The one-shot `audioDeviceListPushed` latch is gone.
- Pushes are deduped against the last-serialized payload so a re-open with no hardware change doesn't churn the PI's `sdpi-components` data source.
- Initial seed is still done on the first `onGlobalSettingsChange` so the PI sees a populated list on its very first open.
- New Mirabox adapter tests cover the new subscription.

## How to test

1. Start Stream Deck **without** a USB headset connected. Place the Pit Crew action on a key and open its Property Inspector. Confirm the Output Device dropdown lists only the built-in devices.
2. Plug in a USB headset (wireless dongle, etc.).
3. Close the PI, then reopen it on the same Pit Crew button.
4. **Expected:** the new headset now appears in the Output Device dropdown — no Stream Deck restart needed.
5. Unplug the headset while the PI is open, then close + reopen the PI. The headset disappears from the dropdown, and if it was the persisted selection the `ird-audio-device-select` component falls back to System Default (behavior already covered in #430).

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Property Inspector visibility event hook across platform adapters so plugins can register callbacks when the Property Inspector appears.

* **Enhancements**
  * Audio device publishing refactored to seed once and refresh on Property Inspector open; updates are skipped when the device list is unchanged.

* **Tests**
  * Adapter tests and mocks updated to cover the new Property Inspector appearance hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->