### PR TITLE
fix(release): discover packages dynamically (#435)

### DIFF
--- a/scripts/release-hooks.mjs
+++ b/scripts/release-hooks.mjs
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 const version = process.argv[2];
@@ -10,20 +10,31 @@ if (!version) {
 
 const root = new URL("..", import.meta.url).pathname.replace(/^\/([A-Z]:)/, "$1");
 
-// Bump version in all packages/*/package.json
-const packageJsonPaths = [
-  "packages/iracing-actions/package.json",
-  "packages/deck-adapter-elgato/package.json",
-  "packages/deck-adapter-mirabox/package.json",
-  "packages/deck-core/package.json",
-  "packages/icons/package.json",
-  "packages/iracing-native/package.json",
-  "packages/iracing-sdk/package.json",
-  "packages/logger/package.json",
-  "packages/iracing-plugin-stream-deck/package.json",
-  "packages/iracing-plugin-mirabox/package.json",
-  "packages/website/package.json",
-];
+// Packages that intentionally track their own versions and must NOT be bumped
+// by the release process. Empty today — add the package name here if a
+// package ever decouples from the monorepo's shared version.
+const SKIPPED_PACKAGES = new Set();
+
+// Discover every workspace package under packages/* that declares a `version`.
+// Replaces the previous hardcoded list which silently skipped new packages
+// (see issue #435 — eight packages had drifted multiple minors behind because
+// they were never added to the static array).
+const packagesDir = join(root, "packages");
+const packageJsonPaths = readdirSync(packagesDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => `packages/${entry.name}/package.json`)
+  .filter((rel) => {
+    const filePath = join(root, rel);
+    if (!existsSync(filePath)) return false;
+    const pkg = JSON.parse(readFileSync(filePath, "utf-8"));
+    if (!pkg.version) return false;
+    if (SKIPPED_PACKAGES.has(pkg.name)) {
+      console.log(`  Skipping ${pkg.name} (opted out via SKIPPED_PACKAGES)`);
+      return false;
+    }
+    return true;
+  })
+  .sort();
 
 // Bump Version in manifest.json files. Elgato's manifest schema requires a
 // strict 4-part numeric format `{major}.{minor}.{patch}.{build}`
@@ -39,9 +50,12 @@ const manifestPaths = [
 // modify real package.json / manifest.json files and stage them with `git add`.
 // `scripts/release.mjs` sets RELEASE_IT_DRY_RUN=1 when --dry-run is passed.
 if (process.env.RELEASE_IT_DRY_RUN === "1") {
+  console.log(`  [dry-run] Would bump ${packageJsonPaths.length} package.json files to version ${version}:`);
+  for (const rel of packageJsonPaths) console.log(`    - ${rel}`);
   console.log(
-    `  [dry-run] Would bump ${packageJsonPaths.length} package.json files and ${manifestPaths.length} manifest.json files to version ${version}`,
+    `  [dry-run] Would bump ${manifestPaths.length} manifest.json files to version ${version.replace(/[-+].*$/, "")}.0:`,
   );
+  for (const rel of manifestPaths) console.log(`    - ${rel}`);
   process.exit(0);
 }
 

--- a/scripts/release-hooks.mjs
+++ b/scripts/release-hooks.mjs
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -77,6 +77,8 @@ for (const rel of manifestPaths) {
   console.log(`  Updated ${rel} → ${numericVersion}.0`);
 }
 
-// Stage all modified files
+// Stage all modified files. Use argv form (no shell) so package directory
+// names containing spaces or shell metacharacters can't break or inject into
+// the git invocation.
 const allPaths = [...packageJsonPaths, ...manifestPaths];
-execSync(`git add ${allPaths.join(" ")}`, { cwd: root, stdio: "inherit" });
+execFileSync("git", ["add", "--", ...allPaths], { cwd: root, stdio: "inherit" });


### PR DESCRIPTION
## Related Issue

Fixes #435

## What changed?

`scripts/release-hooks.mjs` no longer relies on a hardcoded `packageJsonPaths` array. It now scans `packages/*` for every `package.json` that declares a `version` and bumps each of them. Eight packages (`audio-assets`, `audio-native`, `audio-scenarios`, `audio-service`, `event-bus`, `icon-composer`, `pi-components`, `sim-events-iracing`) had drifted multiple minor versions behind because they were never added to the static list — they will catch up on the next release.

A `SKIPPED_PACKAGES` Set is provided (currently empty) so a future package can intentionally opt out without re-introducing a hardcoded include list.

The dry-run log now enumerates every discovered package + manifest path, so future drift surfaces at release time.

## How to test

Run the dry-run against the current workspace and confirm all 19 packages are listed:

```bash
RELEASE_IT_DRY_RUN=1 node scripts/release-hooks.mjs 1.15.0
```

Expected:

```
  [dry-run] Would bump 19 package.json files to version 1.15.0:
    - packages/audio-assets/package.json
    - packages/audio-native/package.json
    - packages/audio-scenarios/package.json
    - packages/audio-service/package.json
    - packages/deck-adapter-elgato/package.json
    - packages/deck-adapter-mirabox/package.json
    - packages/deck-core/package.json
    - packages/event-bus/package.json
    - packages/icon-composer/package.json
    - packages/icons/package.json
    - packages/iracing-actions/package.json
    - packages/iracing-native/package.json
    - packages/iracing-plugin-mirabox/package.json
    - packages/iracing-plugin-stream-deck/package.json
    - packages/iracing-sdk/package.json
    - packages/logger/package.json
    - packages/pi-components/package.json
    - packages/sim-events-iracing/package.json
    - packages/website/package.json
  [dry-run] Would bump 2 manifest.json files to version 1.15.0.0:
    - packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/manifest.json
    - packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/manifest.json
```

The next real release will backfill all eight stale packages to the new version automatically.

## Checklist

- [x] Linked to an approved issue
- [ ] New code has unit tests — script-only change; no test infrastructure exists for `scripts/*.mjs` and the script's behavior is verified end-to-end via the `RELEASE_IT_DRY_RUN=1` smoke test above
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — release hook is plugin-agnostic; both plugin manifests still bumped
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release automation: dynamic package discovery and ability to exclude specific packages.
  * Safer staging during release to avoid path/shell issues.
  * Enhanced dry-run reporting: lists exact files that would be updated and shows simplified manifest version previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->