### PR TITLE
feat(audio-assets): scope generation via --group/--voice flags (#442)

### DIFF
--- a/packages/audio-assets/README.md
+++ b/packages/audio-assets/README.md
@@ -57,9 +57,11 @@ pnpm --filter @iracedeck/audio-assets generate:manifest
 | `--voice <key>[,<key>...]` | Only iterate the named voices (e.g. `luca`). Repeatable. |
 | `--group <name>[,<name>...]` | Only iterate the named groups (e.g. `numbers`). Repeatable. |
 
-`--voice` and `--group` compose as an intersection. Manifest entries outside
-the filter are not touched, so a subsequent unscoped run still sees them as
-cache hits. Unknown names exit non-zero with the list of valid choices.
+`--voice` and `--group` accept either the space-separated form (`--voice luca`)
+or the equals form (`--voice=luca`). They compose as an intersection. Manifest
+entries outside the filter are not touched, so a subsequent unscoped run still
+sees them as cache hits. Unknown names exit non-zero with the list of valid
+choices.
 
 ### Examples
 
@@ -72,4 +74,7 @@ pnpm --filter @iracedeck/audio-assets generate --voice luca --group flags
 
 # Cost estimate before committing to an ElevenLabs run
 pnpm --filter @iracedeck/audio-assets generate --dry-run --group numbers
+
+# Equals form (interchangeable with the space-separated form)
+pnpm --filter @iracedeck/audio-assets generate --voice=luca --group=numbers
 ```

--- a/packages/audio-assets/README.md
+++ b/packages/audio-assets/README.md
@@ -1,0 +1,75 @@
+# @iracedeck/audio-assets
+
+Shared audio assets (MP3) for iRaceDeck plugins, plus the ElevenLabs TTS
+generator that produces them.
+
+## Layout
+
+```text
+packages/audio-assets/
+├── ambient/                 # Looping ambient audio
+├── voice/                   # Generated TTS clips, keyed by <voice>/<group>/<name>.mp3
+├── generate.config.json     # TTS source: voices, groups, entries, voice settings
+├── generate.manifest.json   # TTS cache: per-entry hash + ElevenLabs request id
+├── manifest.json            # Deployment manifest consumed by audio-service at runtime
+└── src/
+    ├── build/               # Build helpers used during plugin packaging
+    ├── generate/            # TTS generator (this README documents the CLI)
+    └── presets.mjs
+```
+
+`generate.manifest.json` is a build cache for the generator. `manifest.json` is
+the runtime manifest the plugins read; it is regenerated from the file tree by
+`pnpm --filter @iracedeck/audio-assets generate:manifest`.
+
+## TTS generator
+
+Reads `generate.config.json`, iterates voices × groups × entries, and writes
+any missing or stale `voice/<voice>/<group>/<name>.mp3` files by calling the
+ElevenLabs TTS API. An entry is considered up-to-date when its output file
+exists *and* its hash in `generate.manifest.json` matches the current
+audio-affecting tuple (voice + model + voice_settings + text + seed +
+prosody/context fields).
+
+### Environment
+
+- `ELEVENLABS_API_KEY` — required for live runs. `.env.local` or `.env` at the
+  repo root is auto-loaded if present.
+
+### Commands
+
+```bash
+# Generate everything that's missing or stale
+pnpm --filter @iracedeck/audio-assets generate
+
+# Report which entries would be generated, without calling the API
+pnpm --filter @iracedeck/audio-assets generate:dry-run
+
+# Rebuild the runtime manifest.json from the file tree
+pnpm --filter @iracedeck/audio-assets generate:manifest
+```
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `--dry-run` | List entries that would be generated/skipped. No API calls, no file writes, no manifest changes. |
+| `--voice <key>[,<key>...]` | Only iterate the named voices (e.g. `luca`). Repeatable. |
+| `--group <name>[,<name>...]` | Only iterate the named groups (e.g. `numbers`). Repeatable. |
+
+`--voice` and `--group` compose as an intersection. Manifest entries outside
+the filter are not touched, so a subsequent unscoped run still sees them as
+cache hits. Unknown names exit non-zero with the list of valid choices.
+
+### Examples
+
+```bash
+# Add a new line under one group without disturbing the other groups' cache
+pnpm --filter @iracedeck/audio-assets generate --group numbers
+
+# Re-cut just one voice/group combination after a per-voice settings tweak
+pnpm --filter @iracedeck/audio-assets generate --voice luca --group flags
+
+# Cost estimate before committing to an ElevenLabs run
+pnpm --filter @iracedeck/audio-assets generate --dry-run --group numbers
+```

--- a/packages/audio-assets/src/generate/generate.ts
+++ b/packages/audio-assets/src/generate/generate.ts
@@ -17,12 +17,23 @@
  * plugin's MIRABOX_PLUGINS_DIR setup).
  *
  * Flags:
- *   --dry-run    Report which entries would be generated / skipped without
- *                calling the API, writing files, or updating the manifest.
+ *   --dry-run                       Report which entries would be generated /
+ *                                   skipped without calling the API, writing
+ *                                   files, or updating the manifest.
+ *   --voice <key>[,<key>...]        Only iterate the named voices. Repeatable;
+ *                                   --voice luca --voice titan == --voice luca,titan.
+ *   --group <name>[,<name>...]      Only iterate the named groups. Repeatable.
+ *
+ * Voice and group filters compose as an intersection: --voice luca --group
+ * numbers only touches voice/luca/numbers/. Manifest entries outside the
+ * filter are left untouched, so a subsequent unscoped run still sees them
+ * as cache hits. Unknown names exit non-zero with the list of valid choices.
  *
  * Usage (from repo root):
  *   pnpm --filter @iracedeck/audio-assets generate
  *   pnpm --filter @iracedeck/audio-assets generate:dry-run
+ *   pnpm --filter @iracedeck/audio-assets generate --group acknowledgment
+ *   pnpm --filter @iracedeck/audio-assets generate --voice luca --group numbers
  */
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
@@ -33,6 +44,7 @@ import url from "node:url";
 import { type Config, type Entry, loadConfig, resolveVoiceSettings, type Voice } from "./config.ts";
 import { type SynthesizeOptions, synthesizeSpeech } from "./elevenlabs.ts";
 import { loadManifest, saveManifest } from "./manifest.ts";
+import { formatScope, parseScopeArgs, type Scope, validateScope } from "./scope.ts";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const packageRoot = path.resolve(__dirname, "../..");
@@ -123,7 +135,17 @@ function textPreview(text: string, max = 60): string {
 async function main(): Promise<void> {
   loadDotenv();
 
-  const dryRun = process.argv.slice(2).includes("--dry-run");
+  let scope: Scope;
+  let remaining: string[];
+
+  try {
+    ({ scope, remaining } = parseScopeArgs(process.argv.slice(2)));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  const dryRun = remaining.includes("--dry-run");
   const apiKey = process.env.ELEVENLABS_API_KEY;
 
   if (!dryRun && !apiKey) {
@@ -132,7 +154,19 @@ async function main(): Promise<void> {
   }
 
   const config = loadConfig(CONFIG_PATH);
+
+  try {
+    validateScope(scope, config);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
   const manifest = loadManifest(MANIFEST_PATH);
+
+  const scopeSummary = formatScope(scope);
+
+  if (scopeSummary) console.log(`[scope] ${scopeSummary}`);
 
   if (dryRun) console.log("[dry-run] No API calls, no file writes, no manifest changes.");
 
@@ -141,7 +175,11 @@ async function main(): Promise<void> {
   let failed = 0;
 
   for (const [voiceName, voice] of Object.entries(config.voices)) {
+    if (scope.voices && !scope.voices.includes(voiceName)) continue;
+
     for (const [groupName, entries] of Object.entries(config.groups)) {
+      if (scope.groups && !scope.groups.includes(groupName)) continue;
+
       for (const entry of entries) {
         const relPath = path.posix.join("voice", voiceName, groupName, `${entry.name}.mp3`);
         const absPath = path.join(packageRoot, relPath);

--- a/packages/audio-assets/src/generate/scope.test.ts
+++ b/packages/audio-assets/src/generate/scope.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import type { Config } from "./config.ts";
+import { formatScope, parseScopeArgs, validateScope } from "./scope.ts";
+
+// Minimal Config shape — validateScope only reads keys of voices/groups.
+const config = {
+  voices: { luca: {}, titan: {} },
+  groups: { acknowledgment: [], numbers: [], flags: [] },
+} as unknown as Config;
+
+describe("parseScopeArgs", () => {
+  it("returns a null scope when no flags are present", () => {
+    const { scope, remaining } = parseScopeArgs(["--dry-run"]);
+
+    expect(scope).toEqual({ voices: null, groups: null });
+    expect(remaining).toEqual(["--dry-run"]);
+  });
+
+  it("parses --group with a value as the next token", () => {
+    const { scope, remaining } = parseScopeArgs(["--group", "acknowledgment", "--dry-run"]);
+
+    expect(scope).toEqual({ voices: null, groups: ["acknowledgment"] });
+    expect(remaining).toEqual(["--dry-run"]);
+  });
+
+  it("parses the --group=value (equals) form", () => {
+    const { scope, remaining } = parseScopeArgs(["--group=acknowledgment", "--dry-run"]);
+
+    expect(scope.groups).toEqual(["acknowledgment"]);
+    expect(remaining).toEqual(["--dry-run"]);
+  });
+
+  it("splits comma-separated values and trims whitespace", () => {
+    const { scope } = parseScopeArgs(["--group", "acknowledgment, numbers ,flags"]);
+
+    expect(scope.groups).toEqual(["acknowledgment", "numbers", "flags"]);
+  });
+
+  it("unions repeated flags and dedupes", () => {
+    const { scope } = parseScopeArgs(["--group", "a", "--group=b,a", "--group", "c"]);
+
+    expect(scope.groups).toEqual(["a", "b", "c"]);
+  });
+
+  it("composes --voice and --group", () => {
+    const { scope } = parseScopeArgs(["--voice", "luca", "--group", "numbers"]);
+
+    expect(scope).toEqual({ voices: ["luca"], groups: ["numbers"] });
+  });
+
+  it("leaves unknown args in remaining", () => {
+    const { remaining } = parseScopeArgs(["--dry-run", "--voice", "luca", "--other", "value"]);
+
+    expect(remaining).toEqual(["--dry-run", "--other", "value"]);
+  });
+
+  it("throws when --group has no value (last token)", () => {
+    expect(() => parseScopeArgs(["--group"])).toThrow(/--group: expected a name/);
+  });
+
+  it("throws when --group=<empty> is supplied", () => {
+    expect(() => parseScopeArgs(["--group="])).toThrow(/--group: expected a name/);
+  });
+
+  it("throws when --group is followed by only commas/whitespace", () => {
+    expect(() => parseScopeArgs(["--group", " , , "])).toThrow(/--group: expected a name/);
+  });
+
+  it("does not consume tokens that merely start with --group (e.g. --groups)", () => {
+    const { scope, remaining } = parseScopeArgs(["--groups", "ack"]);
+
+    expect(scope.groups).toBeNull();
+    expect(remaining).toEqual(["--groups", "ack"]);
+  });
+});
+
+describe("validateScope", () => {
+  it("accepts a null scope", () => {
+    expect(() => validateScope({ voices: null, groups: null }, config)).not.toThrow();
+  });
+
+  it("accepts known voice and group keys", () => {
+    expect(() => validateScope({ voices: ["luca"], groups: ["acknowledgment", "numbers"] }, config)).not.toThrow();
+  });
+
+  it("throws on an unknown group with a helpful message", () => {
+    expect(() => validateScope({ voices: null, groups: ["nope"] }, config)).toThrow(
+      /--group: unknown name "nope"\.\n {2}Valid: acknowledgment, numbers, flags/,
+    );
+  });
+
+  it("throws on an unknown voice with a helpful message", () => {
+    expect(() => validateScope({ voices: ["mystery"], groups: null }, config)).toThrow(
+      /--voice: unknown name "mystery"\.\n {2}Valid: luca, titan/,
+    );
+  });
+
+  it("lists multiple unknowns in one error", () => {
+    expect(() => validateScope({ voices: null, groups: ["foo", "bar"] }, config)).toThrow(/unknown names "foo", "bar"/);
+  });
+});
+
+describe("formatScope", () => {
+  it("returns null when no filter is active", () => {
+    expect(formatScope({ voices: null, groups: null })).toBeNull();
+  });
+
+  it("includes only the populated axes", () => {
+    expect(formatScope({ voices: ["luca"], groups: null })).toBe("voices=luca");
+    expect(formatScope({ voices: null, groups: ["a", "b"] })).toBe("groups=a,b");
+    expect(formatScope({ voices: ["luca"], groups: ["numbers"] })).toBe("voices=luca, groups=numbers");
+  });
+});

--- a/packages/audio-assets/src/generate/scope.test.ts
+++ b/packages/audio-assets/src/generate/scope.test.ts
@@ -67,6 +67,14 @@ describe("parseScopeArgs", () => {
     expect(() => parseScopeArgs(["--group", " , , "])).toThrow(/--group: expected a name/);
   });
 
+  it("throws when --group is followed by another flag (does not swallow it)", () => {
+    expect(() => parseScopeArgs(["--group", "--dry-run"])).toThrow(/--group: expected a name.*looks like a flag/);
+  });
+
+  it("throws when a comma list contains an empty entry", () => {
+    expect(() => parseScopeArgs(["--group", "a,,b"])).toThrow(/--group: expected a name/);
+  });
+
   it("does not consume tokens that merely start with --group (e.g. --groups)", () => {
     const { scope, remaining } = parseScopeArgs(["--groups", "ack"]);
 

--- a/packages/audio-assets/src/generate/scope.ts
+++ b/packages/audio-assets/src/generate/scope.ts
@@ -1,0 +1,123 @@
+import type { Config } from "./config.ts";
+
+/**
+ * Filter applied to the voices × groups iteration in the TTS generator.
+ * `null` means "no filter" — iterate all of that axis.
+ */
+export interface Scope {
+  voices: string[] | null;
+  groups: string[] | null;
+}
+
+const FLAGS = ["--voice", "--group"] as const;
+type FlagName = (typeof FLAGS)[number];
+
+function flagToKey(flag: FlagName): keyof Scope {
+  return flag === "--voice" ? "voices" : "groups";
+}
+
+function splitValue(flag: FlagName, raw: string): string[] {
+  const parts = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  if (parts.length === 0) {
+    throw new Error(`${flag}: expected a name (got "${raw}")`);
+  }
+
+  return parts;
+}
+
+/**
+ * Parse `--voice` / `--group` flags out of argv. Both forms are accepted:
+ *   --group acknowledgment        (value as next token)
+ *   --group=acknowledgment        (equals form)
+ * Values may be comma-separated and the flag may repeat; the union of all
+ * values is returned, deduped while preserving first-seen order.
+ *
+ * Args that aren't `--voice`/`--group` (e.g. `--dry-run`) pass through
+ * untouched in `remaining` so the caller can interpret them.
+ *
+ * Throws if a flag is followed by no value or an empty value.
+ */
+export function parseScopeArgs(argv: readonly string[]): { scope: Scope; remaining: string[] } {
+  const acc: Record<keyof Scope, string[]> = { voices: [], groups: [] };
+  const remaining: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+
+    const eqFlag = FLAGS.find((f) => arg.startsWith(`${f}=`));
+
+    if (eqFlag) {
+      acc[flagToKey(eqFlag)].push(...splitValue(eqFlag, arg.slice(eqFlag.length + 1)));
+      continue;
+    }
+
+    if ((FLAGS as readonly string[]).includes(arg)) {
+      const flag = arg as FlagName;
+      const next = argv[i + 1];
+
+      if (next === undefined) {
+        throw new Error(`${flag}: expected a name`);
+      }
+
+      acc[flagToKey(flag)].push(...splitValue(flag, next));
+      i++;
+      continue;
+    }
+
+    remaining.push(arg);
+  }
+
+  return {
+    scope: {
+      voices: acc.voices.length > 0 ? Array.from(new Set(acc.voices)) : null,
+      groups: acc.groups.length > 0 ? Array.from(new Set(acc.groups)) : null,
+    },
+    remaining,
+  };
+}
+
+/**
+ * Throw with a helpful message if any requested voice/group key is missing
+ * from the loaded config. Lists the unknown names and the valid options so
+ * the user can correct the typo without spelunking through the config file.
+ */
+export function validateScope(scope: Scope, config: Config): void {
+  if (scope.voices) {
+    requireKnown("--voice", scope.voices, Object.keys(config.voices));
+  }
+
+  if (scope.groups) {
+    requireKnown("--group", scope.groups, Object.keys(config.groups));
+  }
+}
+
+function requireKnown(flag: string, requested: string[], available: string[]): void {
+  const unknown = requested.filter((name) => !available.includes(name));
+
+  if (unknown.length === 0) return;
+
+  const formattedUnknown = unknown.map((u) => `"${u}"`).join(", ");
+  const formattedAvailable = available.length > 0 ? available.join(", ") : "(none)";
+
+  throw new Error(
+    `${flag}: unknown ${unknown.length === 1 ? "name" : "names"} ${formattedUnknown}.\n  Valid: ${formattedAvailable}`,
+  );
+}
+
+/**
+ * Format a scope summary for log output. Returns null when no filter is set
+ * (callers can use the null to skip the log line entirely).
+ */
+export function formatScope(scope: Scope): string | null {
+  const parts: string[] = [];
+
+  if (scope.voices) parts.push(`voices=${scope.voices.join(",")}`);
+
+  if (scope.groups) parts.push(`groups=${scope.groups.join(",")}`);
+
+  return parts.length > 0 ? parts.join(", ") : null;
+}

--- a/packages/audio-assets/src/generate/scope.ts
+++ b/packages/audio-assets/src/generate/scope.ts
@@ -17,13 +17,20 @@ function flagToKey(flag: FlagName): keyof Scope {
 }
 
 function splitValue(flag: FlagName, raw: string): string[] {
-  const parts = raw
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
+  const parts = raw.split(",").map((s) => s.trim());
 
-  if (parts.length === 0) {
+  if (parts.length === 0 || parts.some((p) => p.length === 0)) {
     throw new Error(`${flag}: expected a name (got "${raw}")`);
+  }
+
+  // A leading "-" can only mean the user wrote `--group --dry-run` (forgetting
+  // the value) or `--group=-foo` (typo). Kebab keys can't start with "-" per
+  // the config schema, so any "-"-prefixed token is a CLI mistake — reject it
+  // here rather than letting the dry-run flag get silently consumed as a name.
+  const flagLike = parts.find((p) => p.startsWith("-"));
+
+  if (flagLike !== undefined) {
+    throw new Error(`${flag}: expected a name (got "${flagLike}", looks like a flag)`);
   }
 
   return parts;


### PR DESCRIPTION
## Related Issue

Fixes #442

## What changed?

Adds `--voice <key>[,<key>...]` and `--group <name>[,<name>...]` CLI flags to the TTS generator so users can scope a run to specific voices and/or groups. Without this, any change to a voice's `voice_settings` block invalidates the per-entry hash for every entry under that voice — even entries whose own text didn't change — forcing 200+ unintended ElevenLabs requests during routine work like adding a new line.

- New `packages/audio-assets/src/generate/scope.ts` — pure `parseScopeArgs` / `validateScope` / `formatScope` helpers.
- New `scope.test.ts` — 18 unit tests covering argv parsing variants and validation error messages.
- `generate.ts` parses scope, validates against the loaded config, gates the voices × groups loops, and logs a one-line `[scope] …` summary when a filter is active.
- New minimal README for `@iracedeck/audio-assets` documenting the generator CLI (none existed before).

Both the `--flag value` and `--flag=value` forms work; values can be comma-separated; repeating a flag unions the values (deduped). Filters compose as an intersection. Unknown names exit non-zero with the list of valid choices. `--dry-run` honors the filters. Manifest entries outside the filter are never touched in memory, so a subsequent unscoped run still sees them as cache hits.

`--force` from the issue's "Optional follow-up" is intentionally out of scope.

## How to test

```bash
# Baseline — no scope, all entries
pnpm --filter @iracedeck/audio-assets generate:dry-run

# Single group across all voices
pnpm --filter @iracedeck/audio-assets generate -- --dry-run --group names
# expect: [scope] groups=names; only voice/*/names/* listed

# Voice + group composition
pnpm --filter @iracedeck/audio-assets generate -- --dry-run --voice luca --group numbers
# expect: [scope] voices=luca, groups=numbers; only voice/luca/numbers/* listed

# Equals form + comma-separated values
pnpm --filter @iracedeck/audio-assets generate -- --dry-run --group=names,numbers --voice=luca

# Unknown name → exit 1 with valid choices
pnpm --filter @iracedeck/audio-assets generate -- --dry-run --voice mystery
# expect: '--voice: unknown name "mystery". Valid: luca, titan' on stderr, exit 1

# Manifest byte-identity across a scoped dry-run
md5sum packages/audio-assets/generate.manifest.json
pnpm --filter @iracedeck/audio-assets generate -- --dry-run --group names --voice luca > /dev/null
md5sum packages/audio-assets/generate.manifest.json
# expect: identical hashes

# Unit tests
pnpm vitest run packages/audio-assets/src/generate/scope.test.ts
```

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — N/A; package-local change to `@iracedeck/audio-assets` CLI only
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scoped CLI filtering for selective audio generation using repeated/comma-separated voice and group flags, plus dry-run behavior and non-zero exit on unknown names
  * Scope validation with clear error messages and a concise scope summary when applied

* **Documentation**
  * New README detailing package layout, TTS generation workflow, env setup, commands, and CLI flag usage

* **Tests**
  * Added tests covering scope parsing, validation, and formatting behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->