### PR TITLE
chore(release): revert accidental v1.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iracedeck",
-  "version": "1.15.0",
+  "version": "1.14.0",
   "private": true,
   "packageManager": "pnpm@10.0.0",
   "type": "module",

--- a/packages/deck-adapter-elgato/package.json
+++ b/packages/deck-adapter-elgato/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iracedeck/deck-adapter-elgato",
-  "version": "1.15.0",
+  "version": "1.14.0",
   "description": "Elgato Stream Deck adapter for @iracedeck/deck-core",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/deck-adapter-mirabox/package.json
+++ b/packages/deck-adapter-mirabox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iracedeck/deck-adapter-mirabox",
-  "version": "1.15.0",
+  "version": "1.14.0",
   "description": "Mirabox adapter for @iracedeck/deck-core",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/deck-core/package.json
+++ b/packages/deck-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iracedeck/deck-core",
-  "version": "1.15.0",
+  "version": "1.14.0",
   "description": "Platform-agnostic core interfaces and base classes for deck device plugins",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iracedeck/icons",
-  "version": "1.15.0",
+  "version": "1.14.0",
   "private": true,
   "description": "Shared SVG icon assets for iRaceDeck"
 }

--- a/packages/iracing-actions/package.json
+++ b/packages/iracing-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iracedeck/iracing-actions",
-  "version": "1.15.0",
+  "version": "1.14.0",
   "description": "Platform-agnostic iRaceDeck action classes",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/iracing-native/package.json
+++ b/packages/iracing-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iracedeck/iracing-native",
-  "version": "1.15.0",
+  "version": "1.14.0",
   "description": "Native Node.js addon for iRacing SDK - Win32 memory-mapped file and window messaging",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/manifest.json
+++ b/packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "Name": "iRaceDeck",
-  "Version": "1.15.0.0",
+  "Version": "1.14.0.0",
   "Author": "Niklas Lampén",
   "Actions": [
     {

--- a/packages/iracing-plugin-mirabox/package.json
+++ b/packages/iracing-plugin-mirabox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iracedeck/iracing-plugin-mirabox",
-  "version": "1.15.0",
+  "version": "1.14.0",
   "description": "Mirabox plugin for iRacing - Core driving and interface controls",
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/manifest.json
+++ b/packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schemas.elgato.com/streamdeck/plugins/manifest.json",
   "Name": "iRaceDeck",
-  "Version": "1.15.0.0",
+  "Version": "1.14.0.0",
   "Author": "Niklas Lampén",
   "Actions": [
     {

--- a/packages/iracing-plugin-stream-deck/package.json
+++ b/packages/iracing-plugin-stream-deck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iracedeck/iracing-plugin-stream-deck",
-  "version": "1.15.0",
+  "version": "1.14.0",
   "description": "Stream Deck plugin for iRacing - Core driving and interface controls",
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/packages/iracing-sdk/package.json
+++ b/packages/iracing-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iracedeck/iracing-sdk",
-  "version": "1.15.0",
+  "version": "1.14.0",
   "description": "iRacing SDK for Node.js - telemetry reading and broadcast commands",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iracedeck/logger",
-  "version": "1.15.0",
+  "version": "1.14.0",
   "description": "Logger interface for iRaceDeck packages",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iracedeck/website",
-  "version": "1.15.0",
+  "version": "1.14.0",
   "private": true,
   "description": "Documentation website for iRaceDeck Stream Deck plugins",
   "type": "module",


### PR DESCRIPTION
## Summary

Reverts `5f5dfb3b chore(release): v1.15.0`, which was created by an unintended `release-it` invocation that bumped the repo to `1.15.0` with no alpha suffix. The tag `v1.15.0` and GitHub Release were already deleted; this PR restores package.json and manifest.json versions back to `1.14.0` / `1.14.0.0`.

## Test plan

- [x] All 14 files restored to 1.14.0 state (inverse of the accidental release commit)
- [x] Root `package.json` reports version `1.14.0`
- [ ] After merge: `pnpm install` still works and master builds cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Reverted all package and plugin versions from 1.15.0 to 1.14.0 across the entire project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->