### PR TITLE
feat(actions): cycle Next/Prev Car via configurable keystroke (#492)

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -240,9 +240,9 @@
 
 | Action | Shortcut(s) | Available via SDK | iRacing Setting |
 |--------|-------------|-------------------|-----------------|
-| Cycle Camera | Shift+C / C | Yes | Next Camera / Previous Camera |
-| Cycle Sub Camera | Shift+B / B | Yes | Next Sub Camera / Previous Sub Camera |
-| Cycle Car | Shift+V / V | Yes | Next Car / Previous Car |
+| Cycle Camera | C / Shift+C | Yes | Next Camera / Previous Camera |
+| Cycle Sub Camera | B / Shift+B | Yes | Next Sub Camera / Previous Sub Camera |
+| Cycle Car | V / Shift+V | Yes | Next Car / Previous Car |
 | Focus on Your Car | Ctrl+V | Yes | Your Car |
 | Cycle Driving Camera | PageDown / PageUp | Yes | Next Driving Camera / Previous Driving Camera |
 | Recenter Head Mounted Display | ; | No | Recenter Head Mounted Display |

--- a/packages/iracing-actions/src/actions/data/key-bindings.json
+++ b/packages/iracing-actions/src/actions/data/key-bindings.json
@@ -959,6 +959,10 @@
       "setting": "spotterSilence"
     }
   ],
+  "replayControl": [
+    { "id": "nextCar", "label": "Next Car", "default": "V", "setting": "replayControlNextCar" },
+    { "id": "prevCar", "label": "Previous Car", "default": "Shift+V", "setting": "replayControlPrevCar" }
+  ],
   "audioControls": [
     {
       "id": "pushToTalk",

--- a/packages/iracing-actions/src/actions/replay-control/replay-control.ejs
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.ejs
@@ -95,6 +95,7 @@
 
 		<%- include('section-header', { title: 'Global Settings' }) %>
 
+		<%- include('global-key-bindings', { keyBindings: require('./data/key-bindings.json').replayControl }) %>
 		<%- include('global-title-defaults') %>
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>

--- a/packages/iracing-actions/src/actions/replay-control/replay-control.test.ts
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.test.ts
@@ -124,6 +124,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     setRegenerateCallback = vi.fn();
     updateKeyImage = vi.fn();
     setActiveBinding = vi.fn();
+    tapBinding = vi.fn().mockResolvedValue(undefined);
     async onWillAppear() {}
     async onDidReceiveSettings() {}
     async onWillDisappear() {}
@@ -1071,6 +1072,91 @@ describe("ReplayControl", () => {
         expect((action as any).replaySpeed.get("ctx-1")).toBe(0);
         expect((action as any).replaySlowMotion.get("ctx-1")).toBe(false);
       });
+    });
+  });
+
+  describe("car cycling (keystroke dispatch)", () => {
+    function fakeEvent(actionId: string, settings: Record<string, unknown> = {}) {
+      return {
+        action: { id: actionId, setTitle: vi.fn(), setImage: vi.fn() },
+        payload: { settings },
+      };
+    }
+
+    let action: ReplayControl;
+
+    beforeEach(async () => {
+      vi.clearAllMocks();
+      action = new ReplayControl();
+    });
+
+    it("next-car onKeyDown taps the replayControlNextCar global binding", async () => {
+      await action.onWillAppear(fakeEvent("ctx-1", { mode: "next-car" }) as any);
+      await action.onKeyDown(fakeEvent("ctx-1", { mode: "next-car" }) as any);
+
+      expect(action.tapBinding).toHaveBeenCalledWith("replayControlNextCar");
+    });
+
+    it("prev-car onKeyDown taps the replayControlPrevCar global binding", async () => {
+      await action.onWillAppear(fakeEvent("ctx-1", { mode: "prev-car" }) as any);
+      await action.onKeyDown(fakeEvent("ctx-1", { mode: "prev-car" }) as any);
+
+      expect(action.tapBinding).toHaveBeenCalledWith("replayControlPrevCar");
+    });
+
+    it("next-car does NOT consult telemetry for car selection", async () => {
+      // Arrange: telemetry that would normally be inspected by the legacy path
+      action.sdkController.getCurrentTelemetry = vi.fn(() => ({
+        CamCarIdx: 0,
+        CarIdxLapDistPct: [0.1, 0.2],
+        CarIdxOnPitRoad: [false, false],
+        CarIdxTrackSurface: [TrkLoc.OnTrack, TrkLoc.OnTrack],
+      }));
+
+      await action.onWillAppear(fakeEvent("ctx-1", { mode: "next-car" }) as any);
+      await action.onKeyDown(fakeEvent("ctx-1", { mode: "next-car" }) as any);
+
+      // No camera.switchNum call — keystroke is the only dispatch.
+      const { getCommands } = await import("@iracedeck/deck-core");
+      const cameraMock = vi.mocked(getCommands)().camera as unknown as { switchNum: ReturnType<typeof vi.fn> };
+      expect(cameraMock.switchNum).not.toHaveBeenCalled();
+    });
+
+    it("dial rotation on next-car routes through the keystroke path", async () => {
+      await action.onWillAppear(fakeEvent("ctx-1", { mode: "next-car" }) as any);
+
+      await action.onDialRotate({
+        action: { id: "ctx-1", setTitle: vi.fn(), setImage: vi.fn() },
+        payload: { settings: { mode: "next-car" }, ticks: 1 },
+      } as any);
+
+      expect(action.tapBinding).toHaveBeenCalledWith("replayControlNextCar");
+    });
+
+    it("dial counter-rotation on next-car taps the prev-car binding", async () => {
+      await action.onWillAppear(fakeEvent("ctx-1", { mode: "next-car" }) as any);
+
+      await action.onDialRotate({
+        action: { id: "ctx-1", setTitle: vi.fn(), setImage: vi.fn() },
+        payload: { settings: { mode: "next-car" }, ticks: -1 },
+      } as any);
+
+      expect(action.tapBinding).toHaveBeenCalledWith("replayControlPrevCar");
+    });
+
+    it("declares the active binding so readiness tracking matches the configured key", async () => {
+      await action.onWillAppear(fakeEvent("ctx-1", { mode: "next-car" }) as any);
+
+      expect(action.setActiveBinding).toHaveBeenCalledWith("replayControlNextCar");
+    });
+
+    it("clears the active binding when switched to a non-keystroke mode", async () => {
+      await action.onWillAppear(fakeEvent("ctx-1", { mode: "next-car" }) as any);
+      vi.mocked(action.setActiveBinding).mockClear();
+
+      await action.onDidReceiveSettings(fakeEvent("ctx-1", { mode: "next-session" }) as any);
+
+      expect(action.setActiveBinding).toHaveBeenCalledWith(null);
     });
   });
 

--- a/packages/iracing-actions/src/actions/replay-control/replay-control.ts
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.ts
@@ -168,6 +168,22 @@ const DIRECTIONAL_PAIRS: Partial<Record<ReplayControlMode, { next: ReplayControl
   "prev-car-number": { next: "next-car-number", prev: "prev-car-number" },
 };
 
+/**
+ * @internal Exported for testing
+ *
+ * Global setting keys for the configurable car-cycle keystrokes.
+ * The defaults (V / Shift+V) are declared in
+ * `packages/iracing-actions/src/actions/data/key-bindings.json` under `replayControl`.
+ */
+export const NEXT_CAR_BINDING_KEY = "replayControlNextCar";
+export const PREV_CAR_BINDING_KEY = "replayControlPrevCar";
+
+/** Modes that depend on a global key binding (rather than an SDK command). */
+const KEYSTROKE_MODES: Partial<Record<ReplayControlMode, string>> = {
+  "next-car": NEXT_CAR_BINDING_KEY,
+  "prev-car": PREV_CAR_BINDING_KEY,
+};
+
 /** Modes whose display changes based on telemetry state */
 const TELEMETRY_DISPLAY_MODES: ReadonlySet<ReplayControlMode> = new Set([
   "play-pause",
@@ -479,6 +495,7 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
     await super.onWillAppear(ev);
     const settings = this.parseSettings(ev.payload.settings);
     this.activeContexts.set(ev.action.id, settings);
+    this.setActiveBinding(KEYSTROKE_MODES[settings.mode] ?? null);
 
     // Seed initial state from current telemetry
     const current = this.sdkController.getCurrentTelemetry();
@@ -521,6 +538,7 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
     this.repeat.clear(ev.action.id);
     const settings = this.parseSettings(ev.payload.settings);
     this.activeContexts.set(ev.action.id, settings);
+    this.setActiveBinding(KEYSTROKE_MODES[settings.mode] ?? null);
     await this.updateDisplay(ev, settings);
   }
 
@@ -926,45 +944,16 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
         break;
       }
       case "next-car": {
-        const nextCarIdx = this.findAdjacentCarOnTrack("ahead");
-
-        if (nextCarIdx === null) {
-          this.logger.warn("No car found ahead on track");
-          break;
-        }
-
-        const nextCarNum = this.getCarNumberRawByIdx(nextCarIdx);
-
-        if (nextCarNum === null) {
-          this.logger.warn("Could not find car number for next car");
-          break;
-        }
-
-        const camera = getCommands().camera;
-        const success = camera.switchNum(nextCarNum, 0, 0);
-        this.logger.info("Next car executed");
-        this.logger.debug(`Result: ${success}, carNum: ${nextCarNum}`);
+        // Send the configured keystroke (default: V) so iRacing's own car-ordering
+        // drives the cycle. Telemetry-driven selection picks the wrong driver during
+        // replay-while-towed, where CamCarIdx reflects the live field.
+        void this.tapBinding(NEXT_CAR_BINDING_KEY);
+        this.logger.info("Next car executed (keystroke)");
         break;
       }
       case "prev-car": {
-        const prevCarIdx = this.findAdjacentCarOnTrack("behind");
-
-        if (prevCarIdx === null) {
-          this.logger.warn("No car found behind on track");
-          break;
-        }
-
-        const prevCarNum = this.getCarNumberRawByIdx(prevCarIdx);
-
-        if (prevCarNum === null) {
-          this.logger.warn("Could not find car number for previous car");
-          break;
-        }
-
-        const camera = getCommands().camera;
-        const success = camera.switchNum(prevCarNum, 0, 0);
-        this.logger.info("Previous car executed");
-        this.logger.debug(`Result: ${success}, carNum: ${prevCarNum}`);
+        void this.tapBinding(PREV_CAR_BINDING_KEY);
+        this.logger.info("Previous car executed (keystroke)");
         break;
       }
       case "next-car-number":

--- a/packages/website/src/content/docs/docs/actions/view-camera/replay-control.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/replay-control.md
@@ -357,12 +357,12 @@ Jump the replay camera to your own car.
 
 ### Next Car
 
-Switch the replay camera to the next car ahead on track. Skips cars currently on pit road.
+Switch the replay camera to the next car. Defers to iRacing's own car-ordering by sending the configured keystroke, so cycling stays correct in live and replay (including replay-while-towed, where telemetry-driven selection picks the wrong driver).
 
 #### Details
 
-- **Dial:** Rotation cycles cars on track (clockwise = next ahead, counter-clockwise = previous behind)
-- **Default binding:** No keyboard binding
+- **Dial:** Clockwise sends Next Car, counter-clockwise sends Previous Car
+- **Default binding:** `V`
 - **Telemetry-aware icon:** No
 
 #### Settings
@@ -373,12 +373,12 @@ Switch the replay camera to the next car ahead on track. Skips cars currently on
 
 ### Previous Car
 
-Switch the replay camera to the next car behind on track. Skips cars currently on pit road.
+Switch the replay camera to the previous car. Defers to iRacing's own car-ordering by sending the configured keystroke, so cycling stays correct in live and replay (including replay-while-towed).
 
 #### Details
 
-- **Dial:** Rotation cycles cars on track (clockwise = next ahead, counter-clockwise = previous behind)
-- **Default binding:** No keyboard binding
+- **Dial:** Clockwise sends Next Car, counter-clockwise sends Previous Car
+- **Default binding:** `Shift+V`
 - **Telemetry-aware icon:** No
 
 #### Settings

--- a/packages/website/src/content/docs/docs/reference/keyboard-shortcuts.md
+++ b/packages/website/src/content/docs/docs/reference/keyboard-shortcuts.md
@@ -154,9 +154,9 @@ Actions marked "Available via SDK" use SDK commands directly and don't require k
 
 | Action | Default Shortcut | Available via SDK | iRacing Setting |
 |--------|-----------------|-------------------|-----------------|
-| Cycle Camera | Shift+C / C | Yes | Next / Previous Camera |
-| Cycle Sub Camera | Shift+B / B | Yes | Next / Previous Sub Camera |
-| Cycle Car | Shift+V / V | Yes | Next / Previous Car |
+| Cycle Camera | C / Shift+C | Yes | Next / Previous Camera |
+| Cycle Sub Camera | B / Shift+B | Yes | Next / Previous Sub Camera |
+| Cycle Car | V / Shift+V | Yes | Next / Previous Car |
 | Focus on Your Car | Ctrl+V | Yes | Your Car |
 | Cycle Driving Camera | PageDown / PageUp | Yes | Next / Previous Driving Camera |
 


### PR DESCRIPTION
## Related Issue

Fixes #492

## What changed?

Replay Control's **Next Car** / **Previous Car** modes used to select the physically-nearest car from live telemetry (`CarIdxLapDistPct`). During replay-while-towed that picks the wrong driver — telemetry reflects the live field while the replay shows a situation from minutes earlier. Now both modes defer to iRacing's own car-ordering by sending a configurable keystroke (default **V** / **Shift+V**), so cycling stays correct in live and replay.

- New global key bindings: `replayControlNextCar` (default `V`), `replayControlPrevCar` (default `Shift+V`).
- `replay-control.ts`: `next-car` / `prev-car` cases now `void this.tapBinding(...)`; `setActiveBinding` tracks the configured binding so the readiness overlay matches.
- `replay-control.ejs`: includes the `global-key-bindings` partial under Global Settings, exposing both bindings via `ird-key-binding`.
- The legacy `findAdjacentCarOnTrack` helper stays — it still backs the `jump-to-my-car` encoder rotation.

### Sub-task: docs flip

Fixed the V/Shift+V column flip in `docs/keyboard-shortcuts.md` (the issue's main complaint) and its website mirror. Same flip was present on Cycle Camera (C/Shift+C) and Cycle Sub Camera (B/Shift+B); fixed both alongside per the issue's spot-check ask.

### Tests

7 new tests in `replay-control.test.ts` cover keystroke dispatch, no telemetry consultation, dial routing through the keystroke path, and the active-binding lifecycle on mode switch. Existing 121 tests untouched and passing.

## How to test

1. `pnpm install && pnpm build` — both Stream Deck and Mirabox plugins build clean.
2. `npx vitest run` from the repo root — 3583 tests pass, including the 7 new keystroke-dispatch tests.
3. In Stream Deck (with iRacing running, in or out of replay): set a button to **Replay Control → Next Car**. Confirm the PI shows the new "Global Settings → Next Car / Previous Car" key-binding inputs with `V` / `Shift+V` defaults. Pressing the button should cycle exactly as iRacing's V/Shift+V do — including correctly during replay-while-towed.
4. Change the binding in the PI (e.g., `Ctrl+V` → `Ctrl+Shift+V`) and confirm the new keystroke fires; matching iRacing binding must be set in iRacing's controls UI.
5. On a Stream Deck+ encoder mapped to Next Car: rotate clockwise → next, counter-clockwise → previous. Pushing the dial fires Next.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — both plugins compile the same `replay-control.ejs` and consume the same global-bindings JSON, so both PIs include the new inputs (verified in compiled `ui/replay-control.html`)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for replay car navigation: `V` cycles to the next car and `Shift+V` to the previous car

* **Documentation**
  * Updated keyboard shortcuts reference with new replay navigation keybindings
  * Updated replay control documentation to describe keystroke-based car cycling behavior for live and replay scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->