### PR TITLE
fix(pit-crew): default Race Engineer and Radar to off (#378)

### DIFF
--- a/docs/plugins/core/actions/pit-crew.md
+++ b/docs/plugins/core/actions/pit-crew.md
@@ -11,11 +11,15 @@ Multi-mode action covering the iRaceDeck pit-side audio framework. Modes availab
 | SDK Support | No |
 | Encoder Support | No |
 
+## Default state
+
+Both `raceEngineerEnabled` and `radarEnabled` ship **off** (issue #378). A fresh install — and any user who has never pressed either toggle — stays quiet until they explicitly enable the feature with a Race Engineer Toggle or Radar key press. The status bar on each toggle's icon paints red on first launch, flipping green only after the first press.
+
 ## Behavior
 
 ### Button Press
-- **Race Engineer Toggle mode**: Flips the plugin-global `raceEngineerEnabled` gate. When off, both `AudioBus.Voice` (engineer messages, acks, toggle confirmations) and `AudioBus.Background` (pit ambient loop and walkie-talkie SFX) are zeroed synchronously, so any in-flight clip silences on the same key press. `AudioBus.Alerts` (radar) is intentionally untouched — radar has its own toggle. Re-enabling restores Voice to the configured `Race Engineer Volume` and Background to unity.
-- **Radar mode**: Flips the plugin-global `radarEnabled` and stops/starts the directional proximity tick loop synchronously. Used by Radar alongside the per-instance Radar Test button.
+- **Race Engineer Toggle mode**: Flips the plugin-global `raceEngineerEnabled` gate. When off (the default), both `AudioBus.Voice` (engineer messages, acks, toggle confirmations) and `AudioBus.Background` (pit ambient loop and walkie-talkie SFX) are zeroed synchronously, so any in-flight clip silences on the same key press. `AudioBus.Alerts` (radar) is intentionally untouched — radar has its own toggle. Re-enabling restores Voice to the configured `Race Engineer Volume` and Background to unity.
+- **Radar mode**: Flips the plugin-global `radarEnabled` and stops/starts the directional proximity tick loop synchronously. Off by default — pressing the key once starts the loop. Used by Radar alongside the per-instance Radar Test button.
 - **Radar Volume mode**: Steps the plugin-global `radarVolume` by ±5, clamped to 0–100. Takes effect immediately on `AudioBus.Alerts`. Direction is configured per button (Up or Down). Stepping to 0 mutes the radar without toggling the feature off.
 
 ### Race Engineer voice coverage

--- a/packages/deck-core/src/global-settings.test.ts
+++ b/packages/deck-core/src/global-settings.test.ts
@@ -85,20 +85,22 @@ describe("global-settings cache (synchronous update on local writes)", () => {
   });
 
   it("matches the toggle pattern used by Pit Crew (read → flip → write → read)", () => {
-    // Simulates toggleRadar: reads isRadarEnabled(), flips, writes.
+    // Simulates toggleRadar: reads isRadarEnabled(), flips, writes. The
+    // production helper uses `=== true` (default-off semantic, #378), so
+    // the first read on an unset cache returns false → flip → write true.
     const readFlipWrite = () => {
-      const current = (getGlobalSettings() as Record<string, unknown>).radarEnabled !== false;
+      const current = (getGlobalSettings() as Record<string, unknown>).radarEnabled === true;
       updateGlobalSettings({ radarEnabled: !current });
     };
-
-    readFlipWrite();
-    expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(false);
 
     readFlipWrite();
     expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(true);
 
     readFlipWrite();
     expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(false);
+
+    readFlipWrite();
+    expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(true);
   });
 
   it("applies the same behaviour to raceEngineerEnabled (same toggle code path)", () => {
@@ -131,7 +133,7 @@ describe("global-settings cache (synchronous update on local writes)", () => {
     // not just the caller's bare partial.
     expect(sent).toMatchObject({
       radarEnabled: false,
-      raceEngineerEnabled: true,
+      raceEngineerEnabled: false,
       radarVolume: 100,
       disableWhenDisconnected: true,
       focusIRacingWindow: false,
@@ -162,10 +164,10 @@ describe("global-settings cache (synchronous update on local writes)", () => {
     _resetGlobalSettings();
     // Not calling initGlobalSettings — adapterRef stays null.
 
-    updateGlobalSettings({ radarEnabled: false });
+    updateGlobalSettings({ radarEnabled: true });
 
-    // No throw; cache stays at the schema default.
-    expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(true);
+    // No throw; cache stays at the schema default (false per #378).
+    expect((getGlobalSettings() as Record<string, unknown>).radarEnabled).toBe(false);
   });
 });
 

--- a/packages/deck-core/src/global-settings.ts
+++ b/packages/deck-core/src/global-settings.ts
@@ -99,25 +99,27 @@ export const GlobalSettingsSchema = z
       .default(true),
     /**
      * On/off for the Race Engineer voice (Pit Crew action, Race Engineer
-     * mode). Toggled by pressing the Race Engineer button — gates every
-     * engineer voice scenario via `setEnabled` so audio stops immediately
-     * when off. Persists across plugin restarts. Default: true.
+     * mode). Toggled by pressing the Race Engineer button — when off, the
+     * Voice and Background audio buses are zeroed so any in-flight clip
+     * silences immediately. Persists across plugin restarts. Default: false
+     * — fresh installs stay quiet until the user opts in (issue #378).
      */
     raceEngineerEnabled: z
       .union([z.boolean(), z.string()])
       .transform((val) => val === true || val === "true")
-      .default(true),
+      .default(false),
     /**
      * On/off for the directional Radar proximity ticks (Pit Crew action,
      * Radar mode). Toggled by pressing the Radar button — independent from
      * Race Engineer so silencing the voice to talk to teammates on Discord
      * doesn't kill the proximity alerts. Persists across plugin restarts.
-     * Default: true.
+     * Default: false — fresh installs stay quiet until the user opts in
+     * (issue #378).
      */
     radarEnabled: z
       .union([z.boolean(), z.string()])
       .transform((val) => val === true || val === "true")
-      .default(true),
+      .default(false),
     /**
      * Volume for the directional Radar ticks, 0–100 (mapped to 0.0–1.0 on
      * `AudioBus.Alerts`). Stepped by the Radar Volume Up/Down modes of the

--- a/packages/iracing-actions/src/actions/pit-crew/pit-crew.ts
+++ b/packages/iracing-actions/src/actions/pit-crew/pit-crew.ts
@@ -71,11 +71,14 @@ type Mode = PitCrewSettings["mode"];
 // ─── Global-state helpers ─────────────────────────────────────────────────────
 
 function isRaceEngineerEnabled(): boolean {
-  return (getGlobalSettings() as Record<string, unknown>).raceEngineerEnabled !== false;
+  // Both feature gates default to off — fresh installs and never-toggled
+  // setups stay quiet until the user opts in. Only an explicit `true`
+  // (set when the user presses the toggle) enables the feature.
+  return (getGlobalSettings() as Record<string, unknown>).raceEngineerEnabled === true;
 }
 
 function isRadarEnabled(): boolean {
-  return (getGlobalSettings() as Record<string, unknown>).radarEnabled !== false;
+  return (getGlobalSettings() as Record<string, unknown>).radarEnabled === true;
 }
 
 function readRadarVolume(): number {

--- a/packages/scenario-harness/src/main.ts
+++ b/packages/scenario-harness/src/main.ts
@@ -86,7 +86,10 @@ async function main(): Promise<void> {
   // if something routes it to the audio engine.
   let currentAudioDeviceId = "";
   const applyAudioSettings = (settings: Record<string, unknown>): void => {
-    const radarEnabled = settings.radarEnabled !== false;
+    // Match the production Pit Crew helper's `=== true` semantic so the
+    // harness behaves identically to the shipped plugin (radar off until
+    // explicitly enabled — #378).
+    const radarEnabled = settings.radarEnabled === true;
     setRadarEnabled(radarEnabled);
 
     const radarVol = clampVolume(settings.radarVolume);

--- a/packages/website/src/content/docs/docs/actions/driving/pit-crew.md
+++ b/packages/website/src/content/docs/docs/actions/driving/pit-crew.md
@@ -9,13 +9,15 @@ sidebar:
 
 Pit Crew bundles iRaceDeck's pit-side audio into one Stream Deck action. It exposes **Race Engineer Toggle** (the default — flips the engineer voice on/off), **Radar** (directional proximity ticks when a car pulls alongside), and **Radar Volume** (Up/Down stepping for the radar volume).
 
+Both the Race Engineer and Radar gates ship **off by default** so a fresh install stays quiet until you opt in. The first press of each toggle is what enables it; the on/off state is plugin-wide, so two Pit Crew buttons (e.g. one on a Stream Deck, one on a Mirabox) always agree.
+
 ## Modes
 
 Select the mode from the **Mode** dropdown in the Property Inspector. For the Radar Volume mode, also pick **Up** or **Down** from the **Direction** dropdown.
 
 ### Race Engineer Toggle
 
-The default mode. Pressing the button flips `raceEngineerEnabled` in plugin-global settings. When off, both the engineer voice (Voice bus — messages, acknowledgments, toggle confirmations) and the pit ambience (Background bus — pit ambient loop and walkie-talkie SFX) are silenced synchronously, so any in-flight clip cuts off on the same key press. Radar ticks are unaffected — they have their own toggle. Re-enabling restores Voice to the configured Race Engineer Volume and Background to its default mix.
+The default mode. Pressing the button flips `raceEngineerEnabled` in plugin-global settings (off by default). When off, both the engineer voice (Voice bus — messages, acknowledgments, toggle confirmations) and the pit ambience (Background bus — pit ambient loop and walkie-talkie SFX) are silenced synchronously, so any in-flight clip cuts off on the same key press. Radar ticks are unaffected — they have their own toggle. Re-enabling restores Voice to the configured Race Engineer Volume and Background to its default mix.
 
 #### Details
 
@@ -25,7 +27,7 @@ The default mode. Pressing the button flips `raceEngineerEnabled` in plugin-glob
 
 ### Radar
 
-Toggles the directional proximity tick loop on/off. Pressing the button flips `radarEnabled` in plugin-global settings and synchronously stops or starts the tick loop on `AudioChannel.Radar` (so a tick can't fire after the user already muted it). The status bar flips green ↔ red.
+Toggles the directional proximity tick loop on/off. Pressing the button flips `radarEnabled` in plugin-global settings (off by default) and synchronously stops or starts the tick loop on `AudioChannel.Radar` (so a tick can't fire after the user already muted it). The status bar flips green ↔ red.
 
 #### Details
 


### PR DESCRIPTION
## Related Issue

Fixes #378

## What changed?

Both `raceEngineerEnabled` and `radarEnabled` previously defaulted to `true`, so a fresh install — or any user who had never pressed either toggle — started with the engineer voice and proximity ticks already running. Per issue #378, the master gate(s) must default **off** so onboarding is quiet and users explicitly opt in. The user requested the same change for Radar (same UX problem), so this PR flips both.

### Schema (`packages/deck-core/src/global-settings.ts`)

- `raceEngineerEnabled: ...default(false)`
- `radarEnabled: ...default(false)`
- Doc comments updated with the rationale and the issue link.

### Action helpers (`packages/iracing-actions/src/actions/pit-crew/pit-crew.ts`)

- `isRaceEngineerEnabled()` and `isRadarEnabled()` now use `=== true` instead of `!== false`, so an unset cache reads as off (matching the schema default and #378's \"fresh install stays quiet\" intent).

### Scenario harness (`packages/scenario-harness/src/main.ts`)

- `applyAudioSettings` now uses the same `=== true` semantic so the harness behaves identically to the shipped plugin. The harness bootstrap still seeds both flags as true so demo runs start with audio audible — that's intentional and unchanged.

### Tests (`packages/deck-core/src/global-settings.test.ts`)

- `read → flip → write → read` simulation rewritten for the new helper semantic: first read on the unset cache is now `false` → flips → writes `true`, and the alternation continues from there.
- The Zod-default merge test now expects `raceEngineerEnabled: false`.
- The \"no-ops when adapter is not initialized\" test seeds `radarEnabled: true` and asserts the cached default stays at `false`.

### Docs

- `docs/plugins/core/actions/pit-crew.md` — new \"Default state\" section spelling out that both gates ship off and that the icon paints red until the user opts in.
- `packages/website/src/content/docs/docs/actions/driving/pit-crew.md` — top-level note about default-off behavior plus per-mode hints.

## How to test

- [x] `pnpm test` — 3389 / 3389 pass.
- [x] `pnpm lint` — clean.
- [x] `pnpm build` — 17/17 turbo tasks succeed.
- [ ] **Manual** (post-merge, fresh install): drop a Pit Crew \"Race Engineer Toggle\" key onto a fresh Stream Deck profile. Expected: the icon's status bar paints red on first load, and pit-service / flag callouts stay silent. Press once: status bar flips green and the engineer audio resumes. Repeat for the Radar mode (status bar red until first press, ticks silent until then).

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests _(updated existing global-settings tests; the pit-crew suite already covers both enabled / disabled bus states)_
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) _(action lives in shared `@iracedeck/iracing-actions`; both plugins share the deck-core schema)_
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Race Engineer and Radar features now default to disabled on fresh installs, requiring explicit key press activation to enable. System starts in quiet mode until user enables these features.

* **Documentation**
  * Updated documentation to clarify that Race Engineer and Radar modes start disabled by default, with enabled state synchronized globally across all Pit Crew buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->