### PR TITLE
fix(build): clear Win32 MAX_PATH on installed plugin

### DIFF
--- a/packages/audio-native/package.json
+++ b/packages/audio-native/package.json
@@ -18,11 +18,9 @@
     "src/*.cc",
     "src/*.h"
   ],
-  "dependencies": {
-    "node-addon-api": "8.7.0"
-  },
   "devDependencies": {
     "@types/node": "25.6.0",
+    "node-addon-api": "8.7.0",
     "node-gyp": "12.2.0",
     "rimraf": "6.1.3",
     "typescript": "5.9.3",

--- a/packages/iracing-native/package.json
+++ b/packages/iracing-native/package.json
@@ -17,11 +17,9 @@
     "build/Release/*.node",
     "src/*.cc"
   ],
-  "dependencies": {
-    "node-addon-api": "8.7.0"
-  },
   "devDependencies": {
     "@types/node": "25.6.0",
+    "node-addon-api": "8.7.0",
     "node-gyp": "12.2.0",
     "rimraf": "6.1.3",
     "typescript": "5.9.3",

--- a/packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/.sdignore
+++ b/packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/.sdignore
@@ -15,8 +15,17 @@
 # MSBuild tracking logs
 *.tlog
 
+# node-gyp generated build files (only build/Release/*.node is needed at runtime)
+**/build/*.sln
+**/build/*.gypi
+**/build/*.vcxproj
+**/build/*.vcxproj.filters
+
 # Python bytecode cache (node-gyp)
 **/__pycache__/
+
+# Standalone Python distribution downloaded by node-gyp
+**/node_modules/@iracedeck/*/Python/
 
 # Dev dependencies (nested in native modules)
 **/node_modules/typescript/
@@ -28,6 +37,11 @@
 # Source files (already compiled)
 **/node_modules/*/src/
 **/node_modules/@*/*/src/
+
+# iRacing SDK reference projects and build scripts (not runtime artifacts)
+**/node_modules/@iracedeck/*/assets/
+**/node_modules/@iracedeck/*/scripts/
+**/node_modules/@iracedeck/*/README.md
 
 # Dev/build config files
 **/tsconfig.json

--- a/packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/.sdignore
+++ b/packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/.sdignore
@@ -25,7 +25,8 @@
 **/__pycache__/
 
 # Standalone Python distribution downloaded by node-gyp
-**/node_modules/@iracedeck/*/Python/
+**/node_modules/@iracedeck/audio-native/Python/
+**/node_modules/@iracedeck/iracing-native/Python/
 
 # Dev dependencies (nested in native modules)
 **/node_modules/typescript/
@@ -41,10 +42,15 @@
 # Compiled test artifacts in shipped dist/ folders
 **/node_modules/**/dist/**/*.test.*
 
-# iRacing SDK reference projects and build scripts (not runtime artifacts)
-**/node_modules/@iracedeck/*/assets/
-**/node_modules/@iracedeck/*/scripts/
-**/node_modules/@iracedeck/*/README.md
+# iRacing SDK reference projects and build scripts (not runtime artifacts).
+# Listed per-package on purpose: a wildcard like @iracedeck/*/ would silently
+# drop runtime files from any future @iracedeck package shipped via file: dep.
+**/node_modules/@iracedeck/audio-native/assets/
+**/node_modules/@iracedeck/audio-native/scripts/
+**/node_modules/@iracedeck/audio-native/README.md
+**/node_modules/@iracedeck/iracing-native/assets/
+**/node_modules/@iracedeck/iracing-native/scripts/
+**/node_modules/@iracedeck/iracing-native/README.md
 
 # Dev/build config files
 **/tsconfig.json

--- a/packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/.sdignore
+++ b/packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/.sdignore
@@ -38,6 +38,9 @@
 **/node_modules/*/src/
 **/node_modules/@*/*/src/
 
+# Compiled test artifacts in shipped dist/ folders
+**/node_modules/**/dist/**/*.test.*
+
 # iRacing SDK reference projects and build scripts (not runtime artifacts)
 **/node_modules/@iracedeck/*/assets/
 **/node_modules/@iracedeck/*/scripts/

--- a/packages/iracing-plugin-mirabox/rollup.config.mjs
+++ b/packages/iracing-plugin-mirabox/rollup.config.mjs
@@ -241,7 +241,7 @@ const config = {
 		},
 		inlineDynamicImports: true
 	},
-	external: ["@iracedeck/audio-native", "@iracedeck/audio-service", "@iracedeck/iracing-native", "yaml", "keysender", "ws"],
+	external: ["@iracedeck/audio-native", "@iracedeck/iracing-native", "yaml", "keysender", "ws"],
 	plugins: [
 		// Resolve .js imports to .ts files for the raw-TypeScript actions package.
 		// Only applies to relative imports (starting with ".") within the actions package.
@@ -329,7 +329,6 @@ const config = {
 					type: "module",
 					dependencies: {
 						"@iracedeck/audio-native": "file:../../../audio-native",
-						"@iracedeck/audio-service": "file:../../../audio-service",
 						"@iracedeck/iracing-native": "file:../../../iracing-native",
 						ws: "8.18.2",
 						yaml: "2.8.2",

--- a/packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/.sdignore
+++ b/packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/.sdignore
@@ -15,8 +15,17 @@
 # MSBuild tracking logs
 *.tlog
 
+# node-gyp generated build files (only build/Release/*.node is needed at runtime)
+**/build/*.sln
+**/build/*.gypi
+**/build/*.vcxproj
+**/build/*.vcxproj.filters
+
 # Python bytecode cache (node-gyp)
 **/__pycache__/
+
+# Standalone Python distribution downloaded by node-gyp
+**/node_modules/@iracedeck/*/Python/
 
 # Dev dependencies (nested in native modules)
 **/node_modules/typescript/
@@ -28,6 +37,11 @@
 # Source files (already compiled)
 **/node_modules/*/src/
 **/node_modules/@*/*/src/
+
+# iRacing SDK reference projects and build scripts (not runtime artifacts)
+**/node_modules/@iracedeck/*/assets/
+**/node_modules/@iracedeck/*/scripts/
+**/node_modules/@iracedeck/*/README.md
 
 # Dev/build config files
 **/tsconfig.json

--- a/packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/.sdignore
+++ b/packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/.sdignore
@@ -25,7 +25,8 @@
 **/__pycache__/
 
 # Standalone Python distribution downloaded by node-gyp
-**/node_modules/@iracedeck/*/Python/
+**/node_modules/@iracedeck/audio-native/Python/
+**/node_modules/@iracedeck/iracing-native/Python/
 
 # Dev dependencies (nested in native modules)
 **/node_modules/typescript/
@@ -41,10 +42,15 @@
 # Compiled test artifacts in shipped dist/ folders
 **/node_modules/**/dist/**/*.test.*
 
-# iRacing SDK reference projects and build scripts (not runtime artifacts)
-**/node_modules/@iracedeck/*/assets/
-**/node_modules/@iracedeck/*/scripts/
-**/node_modules/@iracedeck/*/README.md
+# iRacing SDK reference projects and build scripts (not runtime artifacts).
+# Listed per-package on purpose: a wildcard like @iracedeck/*/ would silently
+# drop runtime files from any future @iracedeck package shipped via file: dep.
+**/node_modules/@iracedeck/audio-native/assets/
+**/node_modules/@iracedeck/audio-native/scripts/
+**/node_modules/@iracedeck/audio-native/README.md
+**/node_modules/@iracedeck/iracing-native/assets/
+**/node_modules/@iracedeck/iracing-native/scripts/
+**/node_modules/@iracedeck/iracing-native/README.md
 
 # Dev/build config files
 **/tsconfig.json

--- a/packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/.sdignore
+++ b/packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/.sdignore
@@ -38,6 +38,9 @@
 **/node_modules/*/src/
 **/node_modules/@*/*/src/
 
+# Compiled test artifacts in shipped dist/ folders
+**/node_modules/**/dist/**/*.test.*
+
 # iRacing SDK reference projects and build scripts (not runtime artifacts)
 **/node_modules/@iracedeck/*/assets/
 **/node_modules/@iracedeck/*/scripts/

--- a/packages/iracing-plugin-stream-deck/rollup.config.mjs
+++ b/packages/iracing-plugin-stream-deck/rollup.config.mjs
@@ -167,7 +167,7 @@ const config = {
 		},
 		inlineDynamicImports: true
 	},
-	external: ["@iracedeck/audio-native", "@iracedeck/audio-service", "@iracedeck/iracing-native", "yaml", "keysender"],
+	external: ["@iracedeck/audio-native", "@iracedeck/iracing-native", "yaml", "keysender"],
 	plugins: [
 		// Resolve .js imports to .ts files for the raw-TypeScript actions package.
 		// Only applies to relative imports (starting with ".") within the actions package.
@@ -285,7 +285,6 @@ const config = {
 					type: "module",
 					dependencies: {
 						"@iracedeck/audio-native": "file:../../../audio-native",
-						"@iracedeck/audio-service": "file:../../../audio-service",
 						"@iracedeck/iracing-native": "file:../../../iracing-native",
 						yaml: "2.8.2",
 					},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,14 +87,13 @@ importers:
   packages/audio-assets: {}
 
   packages/audio-native:
-    dependencies:
-      node-addon-api:
-        specifier: 8.7.0
-        version: 8.7.0
     devDependencies:
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
+      node-addon-api:
+        specifier: 8.7.0
+        version: 8.7.0
       node-gyp:
         specifier: 12.2.0
         version: 12.2.0
@@ -340,14 +339,13 @@ importers:
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.0.2)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   packages/iracing-native:
-    dependencies:
-      node-addon-api:
-        specifier: 8.7.0
-        version: 8.7.0
     devDependencies:
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
+      node-addon-api:
+        specifier: 8.7.0
+        version: 8.7.0
       node-gyp:
         specifier: 12.2.0
         version: 12.2.0


### PR DESCRIPTION
## Related Issue

N/A — discovered during a build-output audit, not from a pre-existing issue. Two follow-up issues were filed during the work: #435 (release-it bumps an incomplete subset of workspace packages) and #436 (lazy-load mock-impl/mock-data on non-Windows so they don't ship in the Windows pack).

## What changed?

Three commits that together drop the longest path inside the packaged `.streamDeckPlugin` from **128 chars to ~76 chars**, clearing the 260-char Win32 `MAX_PATH` limit with comfortable headroom (and shrinking the install at the same time).

### Commit 1 — `fix(build): shorten installed plugin paths to clear Win32 MAX_PATH` (`f59c6161`)

- Move `node-addon-api` from `dependencies` → `devDependencies` in both `@iracedeck/audio-native` and `@iracedeck/iracing-native`. It is a build-time-only set of C++ headers consumed by `binding.gyp` (`require('node-addon-api').include`); the compiled `.node` artefact does not need it at runtime, so it shouldn't ship in the installed plugin's `node_modules`. This eliminates the deepest `node-addon-api/` subtree.
- Bundle `@iracedeck/audio-service` into `plugin.js` for both the Stream Deck and Mirabox plugins (drop it from the `external` array and from the emitted `bin/package.json`). audio-service is pure TypeScript with audio-native as its only runtime peer (which stays external), so rollup can inline it the same way it inlines deck-core. This eliminates the entire `bin/node_modules/@iracedeck/audio-service/` subtree, which previously contained a *duplicated nested copy* of audio-native + node-addon-api.

### Commit 2 — `fix(build): drop unused native-package files from the packed plugin` (`0dada74a`)

Add `.sdignore` rules (identical for both plugins) that match each native package's published `files` whitelist in `package.json`. `file:` deps don't honor `files`, so without these rules the entire package directory ships:

- `**/node_modules/@iracedeck/*/assets/` — kills the iRacing SDK reference projects (~413 KB; previously the source of the 100-char paths).
- `**/node_modules/@iracedeck/*/scripts/` and `README.md` — never read at runtime.
- `**/build/{*.sln,*.gypi,*.vcxproj,*.vcxproj.filters}` — only the `.node` binary in `build/Release/` is needed.
- `**/node_modules/@iracedeck/*/Python/` — defensive, catches a node-gyp Python tree that can appear in the pre-pack tree under some build states.

### Commit 3 — `fix(build): drop compiled test artifacts from packed plugin dist/` (`1f20659b`)

Add `**/node_modules/**/dist/**/*.test.*`. Strips 9 `.test.js` / `.test.d.ts` / `.test.d.ts.map` files (the longest 3 paths after commit 2). `mock-data/*.{js,d.ts}` are intentionally retained — `mock-impl.ts` top-level-imports them, so they must resolve at module-load time on every platform. See #436 for a follow-up that would let these be dropped too via a code refactor.

### Path-length progression (verified against extracted `.streamDeckPlugin`)

| Build | Longest relative path | Top culprit |
|---|---|---|
| Original | 128 chars | `audio-service/node_modules/@iracedeck/audio-native/node_modules/node-addon-api/...` |
| After commit 1 | 100 chars | `iracing-native/assets/irsdk_1_19/.../*.vcxproj` |
| After commit 2 | 81 chars | `iracing-native/dist/mock-data/telemetry.test.d.ts.map` |
| After commit 3 | ~76 chars | The `.node` binary itself (`build/Release/iracing_native.node`) — intentional |

Headroom on a typical install (`%APPDATA%\Elgato\StreamDeck\Plugins\com.iracedeck.sd.core.sdPlugin\` ≈ 87 chars): **~97 chars of slack** under MAX_PATH; ~75 chars even with a long-username + OneDrive prefix.

## How to test

- [ ] `pnpm build` succeeds for both plugins.
- [ ] Pack each plugin (e.g. via the existing GitHub Action), extract the resulting `.streamDeckPlugin`, and recursively measure file paths. Confirm:
  - No `bin/node_modules/@iracedeck/audio-service/` subtree.
  - No `bin/node_modules/@iracedeck/audio-native/node_modules/` subtree.
  - No `node_modules/.../assets/irsdk_1_19/...` paths.
  - No `dist/**/*.test.*` files.
  - Longest path ≤ ~80 chars.
- [ ] Install the rebuilt Stream Deck plugin and trigger a Pit Crew action (exercises bundled audio-service → external audio-native at runtime). Confirm audio plays.
- [ ] `pnpm test` passes across the workspace.

## Checklist

- [ ] Linked to an approved issue *(N/A — internal build-output finding; see Related Issue)*
- [x] New code has unit tests *(N/A — build/packaging configuration only, no new code paths)*
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved native helper package to development-only to reduce runtime installs.
  * Expanded packaging ignores to exclude build artifacts and bundled non-runtime files, slimming plugin packages.
* **Build / Packaging**
  * Plugins now bundle the audio service instead of treating it as an external dependency, so the service is included in plugin installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->