### PR TITLE
feat(session-info): support information display sizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ yarn.lock
 /build/
 /packages/*/build/
 
+# Astro/Starlight generated files
+/packages/website/.astro/
+
 # Stream Deck plugin packages (built artifacts)
 *.streamDeckPlugin
 
@@ -75,6 +78,9 @@ scripts/radio-effect/output/*
 # Claude Code
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+
+# Serena local project metadata
+.serena/
 
 # Superpowers brainstorming artifacts
 .superpowers/

--- a/packages/deck-adapter-mirabox/src/adapter.test.ts
+++ b/packages/deck-adapter-mirabox/src/adapter.test.ts
@@ -413,5 +413,25 @@ describe("VSDPlatformAdapter", () => {
       const ev = (handler.onWillAppear as ReturnType<typeof vi.fn>).mock.calls[0][0];
       expect(ev.action.isKey()).toBe(false);
     });
+
+    it("should return isKey=true for Information controller because 293S updates the info area with setImage", async () => {
+      const handler: IDeckActionHandler = {
+        onWillAppear: vi.fn(),
+      };
+      adapter.registerAction("com.test.action", handler);
+
+      const willAppearCall = client.onActionEvent.mock.calls.find(
+        (call: [string, string, unknown]) => call[1] === "willAppear",
+      );
+      await willAppearCall[2]({
+        event: "willAppear",
+        action: "com.test.action",
+        context: "ctx-info",
+        payload: { settings: {}, controller: "Information" },
+      });
+
+      const ev = (handler.onWillAppear as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(ev.action.isKey()).toBe(true);
+    });
   });
 });

--- a/packages/deck-adapter-mirabox/src/adapter.ts
+++ b/packages/deck-adapter-mirabox/src/adapter.ts
@@ -19,7 +19,7 @@ import { createConsoleLogger } from "@iracedeck/logger";
 import { parseConnectionParams, VSDClient, type VSDEvent } from "./vsd-client.js";
 
 /** Valid controller types for VSD/Elgato devices. */
-type ControllerType = "Keypad" | "Encoder" | "Knob" | "Information" | "SecondaryScreen";
+type ControllerType = "Keypad" | "Encoder" | "Knob" | "Information";
 
 /**
  * Wraps a VSD action context (identified by context string) into

--- a/packages/deck-adapter-mirabox/src/adapter.ts
+++ b/packages/deck-adapter-mirabox/src/adapter.ts
@@ -19,7 +19,7 @@ import { createConsoleLogger } from "@iracedeck/logger";
 import { parseConnectionParams, VSDClient, type VSDEvent } from "./vsd-client.js";
 
 /** Valid controller types for VSD/Elgato devices. */
-type ControllerType = "Keypad" | "Encoder" | "Knob";
+type ControllerType = "Keypad" | "Encoder" | "Knob" | "Information" | "SecondaryScreen";
 
 /**
  * Wraps a VSD action context (identified by context string) into
@@ -45,7 +45,9 @@ class VSDActionContext implements IDeckActionContext {
   }
 
   isKey(): boolean {
-    return this.controllerType === "Keypad";
+    // Stream Dock 293S exposes its read-only information area through
+    // setImage, so display-only contexts should use the shared image path.
+    return this.controllerType === "Keypad" || this.controllerType === "Information";
   }
 }
 

--- a/packages/iracing-actions/src/actions/session-info/session-info.ejs
+++ b/packages/iracing-actions/src/actions/session-info/session-info.ejs
@@ -17,6 +17,10 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<sdpi-item label="Font Size">
+			<sdpi-textfield setting="fontSize" type="number" min="5" max="36" placeholder="Auto"></sdpi-textfield>
+		</sdpi-item>
+
 		<sdpi-item id="position-settings" label="Show Total Cars" class="hidden">
 			<sdpi-checkbox setting="positionShowTotal"></sdpi-checkbox>
 		</sdpi-item>

--- a/packages/iracing-actions/src/actions/session-info/session-info.ejs
+++ b/packages/iracing-actions/src/actions/session-info/session-info.ejs
@@ -18,7 +18,7 @@
 		</sdpi-item>
 
 		<sdpi-item label="Font Size">
-			<sdpi-textfield setting="fontSize" type="number" min="5" max="36" placeholder="Auto"></sdpi-textfield>
+			<ird-range-input setting="fontSize" min="5" max="36" step="1" default="14" showlabels></ird-range-input>
 		</sdpi-item>
 
 		<sdpi-item id="position-settings" label="Show Total Cars" class="hidden">

--- a/packages/iracing-actions/src/actions/session-info/session-info.test.ts
+++ b/packages/iracing-actions/src/actions/session-info/session-info.test.ts
@@ -89,6 +89,7 @@ vi.mock("@iracedeck/deck-core", () => ({
 function defaultSettings(
   overrides: Partial<{
     mode: "incidents" | "time-remaining" | "laps" | "position" | "fuel" | "flags";
+    fontSize: number;
     positionShowTotal: boolean;
     fuelFormat: "amount" | "percentage";
   }> = {},
@@ -420,6 +421,13 @@ describe("SessionInfo", () => {
       const decoded = decodeURIComponent(result);
 
       expect(decoded).toContain("48");
+    });
+
+    it("should use custom value font size when configured", () => {
+      const result = generateSessionInfoSvg(defaultSettings({ fontSize: 20 }), "0x", false);
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain("40");
     });
 
     it("should use font size 36 for short time values (144x144)", () => {

--- a/packages/iracing-actions/src/actions/session-info/session-info.test.ts
+++ b/packages/iracing-actions/src/actions/session-info/session-info.test.ts
@@ -416,39 +416,39 @@ describe("SessionInfo", () => {
       expect(decoded).toContain("TIME LEFT");
     });
 
-    it("should use font size 48 for incidents mode (144x144)", () => {
+    it("should fall back to value font size 28 (144x144) when fontSize is unset", () => {
       const result = generateSessionInfoSvg(defaultSettings(), "0x", false);
       const decoded = decodeURIComponent(result);
 
-      expect(decoded).toContain("48");
+      expect(decoded).toContain('font-size="28"');
     });
 
-    it("should use custom value font size when configured", () => {
+    it("should use the same fallback regardless of mode when fontSize is unset", () => {
+      const incidents = decodeURIComponent(generateSessionInfoSvg(defaultSettings(), "0x", false));
+      const timeRemaining = decodeURIComponent(
+        generateSessionInfoSvg(defaultSettings({ mode: "time-remaining" }), "12:34", false),
+      );
+      const longTime = decodeURIComponent(
+        generateSessionInfoSvg(defaultSettings({ mode: "time-remaining" }), "1:23:45", false),
+      );
+
+      expect(incidents).toContain('font-size="28"');
+      expect(timeRemaining).toContain('font-size="28"');
+      expect(longTime).toContain('font-size="28"');
+    });
+
+    it("should use custom value font size when configured (PI units doubled to SVG)", () => {
       const result = generateSessionInfoSvg(defaultSettings({ fontSize: 20 }), "0x", false);
       const decoded = decodeURIComponent(result);
 
       expect(decoded).toContain('font-size="40"');
     });
 
-    it("should use font size 36 for short time values (144x144)", () => {
-      const result = generateSessionInfoSvg(defaultSettings({ mode: "time-remaining" }), "12:34", false);
+    it("should use the EJS default 14 PI units (= 28 SVG) when persisted", () => {
+      const result = generateSessionInfoSvg(defaultSettings({ fontSize: 14 }), "0x", false);
       const decoded = decodeURIComponent(result);
 
-      expect(decoded).toContain("36");
-    });
-
-    it("should use font size 28 for long time values (144x144)", () => {
-      const result = generateSessionInfoSvg(defaultSettings({ mode: "time-remaining" }), "1:23:45", false);
-      const decoded = decodeURIComponent(result);
-
-      expect(decoded).toContain("28");
-    });
-
-    it("should use font size 36 for UNLIM (144x144)", () => {
-      const result = generateSessionInfoSvg(defaultSettings({ mode: "time-remaining" }), "UNLIM", false);
-      const decoded = decodeURIComponent(result);
-
-      expect(decoded).toContain("36");
+      expect(decoded).toContain('font-size="28"');
     });
 
     it("should use default background when not flashing", () => {
@@ -484,20 +484,6 @@ describe("SessionInfo", () => {
       const decoded = decodeURIComponent(result);
 
       expect(decoded).toContain("LAPS");
-    });
-
-    it("should use font size 36 for short lap values (144x144)", () => {
-      const result = generateSessionInfoSvg(defaultSettings({ mode: "laps" }), "5/20", false);
-      const decoded = decodeURIComponent(result);
-
-      expect(decoded).toContain("36");
-    });
-
-    it("should use font size 28 for long lap values (144x144)", () => {
-      const result = generateSessionInfoSvg(defaultSettings({ mode: "laps" }), "100/200", false);
-      const decoded = decodeURIComponent(result);
-
-      expect(decoded).toContain("28");
     });
 
     it("should include infinity symbol for unlimited laps", () => {

--- a/packages/iracing-actions/src/actions/session-info/session-info.test.ts
+++ b/packages/iracing-actions/src/actions/session-info/session-info.test.ts
@@ -80,7 +80,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     textColor: "#ffffff",
   })),
   renderIconTemplate: vi.fn((_template: string, data: Record<string, string>) => {
-    return `<svg>${data.backgroundColor || ""}|${data.titleContent || ""}|${data.value || ""}|${data.valueFontSize || ""}|${data.valueY || ""}|${data.textColor || ""}</svg>`;
+    return `<svg>${data.backgroundColor || ""}|${data.titleContent || ""}|<text font-size="${data.valueFontSize || ""}" y="${data.valueY || ""}" fill="${data.textColor || ""}">${data.value || ""}</text></svg>`;
   }),
   svgToDataUri: vi.fn((svg: string) => `data:image/svg+xml,${encodeURIComponent(svg)}`),
 }));
@@ -427,7 +427,7 @@ describe("SessionInfo", () => {
       const result = generateSessionInfoSvg(defaultSettings({ fontSize: 20 }), "0x", false);
       const decoded = decodeURIComponent(result);
 
-      expect(decoded).toContain("40");
+      expect(decoded).toContain('font-size="40"');
     });
 
     it("should use font size 36 for short time values (144x144)", () => {

--- a/packages/iracing-actions/src/actions/session-info/session-info.ts
+++ b/packages/iracing-actions/src/actions/session-info/session-info.ts
@@ -133,8 +133,7 @@ export function generateSessionInfoSvg(
     flags: "FLAGS",
   };
   const actionDefaultTitle = titleLabels[settings.mode] ?? "INCIDENTS";
-  const autoValueFontSizeNum = settings.mode === "incidents" ? 48 : value.length > 5 ? 28 : 36;
-  const valueFontSizeNum = settings.fontSize !== undefined ? settings.fontSize * 2 : autoValueFontSizeNum;
+  const valueFontSizeNum = settings.fontSize !== undefined ? settings.fontSize * 2 : 28;
   const valueFontSize = String(valueFontSizeNum);
   const valueY = String(88 + (valueFontSizeNum - 44) / 3);
 

--- a/packages/iracing-actions/src/actions/session-info/session-info.ts
+++ b/packages/iracing-actions/src/actions/session-info/session-info.ts
@@ -44,6 +44,10 @@ const LITERS_PER_GALLON = 3.78541;
 
 const SessionInfoSettings = CommonSettings.extend({
   mode: z.enum(["incidents", "time-remaining", "laps", "position", "fuel", "flags"]).default("incidents"),
+  fontSize: z.preprocess(
+    (val) => (val === "" || val === null || val === undefined ? undefined : val),
+    z.coerce.number().min(5).max(36).optional(),
+  ),
   positionShowTotal: z
     .union([z.boolean(), z.string()])
     .transform((val) => val === true || val === "true")
@@ -129,7 +133,8 @@ export function generateSessionInfoSvg(
     flags: "FLAGS",
   };
   const actionDefaultTitle = titleLabels[settings.mode] ?? "INCIDENTS";
-  const valueFontSizeNum = settings.mode === "incidents" ? 48 : value.length > 5 ? 28 : 36;
+  const autoValueFontSizeNum = settings.mode === "incidents" ? 48 : value.length > 5 ? 28 : 36;
+  const valueFontSizeNum = settings.fontSize !== undefined ? settings.fontSize * 2 : autoValueFontSizeNum;
   const valueFontSize = String(valueFontSizeNum);
   const valueY = String(88 + (valueFontSizeNum - 44) / 3);
 

--- a/packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/manifest.json
+++ b/packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/manifest.json
@@ -812,7 +812,8 @@
       "Tooltip": "Display live session data (incidents, time, laps, position, fuel, flags)",
       "PropertyInspectorPath": "ui/session-info.html",
       "Controllers": [
-        "Keypad"
+        "Keypad",
+        "Information"
       ],
       "States": [
         {
@@ -829,7 +830,8 @@
       "Tooltip": "Display live telemetry values using custom templates",
       "PropertyInspectorPath": "ui/telemetry-display.html",
       "Controllers": [
-        "Keypad"
+        "Keypad",
+        "Information"
       ],
       "States": [
         {

--- a/packages/website/src/content/docs/docs/actions/display-session/session-info.md
+++ b/packages/website/src/content/docs/docs/actions/display-session/session-info.md
@@ -23,13 +23,13 @@ Select the mode from the **Mode** dropdown in the Property Inspector.
 
 Show the live incident count. The icon flashes red when a new incident is received so you notice it even if you weren't looking.
 
-#### Incidents Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the incident count updates live and the icon flashes when a new incident is added
 
-#### Incidents Settings
+#### Settings
 
 - **Font Size** — Optional value-size override. Leave blank for automatic sizing.
 
@@ -39,13 +39,13 @@ Show the live incident count. The icon flashes red when a new incident is receiv
 
 Display the session time remaining. The icon flashes when less than 5 minutes remain so you can spot the cutoff at a glance.
 
-#### Time Remaining Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the countdown updates every second and the icon flashes when under 5 minutes remain
 
-#### Time Remaining Settings
+#### Settings
 
 - **Font Size** — Optional value-size override. Leave blank for automatic sizing.
 
@@ -55,13 +55,13 @@ Display the session time remaining. The icon flashes when less than 5 minutes re
 
 Show the current lap number.
 
-#### Laps Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the lap number updates as you cross the start/finish line
 
-#### Laps Settings
+#### Settings
 
 - **Font Size** — Optional value-size override. Leave blank for automatic sizing.
 
@@ -71,18 +71,18 @@ Show the current lap number.
 
 Display the current race position. Optionally shows total cars (e.g., `3/24`) by enabling the **Show Total** setting.
 
-#### Position Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the position updates live as drivers pass or are overtaken
 
-#### Position Setting: Show Total
+#### Setting: Show Total
 
 - **Off** (default) — Show just your position (e.g., `3`)
 - **On** — Show position out of field size (e.g., `3/24`)
 
-#### Position Setting: Font Size
+#### Setting: Font Size
 
 Optional value-size override. Leave blank for automatic sizing.
 
@@ -92,18 +92,18 @@ Optional value-size override. Leave blank for automatic sizing.
 
 Show fuel amount or fuel percentage remaining.
 
-#### Fuel Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the fuel reading updates live
 
-#### Fuel Setting: Fuel Format
+#### Setting: Fuel Format
 
 - **Amount** (default) — Show the absolute fuel amount, respecting your iRacing display units (liters or gallons)
 - **Percentage** — Show fuel as a percentage of tank capacity
 
-#### Fuel Setting: Font Size
+#### Setting: Font Size
 
 Optional value-size override. Leave blank for automatic sizing.
 
@@ -113,12 +113,12 @@ Optional value-size override. Leave blank for automatic sizing.
 
 Display currently active flags with the corresponding colors and a pulsing animation when flags change.
 
-#### Flags Details
+#### Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the icon updates to reflect the active flag (green, yellow, white, checkered, etc.) and pulses when a new flag is raised
 
-#### Flags Settings
+#### Settings
 
 - **Font Size** — Optional value-size override. Leave blank for automatic sizing.

--- a/packages/website/src/content/docs/docs/actions/display-session/session-info.md
+++ b/packages/website/src/content/docs/docs/actions/display-session/session-info.md
@@ -13,7 +13,7 @@ Display real-time session data on your Stream Deck button. Each mode shows diffe
 
 ### Font Size
 
-Override the size of the rendered session value. Leave blank to use the automatic size for the selected mode and value length.
+Override the size of the rendered session value. Accepts values from 5 to 36, interpreted as pixels. Leave blank to use the automatic size for the selected mode and value length.
 
 ## Modes
 
@@ -31,7 +31,7 @@ Show the live incident count. The icon flashes red when a new incident is receiv
 
 #### Settings
 
-- **Font Size** — Optional value-size override. Leave blank for automatic sizing.
+- **Font Size** — See **Shared Settings** above for Font Size details.
 
 ---
 
@@ -47,7 +47,7 @@ Display the session time remaining. The icon flashes when less than 5 minutes re
 
 #### Settings
 
-- **Font Size** — Optional value-size override. Leave blank for automatic sizing.
+- **Font Size** — See **Shared Settings** above for Font Size details.
 
 ---
 
@@ -63,7 +63,7 @@ Show the current lap number.
 
 #### Settings
 
-- **Font Size** — Optional value-size override. Leave blank for automatic sizing.
+- **Font Size** — See **Shared Settings** above for Font Size details.
 
 ---
 
@@ -84,7 +84,7 @@ Display the current race position. Optionally shows total cars (e.g., `3/24`) by
 
 #### Setting: Font Size
 
-Optional value-size override. Leave blank for automatic sizing.
+See **Shared Settings** above for Font Size details.
 
 ---
 
@@ -105,7 +105,7 @@ Show fuel amount or fuel percentage remaining.
 
 #### Setting: Font Size
 
-Optional value-size override. Leave blank for automatic sizing.
+See **Shared Settings** above for Font Size details.
 
 ---
 
@@ -121,4 +121,4 @@ Display currently active flags with the corresponding colors and a pulsing anima
 
 #### Settings
 
-- **Font Size** — Optional value-size override. Leave blank for automatic sizing.
+- **Font Size** — See **Shared Settings** above for Font Size details.

--- a/packages/website/src/content/docs/docs/actions/display-session/session-info.md
+++ b/packages/website/src/content/docs/docs/actions/display-session/session-info.md
@@ -9,6 +9,12 @@ sidebar:
 
 Display real-time session data on your Stream Deck button. Each mode shows different telemetry with a live-updating icon. Session Info is purely a display action — pressing the button does nothing.
 
+## Shared Settings
+
+### Font Size
+
+Override the size of the rendered session value. Leave blank to use the automatic size for the selected mode and value length.
+
 ## Modes
 
 Select the mode from the **Mode** dropdown in the Property Inspector.
@@ -17,15 +23,15 @@ Select the mode from the **Mode** dropdown in the Property Inspector.
 
 Show the live incident count. The icon flashes red when a new incident is received so you notice it even if you weren't looking.
 
-#### Details
+#### Incidents Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the incident count updates live and the icon flashes when a new incident is added
 
-#### Settings
+#### Incidents Settings
 
-- No additional settings
+- **Font Size** — Optional value-size override. Leave blank for automatic sizing.
 
 ---
 
@@ -33,15 +39,15 @@ Show the live incident count. The icon flashes red when a new incident is receiv
 
 Display the session time remaining. The icon flashes when less than 5 minutes remain so you can spot the cutoff at a glance.
 
-#### Details
+#### Time Remaining Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the countdown updates every second and the icon flashes when under 5 minutes remain
 
-#### Settings
+#### Time Remaining Settings
 
-- No additional settings
+- **Font Size** — Optional value-size override. Leave blank for automatic sizing.
 
 ---
 
@@ -49,15 +55,15 @@ Display the session time remaining. The icon flashes when less than 5 minutes re
 
 Show the current lap number.
 
-#### Details
+#### Laps Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the lap number updates as you cross the start/finish line
 
-#### Settings
+#### Laps Settings
 
-- No additional settings
+- **Font Size** — Optional value-size override. Leave blank for automatic sizing.
 
 ---
 
@@ -65,16 +71,20 @@ Show the current lap number.
 
 Display the current race position. Optionally shows total cars (e.g., `3/24`) by enabling the **Show Total** setting.
 
-#### Details
+#### Position Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the position updates live as drivers pass or are overtaken
 
-#### Setting: Show Total
+#### Position Setting: Show Total
 
 - **Off** (default) — Show just your position (e.g., `3`)
 - **On** — Show position out of field size (e.g., `3/24`)
+
+#### Position Setting: Font Size
+
+Optional value-size override. Leave blank for automatic sizing.
 
 ---
 
@@ -82,16 +92,20 @@ Display the current race position. Optionally shows total cars (e.g., `3/24`) by
 
 Show fuel amount or fuel percentage remaining.
 
-#### Details
+#### Fuel Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the fuel reading updates live
 
-#### Setting: Fuel Format
+#### Fuel Setting: Fuel Format
 
 - **Amount** (default) — Show the absolute fuel amount, respecting your iRacing display units (liters or gallons)
 - **Percentage** — Show fuel as a percentage of tank capacity
+
+#### Fuel Setting: Font Size
+
+Optional value-size override. Leave blank for automatic sizing.
 
 ---
 
@@ -99,12 +113,12 @@ Show fuel amount or fuel percentage remaining.
 
 Display currently active flags with the corresponding colors and a pulsing animation when flags change.
 
-#### Details
+#### Flags Details
 
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the icon updates to reflect the active flag (green, yellow, white, checkered, etc.) and pulses when a new flag is raised
 
-#### Settings
+#### Flags Settings
 
-- No additional settings
+- **Font Size** — Optional value-size override. Leave blank for automatic sizing.

--- a/packages/website/src/content/docs/docs/actions/display-session/session-info.md
+++ b/packages/website/src/content/docs/docs/actions/display-session/session-info.md
@@ -9,12 +9,6 @@ sidebar:
 
 Display real-time session data on your Stream Deck button. Each mode shows different telemetry with a live-updating icon. Session Info is purely a display action — pressing the button does nothing.
 
-## Shared Settings
-
-### Font Size
-
-Override the size of the rendered session value. Accepts values from 5 to 36, interpreted as pixels. Leave blank to use the automatic size for the selected mode and value length.
-
 ## Modes
 
 Select the mode from the **Mode** dropdown in the Property Inspector.
@@ -29,9 +23,9 @@ Show the live incident count. The icon flashes red when a new incident is receiv
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the incident count updates live and the icon flashes when a new incident is added
 
-#### Settings
+#### Setting: Font Size
 
-- **Font Size** — See **Shared Settings** above for Font Size details.
+Size of the rendered value, in PI units (5–36, doubled for SVG render). Defaults to `14`.
 
 ---
 
@@ -45,9 +39,9 @@ Display the session time remaining. The icon flashes when less than 5 minutes re
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the countdown updates every second and the icon flashes when under 5 minutes remain
 
-#### Settings
+#### Setting: Font Size
 
-- **Font Size** — See **Shared Settings** above for Font Size details.
+Size of the rendered value, in PI units (5–36, doubled for SVG render). Defaults to `14`.
 
 ---
 
@@ -61,9 +55,9 @@ Show the current lap number.
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the lap number updates as you cross the start/finish line
 
-#### Settings
+#### Setting: Font Size
 
-- **Font Size** — See **Shared Settings** above for Font Size details.
+Size of the rendered value, in PI units (5–36, doubled for SVG render). Defaults to `14`.
 
 ---
 
@@ -84,7 +78,7 @@ Display the current race position. Optionally shows total cars (e.g., `3/24`) by
 
 #### Setting: Font Size
 
-See **Shared Settings** above for Font Size details.
+Size of the rendered value, in PI units (5–36, doubled for SVG render). Defaults to `14`.
 
 ---
 
@@ -105,7 +99,7 @@ Show fuel amount or fuel percentage remaining.
 
 #### Setting: Font Size
 
-See **Shared Settings** above for Font Size details.
+Size of the rendered value, in PI units (5–36, doubled for SVG render). Defaults to `14`.
 
 ---
 
@@ -119,6 +113,6 @@ Display currently active flags with the corresponding colors and a pulsing anima
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the icon updates to reflect the active flag (green, yellow, white, checkered, etc.) and pulses when a new flag is raised
 
-#### Settings
+#### Setting: Font Size
 
-- **Font Size** — See **Shared Settings** above for Font Size details.
+Size of the rendered value, in PI units (5–36, doubled for SVG render). Defaults to `14`.


### PR DESCRIPTION
## Related Issue

N/A - no linked issue for this follow-up.

## What changed?

- Add a Session Info font size override and document the shared setting.
- Allow Mirabox Information controller contexts to receive image updates for display-only areas.
- Register Session Info and Telemetry Display for Mirabox Information controllers.
- Ignore local Astro and Serena generated files so local build/test artifacts stay out of git.
- Tighten the Session Info font-size test assertion to check the rendered `font-size` attribute.
- Keep Session Info website headings aligned with the existing action docs pattern (`Details`, `Settings`, `Setting: ...`).
- Clarify the Font Size documentation with the valid range and Shared Settings references.

## How to test

- PASS: `corepack pnpm exec vitest run packages/deck-adapter-mirabox/src/adapter.test.ts`
- PASS: `corepack pnpm exec vitest run packages/iracing-actions/src/actions/session-info/session-info.test.ts`
- PASS: `corepack pnpm --filter @iracedeck/iracing-plugin-mirabox build`
- PASS: `corepack pnpm --filter @iracedeck/website build`
- PASS: `corepack pnpm exec prettier --check packages/deck-adapter-mirabox/src/adapter.ts packages/deck-adapter-mirabox/src/adapter.test.ts packages/iracing-actions/src/actions/session-info/session-info.ts packages/iracing-actions/src/actions/session-info/session-info.test.ts packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/manifest.json`

## Checklist

- [x] Linked to an approved issue (N/A - no linked issue for this follow-up)
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Font Size control to Session Info action, allowing customization of text size (5–36 pixels) with automatic sizing as default.
  * Session Info and Telemetry Display actions now support Information displays in addition to Keypad controllers.

* **Documentation**
  * Updated documentation with Font Size setting details for Session Info action modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->