### PR TITLE
fix(pit-crew): silence Voice + Background buses on Race Engineer disable (#457)

### DIFF
--- a/docs/plugins/core/actions/pit-crew.md
+++ b/docs/plugins/core/actions/pit-crew.md
@@ -14,7 +14,7 @@ Multi-mode action covering the iRaceDeck pit-side audio framework. Modes availab
 ## Behavior
 
 ### Button Press
-- **Race Engineer Toggle mode**: Flips the plugin-global `raceEngineerEnabled` gate. When off, every voice scenario is suppressed at the audio layer (audio stops immediately).
+- **Race Engineer Toggle mode**: Flips the plugin-global `raceEngineerEnabled` gate. When off, both `AudioBus.Voice` (engineer messages, acks, toggle confirmations) and `AudioBus.Background` (pit ambient loop and walkie-talkie SFX) are zeroed synchronously, so any in-flight clip silences on the same key press. `AudioBus.Alerts` (radar) is intentionally untouched — radar has its own toggle. Re-enabling restores Voice to the configured `Race Engineer Volume` and Background to unity.
 - **Radar mode**: Flips the plugin-global `radarEnabled` and stops/starts the directional proximity tick loop synchronously. Used by Radar alongside the per-instance Radar Test button.
 - **Radar Volume mode**: Steps the plugin-global `radarVolume` by ±5, clamped to 0–100. Takes effect immediately on `AudioBus.Alerts`. Direction is configured per button (Up or Down). Stepping to 0 mutes the radar without toggling the feature off.
 

--- a/packages/iracing-actions/src/actions/pit-crew/pit-crew.test.ts
+++ b/packages/iracing-actions/src/actions/pit-crew/pit-crew.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // statements. Vitest transforms `vi.mock(...)` to run before any import at
 // module init, so the mocks still apply to the action import below.
 import {
+  applyRaceEngineerAudio,
   applyRadarEnabled,
   applyRadarVolume,
   generatePitCrewSvg,
@@ -272,6 +273,39 @@ describe("applyRadarEnabled", () => {
   });
 });
 
+describe("applyRaceEngineerAudio", () => {
+  it("copies raceEngineerVolume onto AudioBus.Voice and unities AudioBus.Background when enabled", () => {
+    hoisted.setGlobalSettings({ raceEngineerEnabled: true, raceEngineerVolume: 60 });
+    applyRaceEngineerAudio();
+
+    expect(hoisted.setBusVolume).toHaveBeenCalledWith(0, 0.6);
+    expect(hoisted.setBusVolume).toHaveBeenCalledWith(1, 1);
+  });
+
+  it("zeroes both Voice and Background when disabled, regardless of raceEngineerVolume", () => {
+    hoisted.setGlobalSettings({ raceEngineerEnabled: false, raceEngineerVolume: 90 });
+    applyRaceEngineerAudio();
+
+    expect(hoisted.setBusVolume).toHaveBeenCalledWith(0, 0);
+    expect(hoisted.setBusVolume).toHaveBeenCalledWith(1, 0);
+  });
+
+  it("never touches AudioBus.Alerts (radar has its own gate)", () => {
+    hoisted.setGlobalSettings({ raceEngineerEnabled: false, raceEngineerVolume: 75 });
+    applyRaceEngineerAudio();
+
+    const alertsCalls = hoisted.setBusVolume.mock.calls.filter(([bus]) => bus === 2);
+    expect(alertsCalls).toHaveLength(0);
+  });
+
+  it("defaults raceEngineerVolume to 100% when the global is missing", () => {
+    hoisted.setGlobalSettings({ raceEngineerEnabled: true });
+    applyRaceEngineerAudio();
+
+    expect(hoisted.setBusVolume).toHaveBeenCalledWith(0, 1);
+  });
+});
+
 describe("PitCrew action", () => {
   describe("onWillAppear", () => {
     it("subscribes to global-settings changes so icons re-render on any feature flip", async () => {
@@ -390,6 +424,45 @@ describe("PitCrew action", () => {
       const updates = hoisted.updateGlobalSettings.mock.calls.flatMap(([partial]) => Object.keys(partial));
       expect(updates).not.toContain("radarEnabled");
       expect(updates).not.toContain("radarVolume");
+    });
+
+    it("synchronously silences Voice and Background buses when disabling (#457)", async () => {
+      hoisted.setGlobalSettings({ raceEngineerEnabled: true, raceEngineerVolume: 80, radarVolume: 100 });
+      const action = new PitCrew();
+      await action.onWillAppear(buildAppearEvent({ mode: "race-engineer" }) as never);
+      vi.clearAllMocks();
+
+      await action.onKeyDown(buildAppearEvent({ mode: "race-engineer" }) as never);
+
+      expect(hoisted.setBusVolume).toHaveBeenCalledWith(0, 0);
+      expect(hoisted.setBusVolume).toHaveBeenCalledWith(1, 0);
+    });
+
+    it("leaves AudioBus.Alerts (radar) audible when Race Engineer is disabled (#457)", async () => {
+      hoisted.setGlobalSettings({ raceEngineerEnabled: true, raceEngineerVolume: 80, radarVolume: 75 });
+      const action = new PitCrew();
+      await action.onWillAppear(buildAppearEvent({ mode: "race-engineer" }) as never);
+      vi.clearAllMocks();
+
+      await action.onKeyDown(buildAppearEvent({ mode: "race-engineer" }) as never);
+
+      // The toggle must not zero the radar bus. `applyRadarVolume` is
+      // unrelated and is not called from `toggleRaceEngineer`, so no
+      // Alerts-bus write is expected on this code path.
+      const alertsCalls = hoisted.setBusVolume.mock.calls.filter(([bus]) => bus === 2);
+      expect(alertsCalls).toHaveLength(0);
+    });
+
+    it("restores Voice volume and unmutes Background when re-enabling (#457)", async () => {
+      hoisted.setGlobalSettings({ raceEngineerEnabled: false, raceEngineerVolume: 65, radarVolume: 100 });
+      const action = new PitCrew();
+      await action.onWillAppear(buildAppearEvent({ mode: "race-engineer" }) as never);
+      vi.clearAllMocks();
+
+      await action.onKeyDown(buildAppearEvent({ mode: "race-engineer" }) as never);
+
+      expect(hoisted.setBusVolume).toHaveBeenCalledWith(0, 0.65);
+      expect(hoisted.setBusVolume).toHaveBeenCalledWith(1, 1);
     });
   });
 

--- a/packages/iracing-actions/src/actions/pit-crew/pit-crew.ts
+++ b/packages/iracing-actions/src/actions/pit-crew/pit-crew.ts
@@ -110,11 +110,21 @@ function readRaceEngineerVolume(): number {
 /**
  * @internal Exported for testing.
  *
- * Copy the current global `raceEngineerVolume` onto `AudioBus.Voice`.
- * Mirrors `applyRadarVolume` for the engineer voice channel.
+ * Apply the Race Engineer master gate to the relevant audio buses:
+ *   - `AudioBus.Voice` — engineer voice clips, acks, toggle confirmations.
+ *   - `AudioBus.Background` — pit ambient loop and walkie-talkie SFX.
+ *
+ * When the gate is on, Voice tracks `raceEngineerVolume`; Background sits
+ * at unity (its per-channel mix ratios already keep it under the voice).
+ * When the gate is off, both buses are silenced. `AudioBus.Alerts` (radar)
+ * is intentionally untouched — it has its own toggle.
  */
-export function applyRaceEngineerVolume(): void {
-  getAudio().setBusVolume(AudioBus.Voice, readRaceEngineerVolume() / 100);
+export function applyRaceEngineerAudio(): void {
+  const enabled = isRaceEngineerEnabled();
+  const voice = readRaceEngineerVolume() / 100;
+
+  getAudio().setBusVolume(AudioBus.Voice, enabled ? voice : 0);
+  getAudio().setBusVolume(AudioBus.Background, enabled ? 1 : 0);
 }
 
 /**
@@ -410,7 +420,7 @@ export class PitCrew extends ConnectionStateAwareAction<PitCrewSettings> {
       onGlobalSettingsChange(() => {
         applyRadarVolume();
         applyRadarEnabled();
-        applyRaceEngineerVolume();
+        applyRaceEngineerAudio();
         void this.rerender(contextId);
       }),
     );
@@ -419,7 +429,7 @@ export class PitCrew extends ConnectionStateAwareAction<PitCrewSettings> {
     // the first mount sets the initial values; later mounts re-assert them.
     applyRadarVolume();
     applyRadarEnabled();
-    applyRaceEngineerVolume();
+    applyRaceEngineerAudio();
 
     await this.setKeyImage(ev, generatePitCrewSvg(settings));
 
@@ -507,9 +517,12 @@ export class PitCrew extends ConnectionStateAwareAction<PitCrewSettings> {
     const next = !isRaceEngineerEnabled();
     this.logger.info(`Race Engineer ${next ? "enabled" : "disabled"}`);
     updateGlobalSettings({ raceEngineerEnabled: next });
-    // Voice scenarios are unregistered today (#410). When they come back in
-    // follow-up PRs, their catalog code will read the same global flag via
-    // `engine.setEnabled`. No audio output hinges on the action here.
+    // Mirror the radar pattern: apply the gate to Voice + Background
+    // synchronously so an in-flight engineer clip is silenced on the same
+    // tick the user pressed the key. Relying on the global-settings
+    // round-trip echo would let a clip continue for the IPC round trip,
+    // and the user perceives the toggle as broken.
+    applyRaceEngineerAudio();
   }
 
   private toggleRadar(): void {

--- a/packages/website/src/content/docs/docs/actions/driving/pit-crew.md
+++ b/packages/website/src/content/docs/docs/actions/driving/pit-crew.md
@@ -15,7 +15,7 @@ Select the mode from the **Mode** dropdown in the Property Inspector. For the Ra
 
 ### Race Engineer Toggle
 
-The default mode. Pressing the button flips `raceEngineerEnabled` in plugin-global settings, suppressing every voice scenario at the audio layer when off (audio stops immediately).
+The default mode. Pressing the button flips `raceEngineerEnabled` in plugin-global settings. When off, both the engineer voice (Voice bus — messages, acknowledgments, toggle confirmations) and the pit ambience (Background bus — pit ambient loop and walkie-talkie SFX) are silenced synchronously, so any in-flight clip cuts off on the same key press. Radar ticks are unaffected — they have their own toggle. Re-enabling restores Voice to the configured Race Engineer Volume and Background to its default mix.
 
 #### Details
 


### PR DESCRIPTION
## Related Issue

Fixes #457

## What changed?

The Race Engineer Toggle previously only flipped `raceEngineerEnabled` in plugin-global settings; no audio path consumed the flag, so engineer voice clips and pit ambience kept playing after the user toggled the feature off.

This PR wires the gate at the audio bus layer:

- `packages/iracing-actions/src/actions/pit-crew/pit-crew.ts`
  - Rename `applyRaceEngineerVolume` → `applyRaceEngineerAudio`. When `raceEngineerEnabled` is false, both `AudioBus.Voice` and `AudioBus.Background` are zeroed; when true, Voice tracks `raceEngineerVolume` and Background sits at unity. `AudioBus.Alerts` (radar) is intentionally untouched — radar has its own toggle.
  - Call `applyRaceEngineerAudio()` synchronously inside `toggleRaceEngineer`, mirroring how `toggleRadar` calls `setRadarEnabled` synchronously. This silences any in-flight clip on the same key press rather than waiting for the global-settings round-trip echo.
- `packages/iracing-actions/src/actions/pit-crew/pit-crew.test.ts`
  - 4 new `applyRaceEngineerAudio` unit tests (enabled / disabled / default volume / Alerts-bus isolation).
  - 3 new `onKeyDown` tests covering live mute on disable, Alerts-bus left alone, and live restore on re-enable.
- `docs/plugins/core/actions/pit-crew.md` + `packages/website/src/content/docs/docs/actions/driving/pit-crew.md`
  - Replaced the imprecise \"every voice scenario is suppressed\" line with the actual semantics (Voice + Background zeroed, Alerts untouched, restore on re-enable).

## How to test

- [x] `pnpm test` — 3389 tests across 107 files pass (was 3382 before; +7 new tests).
- [x] `pnpm lint` is clean.
- [x] `pnpm build` succeeds locally on Windows.
- [ ] **Manual:** add a Pit Crew key with `mode = Race Engineer Toggle`. Trigger any voice scenario (e.g. fuel toggle) so engineer audio plays plus the walkie SFX. Press the toggle: voice + background go silent immediately, status bar flips red. Press again: next scenario plays at the configured volume, status bar flips green. Confirm radar ticks (if Radar mode is on a separate key) keep playing throughout.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) _(action lives in shared `@iracedeck/iracing-actions`; both plugins register the same `PitCrew` class)_
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Race Engineer toggle now synchronously mutes voice and background audio immediately on key press, cutting off in-flight clips for instant silence.

* **Documentation**
  * Clarified Race Engineer toggle behavior: mutes voice and background buses while keeping Radar unaffected; re-enabling restores configured volumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->