### PR TITLE
fix(sim-events-iracing): clear-tires no longer mis-fires compound callout (#484)

### DIFF
--- a/packages/sim-events-iracing/src/diff/toggles.ts
+++ b/packages/sim-events-iracing/src/diff/toggles.ts
@@ -182,9 +182,18 @@ export function diffToggles(state: TranslatorState, telemetry: TelemetryData, no
   // absorb the cascading tire-set diff so the compound voice line is the
   // single canonical confirmation (otherwise the engineer would also call
   // out "all four tires" 500 ms later).
+  //
+  // Issue #484: a "clear tires" press also flips the compound bit (iRacing
+  // resets compound to the car default as a side-effect of clearing pit
+  // service) but with `currTireBits === 0` instead of `TIRE_FLAGS_MASK`.
+  // That isn't a user-initiated compound change — it's a consequence of
+  // the clear — so emitting "switching to dry" would be misleading and
+  // would also suppress the legitimate "tires cleared" callout. Gate the
+  // compound emit on the all-four-tires cascade so only genuine user
+  // compound flips fire the compound voice line.
   let compoundJustChanged = false;
 
-  if (state.lastPitSvCompound !== pitSvCompound) {
+  if (state.lastPitSvCompound !== pitSvCompound && currTireBits === TIRE_FLAGS_MASK) {
     emit({
       event: "tireService.compoundChanged",
       data: { from: state.lastPitSvCompound, to: pitSvCompound },

--- a/packages/sim-events-iracing/src/translator.test.ts
+++ b/packages/sim-events-iracing/src/translator.test.ts
@@ -509,8 +509,16 @@ describe("sim-events-iracing translator", () => {
       bus.subscribe("tireService.compoundChanged", handler);
       initializeSimEventsIracing(bus, controller, createMockLogger());
 
-      controller.__tick(telemetry({ PitSvTireCompound: 0 }));
-      controller.__tick(telemetry({ PitSvTireCompound: 1 }));
+      const allTires =
+        PitSvFlags.LFTireChange | PitSvFlags.RFTireChange | PitSvFlags.LRTireChange | PitSvFlags.RRTireChange;
+
+      // iRacing always force-sets all four tire bits in the same tick as a
+      // user-initiated compound flip; the translator gates the
+      // compoundChanged emit on that cascade so an isolated compound bit
+      // change (e.g. side-effect of clear-tires, issue #484) does NOT
+      // mis-fire.
+      controller.__tick(telemetry({ PitSvFlags: 0, PitSvTireCompound: 0 }));
+      controller.__tick(telemetry({ PitSvFlags: allTires, PitSvTireCompound: 1 }));
 
       expect(handler).toHaveBeenCalledTimes(1);
       const ev = handler.mock.calls[0]![0] as SimEventOf<"tireService.compoundChanged">;
@@ -524,8 +532,11 @@ describe("sim-events-iracing translator", () => {
       bus.subscribe("tireService.compoundChanged", handler);
       initializeSimEventsIracing(bus, controller, createMockLogger());
 
-      controller.__tick(telemetry({ PitSvTireCompound: 1 }));
-      controller.__tick(telemetry({ PitSvTireCompound: 0 }));
+      const allTires =
+        PitSvFlags.LFTireChange | PitSvFlags.RFTireChange | PitSvFlags.LRTireChange | PitSvFlags.RRTireChange;
+
+      controller.__tick(telemetry({ PitSvFlags: allTires, PitSvTireCompound: 1 }));
+      controller.__tick(telemetry({ PitSvFlags: allTires, PitSvTireCompound: 0 }));
 
       expect(handler).toHaveBeenCalledTimes(1);
       const ev = handler.mock.calls[0]![0] as SimEventOf<"tireService.compoundChanged">;
@@ -607,6 +618,62 @@ describe("sim-events-iracing translator", () => {
       controller.__tick(telemetry({ PlayerCarInPitStall: true, PitSvTireCompound: 1 }));
 
       expect(handler).not.toHaveBeenCalled();
+    });
+
+    // Issue #484 — "clear tires" with a non-default compound queued.
+    // iRacing resets the compound bit back to the car default in the same
+    // tick that all four tire bits clear. That's a side-effect of the
+    // clear, not a user-initiated compound flip: emitting
+    // tireService.compoundChanged would mis-fire a "switching to dry"
+    // callout and would suppress the legitimate "tires cleared" event.
+    // The translator distinguishes the two cases by inspecting the
+    // post-tick tire bits — `TIRE_FLAGS_MASK` for a real compound flip,
+    // `0` for the clear cascade.
+    it("issue #484: clearing tires with a non-default compound suppresses compoundChanged and emits tireService.changed", () => {
+      const controller = createMockController();
+      const bus = getEventBus();
+      const compoundHandler = vi.fn();
+      const tireHandler = vi.fn();
+      bus.subscribe("tireService.compoundChanged", compoundHandler);
+      bus.subscribe("tireService.changed", tireHandler);
+      initializeSimEventsIracing(bus, controller, createMockLogger());
+
+      const allTires =
+        PitSvFlags.LFTireChange | PitSvFlags.RFTireChange | PitSvFlags.LRTireChange | PitSvFlags.RRTireChange;
+
+      // Seed: dry, no tires queued.
+      controller.__tick(telemetry({ PitSvFlags: 0, PitSvTireCompound: 0 }));
+      // User switches to wet — compound flips, all four tires force-set.
+      controller.__tick(telemetry({ PitSvFlags: allTires, PitSvTireCompound: 1 }));
+      // Past the tire debounce so any cascading tireService.changed would
+      // have surfaced by now.
+      vi.useFakeTimers();
+      vi.setSystemTime(Date.now() + 600);
+      controller.__tick(telemetry({ PitSvFlags: allTires, PitSvTireCompound: 1 }));
+
+      // Sanity: the genuine compound flip fired exactly once and was the
+      // sole tire-related event.
+      expect(compoundHandler).toHaveBeenCalledTimes(1);
+      expect(tireHandler).not.toHaveBeenCalled();
+
+      // User presses "clear tires". iRacing clears all four tire bits AND
+      // resets compound to the car default (0 / dry) in the same tick.
+      controller.__tick(telemetry({ PitSvFlags: 0, PitSvTireCompound: 0 }));
+      // Past the debounce so the cleared tires surface.
+      vi.setSystemTime(Date.now() + 600);
+      controller.__tick(telemetry({ PitSvFlags: 0, PitSvTireCompound: 0 }));
+      vi.useRealTimers();
+
+      // The clear must NOT count as a second compound flip — the user
+      // didn't switch back to dry, the clear reset it as a side-effect.
+      expect(compoundHandler).toHaveBeenCalledTimes(1);
+
+      // The clear must produce a tireService.changed with empty current
+      // (the "tires cleared" / "skip tires" callout fires off this).
+      expect(tireHandler).toHaveBeenCalledTimes(1);
+      const ev = tireHandler.mock.calls[0]![0] as SimEventOf<"tireService.changed">;
+      expect(ev.data.current).toEqual([]);
+      expect(ev.data.removed.sort()).toEqual(["LF", "LR", "RF", "RR"]);
     });
   });
 


### PR DESCRIPTION
## Related Issue

Fixes #484

## What changed?

Pressing "clear tires" while a non-default compound was queued caused
iRacing to reset the compound bit back to the car default in the same
tick that all four tire bits cleared. The translator treated that as a
genuine user-initiated compound flip and:

1. Emitted `tireService.compoundChanged` → engineer mis-spoke
   "switching to dry" instead of acknowledging the clear.
2. Suppressed the cascading `tireService.changed { current: [] }` under
   the same compound-flip absorption rule, so the legitimate "tires
   cleared" callout never fired.

The two cases differ at the data level: a real user-initiated compound
flip force-sets all four tire bits (`currTireBits === TIRE_FLAGS_MASK`);
the clear-tires side-effect leaves them at zero. The fix gates the
`tireService.compoundChanged` emit on the all-four-tires cascade so the
clear-tires path falls through to the regular tire-set diff and the
"tires cleared" callout fires.

Tests:
- Adds a translator test exercising the clear-tires-with-non-default-
  compound sequence end-to-end (compound-flip first, then clear, asserts
  exactly one compound event + one `tireService.changed { current: [] }`).
- Updates the existing dry↔wet compound tests to include the all-four-
  tires cascade so they reflect real iRacing behavior rather than the
  synthetic isolated-bit-flip case (which the new gating no longer
  honors).

## How to test

- `pnpm test` — 3556 tests pass, including the new #484 regression test.
- `pnpm build` — full workspace build green.
- Manual repro:
  1. In iRacing, queue a non-default tire compound (e.g. wet on a
     dry-default car). Engineer says "switching to wet".
  2. Press "clear tires" (or "clear all pit service").
  3. Engineer should now say "tires cleared" / "skip tires" — NOT
     "switching to dry".

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included