### PR TITLE
fix(audio-scenarios): readback replay reads fresh snapshot at fire time (#481)

### DIFF
--- a/packages/audio-scenarios/src/catalog/pit-crew/index.ts
+++ b/packages/audio-scenarios/src/catalog/pit-crew/index.ts
@@ -36,8 +36,15 @@
  * because the gate runs before `attemptFire` (which owns expansion,
  * preemption, and channel playback). Default `() => true` preserves
  * legacy behavior for callers that don't pass the closure (e.g. tests).
+ *
+ * `getReadbackSnapshot` is consulted at fire time inside every conditional
+ * predicate of the pit-readback scenarios (issue #481). Plugins wire it
+ * to `getReadbackSnapshot()` from `@iracedeck/sim-events-iracing` so a
+ * deferred-replay readback (busy-bus low-priority hold or urgent-flag
+ * preempt) speaks the *current* queued-services state, not the one
+ * frozen into the original event payload.
  */
-import type { IEventBus } from "@iracedeck/event-bus";
+import type { IEventBus, PitReadbackSnapshot } from "@iracedeck/event-bus";
 import type { ILogger } from "@iracedeck/logger";
 
 import type { Scenario } from "../../dsl.js";
@@ -46,7 +53,7 @@ import { FLAG_ALERTS } from "./flag-alerts.js";
 import { POOLS } from "./pools.js";
 import { registerRadarEngine } from "./radar-engine.js";
 import { RADIO_CLOSE, RADIO_OPEN } from "./radio-frame.js";
-import { PIT_READBACK_SCENARIOS, type PitReadbackCalloutId, SCENARIO_ID_TO_PIT_READBACK_ID } from "./readback.js";
+import { buildPitReadbackScenarios, type PitReadbackCalloutId, SCENARIO_ID_TO_PIT_READBACK_ID } from "./readback.js";
 import {
   FAST_REPAIR_TOGGLE_SCENARIOS,
   FUEL_TOGGLE_SCENARIOS,
@@ -63,7 +70,12 @@ export {
   type RadarVisualState,
   subscribeRadarVisualState,
 } from "./radar-engine.js";
-export { PIT_READBACK_CALLOUT_SETTING_KEYS, type PitReadbackCalloutId, PIT_READBACK_SCENARIOS } from "./readback.js";
+export {
+  buildPitReadbackScenarios,
+  PIT_READBACK_CALLOUT_SETTING_KEYS,
+  type PitReadbackCalloutId,
+  type ReadbackSnapshotResolver,
+} from "./readback.js";
 
 /**
  * Stable identifier for each user-toggleable flag callout (issue #467).
@@ -135,6 +147,15 @@ export function registerPitCrew(
   // from `getPitActionsAllowed` (engine-internal cooldown vs persistent
   // user preference) so they can move independently.
   getPitServiceRequestsEnabled: () => boolean = () => true,
+  // Pit-readback queued-services snapshot (issue #481). Plugins wire this
+  // to `getReadbackSnapshot()` from `@iracedeck/sim-events-iracing`, which
+  // builds a snapshot from the latest telemetry tick. Read at fire time
+  // inside every readback predicate so deferred replays speak the
+  // *current* queue rather than a snapshot frozen into the original
+  // event. Default `() => null` collapses every readback to the
+  // empty-fallback clip — a safe stub for tests that don't supply a
+  // resolver.
+  getReadbackSnapshot: () => PitReadbackSnapshot | null = () => null,
 ): void {
   registerRadarEngine(bus);
 
@@ -185,7 +206,7 @@ export function registerPitCrew(
     );
   }
 
-  for (const s of PIT_READBACK_SCENARIOS) {
+  for (const s of buildPitReadbackScenarios(getReadbackSnapshot)) {
     engine.defineScenario(
       wrapCalloutScenario(s, SCENARIO_ID_TO_PIT_READBACK_ID, getPitReadbackEnabled, "pit readback callout", logger),
     );

--- a/packages/audio-scenarios/src/catalog/pit-crew/readback-graph.test.ts
+++ b/packages/audio-scenarios/src/catalog/pit-crew/readback-graph.test.ts
@@ -21,7 +21,7 @@
  */
 import type { IAudioService } from "@iracedeck/audio-service";
 import { AudioChannel } from "@iracedeck/audio-service";
-import type { IEventBus, SimEventMap, SimEventName, SimEventOf } from "@iracedeck/event-bus";
+import type { IEventBus, PitReadbackSnapshot, SimEventMap, SimEventName, SimEventOf } from "@iracedeck/event-bus";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AudioAssetsManifest } from "../../interpreter.js";
@@ -237,14 +237,16 @@ const manifest: AudioAssetsManifest = {
 
 let bus: ReturnType<typeof createMockBus>;
 let audio: FakeAudio;
+let currentSnapshot: PitReadbackSnapshot | null;
 
 beforeEach(() => {
   vi.useFakeTimers();
   mockSessionType.mockReturnValue("Race");
   bus = createMockBus();
   audio = createFakeAudio();
+  currentSnapshot = null;
   initializeAudioScenarios(bus, audio, manifest, mockLogger as never, () => VOICE);
-  registerPitCrew(bus, undefined, mockLogger as never);
+  registerPitCrew(bus, undefined, mockLogger as never, undefined, undefined, undefined, () => currentSnapshot);
 });
 
 afterEach(() => {
@@ -254,9 +256,9 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-type Snapshot = SimEventMap["pitService.readbackRequested"]["data"];
+type Reason = SimEventMap["pitService.readbackRequested"]["data"]["reason"];
 
-const TIRE_PATTERNS: ReadonlyArray<Snapshot["tires"]> = [
+const TIRE_PATTERNS: ReadonlyArray<PitReadbackSnapshot["tires"]> = [
   { lf: false, rf: false, lr: false, rr: false }, // none
   { lf: true, rf: true, lr: true, rr: true },
   { lf: true, rf: true, lr: false, rr: false },
@@ -275,7 +277,11 @@ const TIRE_PATTERNS: ReadonlyArray<Snapshot["tires"]> = [
   { lf: false, rf: false, lr: false, rr: true },
 ];
 
-const COMPOUND_OPTIONS: ReadonlyArray<Snapshot["compoundChange"]> = [null, { from: 0, to: 1 }, { from: 1, to: 0 }];
+const COMPOUND_OPTIONS: ReadonlyArray<PitReadbackSnapshot["compoundChange"]> = [
+  null,
+  { from: 0, to: 1 },
+  { from: 1, to: 0 },
+];
 
 const BOOLS = [false, true] as const;
 
@@ -298,9 +304,12 @@ function flush(): void {
   }
 }
 
-function recordSequence(snapshot: Snapshot): string[] {
+function recordSequence(reason: Reason, snapshot: PitReadbackSnapshot): string[] {
   audio._reset();
-  bus.publishEvent("pitService.readbackRequested", snapshot);
+  // Publish only `reason` per issue #481; the audio scenarios pull the
+  // queued-services snapshot via the resolver closure at fire time.
+  currentSnapshot = snapshot;
+  bus.publishEvent("pitService.readbackRequested", { reason });
   flush();
 
   // Filter to readback clips only (drop the radio-frame ticks and any
@@ -368,7 +377,7 @@ describe("pit-readback path-graph invariant", () => {
       }
     }
 
-    const reasons: ReadonlyArray<Snapshot["reason"]> = ["entry", "exit"];
+    const reasons: ReadonlyArray<Reason> = ["entry", "exit"];
 
     for (const reason of reasons) {
       for (const tires of TIRE_PATTERNS) {
@@ -388,8 +397,7 @@ describe("pit-readback path-graph invariant", () => {
                     if (wsQ && !wsAvail) continue;
 
                     for (const limiter of BOOLS) {
-                      const seq = recordSequence({
-                        reason,
+                      const seq = recordSequence(reason, {
                         fuel: { queued: fuelQ },
                         tires,
                         compoundChange,

--- a/packages/audio-scenarios/src/catalog/pit-crew/readback.test.ts
+++ b/packages/audio-scenarios/src/catalog/pit-crew/readback.test.ts
@@ -1,14 +1,20 @@
 /**
- * Pit-service readback scenario tests (issue #476).
+ * Pit-service readback scenario tests (issue #476, #481).
  *
  * Pins the slot-resolution behavior, family preemption on refire, and
  * per-callout opt-out gating. Drives the scenarios through the real
  * scenario engine so we exercise validation and the same expansion path
  * production uses.
+ *
+ * Issue #481 changed the data flow: the queued-services snapshot is no
+ * longer carried on the event payload; the audio scenarios read it from
+ * a resolver closure at fire time. These tests set the closure's source
+ * (`currentSnapshot`) before publishing the event so each fire sees the
+ * intended state.
  */
 import type { IAudioService } from "@iracedeck/audio-service";
 import { AudioChannel } from "@iracedeck/audio-service";
-import type { IEventBus, SimEventMap, SimEventName, SimEventOf } from "@iracedeck/event-bus";
+import type { IEventBus, PitReadbackSnapshot, SimEventMap, SimEventName, SimEventOf } from "@iracedeck/event-bus";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AudioAssetsManifest } from "../../interpreter.js";
@@ -233,11 +239,11 @@ let bus: ReturnType<typeof createMockBus>;
 let audio: FakeAudio;
 let flagsEnabled: Map<FlagCalloutId, boolean>;
 let readbackEnabled: Map<PitReadbackCalloutId, boolean>;
+let currentSnapshot: PitReadbackSnapshot | null;
 
-type Snapshot = SimEventMap["pitService.readbackRequested"]["data"];
+type Reason = SimEventMap["pitService.readbackRequested"]["data"]["reason"];
 
-const EMPTY_SNAPSHOT: Snapshot = {
-  reason: "entry",
+const EMPTY_SNAPSHOT: PitReadbackSnapshot = {
   fuel: { queued: false },
   tires: { lf: false, rf: false, lr: false, rr: false },
   compoundChange: null,
@@ -246,7 +252,7 @@ const EMPTY_SNAPSHOT: Snapshot = {
   limiterEngaged: false,
 };
 
-function snap(overrides: Partial<Snapshot>): Snapshot {
+function snap(overrides: Partial<PitReadbackSnapshot>): PitReadbackSnapshot {
   return { ...EMPTY_SNAPSHOT, ...overrides };
 }
 
@@ -254,8 +260,15 @@ function voicePaths(): string[] {
   return audio._played.filter((p) => p.channel === AudioChannel.Voice).map((p) => p.path);
 }
 
-function fireReadback(snapshot: Snapshot): void {
-  bus.publishEvent("pitService.readbackRequested", snapshot);
+/**
+ * Fire a readback by setting the resolver's snapshot then publishing the
+ * (slim) event. Mirrors production: the diff publishes only `reason`,
+ * the audio scenario reads the queued-services state via the resolver
+ * at fire time.
+ */
+function fireReadback(reason: Reason, snapshot: PitReadbackSnapshot): void {
+  currentSnapshot = snapshot;
+  bus.publishEvent("pitService.readbackRequested", { reason });
   flush(audio);
 }
 
@@ -263,6 +276,7 @@ beforeEach(() => {
   vi.useFakeTimers();
   flagsEnabled = new Map();
   readbackEnabled = new Map();
+  currentSnapshot = null;
   mockSessionType.mockReturnValue("Race");
   bus = createMockBus();
   audio = createFakeAudio();
@@ -272,6 +286,9 @@ beforeEach(() => {
     (id) => flagsEnabled.get(id) ?? true,
     mockLogger as never,
     (id) => readbackEnabled.get(id) ?? true,
+    undefined,
+    undefined,
+    () => currentSnapshot,
   );
 });
 
@@ -286,8 +303,8 @@ describe("pit readback scenarios", () => {
   describe("entry readback", () => {
     it("fires on entry reason and plays the entry opener", () => {
       fireReadback(
+        "entry",
         snap({
-          reason: "entry",
           fuel: { queued: true },
           tires: { lf: true, rf: true, lr: true, rr: true },
           limiterEngaged: true,
@@ -301,7 +318,7 @@ describe("pit readback scenarios", () => {
     });
 
     it("prepends the limiter pre-opener when limiter is not engaged, then plays opener-entry", () => {
-      fireReadback(snap({ reason: "entry", fuel: { queued: true }, limiterEngaged: false }));
+      fireReadback("entry", snap({ fuel: { queued: true }, limiterEngaged: false }));
 
       const paths = voicePaths();
       const limiterIdx = paths.findIndex((p) => p.endsWith("/pit-readback/opener-entry-limiter.mp3"));
@@ -313,14 +330,14 @@ describe("pit readback scenarios", () => {
     });
 
     it("plays only opener-entry (no limiter pre-opener) when limiter is already engaged", () => {
-      fireReadback(snap({ reason: "entry", fuel: { queued: true }, limiterEngaged: true }));
+      fireReadback("entry", snap({ fuel: { queued: true }, limiterEngaged: true }));
 
       expect(voicePaths().some((p) => p.endsWith("/pit-readback/opener-entry.mp3"))).toBe(true);
       expect(voicePaths().some((p) => p.endsWith("/pit-readback/opener-entry-limiter.mp3"))).toBe(false);
     });
 
     it("entry-refire reason fires the entry scenario but skips the opener", () => {
-      fireReadback(snap({ reason: "entry-refire", fuel: { queued: true } }));
+      fireReadback("entry-refire", snap({ fuel: { queued: true } }));
 
       const paths = voicePaths();
       // Slot content still plays on a refire so the recap reflects the
@@ -332,13 +349,13 @@ describe("pit readback scenarios", () => {
     });
 
     it("entry-refire skips the limiter pre-opener even when limiter is not engaged", () => {
-      fireReadback(snap({ reason: "entry-refire", fuel: { queued: true }, limiterEngaged: false }));
+      fireReadback("entry-refire", snap({ fuel: { queued: true }, limiterEngaged: false }));
 
       expect(voicePaths().some((p) => p.endsWith("/pit-readback/opener-entry-limiter.mp3"))).toBe(false);
     });
 
     it("does not fire the exit scenario", () => {
-      fireReadback(snap({ reason: "entry", fuel: { queued: true } }));
+      fireReadback("entry", snap({ fuel: { queued: true } }));
 
       expect(voicePaths().some((p) => p.endsWith("/pit-readback/opener-exit.mp3"))).toBe(false);
     });
@@ -346,7 +363,7 @@ describe("pit readback scenarios", () => {
 
   describe("exit readback", () => {
     it("fires on exit reason with the exit opener", () => {
-      fireReadback(snap({ reason: "exit", fuel: { queued: true } }));
+      fireReadback("exit", snap({ fuel: { queued: true } }));
 
       const paths = voicePaths();
       expect(paths.some((p) => p.endsWith("/pit-readback/opener-exit.mp3"))).toBe(true);
@@ -354,7 +371,7 @@ describe("pit readback scenarios", () => {
     });
 
     it("does not fire on entry / entry-refire reasons", () => {
-      fireReadback(snap({ reason: "entry", fuel: { queued: true } }));
+      fireReadback("entry", snap({ fuel: { queued: true } }));
       const entryPaths = voicePaths().slice();
       expect(entryPaths.some((p) => p.endsWith("/pit-readback/opener-exit.mp3"))).toBe(false);
     });
@@ -362,7 +379,7 @@ describe("pit readback scenarios", () => {
 
   describe("empty snapshot", () => {
     it("entry empty plays the limiter pre-opener (when not engaged) + fallback, no opener / no slots", () => {
-      fireReadback(snap({ reason: "entry", limiterEngaged: false }));
+      fireReadback("entry", snap({ limiterEngaged: false }));
 
       const paths = voicePaths();
       const limiterIdx = paths.findIndex((p) => p.endsWith("/pit-readback/opener-entry-limiter.mp3"));
@@ -378,7 +395,7 @@ describe("pit readback scenarios", () => {
     });
 
     it("entry empty with limiter engaged plays only the empty-fallback (no openers)", () => {
-      fireReadback(snap({ reason: "entry", limiterEngaged: true }));
+      fireReadback("entry", snap({ limiterEngaged: true }));
 
       const paths = voicePaths();
       expect(paths.some((p) => p.endsWith("/pit-readback/empty-fallback.mp3"))).toBe(true);
@@ -387,7 +404,7 @@ describe("pit readback scenarios", () => {
     });
 
     it("exit keeps the opener around the empty-fallback", () => {
-      fireReadback(snap({ reason: "exit" }));
+      fireReadback("exit", snap({}));
 
       const paths = voicePaths();
       const openerIdx = paths.findIndex((p) => p.endsWith("/pit-readback/opener-exit.mp3"));
@@ -401,8 +418,8 @@ describe("pit readback scenarios", () => {
 
     it("treats an unavailable-only fast-repair queue as empty", () => {
       fireReadback(
+        "entry",
         snap({
-          reason: "entry",
           fastRepair: { queued: true, available: false },
         }),
       );
@@ -412,7 +429,7 @@ describe("pit readback scenarios", () => {
   });
 
   describe("tire pattern slot", () => {
-    type Tires = Snapshot["tires"];
+    type Tires = PitReadbackSnapshot["tires"];
 
     const PATTERNS: ReadonlyArray<[Tires, string]> = [
       [{ lf: true, rf: true, lr: true, rr: true }, "tires-all.mp3"],
@@ -433,7 +450,7 @@ describe("pit readback scenarios", () => {
     ];
 
     it.each(PATTERNS)("pattern %j resolves to %s", (tires, expectedClip) => {
-      fireReadback(snap({ reason: "entry", tires }));
+      fireReadback("entry", snap({ tires }));
 
       const paths = voicePaths();
       expect(paths.some((p) => p.endsWith(`/pit-readback/${expectedClip}`))).toBe(true);
@@ -446,7 +463,7 @@ describe("pit readback scenarios", () => {
     });
 
     it("falls back to tires-off when no bits are set and no compound change", () => {
-      fireReadback(snap({ reason: "entry", fuel: { queued: true } }));
+      fireReadback("entry", snap({ fuel: { queued: true } }));
 
       expect(voicePaths().some((p) => p.endsWith("/pit-readback/tires-off.mp3"))).toBe(true);
     });
@@ -455,8 +472,8 @@ describe("pit readback scenarios", () => {
   describe("compound slot", () => {
     it("plays compound-dry and skips the tire-pattern slot", () => {
       fireReadback(
+        "entry",
         snap({
-          reason: "entry",
           tires: { lf: true, rf: true, lr: true, rr: true },
           compoundChange: { from: 1, to: 0 },
         }),
@@ -469,8 +486,8 @@ describe("pit readback scenarios", () => {
 
     it("plays compound-wet and skips the tire-pattern slot", () => {
       fireReadback(
+        "entry",
         snap({
-          reason: "entry",
           tires: { lf: true, rf: true, lr: true, rr: true },
           compoundChange: { from: 0, to: 1 },
         }),
@@ -485,8 +502,8 @@ describe("pit readback scenarios", () => {
   describe("fast repair / windshield slots", () => {
     it("stays silent on both fast-repair and windshield when neither is queued", () => {
       fireReadback(
+        "entry",
         snap({
-          reason: "entry",
           fuel: { queued: true },
           fastRepair: { queued: false, available: true },
           windshield: { queued: false, available: true },
@@ -502,8 +519,8 @@ describe("pit readback scenarios", () => {
 
     it("plays fast-repair-on when queued", () => {
       fireReadback(
+        "entry",
         snap({
-          reason: "entry",
           fuel: { queued: true },
           fastRepair: { queued: true, available: true },
         }),
@@ -514,8 +531,8 @@ describe("pit readback scenarios", () => {
 
     it("stays silent on windshield when not queued (no false 'no windshield' on open-wheel cars)", () => {
       fireReadback(
+        "entry",
         snap({
-          reason: "entry",
           fuel: { queued: true },
           windshield: { queued: false, available: true },
         }),
@@ -529,21 +546,21 @@ describe("pit readback scenarios", () => {
   describe("opt-out gating", () => {
     it("entry callout suppressed when opt-out is off", () => {
       readbackEnabled.set("pit-readback-entry", false);
-      fireReadback(snap({ reason: "entry", fuel: { queued: true } }));
+      fireReadback("entry", snap({ fuel: { queued: true } }));
 
       expect(voicePaths().some((p) => p.includes("/pit-readback/"))).toBe(false);
     });
 
     it("exit callout suppressed when opt-out is off", () => {
       readbackEnabled.set("pit-readback-exit", false);
-      fireReadback(snap({ reason: "exit", fuel: { queued: true } }));
+      fireReadback("exit", snap({ fuel: { queued: true } }));
 
       expect(voicePaths().some((p) => p.includes("/pit-readback/"))).toBe(false);
     });
 
     it("entry off does not affect exit", () => {
       readbackEnabled.set("pit-readback-entry", false);
-      fireReadback(snap({ reason: "exit", fuel: { queued: true } }));
+      fireReadback("exit", snap({ fuel: { queued: true } }));
 
       expect(voicePaths().some((p) => p.endsWith("/pit-readback/opener-exit.mp3"))).toBe(true);
     });
@@ -552,8 +569,8 @@ describe("pit readback scenarios", () => {
   describe("slot composition", () => {
     it("emits each populated slot back-to-back without glue clips", () => {
       fireReadback(
+        "entry",
         snap({
-          reason: "entry",
           fuel: { queued: true },
           tires: { lf: true, rf: true, lr: true, rr: true },
           fastRepair: { queued: true, available: true },
@@ -576,6 +593,85 @@ describe("pit readback scenarios", () => {
         "fast-repair-on.mp3",
         "windshield-on.mp3",
       ]);
+    });
+  });
+
+  // Issue #481 regression: a low-priority readback that gets stashed in
+  // `deferredLowFire` (busy-bus or higher-priority preempt) must speak the
+  // CURRENT queued-services state when it eventually replays — not the
+  // state captured at the moment the original event was emitted. The bug
+  // before #481 was that the snapshot rode on the event payload, so the
+  // deferred replay walked stale data. With the resolver pulled at fire
+  // time, the replay reads whatever the user has queued NOW.
+  describe("deferred-replay snapshot freshness (issue #481)", () => {
+    it("uses the latest snapshot when a busy-bus deferred low fire replays", () => {
+      // 1. Stash an "all four tires" snapshot the first event would see.
+      currentSnapshot = snap({ fuel: { queued: true }, tires: { lf: true, rf: true, lr: true, rr: true } });
+
+      // 2. Pre-occupy the bus with a normal-priority fuel-toggle confirmation
+      //    so the readback can't fire immediately and gets deferred.
+      bus.publishEvent("pitService.toggled", { service: "fuel", on: true });
+
+      // 3. Publish the readback while the bus is still busy with the
+      //    fuel-toggle. The interpreter stashes it in `deferredLowFire` —
+      //    no clips play yet for the readback.
+      bus.publishEvent("pitService.readbackRequested", { reason: "entry" });
+
+      // 4. Sim state changes between event emit and deferred replay: the
+      //    user toggles tires down to FRONTS only.
+      currentSnapshot = snap({
+        fuel: { queued: true },
+        tires: { lf: true, rf: true, lr: false, rr: false },
+      });
+
+      // 5. Drain the bus. Toggle confirmation finishes, deferred replay
+      //    runs against the CURRENT snapshot.
+      flush(audio);
+
+      const readbackPaths = voicePaths()
+        .filter((p) => p.includes("/pit-readback/"))
+        .map((p) => p.split("/pit-readback/")[1]);
+
+      // The replay must reflect the post-toggle state (fronts only).
+      // Pre-#481 the deferred fire walked the stale "all four" snapshot
+      // and mis-spoke the tire pattern.
+      expect(readbackPaths).toContain("tires-fronts.mp3");
+      expect(readbackPaths).not.toContain("tires-all.mp3");
+    });
+
+    it("uses the latest snapshot when a higher-priority preempt stashes the readback", () => {
+      // 1. Set the snapshot the original event would have captured.
+      currentSnapshot = snap({ fuel: { queued: true }, tires: { lf: true, rf: true, lr: true, rr: true } });
+
+      // 2. Fire the low-priority readback. It starts playing immediately
+      //    (radio-open → opener → …).
+      bus.publishEvent("pitService.readbackRequested", { reason: "entry" });
+
+      // 3. Mid-playback, fire a normal-priority toggle confirmation
+      //    belonging to a different family. The interpreter preempts
+      //    the running readback and stashes its event in
+      //    `deferredLowFire` for replay once the toggle completes.
+      bus.publishEvent("pitService.toggled", { service: "fuel", on: false });
+
+      // 4. While the toggle confirmation plays, the user changes the
+      //    queue (e.g. cancels two tires). The replay must reflect this.
+      currentSnapshot = snap({
+        fuel: { queued: true },
+        tires: { lf: true, rf: true, lr: false, rr: false },
+      });
+
+      // 5. Drain — toggle finishes, deferred readback replays.
+      flush(audio);
+
+      const readbackPaths = voicePaths()
+        .filter((p) => p.includes("/pit-readback/"))
+        .map((p) => p.split("/pit-readback/")[1]);
+
+      // Both the original (pre-empted) and the replay run inside one
+      // flush window; the replay's tire pattern must be the post-toggle
+      // one. Pre-#481 the replay re-expanded the stashed event's frozen
+      // snapshot and reported "tires-all".
+      expect(readbackPaths).toContain("tires-fronts.mp3");
     });
   });
 });

--- a/packages/audio-scenarios/src/catalog/pit-crew/readback.ts
+++ b/packages/audio-scenarios/src/catalog/pit-crew/readback.ts
@@ -1,5 +1,5 @@
 /**
- * Pit-service readback scenarios — issue #476.
+ * Pit-service readback scenarios — issue #476, #481.
  *
  * Two scenarios driven by `pitService.readbackRequested` (one per `reason`
  * value the sim translator emits):
@@ -7,12 +7,18 @@
  *   - `pit-crew.pit-readback-entry`  — fires on `entry` and `entry-refire`.
  *   - `pit-crew.pit-readback-exit`   — fires on `exit`.
  *
- * Both scenarios are pure slot compositions over the event payload (no
- * live telemetry reads from inside the DSL). Each slot picks zero or one
- * clip based on the snapshot; slots that resolve to "omit" contribute
- * nothing. There are no connectors between slots — the slot clips are
- * authored with consistent lead-in / lead-out so they flow naturally
- * back-to-back.
+ * Each slot picks zero or one clip based on the queued-services snapshot;
+ * slots that resolve to "omit" contribute nothing. There are no connectors
+ * between slots — the slot clips are authored with consistent lead-in /
+ * lead-out so they flow naturally back-to-back.
+ *
+ * The snapshot is resolved at fire time via the `getSnapshot` closure
+ * (issue #481) — NOT pulled from the event payload. The event carries
+ * only the trigger `reason`. Reading at fire time keeps the recap fresh
+ * when the scenario engine deferred the fire (busy-bus low-priority hold
+ * or urgent-flag preempt that stashed the readback for replay) — the
+ * snapshot frozen at emit time would be stale by the time the engineer
+ * actually speaks.
  *
  * Slot order:
  *   1. Opener           — exit: "To confirm:".
@@ -36,36 +42,45 @@
  *
  * Empty-snapshot fallback: when fuel + tires + extras all resolve to
  * "omit"/"no", the dedicated empty-fallback clip plays alone instead
- * of stitching a series of negatives.
+ * of stitching a series of negatives. A null snapshot (translator has
+ * no telemetry yet) is treated as empty.
  *
  * Family preemption: both scenarios share `family: "pit-readback"` so a
  * refire (mid-lane toggle) replaces the running readback wholesale —
  * distinct from #464's per-toggle stitching, which merges live.
  */
 import { AudioBus, AudioChannel } from "@iracedeck/audio-service";
-import type { SimEventOf } from "@iracedeck/event-bus";
+import type { PitReadbackSnapshot, SimEventOf } from "@iracedeck/event-bus";
 
 import type { Scenario, ScenarioContext, Step } from "../../dsl.js";
 
-type ReadbackPayload = SimEventOf<"pitService.readbackRequested">["data"];
+type ReadbackEventData = SimEventOf<"pitService.readbackRequested">["data"];
 
-function payload(ctx: ScenarioContext): ReadbackPayload {
-  return ctx.data as ReadbackPayload;
+function reasonOf(ctx: ScenarioContext): ReadbackEventData["reason"] {
+  return (ctx.data as ReadbackEventData).reason;
 }
 
-function hasAnyTire(p: ReadbackPayload): boolean {
-  return p.tires.lf || p.tires.rf || p.tires.lr || p.tires.rr;
+function hasAnyTire(t: PitReadbackSnapshot["tires"]): boolean {
+  return t.lf || t.rf || t.lr || t.rr;
 }
 
-function hasAnyService(p: ReadbackPayload): boolean {
+function hasAnyService(s: PitReadbackSnapshot): boolean {
   return (
-    p.fuel.queued ||
-    hasAnyTire(p) ||
-    p.compoundChange !== null ||
-    (p.fastRepair.available && p.fastRepair.queued) ||
-    (p.windshield.available && p.windshield.queued)
+    s.fuel.queued ||
+    hasAnyTire(s.tires) ||
+    s.compoundChange !== null ||
+    (s.fastRepair.available && s.fastRepair.queued) ||
+    (s.windshield.available && s.windshield.queued)
   );
 }
+
+/**
+ * Resolver for the queued-services snapshot. Returns `null` when no
+ * snapshot is available (translator hasn't seen telemetry yet); the
+ * predicates treat null as the empty snapshot, which collapses to the
+ * fallback clip rather than fabricating a "no fuel, no tires" recap.
+ */
+export type ReadbackSnapshotResolver = () => PitReadbackSnapshot | null;
 
 /**
  * 15-way exhaustive tire-pattern lookup. Mirrors the names already used by
@@ -74,7 +89,7 @@ function hasAnyService(p: ReadbackPayload): boolean {
  * so at most one entry resolves true per snapshot.
  */
 const TIRE_PATTERN_CLIPS: ReadonlyArray<{
-  match: (t: ReadbackPayload["tires"]) => boolean;
+  match: (t: PitReadbackSnapshot["tires"]) => boolean;
   clip: string;
 }> = [
   // 4 corners
@@ -108,10 +123,25 @@ function clipPath(filename: string): string {
   return `${READBACK_BASE}/${filename}`;
 }
 
-function fuelSlotSteps(): Step[] {
+/**
+ * The empty snapshot — used when the resolver returns `null` (translator
+ * has no live telemetry yet). Treating this as the canonical "nothing
+ * queued" view collapses the readback to the empty-fallback clip rather
+ * than fabricating a "no fuel, no tires" string.
+ */
+const EMPTY_SNAPSHOT: PitReadbackSnapshot = {
+  fuel: { queued: false },
+  tires: { lf: false, rf: false, lr: false, rr: false },
+  compoundChange: null,
+  fastRepair: { queued: false, available: false },
+  windshield: { queued: false, available: false },
+  limiterEngaged: false,
+};
+
+function fuelSlotSteps(getSnap: ReadbackSnapshotResolver): Step[] {
   return [
     {
-      if: (ctx) => payload(ctx).fuel.queued,
+      if: () => (getSnap() ?? EMPTY_SNAPSHOT).fuel.queued,
       then: [clipPath("fuel-on.mp3")],
       else: [clipPath("fuel-off.mp3")],
     },
@@ -124,28 +154,36 @@ function fuelSlotSteps(): Step[] {
  *   - any tire bits set with no compound change — pick from the 15 patterns
  *   - tires explicitly skipped (no bits, no compound) — "no tires"
  */
-function tireCompoundSlotSteps(): Step[] {
+function tireCompoundSlotSteps(getSnap: ReadbackSnapshotResolver): Step[] {
   return [
     {
-      if: (ctx) => payload(ctx).compoundChange?.to === 0,
+      if: () => (getSnap() ?? EMPTY_SNAPSHOT).compoundChange?.to === 0,
       then: [clipPath("compound-dry.mp3")],
     },
     {
-      if: (ctx) => payload(ctx).compoundChange?.to === 1,
+      if: () => (getSnap() ?? EMPTY_SNAPSHOT).compoundChange?.to === 1,
       then: [clipPath("compound-wet.mp3")],
     },
     ...TIRE_PATTERN_CLIPS.map<Step>(({ match, clip }) => ({
-      if: (ctx) => payload(ctx).compoundChange === null && match(payload(ctx).tires),
+      if: () => {
+        const s = getSnap() ?? EMPTY_SNAPSHOT;
+
+        return s.compoundChange === null && match(s.tires);
+      },
       then: [clipPath(clip)],
     })),
     {
-      if: (ctx) => payload(ctx).compoundChange === null && !hasAnyTire(payload(ctx)),
+      if: () => {
+        const s = getSnap() ?? EMPTY_SNAPSHOT;
+
+        return s.compoundChange === null && !hasAnyTire(s.tires);
+      },
       then: [clipPath("tires-off.mp3")],
     },
   ];
 }
 
-function fastRepairSlotSteps(): Step[] {
+function fastRepairSlotSteps(getSnap: ReadbackSnapshotResolver): Step[] {
   // Only mention fast repair when it's queued. Skipping the negative
   // ("no fast repair") sidesteps the false positive on undamaged cars
   // — iRacing doesn't expose pre-stall damage in telemetry, so we
@@ -153,13 +191,13 @@ function fastRepairSlotSteps(): Step[] {
   // signal we have, and it's a positive-only callout.
   return [
     {
-      if: (ctx) => payload(ctx).fastRepair.queued,
+      if: () => (getSnap() ?? EMPTY_SNAPSHOT).fastRepair.queued,
       then: [clipPath("fast-repair-on.mp3")],
     },
   ];
 }
 
-function windshieldSlotSteps(): Step[] {
+function windshieldSlotSteps(getSnap: ReadbackSnapshotResolver): Step[] {
   // Only mention windshield when it's queued. Skipping the negative
   // ("no windshield") sidesteps the open-wheel false-positive — formula
   // / indycar / dirt cars don't have a windshield to clean, and iRacing
@@ -167,13 +205,13 @@ function windshieldSlotSteps(): Step[] {
   // telemetry to gate on.
   return [
     {
-      if: (ctx) => payload(ctx).windshield.queued,
+      if: () => (getSnap() ?? EMPTY_SNAPSHOT).windshield.queued,
       then: [clipPath("windshield-on.mp3")],
     },
   ];
 }
 
-function readbackScenario(reason: "entry" | "exit"): Scenario {
+function readbackScenario(reason: "entry" | "exit", getSnap: ReadbackSnapshotResolver): Scenario {
   const isEntry = reason === "entry";
 
   return {
@@ -205,28 +243,28 @@ function readbackScenario(reason: "entry" | "exit"): Scenario {
           // non-empty plays the regular opener + slots.
           ([
             {
-              if: (ctx) => payload(ctx).reason === "entry" && !payload(ctx).limiterEngaged,
+              if: (ctx) => reasonOf(ctx) === "entry" && !(getSnap() ?? EMPTY_SNAPSHOT).limiterEngaged,
               then: [clipPath("opener-entry-limiter.mp3")],
             },
             {
-              if: (ctx) => !hasAnyService(payload(ctx)),
+              if: () => !hasAnyService(getSnap() ?? EMPTY_SNAPSHOT),
               then: [clipPath("empty-fallback.mp3")],
               else: [
                 // Opener — gated on `reason === "entry"` so refires
                 // (`entry-refire`) skip the carrier sentence and replay
                 // only the slot content.
                 {
-                  if: (ctx) => payload(ctx).reason === "entry",
+                  if: (ctx) => reasonOf(ctx) === "entry",
                   then: [clipPath("opener-entry.mp3")],
                 },
-                ...fuelSlotSteps(),
-                ...tireCompoundSlotSteps(),
+                ...fuelSlotSteps(getSnap),
+                ...tireCompoundSlotSteps(getSnap),
                 // Brief beat after the tire/compound callout so the
                 // optional fast-repair / windshield extras don't crowd
                 // the longest slot in the recap.
                 { pause: 300 },
-                ...fastRepairSlotSteps(),
-                ...windshieldSlotSteps(),
+                ...fastRepairSlotSteps(getSnap),
+                ...windshieldSlotSteps(getSnap),
               ],
             },
           ] as Step[])
@@ -236,17 +274,17 @@ function readbackScenario(reason: "entry" | "exit"): Scenario {
           ([
             { clip: clipPath("opener-exit.mp3") },
             {
-              if: (ctx) => !hasAnyService(payload(ctx)),
+              if: () => !hasAnyService(getSnap() ?? EMPTY_SNAPSHOT),
               then: [clipPath("empty-fallback.mp3")],
               else: [
-                ...fuelSlotSteps(),
-                ...tireCompoundSlotSteps(),
+                ...fuelSlotSteps(getSnap),
+                ...tireCompoundSlotSteps(getSnap),
                 // Brief beat after the tire/compound callout so the
                 // optional fast-repair / windshield extras don't crowd
                 // the longest slot in the recap.
                 { pause: 300 },
-                ...fastRepairSlotSteps(),
-                ...windshieldSlotSteps(),
+                ...fastRepairSlotSteps(getSnap),
+                ...windshieldSlotSteps(getSnap),
               ],
             },
           ] as Step[])),
@@ -255,10 +293,15 @@ function readbackScenario(reason: "entry" | "exit"): Scenario {
   };
 }
 
-export const PIT_READBACK_ENTRY: Scenario = readbackScenario("entry");
-export const PIT_READBACK_EXIT: Scenario = readbackScenario("exit");
-
-export const PIT_READBACK_SCENARIOS: readonly Scenario[] = [PIT_READBACK_ENTRY, PIT_READBACK_EXIT];
+/**
+ * Build both pit-readback scenarios bound to a snapshot resolver. The
+ * resolver is invoked at fire time inside every conditional `if` predicate
+ * so deferred replays read the *current* queued-services state, not the
+ * one captured when the event was emitted (issue #481).
+ */
+export function buildPitReadbackScenarios(getSnapshot: ReadbackSnapshotResolver): readonly Scenario[] {
+  return [readbackScenario("entry", getSnapshot), readbackScenario("exit", getSnapshot)];
+}
 
 /**
  * Stable identifier for each user-toggleable pit-readback callout. Two

--- a/packages/event-bus/src/event-catalog.ts
+++ b/packages/event-bus/src/event-catalog.ts
@@ -50,6 +50,28 @@ export type PitServiceKind = "fuel" | "windshield" | "fastRepair";
 export type FlagScope = "local" | "full";
 
 /**
+ * Pit-service readback snapshot — the queued-services view the readback
+ * scenarios speak to (issue #476). Lives next to the catalog because it's
+ * shared between the sim translator (which builds it from current
+ * telemetry) and the audio scenarios (which read it at fire time via a
+ * resolver closure). Sim-agnostic: any future translator can populate the
+ * same shape.
+ *
+ * Decoupled from `pitService.readbackRequested` event payload (which now
+ * carries only `reason`) so that deferred replay reads a fresh snapshot
+ * at the moment the engineer speaks rather than the one frozen into the
+ * original event.
+ */
+export type PitReadbackSnapshot = {
+  fuel: { queued: boolean };
+  tires: { lf: boolean; rf: boolean; lr: boolean; rr: boolean };
+  compoundChange: { from: number; to: number } | null;
+  fastRepair: { queued: boolean; available: boolean };
+  windshield: { queued: boolean; available: boolean };
+  limiterEngaged: boolean;
+};
+
+/**
  * Discriminated union of every event the bus knows about, keyed by event
  * name. Each entry binds an event name to its payload type — adding an
  * event means adding an entry here.
@@ -69,24 +91,17 @@ export type SimEventMap = {
    *                      while still on pit road, so the running readback
    *                      is preempted and replaced with the new snapshot
    *   - "exit"         — pitLane.exited + a settle delay (default 4500 ms)
-   * The full snapshot is captured at the trigger moment so the readback
-   * scenario stays pure (no live telemetry reads from inside the DSL).
    *
-   * `compoundChange` is non-null only when the queued compound differs
-   * from the player's currently-fitted compound — matches the existing
-   * `isCompoundChange` semantics in `service-reminder.ts`.
+   * The payload carries only the trigger reason. The queued-services
+   * snapshot the readback speaks to is read at fire time via a resolver
+   * closure passed into the audio-scenarios catalog, NOT pulled from the
+   * event payload (issue #481). Reading at fire time keeps the recap
+   * fresh under deferred replay (busy-bus low-priority deferral or a
+   * higher-priority preempt that stashes the readback for later).
    */
   "pitService.readbackRequested": SimEvent<
     "pitService.readbackRequested",
-    {
-      reason: "entry" | "entry-refire" | "exit";
-      fuel: { queued: boolean };
-      tires: { lf: boolean; rf: boolean; lr: boolean; rr: boolean };
-      compoundChange: { from: number; to: number } | null;
-      fastRepair: { queued: boolean; available: boolean };
-      windshield: { queued: boolean; available: boolean };
-      limiterEngaged: boolean;
-    }
+    { reason: "entry" | "entry-refire" | "exit" }
   >;
 
   "flag.yellow.raised": SimEvent<"flag.yellow.raised", { scope: FlagScope }>;

--- a/packages/event-bus/src/index.ts
+++ b/packages/event-bus/src/index.ts
@@ -10,6 +10,7 @@ export { _resetEventBus, getEventBus, initializeEventBus, isEventBusInitialized 
 export type {
   EmptySimEventPayload,
   FlagScope,
+  PitReadbackSnapshot,
   PitServiceKind,
   SimEvent,
   SimEventMap,

--- a/packages/iracing-plugin-mirabox/src/plugin.ts
+++ b/packages/iracing-plugin-mirabox/src/plugin.ts
@@ -105,7 +105,7 @@ import {
   ViewAdjustment,
 } from "@iracedeck/iracing-actions";
 import { IRacingNative } from "@iracedeck/iracing-native";
-import { initializeSimEventsIracing, isPitActionsAllowed } from "@iracedeck/sim-events-iracing";
+import { getReadbackSnapshot, initializeSimEventsIracing, isPitActionsAllowed } from "@iracedeck/sim-events-iracing";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -186,6 +186,10 @@ registerPitCrew(
   // User opt-in for the per-toggle pit-service request confirmations
   // (issue #468). Live read so the toggle takes effect mid-session.
   () => (getGlobalSettings() as Record<string, unknown>).calloutEnabledPitServiceRequests !== false,
+  // Pit-readback queued-services snapshot (issue #481). Read fresh on
+  // every readback fire so deferred replays speak the current queue,
+  // not a snapshot frozen into the original event.
+  () => getReadbackSnapshot(),
 );
 
 // Publish audio device list and apply saved device selection.

--- a/packages/iracing-plugin-stream-deck/src/plugin.ts
+++ b/packages/iracing-plugin-stream-deck/src/plugin.ts
@@ -98,7 +98,7 @@ import {
   ViewAdjustment,
 } from "@iracedeck/iracing-actions";
 import { IRacingNative } from "@iracedeck/iracing-native";
-import { initializeSimEventsIracing, isPitActionsAllowed } from "@iracedeck/sim-events-iracing";
+import { getReadbackSnapshot, initializeSimEventsIracing, isPitActionsAllowed } from "@iracedeck/sim-events-iracing";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -183,6 +183,10 @@ registerPitCrew(
   // User opt-in for the per-toggle pit-service request confirmations
   // (issue #468). Live read so the toggle takes effect mid-session.
   () => (getGlobalSettings() as Record<string, unknown>).calloutEnabledPitServiceRequests !== false,
+  // Pit-readback queued-services snapshot (issue #481). Read fresh on
+  // every readback fire so deferred replays speak the current queue,
+  // not a snapshot frozen into the original event.
+  () => getReadbackSnapshot(),
 );
 
 // Publish audio device list and apply saved device selection.

--- a/packages/scenario-harness/src/main.ts
+++ b/packages/scenario-harness/src/main.ts
@@ -15,7 +15,7 @@ import { initGlobalSettings, onGlobalSettingsChange, resolveActiveRaceEngineerVo
 import { initializeEventBus } from "@iracedeck/event-bus";
 import type { SDKController } from "@iracedeck/iracing-sdk";
 import { createConsoleLogger, LogLevel } from "@iracedeck/logger";
-import { initializeSimEventsIracing, isPitActionsAllowed } from "@iracedeck/sim-events-iracing";
+import { getReadbackSnapshot, initializeSimEventsIracing, isPitActionsAllowed } from "@iracedeck/sim-events-iracing";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -70,8 +70,18 @@ async function main(): Promise<void> {
     resolveActiveRaceEngineerVoice(raceEngineerVoices),
   );
   // Wire the pit-action cooldown so the harness sees the same suppression
-  // window the production plugins do. Other closures keep their defaults.
-  registerPitCrew(eventBus, undefined, undefined, undefined, () => isPitActionsAllowed());
+  // window the production plugins do, plus the readback-snapshot resolver
+  // so deferred replays speak the current queue (issue #481). Other
+  // closures keep their defaults.
+  registerPitCrew(
+    eventBus,
+    undefined,
+    undefined,
+    undefined,
+    () => isPitActionsAllowed(),
+    undefined,
+    () => getReadbackSnapshot(),
+  );
 
   // ── deck-core global-settings pipeline ──────────────────────────────────
   // Done AFTER seeding so the listener delivers the seeded values to the

--- a/packages/sim-events-iracing/src/diff/pit-readback.test.ts
+++ b/packages/sim-events-iracing/src/diff/pit-readback.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the pit-readback diff translator (issue #476).
+ * Unit tests for the pit-readback diff translator (issue #476, #481).
  *
  * Pins:
  *   - first-tick seeding (no spurious entry from boot-on-pit-road)
@@ -7,13 +7,15 @@
  *   - on-pit-road + user toggle in the same tick emits "entry-refire"
  *   - on→off schedules an exit fire that emits after the delay elapses
  *   - re-entering during the delay window cancels the scheduled exit
- *   - committed snapshot survives the bit-clearing seed during stall
+ *   - issue #481: event payload carries only `reason` (the
+ *     queued-services snapshot is read at fire time by the audio side
+ *     via `getReadbackSnapshot()`)
  */
 import { EngineWarnings, PitSvFlags, type TelemetryData } from "@iracedeck/iracing-sdk";
 import { describe, expect, it } from "vitest";
 
 import { createInitialState } from "../state.js";
-import { diffPitReadback, PIT_READBACK_EXIT_DELAY_MS } from "./pit-readback.js";
+import { buildSnapshot, diffPitReadback, PIT_READBACK_EXIT_DELAY_MS } from "./pit-readback.js";
 import type { PendingEvent } from "./types.js";
 
 function tick(overrides: Partial<TelemetryData> = {}): TelemetryData {
@@ -36,6 +38,55 @@ function collect(): { events: PendingEvent[]; emit: (e: PendingEvent) => void } 
 function readbackEvents(events: PendingEvent[]): PendingEvent[] {
   return events.filter((e) => e.event === "pitService.readbackRequested");
 }
+
+describe("buildSnapshot", () => {
+  it("decodes pit-service flags into the queued-services view", () => {
+    expect(
+      buildSnapshot(
+        tick({
+          PitSvFlags: PitSvFlags.FuelFill | PitSvFlags.LFTireChange | PitSvFlags.RFTireChange,
+          EngineWarnings: 0,
+        }),
+      ),
+    ).toMatchObject({
+      fuel: { queued: true },
+      tires: { lf: true, rf: true, lr: false, rr: false },
+      compoundChange: null,
+      limiterEngaged: false,
+    });
+  });
+
+  it("captures limiterEngaged from EngineWarnings", () => {
+    expect(buildSnapshot(tick({ EngineWarnings: EngineWarnings.PitSpeedLimiter }))).toMatchObject({
+      limiterEngaged: true,
+    });
+  });
+
+  it("flags a compound change when queued compound differs from player", () => {
+    expect(
+      buildSnapshot(
+        tick({
+          PitSvFlags:
+            PitSvFlags.LFTireChange | PitSvFlags.RFTireChange | PitSvFlags.LRTireChange | PitSvFlags.RRTireChange,
+          PitSvTireCompound: 1,
+          PlayerTireCompound: 0,
+        }),
+      ),
+    ).toMatchObject({ compoundChange: { from: 0, to: 1 } });
+  });
+
+  it("does not flag a compound change when the queued compound matches the fitted compound", () => {
+    expect(
+      buildSnapshot(
+        tick({
+          PitSvFlags: PitSvFlags.LFTireChange | PitSvFlags.RFTireChange,
+          PitSvTireCompound: 0,
+          PlayerTireCompound: 0,
+        }),
+      ),
+    ).toMatchObject({ compoundChange: null });
+  });
+});
 
 describe("diffPitReadback — seeding", () => {
   it("does not emit anything on the first tick when off pit road", () => {
@@ -61,7 +112,7 @@ describe("diffPitReadback — seeding", () => {
 });
 
 describe("diffPitReadback — entry", () => {
-  it("emits 'entry' on the off→on transition", () => {
+  it("emits 'entry' with reason-only payload on the off→on transition", () => {
     const state = createInitialState();
     state.pitReadbackInitialized = true;
     state.pitReadbackPrevOnPitRoad = false;
@@ -81,69 +132,10 @@ describe("diffPitReadback — entry", () => {
 
     const readbacks = readbackEvents(events);
     expect(readbacks).toHaveLength(1);
-    expect(readbacks[0]?.data).toMatchObject({
-      reason: "entry",
-      fuel: { queued: true },
-      tires: { lf: true, rf: true, lr: false, rr: false },
-      limiterEngaged: false,
-    });
-  });
-
-  it("captures limiterEngaged from EngineWarnings", () => {
-    const state = createInitialState();
-    state.pitReadbackInitialized = true;
-    state.pitReadbackPrevOnPitRoad = false;
-    state.lastOnPitRoad = true;
-
-    const { events, emit } = collect();
-    diffPitReadback(state, tick({ EngineWarnings: EngineWarnings.PitSpeedLimiter }), 0, emit, []);
-
-    expect(readbackEvents(events)[0]?.data).toMatchObject({ limiterEngaged: true });
-  });
-
-  it("captures compound change when queued compound differs from player", () => {
-    const state = createInitialState();
-    state.pitReadbackInitialized = true;
-    state.pitReadbackPrevOnPitRoad = false;
-    state.lastOnPitRoad = true;
-
-    const { events, emit } = collect();
-    diffPitReadback(
-      state,
-      tick({
-        PitSvFlags:
-          PitSvFlags.LFTireChange | PitSvFlags.RFTireChange | PitSvFlags.LRTireChange | PitSvFlags.RRTireChange,
-        PitSvTireCompound: 1,
-        PlayerTireCompound: 0,
-      }),
-      0,
-      emit,
-      [],
-    );
-
-    expect(readbackEvents(events)[0]?.data).toMatchObject({ compoundChange: { from: 0, to: 1 } });
-  });
-
-  it("does not flag a compound change when the queued compound matches the fitted compound", () => {
-    const state = createInitialState();
-    state.pitReadbackInitialized = true;
-    state.pitReadbackPrevOnPitRoad = false;
-    state.lastOnPitRoad = true;
-
-    const { events, emit } = collect();
-    diffPitReadback(
-      state,
-      tick({
-        PitSvFlags: PitSvFlags.LFTireChange | PitSvFlags.RFTireChange,
-        PitSvTireCompound: 0,
-        PlayerTireCompound: 0,
-      }),
-      0,
-      emit,
-      [],
-    );
-
-    expect(readbackEvents(events)[0]?.data).toMatchObject({ compoundChange: null });
+    // Issue #481: the event payload carries only `reason`. The
+    // queued-services snapshot is read at fire time by the audio side
+    // via `getReadbackSnapshot()`, so it doesn't ride on the event.
+    expect(readbacks[0]?.data).toEqual({ reason: "entry" });
   });
 });
 
@@ -161,7 +153,7 @@ describe("diffPitReadback — refire", () => {
 
     const readbacks = readbackEvents(events);
     expect(readbacks).toHaveLength(1);
-    expect(readbacks[0]?.data).toMatchObject({ reason: "entry-refire", fuel: { queued: true } });
+    expect(readbacks[0]?.data).toEqual({ reason: "entry-refire" });
   });
 
   it("does not emit when no user toggle event was queued", () => {
@@ -205,7 +197,7 @@ describe("diffPitReadback — exit", () => {
     expect(state.pitReadbackExitFireAt).toBe(1000 + PIT_READBACK_EXIT_DELAY_MS);
   });
 
-  it("emits the exit readback with FRESH telemetry once the delay has elapsed", () => {
+  it("emits 'exit' once the delay has elapsed", () => {
     const state = createInitialState();
     state.pitReadbackInitialized = true;
     state.pitReadbackPrevOnPitRoad = false;
@@ -214,38 +206,15 @@ describe("diffPitReadback — exit", () => {
     state.lastOnPitRoad = false;
 
     const { events, emit } = collect();
-    // Telemetry at fire moment shows fuel still queued (e.g. user just
-    // toggled it back on while sitting in pit, or kept it queued for
-    // the next stop). The exit recap reflects this CURRENT state, not
-    // a frozen snapshot from earlier in the visit.
     diffPitReadback(state, tick({ PitSvFlags: PitSvFlags.FuelFill }), fireDeadline, emit, []);
 
     const readbacks = readbackEvents(events);
     expect(readbacks).toHaveLength(1);
-    expect(readbacks[0]?.data).toMatchObject({ reason: "exit", fuel: { queued: true } });
+    // Issue #481: the audio side reads queued-services state fresh at
+    // fire time via `getReadbackSnapshot()`. The diff just emits the
+    // trigger reason.
+    expect(readbacks[0]?.data).toEqual({ reason: "exit" });
     expect(state.pitReadbackExitFireAt).toBe(0);
-  });
-
-  it("emits an empty exit recap when nothing is queued at fire time", () => {
-    const state = createInitialState();
-    state.pitReadbackInitialized = true;
-    state.pitReadbackPrevOnPitRoad = false;
-    const fireDeadline = 1000 + PIT_READBACK_EXIT_DELAY_MS;
-    state.pitReadbackExitFireAt = fireDeadline;
-    state.lastOnPitRoad = false;
-
-    const { events, emit } = collect();
-    // All bits cleared by the time the exit fire elapses — the user
-    // toggled tires off mid-stall, fuel was completed, etc.
-    diffPitReadback(state, tick({ PitSvFlags: 0 }), fireDeadline, emit, []);
-
-    const readbacks = readbackEvents(events);
-    expect(readbacks).toHaveLength(1);
-    expect(readbacks[0]?.data).toMatchObject({
-      reason: "exit",
-      fuel: { queued: false },
-      tires: { lf: false, rf: false, lr: false, rr: false },
-    });
   });
 
   it("does not emit while the delay is still running", () => {
@@ -289,7 +258,7 @@ describe("diffPitReadback — exit", () => {
     // the full shape (length + reason) catches a regression where both
     // exit and entry fire in the same tick.
     expect(readbacks).toHaveLength(1);
-    expect(readbacks[0]?.data).toMatchObject({ reason: "entry" });
+    expect(readbacks[0]?.data).toEqual({ reason: "entry" });
     expect(state.pitReadbackExitFireAt).toBe(0);
   });
 });

--- a/packages/sim-events-iracing/src/diff/pit-readback.ts
+++ b/packages/sim-events-iracing/src/diff/pit-readback.ts
@@ -1,27 +1,23 @@
 /**
- * Pit-service readback diff (issue #476).
+ * Pit-service readback diff (issue #476, #481).
  *
- * Emits `pitService.readbackRequested` at three moments during a pit stop,
- * each carrying a committed snapshot of the queued services so the
- * downstream `pit-readback-{entry,exit}` audio scenarios stay pure (no
- * live telemetry reads from inside the DSL):
+ * Emits `pitService.readbackRequested` at three moments during a pit stop:
  *
  *   - "entry"        — `OnPitRoad` off→on transition. The engineer starts
  *                      the readback as the car rolls onto pit road.
  *   - "entry-refire" — any user-intent pit-service toggle while still on
  *                      pit road. The running readback (family
- *                      `"pit-readback"`) is preempted and replaced with
- *                      the new snapshot.
+ *                      `"pit-readback"`) is preempted and replaced.
  *   - "exit"         — `OnPitRoad` on→off, plus `PIT_READBACK_EXIT_DELAY_MS`
  *                      settle delay so the "to confirm" beat doesn't
  *                      collide with the limiter / pit-exit chatter.
  *
- * Snapshot capture is decoupled from live telemetry at exit: `committed`
- * is captured on entry and refreshed on every user-intent toggle event,
- * but never on bit-cleared transitions (which represent the crew finishing
- * service, not the driver un-queueing). At exit time we reuse the last
- * committed snapshot so the readback faithfully recaps what was queued —
- * even though `PitSvFlags` itself has cleared.
+ * Issue #481: the queued-services snapshot is NOT carried on the event
+ * payload anymore — only the trigger `reason` is. Audio scenarios pull a
+ * fresh snapshot from `getReadbackSnapshot()` at fire time so the recap
+ * reflects current telemetry even when the scenario engine deferred the
+ * fire (busy-bus low-priority hold, urgent-flag preemption that stashes
+ * the readback for replay, or in-stall toggling between emit and replay).
  *
  * User-intent detection: this module runs after `diffToggles` in the
  * tick pipeline, so it inspects the per-tick `pending` queue for
@@ -30,9 +26,10 @@
  * stall branch in `diffToggles` silently absorbs the crew's bit-clears),
  * which is exactly the signal we want.
  */
+import type { PitReadbackSnapshot } from "@iracedeck/event-bus";
 import { EngineWarnings, PaceMode, PitSvFlags, SessionState, type TelemetryData } from "@iracedeck/iracing-sdk";
 
-import type { PitReadbackCommittedSnapshot, TranslatorState } from "../state.js";
+import type { TranslatorState } from "../state.js";
 import type { EmitFn, PendingEvent } from "./types.js";
 
 /**
@@ -82,7 +79,12 @@ function isInPreStart(telemetry: TelemetryData): boolean {
 const TIRE_FLAGS_MASK =
   PitSvFlags.LFTireChange | PitSvFlags.RFTireChange | PitSvFlags.LRTireChange | PitSvFlags.RRTireChange;
 
-function buildSnapshot(telemetry: TelemetryData): PitReadbackCommittedSnapshot {
+/**
+ * Build the queued-services snapshot from current telemetry. Public so
+ * the translator's `getReadbackSnapshot()` can reuse it — audio scenarios
+ * call that resolver at fire time (issue #481).
+ */
+export function buildSnapshot(telemetry: TelemetryData): PitReadbackSnapshot {
   const flags = telemetry.PitSvFlags ?? 0;
   const compound = telemetry.PitSvTireCompound ?? 0;
   const playerCompound = telemetry.PlayerTireCompound ?? 0;
@@ -118,12 +120,6 @@ function buildSnapshot(telemetry: TelemetryData): PitReadbackCommittedSnapshot {
   };
 }
 
-/**
- * @internal Exported for testing — confirms the snapshot shape the
- * readback scenarios consume.
- */
-export { buildSnapshot };
-
 const USER_TOGGLE_EVENTS = new Set<PendingEvent["event"]>([
   "pitService.toggled",
   "tireService.changed",
@@ -157,15 +153,11 @@ export function diffPitReadback(
 
   // Pending pre-start fire whose delay has elapsed? Only fires while still
   // in pre-start — if the user dropped out (e.g. left the car / session
-  // changed) the queued readback is dropped silently. Reads telemetry
-  // FRESH at fire time so a user toggle during the 5 s grid window
-  // (when pit-action confirmations are muted) is still reflected.
+  // changed) the queued readback is dropped silently. The snapshot itself
+  // is read fresh by the audio scenario at fire time via the resolver
+  // closure (issue #481).
   if (state.pitReadbackPreStartFireAt > 0 && now >= state.pitReadbackPreStartFireAt && inPreStart) {
-    const preStartSnap = buildSnapshot(telemetry);
-    emit({
-      event: "pitService.readbackRequested",
-      data: { reason: "entry", ...preStartSnap },
-    });
+    emit({ event: "pitService.readbackRequested", data: { reason: "entry" } });
     state.pitReadbackPreStartFireAt = 0;
   } else if (state.pitReadbackPreStartFireAt > 0 && !inPreStart) {
     // Left pre-start before the timer elapsed — cancel.
@@ -179,36 +171,23 @@ export function diffPitReadback(
     // deadline AND off→on re-entry fires only the entry readback, never
     // both in the same tick.
     state.pitReadbackExitFireAt = 0;
-
-    const snap = buildSnapshot(telemetry);
-    emit({ event: "pitService.readbackRequested", data: { reason: "entry", ...snap } });
+    emit({ event: "pitService.readbackRequested", data: { reason: "entry" } });
   } else if (onPitRoad && pending.some((p) => USER_TOGGLE_EVENTS.has(p.event))) {
     // While on pit road, any user-intent toggle event refires the
     // readback. Family preemption (`family: "pit-readback"`) cuts the
     // in-flight readback cleanly.
-    const snap = buildSnapshot(telemetry);
-    emit({ event: "pitService.readbackRequested", data: { reason: "entry-refire", ...snap } });
+    emit({ event: "pitService.readbackRequested", data: { reason: "entry-refire" } });
   } else if (wasOnPitRoad && !onPitRoad) {
-    // On → off: schedule the delayed "to confirm" fire. The snapshot is
-    // built fresh at fire time so a user toggle late in the visit
-    // (e.g. cancelling tires while sitting in the box) is reflected
-    // in the recap. Pit-action confirmations stay silent for the same
-    // window so they don't blurt over the pending readback.
+    // On → off: schedule the delayed "to confirm" fire. Pit-action
+    // confirmations stay silent for the same window so they don't blurt
+    // over the pending readback.
     state.pitReadbackExitFireAt = now + PIT_READBACK_EXIT_DELAY_MS;
 
     state.pitActionCooldownUntil = Math.max(state.pitActionCooldownUntil, now + PIT_READBACK_EXIT_DELAY_MS);
   } else if (state.pitReadbackExitFireAt > 0 && now >= state.pitReadbackExitFireAt && !onPitRoad) {
     // Pending exit fire whose delay has elapsed AND the car is still
-    // off pit road (i.e. no re-entry happened first). Reads telemetry
-    // FRESH at fire time — the user might have toggled services after
-    // pulling out of the stall, so the recap reflects what's actually
-    // queued at the moment the engineer speaks rather than a frozen
-    // snapshot from earlier in the visit.
-    const exitSnap = buildSnapshot(telemetry);
-    emit({
-      event: "pitService.readbackRequested",
-      data: { reason: "exit", ...exitSnap },
-    });
+    // off pit road (i.e. no re-entry happened first).
+    emit({ event: "pitService.readbackRequested", data: { reason: "exit" } });
     state.pitReadbackExitFireAt = 0;
   }
 

--- a/packages/sim-events-iracing/src/index.ts
+++ b/packages/sim-events-iracing/src/index.ts
@@ -9,6 +9,7 @@
 export {
   _resetSimEventsIracing,
   getLatestTelemetry,
+  getReadbackSnapshot,
   getSessionType,
   initializeSimEventsIracing,
   isPitActionsAllowed,

--- a/packages/sim-events-iracing/src/state.ts
+++ b/packages/sim-events-iracing/src/state.ts
@@ -19,23 +19,6 @@ export type ServiceDebounceState = {
   lastSeen: boolean; // most recent observed bit value
 };
 
-/**
- * Committed pit-service snapshot used by the pit-readback diff (issue #476).
- * Captured on `pitLane.entered` and refreshed on every user-intent toggle
- * event (`pitService.toggled` / `tireService.changed` / `tireService.compoundChanged`)
- * so it reflects the driver's intent — not the bit-cleared post-service
- * state visible at exit. Held in state so the delayed pit-exit fire reads
- * the same snapshot the entry / refire emits used.
- */
-export type PitReadbackCommittedSnapshot = {
-  fuel: { queued: boolean };
-  tires: { lf: boolean; rf: boolean; lr: boolean; rr: boolean };
-  compoundChange: { from: number; to: number } | null;
-  fastRepair: { queued: boolean; available: boolean };
-  windshield: { queued: boolean; available: boolean };
-  limiterEngaged: boolean;
-};
-
 export type TranslatorState = {
   // ── Pit lane / stall ────────────────────────────────────────────────────
   pitLaneInitialized: boolean;

--- a/packages/sim-events-iracing/src/translator.ts
+++ b/packages/sim-events-iracing/src/translator.ts
@@ -17,7 +17,7 @@
  *   - On disconnect it resets per-tick state so a later reconnect
  *     doesn't replay stale transitions.
  */
-import type { IEventBus, SimEventMap, SimEventName } from "@iracedeck/event-bus";
+import type { IEventBus, PitReadbackSnapshot, SimEventMap, SimEventName } from "@iracedeck/event-bus";
 import type { SDKController, TelemetryData } from "@iracedeck/iracing-sdk";
 import { type ILogger, silentLogger } from "@iracedeck/logger";
 
@@ -28,7 +28,7 @@ import { diffLifecycle } from "./diff/lifecycle.js";
 import { diffLimiter } from "./diff/limiter.js";
 import { diffOvertakes } from "./diff/overtakes.js";
 import { diffPitLane } from "./diff/pit-lane.js";
-import { diffPitReadback } from "./diff/pit-readback.js";
+import { buildSnapshot as buildReadbackSnapshot, diffPitReadback } from "./diff/pit-readback.js";
 import { diffRadar } from "./diff/radar.js";
 import { diffToggles } from "./diff/toggles.js";
 import type { PendingEvent } from "./diff/types.js";
@@ -130,6 +130,24 @@ export function isPitActionsAllowed(): boolean {
   if (!instance) return true;
 
   return Date.now() >= instance.state.pitActionCooldownUntil;
+}
+
+/**
+ * Build a pit-readback snapshot from the latest telemetry tick (issue
+ * #481). Returns `null` if no telemetry has arrived yet — callers (the
+ * audio scenarios, via the resolver passed into `registerPitCrew`)
+ * treat null as "no queued services known", which collapses to the
+ * empty-fallback recap rather than speaking a stale or fabricated plan.
+ *
+ * Read at fire time so a deferred readback (busy-bus low-priority hold
+ * or higher-priority preempt that stashed the readback for replay)
+ * speaks the user's *current* queue, not the queue from the moment the
+ * `pitService.readbackRequested` event was emitted.
+ */
+export function getReadbackSnapshot(): PitReadbackSnapshot | null {
+  if (!instance || !instance.latestTelemetry) return null;
+
+  return buildReadbackSnapshot(instance.latestTelemetry);
 }
 
 /**


### PR DESCRIPTION
## Related Issue

Fixes #481

## What changed?

The pit-readback's queued-services snapshot used to ride on the
`pitService.readbackRequested` event payload, captured at emit time. When
the scenario engine deferred a low-priority readback (busy-bus stash or
higher-priority preempt that parked the event in `deferredLowFire`), the
replay walked the same frozen snapshot and spoke a stale plan — most
visibly when the user toggled tires while a readback was mid-playback
and the readback restarted with the pre-toggle tire state.

This PR adopts the issue's recommended fix (sketch #1):

- Slim `pitService.readbackRequested` to carry only `{ reason }`. The
  shared `PitReadbackSnapshot` type moves to `@iracedeck/event-bus`.
- Expose `getReadbackSnapshot()` from `@iracedeck/sim-events-iracing` —
  builds a fresh snapshot from the latest telemetry tick via the
  existing `buildSnapshot`.
- Refactor the readback scenarios to take a snapshot resolver closure;
  every conditional `if` predicate calls it at fire time, so a deferred
  replay walks the **current** queued-services state.
- Wire the resolver through `registerPitCrew(...)` to both plugins
  (`iracing-plugin-stream-deck`, `iracing-plugin-mirabox`) and the
  scenario harness.

Also: adds two regression tests in `readback.test.ts` covering the two
deferral paths (busy-bus low-priority hold; preempted-and-stashed by a
normal-priority pit-action), plus a focused `buildSnapshot` test in
`pit-readback.test.ts` (the snapshot-shape coverage previously rode on
the entry-event payload assertions, which are now `{ reason }`-only).

## How to test

- `pnpm test` — 3555 tests pass, including the two new deferred-replay
  freshness tests.
- `pnpm build` — full workspace build green.
- Manual repro of the original bug:
  1. On pit road with tires-all + fuel queued, fire a readback.
  2. While the readback is mid-playback, toggle tires off (or to a
     different pattern).
  3. Confirm the replay speaks the **post-toggle** tire state, not the
     original one.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pit readback scenarios now dynamically resolve current queued-services state at fire time for more accurate readback behavior.

* **Bug Fixes**
  * Fixed pit readback to use fresh state when handling deferred or delayed replay scenarios.

* **Refactor**
  * Simplified pit readback event payload to contain only trigger reason.

* **Tests**
  * Added regression coverage for deferred pit readback scenarios and snapshot freshness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->