### PR TITLE
fix(audio-native): switch native addons to /Z7 to avoid LNK1318 in CI (#456)

### DIFF
--- a/packages/audio-native/binding.gyp
+++ b/packages/audio-native/binding.gyp
@@ -14,7 +14,8 @@
           "libraries": ["ole32.lib"],
           "msvs_settings": {
             "VCCLCompilerTool": {
-              "DisableSpecificWarnings": ["4244", "4267", "4996"]
+              "DisableSpecificWarnings": ["4244", "4267", "4996"],
+              "DebugInformationFormat": "1"
             }
           }
         }]

--- a/packages/iracing-native/binding.gyp
+++ b/packages/iracing-native/binding.gyp
@@ -13,7 +13,12 @@
       "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"],
       "conditions": [
         ["OS=='win'", {
-          "libraries": ["user32.lib", "kernel32.lib"]
+          "libraries": ["user32.lib", "kernel32.lib"],
+          "msvs_settings": {
+            "VCCLCompilerTool": {
+              "DebugInformationFormat": "1"
+            }
+          }
         }]
       ]
     }


### PR DESCRIPTION
## Related Issue

Fixes #456

## What changed?

- `packages/audio-native/binding.gyp`: add `DebugInformationFormat: \"1\"` (`/Z7`) to the Windows `VCCLCompilerTool` settings so debug info is embedded into the `.obj` files rather than written through `mspdbsrv.exe`.
- `packages/iracing-native/binding.gyp`: same change applied for parity, so the inverse failure mode (audio-native winning the race, iracing-native losing it) can't surface either.

The Stream Deck release-pack workflow on `windows-latest` was intermittently failing with `libucrt.lib(fclose.obj) : fatal error LNK1318: Unexpected PDB error; RPC (23)` when `audio-native#build` and `iracing-native#build` linked concurrently against the same `mspdbsrv.exe`. `/Z7` removes that shared resource entirely.

## How to test

- [x] `pnpm install --frozen-lockfile && pnpm build` succeeds locally on Windows.
- [x] `pnpm lint` is clean.
- [x] `pnpm test` — 3382 tests across 107 files pass.
- [x] Verified `<DebugInformationFormat>OldStyle</DebugInformationFormat>` appears in the generated `audio_native.vcxproj` (and `iracing_native.vcxproj`) after a fresh `node-gyp rebuild`.
- [ ] CI: the Stream Deck release-pack workflow needs to run on this branch (or on the next tag) to confirm the link step no longer trips on `LNK1318`.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests _(build-config change — covered by the existing test suite + the CI workflow itself)_
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) _(both plugins consume both native addons; binding.gyp settings are platform-level, not plugin-level)_
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows build configuration settings for native packages to improve debug information handling during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->