### PR TITLE
feat(actions/race-admin): add "Type in Chat" driver-target mode (#491)

### DIFF
--- a/packages/deck-core/src/clipboard-service.test.ts
+++ b/packages/deck-core/src/clipboard-service.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { _resetClipboard, getClipboard, initializeClipboard, isClipboardInitialized } from "./clipboard-service.js";
+
+const mockLogger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  withLevel: vi.fn(),
+  createScope: vi.fn(),
+};
+
+describe("Clipboard Service", () => {
+  beforeEach(() => {
+    _resetClipboard();
+    vi.clearAllMocks();
+  });
+
+  describe("initialization", () => {
+    it("starts uninitialized", () => {
+      expect(isClipboardInitialized()).toBe(false);
+    });
+
+    it("becomes initialized after initializeClipboard", () => {
+      initializeClipboard(mockLogger, () => true);
+      expect(isClipboardInitialized()).toBe(true);
+    });
+
+    it("throws if initialized twice", () => {
+      initializeClipboard(mockLogger, () => true);
+      expect(() => initializeClipboard(mockLogger, () => true)).toThrow(/already initialized/);
+    });
+
+    it("throws when getClipboard called before init", () => {
+      expect(() => getClipboard()).toThrow(/not initialized/);
+    });
+  });
+
+  describe("setClipboardText", () => {
+    it("returns true when writer succeeds", () => {
+      const writer = vi.fn().mockReturnValue(true);
+      initializeClipboard(mockLogger, writer);
+
+      const ok = getClipboard().setClipboardText("!clear ");
+
+      expect(ok).toBe(true);
+      expect(writer).toHaveBeenCalledTimes(1);
+      expect(writer).toHaveBeenCalledWith("!clear ");
+    });
+
+    it("returns false when writer returns false", () => {
+      const writer = vi.fn().mockReturnValue(false);
+      initializeClipboard(mockLogger, writer);
+
+      const ok = getClipboard().setClipboardText("test");
+
+      expect(ok).toBe(false);
+      expect(mockLogger.warn).toHaveBeenCalled();
+    });
+
+    it("returns false when no writer is configured", () => {
+      initializeClipboard(mockLogger);
+
+      const ok = getClipboard().setClipboardText("test");
+
+      expect(ok).toBe(false);
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringMatching(/no writer/i));
+    });
+
+    it("returns false when writer throws", () => {
+      const writer = vi.fn().mockImplementation(() => {
+        throw new Error("clipboard locked");
+      });
+      initializeClipboard(mockLogger, writer);
+
+      const ok = getClipboard().setClipboardText("test");
+
+      expect(ok).toBe(false);
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining("clipboard locked"));
+    });
+
+    it("preserves trailing whitespace in payload", () => {
+      const writer = vi.fn().mockReturnValue(true);
+      initializeClipboard(mockLogger, writer);
+
+      getClipboard().setClipboardText("!dq ");
+
+      expect(writer).toHaveBeenCalledWith("!dq ");
+    });
+  });
+});

--- a/packages/deck-core/src/clipboard-service.ts
+++ b/packages/deck-core/src/clipboard-service.ts
@@ -1,0 +1,132 @@
+/**
+ * Clipboard Service Singleton
+ *
+ * Provides a lazy-initialized singleton for writing text to the OS clipboard.
+ * The platform write is supplied at init time by the plugin entry point
+ * (typically `(text) => native.setClipboardText(text)` from
+ * `@iracedeck/iracing-native`), keeping deck-core platform-agnostic.
+ *
+ * Usage:
+ * 1. Call initializeClipboard() once at plugin startup
+ * 2. Use getClipboard() in your actions to write text to the clipboard
+ *
+ * @example
+ * // In plugin.ts (entry point)
+ * import { initializeClipboard } from "@iracedeck/deck-core";
+ * import { IRacingNative } from "@iracedeck/iracing-native";
+ *
+ * const native = new IRacingNative();
+ * initializeClipboard(logger, (text) => native.setClipboardText(text));
+ *
+ * // In action files
+ * import { getClipboard } from "@iracedeck/deck-core";
+ *
+ * if (getClipboard().setClipboardText("!clear ")) {
+ *   // ...send Ctrl+V via getKeyboard() to paste
+ * }
+ */
+import type { ILogger } from "@iracedeck/logger";
+import { silentLogger } from "@iracedeck/logger";
+
+/**
+ * Function type for writing text to the OS clipboard.
+ * Returns true on success, false on failure.
+ */
+export type ClipboardWriter = (text: string) => boolean;
+
+/**
+ * Interface for the clipboard service.
+ */
+export interface IClipboardService {
+  /**
+   * Write text to the OS clipboard.
+   * @param text - The text to place on the clipboard
+   * @returns true if successful, false otherwise
+   */
+  setClipboardText(text: string): boolean;
+}
+
+class ClipboardService implements IClipboardService {
+  private readonly logger: ILogger;
+  private readonly writer: ClipboardWriter | null;
+
+  constructor(logger: ILogger, writer: ClipboardWriter | null) {
+    this.logger = logger;
+    this.writer = writer;
+  }
+
+  setClipboardText(text: string): boolean {
+    if (!this.writer) {
+      this.logger.warn("Clipboard service has no writer configured");
+
+      return false;
+    }
+
+    try {
+      const ok = this.writer(text);
+
+      if (!ok) {
+        this.logger.warn(`Clipboard writer returned false for ${text.length}-char payload`);
+      } else {
+        this.logger.debug(`Clipboard write succeeded (${text.length} chars)`);
+      }
+
+      return ok;
+    } catch (error) {
+      this.logger.error(`Clipboard write threw: ${error instanceof Error ? error.message : error}`);
+
+      return false;
+    }
+  }
+}
+
+let clipboardService: ClipboardService | null = null;
+
+/**
+ * Initialize the clipboard service singleton.
+ * Should be called once at plugin startup.
+ *
+ * @param logger - Optional logger for clipboard service logging
+ * @param writer - Optional function for writing text to the clipboard.
+ *   When omitted, every `setClipboardText` call returns false and logs a warning.
+ * @returns The initialized clipboard service
+ * @throws Error if called more than once
+ */
+export function initializeClipboard(logger: ILogger = silentLogger, writer?: ClipboardWriter): IClipboardService {
+  if (clipboardService) {
+    throw new Error("Clipboard service already initialized. initializeClipboard() should only be called once.");
+  }
+
+  clipboardService = new ClipboardService(logger, writer ?? null);
+
+  return clipboardService;
+}
+
+/**
+ * Get the clipboard service for writing to the OS clipboard.
+ *
+ * @returns The clipboard service instance
+ * @throws Error if clipboard service hasn't been initialized
+ */
+export function getClipboard(): IClipboardService {
+  if (!clipboardService) {
+    throw new Error("Clipboard service not initialized. Call initializeClipboard() first in your plugin entry point.");
+  }
+
+  return clipboardService;
+}
+
+/**
+ * Check if the clipboard service has been initialized.
+ */
+export function isClipboardInitialized(): boolean {
+  return clipboardService !== null;
+}
+
+/**
+ * Reset the clipboard service singleton (for testing purposes only).
+ * @internal
+ */
+export function _resetClipboard(): void {
+  clipboardService = null;
+}

--- a/packages/deck-core/src/index.ts
+++ b/packages/deck-core/src/index.ts
@@ -171,6 +171,16 @@ export {
   type ScanKeyReleaser,
 } from "./keyboard-service.js";
 
+// Clipboard service singleton
+export {
+  initializeClipboard,
+  getClipboard,
+  isClipboardInitialized,
+  _resetClipboard,
+  type IClipboardService,
+  type ClipboardWriter,
+} from "./clipboard-service.js";
+
 // App monitor for iRacing process detection
 export { initAppMonitor, isIRacingRunning, isAppMonitorInitialized, _resetAppMonitor } from "./app-monitor.js";
 

--- a/packages/iracing-actions/src/actions/race-admin/migrate-use-viewed-car.test.ts
+++ b/packages/iracing-actions/src/actions/race-admin/migrate-use-viewed-car.test.ts
@@ -75,6 +75,48 @@ describe("migrateUseViewedCarToDriverTarget", () => {
     expect(result.migrated).toEqual({});
   });
 
+  it("backfills viewed-car when addedWithVersion is present but useViewedCar is absent", () => {
+    // Pre-existing v1.15 button: user never toggled the "Use Viewed Car" checkbox,
+    // so useViewedCar was never persisted to Stream Deck storage. addedWithVersion
+    // tells us the button has been loaded before — preserve the prior viewed-car
+    // intent rather than silently flipping to the new "type-in-chat" default.
+    const result = migrateUseViewedCarToDriverTarget({
+      mode: "dq-driver",
+      addedWithVersion: "1.15.0",
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.migrated).toEqual({
+      mode: "dq-driver",
+      addedWithVersion: "1.15.0",
+      driverTarget: "viewed-car",
+    });
+  });
+
+  it("does not backfill for a fresh button (no addedWithVersion, no useViewedCar)", () => {
+    // Brand-new button placed under the new build — let the schema default
+    // ("type-in-chat") apply rather than backfilling viewed-car.
+    const result = migrateUseViewedCarToDriverTarget({});
+
+    expect(result.changed).toBe(false);
+    expect(result.migrated).toEqual({});
+  });
+
+  it("explicit useViewedCar wins over addedWithVersion-based backfill", () => {
+    // Even when addedWithVersion is present, if the user explicitly toggled
+    // useViewedCar=false, that explicit choice must be preserved as "specific"
+    // — not overwritten with the implicit-legacy "viewed-car" backfill.
+    const result = migrateUseViewedCarToDriverTarget({
+      addedWithVersion: "1.15.0",
+      useViewedCar: false,
+      carNumber: "42",
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.migrated.driverTarget).toBe("specific");
+    expect(result.migrated.useViewedCar).toBeUndefined();
+  });
+
   it("handles null and undefined raw settings", () => {
     expect(migrateUseViewedCarToDriverTarget(null)).toEqual({ migrated: {}, changed: false });
     expect(migrateUseViewedCarToDriverTarget(undefined)).toEqual({ migrated: {}, changed: false });

--- a/packages/iracing-actions/src/actions/race-admin/migrate-use-viewed-car.test.ts
+++ b/packages/iracing-actions/src/actions/race-admin/migrate-use-viewed-car.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { migrateUseViewedCarToDriverTarget } from "./migrate-use-viewed-car.js";
+
+describe("migrateUseViewedCarToDriverTarget", () => {
+  it("maps useViewedCar=true to driverTarget=viewed-car and drops the legacy key", () => {
+    const result = migrateUseViewedCarToDriverTarget({ useViewedCar: true });
+
+    expect(result.changed).toBe(true);
+    expect(result.migrated).toEqual({ driverTarget: "viewed-car" });
+    expect(result.migrated.useViewedCar).toBeUndefined();
+  });
+
+  it("maps useViewedCar=false to driverTarget=specific and drops the legacy key", () => {
+    const result = migrateUseViewedCarToDriverTarget({ useViewedCar: false });
+
+    expect(result.changed).toBe(true);
+    expect(result.migrated).toEqual({ driverTarget: "specific" });
+    expect(result.migrated.useViewedCar).toBeUndefined();
+  });
+
+  it('treats string "true" as truthy (sdpi-checkbox stores booleans as strings)', () => {
+    const result = migrateUseViewedCarToDriverTarget({ useViewedCar: "true" });
+
+    expect(result.changed).toBe(true);
+    expect(result.migrated.driverTarget).toBe("viewed-car");
+    expect(result.migrated.useViewedCar).toBeUndefined();
+  });
+
+  it("treats other string values as falsy and maps to specific", () => {
+    const result = migrateUseViewedCarToDriverTarget({ useViewedCar: "false" });
+
+    expect(result.changed).toBe(true);
+    expect(result.migrated.driverTarget).toBe("specific");
+  });
+
+  it("preserves other settings keys during migration", () => {
+    const result = migrateUseViewedCarToDriverTarget({
+      mode: "black-flag",
+      useViewedCar: false,
+      carNumber: "42",
+      penaltyValue: "30",
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.migrated).toEqual({
+      mode: "black-flag",
+      driverTarget: "specific",
+      carNumber: "42",
+      penaltyValue: "30",
+    });
+  });
+
+  it("does not change settings that already use driverTarget", () => {
+    const result = migrateUseViewedCarToDriverTarget({ driverTarget: "viewed-car" });
+
+    expect(result.changed).toBe(false);
+    expect(result.migrated).toEqual({ driverTarget: "viewed-car" });
+  });
+
+  it("keeps driverTarget when both keys are present (already-migrated wins)", () => {
+    const result = migrateUseViewedCarToDriverTarget({
+      driverTarget: "type-in-chat",
+      useViewedCar: true,
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.migrated.driverTarget).toBe("type-in-chat");
+  });
+
+  it("handles empty raw settings", () => {
+    const result = migrateUseViewedCarToDriverTarget({});
+
+    expect(result.changed).toBe(false);
+    expect(result.migrated).toEqual({});
+  });
+
+  it("handles null and undefined raw settings", () => {
+    expect(migrateUseViewedCarToDriverTarget(null)).toEqual({ migrated: {}, changed: false });
+    expect(migrateUseViewedCarToDriverTarget(undefined)).toEqual({ migrated: {}, changed: false });
+  });
+
+  it("handles non-object raw settings (string, number, boolean)", () => {
+    expect(migrateUseViewedCarToDriverTarget("string").changed).toBe(false);
+    expect(migrateUseViewedCarToDriverTarget(42).changed).toBe(false);
+    expect(migrateUseViewedCarToDriverTarget(true).changed).toBe(false);
+  });
+});

--- a/packages/iracing-actions/src/actions/race-admin/migrate-use-viewed-car.ts
+++ b/packages/iracing-actions/src/actions/race-admin/migrate-use-viewed-car.ts
@@ -2,15 +2,24 @@
  * One-shot in-place migration helper for the race-admin action's
  * `useViewedCar` boolean → `driverTarget` enum rename (issue #491).
  *
- * Detects raw settings with the legacy `useViewedCar` key but no `driverTarget`,
- * derives the new value (`true` → `"viewed-car"`, `false` → `"specific"`),
- * and **drops** the legacy key. Returns `{ migrated, changed }` so callers can
- * decide whether to persist via `ev.action.setSettings(migrated)`.
+ * Three cases:
  *
- * Safe to call on any settings shape — non-object inputs return an empty
- * unchanged result. Idempotent: once `driverTarget` is present the helper
- * leaves the record alone (preserves a leftover `useViewedCar` key in that
- * case so we don't mutate already-migrated payloads).
+ * 1. **Already migrated** (`driverTarget` present): no-op.
+ * 2. **Explicit legacy** (`useViewedCar` present): map `true` → `"viewed-car"`,
+ *    `false` → `"specific"`, then drop the legacy key.
+ * 3. **Implicit legacy** (`useViewedCar` absent but `addedWithVersion` present):
+ *    the button was previously loaded under a build whose default was
+ *    "Use Viewed Car". Stream Deck only persists settings the user has touched
+ *    or that the action has explicitly written, so an unchanged v1.15 button's
+ *    saved bytes contain no `useViewedCar` even though the user's intent was
+ *    viewed-car. Backfill `driverTarget: "viewed-car"` so the new
+ *    `"type-in-chat"` default doesn't silently override their prior behavior.
+ *
+ * Truly fresh buttons (no `addedWithVersion`, no `useViewedCar`) fall through
+ * unchanged so Zod's `"type-in-chat"` default applies.
+ *
+ * Returns `{ migrated, changed }` so callers can decide whether to persist via
+ * `ev.action.setSettings(migrated)`. Safe on non-object inputs.
  *
  * Mirrors the pattern of `migrateLegacyActionToMode` in `@iracedeck/deck-core`.
  */
@@ -22,15 +31,33 @@ export function migrateUseViewedCarToDriverTarget(raw: unknown): {
 
   const record = raw as Record<string, unknown>;
 
-  if (record.driverTarget !== undefined || record.useViewedCar === undefined) {
+  // Case 1: already migrated — preserve as-is (a leftover `useViewedCar`, if any,
+  // is left alone since the persist-on-appear flow will rewrite this record on
+  // the next legacy-touching event).
+  if (record.driverTarget !== undefined) {
     return { migrated: { ...record }, changed: false };
   }
 
-  const { useViewedCar, ...rest } = record;
-  const isViewed = useViewedCar === true || useViewedCar === "true";
+  // Case 2: explicit legacy boolean — map and drop the legacy key.
+  if (record.useViewedCar !== undefined) {
+    const { useViewedCar, ...rest } = record;
+    const isViewed = useViewedCar === true || useViewedCar === "true";
 
-  return {
-    migrated: { ...rest, driverTarget: isViewed ? "viewed-car" : "specific" },
-    changed: true,
-  };
+    return {
+      migrated: { ...rest, driverTarget: isViewed ? "viewed-car" : "specific" },
+      changed: true,
+    };
+  }
+
+  // Case 3: implicit legacy — pre-existing button (addedWithVersion present)
+  // that never wrote useViewedCar. Backfill viewed-car to preserve prior intent.
+  if (record.addedWithVersion !== undefined) {
+    return {
+      migrated: { ...record, driverTarget: "viewed-car" },
+      changed: true,
+    };
+  }
+
+  // Fresh button — let Zod's default apply.
+  return { migrated: { ...record }, changed: false };
 }

--- a/packages/iracing-actions/src/actions/race-admin/migrate-use-viewed-car.ts
+++ b/packages/iracing-actions/src/actions/race-admin/migrate-use-viewed-car.ts
@@ -1,0 +1,36 @@
+/**
+ * One-shot in-place migration helper for the race-admin action's
+ * `useViewedCar` boolean → `driverTarget` enum rename (issue #491).
+ *
+ * Detects raw settings with the legacy `useViewedCar` key but no `driverTarget`,
+ * derives the new value (`true` → `"viewed-car"`, `false` → `"specific"`),
+ * and **drops** the legacy key. Returns `{ migrated, changed }` so callers can
+ * decide whether to persist via `ev.action.setSettings(migrated)`.
+ *
+ * Safe to call on any settings shape — non-object inputs return an empty
+ * unchanged result. Idempotent: once `driverTarget` is present the helper
+ * leaves the record alone (preserves a leftover `useViewedCar` key in that
+ * case so we don't mutate already-migrated payloads).
+ *
+ * Mirrors the pattern of `migrateLegacyActionToMode` in `@iracedeck/deck-core`.
+ */
+export function migrateUseViewedCarToDriverTarget(raw: unknown): {
+  migrated: Record<string, unknown>;
+  changed: boolean;
+} {
+  if (!raw || typeof raw !== "object") return { migrated: {}, changed: false };
+
+  const record = raw as Record<string, unknown>;
+
+  if (record.driverTarget !== undefined || record.useViewedCar === undefined) {
+    return { migrated: { ...record }, changed: false };
+  }
+
+  const { useViewedCar, ...rest } = record;
+  const isViewed = useViewedCar === true || useViewedCar === "true";
+
+  return {
+    migrated: { ...rest, driverTarget: isViewed ? "viewed-car" : "specific" },
+    changed: true,
+  };
+}

--- a/packages/iracing-actions/src/actions/race-admin/race-admin-commands.ts
+++ b/packages/iracing-actions/src/actions/race-admin/race-admin-commands.ts
@@ -7,9 +7,11 @@ import { buildTemplateContext, resolveTemplate, type SDKController } from "@irac
 
 import { RACE_ADMIN_MODE_META, type RaceAdminMode, type RaceAdminModeMeta } from "./race-admin-modes.js";
 
+export type DriverTarget = "viewed-car" | "specific" | "type-in-chat";
+
 export interface RaceAdminSettings {
   mode: RaceAdminMode;
-  useViewedCar: boolean;
+  driverTarget: DriverTarget;
   carNumber: string;
   message: string;
   penaltyType: string;
@@ -23,6 +25,10 @@ export interface RaceAdminSettings {
 /**
  * Resolve the driver target for a command.
  *
+ * Returns null for the `type-in-chat` driver target — that path doesn't build a
+ * full command string at all. The caller (`executeMode`) must branch on
+ * `driverTarget === "type-in-chat"` before calling `buildAdminCommand`.
+ *
  * @internal Exported for testing
  */
 export function resolveDriverTarget(
@@ -32,13 +38,35 @@ export function resolveDriverTarget(
 ): string | null {
   if (!meta.needsDriver) return null;
 
-  if (settings.useViewedCar) {
+  if (settings.driverTarget === "viewed-car") {
     return viewedCarNumber ?? null;
   }
 
-  const carNum = settings.carNumber?.trim();
+  if (settings.driverTarget === "specific") {
+    const carNum = settings.carNumber?.trim();
 
-  return carNum || null;
+    return carNum || null;
+  }
+
+  return null;
+}
+
+/**
+ * Build the bare command prefix for a mode (e.g. `"!clear "` with trailing
+ * space). Used by the `type-in-chat` flow which pastes the prefix and lets
+ * the user type the driver number themselves.
+ *
+ * Returns null for camera modes (no `meta.command`) — currently unreachable
+ * since all 27 modes have a command, but kept defensive.
+ *
+ * @internal Exported for testing
+ */
+export function buildAdminCommandPrefix(mode: RaceAdminMode): string | null {
+  const meta = RACE_ADMIN_MODE_META[mode];
+
+  if (!meta.command) return null;
+
+  return `${meta.command} `;
 }
 
 /**

--- a/packages/iracing-actions/src/actions/race-admin/race-admin.ejs
+++ b/packages/iracing-actions/src/actions/race-admin/race-admin.ejs
@@ -46,8 +46,12 @@
 
 		<!-- Driver targeting (shown for modes that accept a driver parameter) -->
 		<div id="driver-section" class="hidden">
-			<sdpi-item label="Use Viewed Car">
-				<sdpi-checkbox id="use-viewed-car" setting="useViewedCar" default="true"></sdpi-checkbox>
+			<sdpi-item label="Driver Target">
+				<sdpi-select id="driver-target-select" setting="driverTarget" default="type-in-chat">
+					<option value="viewed-car">Use Viewed Car</option>
+					<option value="specific">Specific Car Number</option>
+					<option value="type-in-chat">Type in Chat</option>
+				</sdpi-select>
 			</sdpi-item>
 			<sdpi-item id="car-number-item" label="Car Number" class="hidden">
 				<sdpi-textfield id="car-number-field" setting="carNumber" placeholder="e.g. 070" inputmode="numeric" pattern="[0-9]*"></sdpi-textfield>
@@ -156,7 +160,7 @@
 				await customElements.whenDefined("sdpi-select");
 
 				var modeSelect = document.getElementById("mode-select");
-				var useViewedCarCheckbox = document.getElementById("use-viewed-car");
+				var driverTargetSelect = document.getElementById("driver-target-select");
 
 				// Restrict car number input to digits only (preserve leading zeros)
 				var carNumberField = document.getElementById("car-number-field");
@@ -187,25 +191,20 @@
 					}, 100);
 				}
 
-				if (useViewedCarCheckbox) {
-					useViewedCarCheckbox.addEventListener("change", function() { updateCarNumberVisibility(); });
-					useViewedCarCheckbox.addEventListener("input", function() { updateCarNumberVisibility(); });
+				if (driverTargetSelect) {
+					driverTargetSelect.addEventListener("change", function() { updateCarNumberVisibility(); });
+					driverTargetSelect.addEventListener("input", function() { updateCarNumberVisibility(); });
 
-					var lastChecked = isCheckboxChecked(useViewedCarCheckbox);
+					// Polling fallback — sdpi-select change events can be unreliable.
+					var lastTarget = driverTargetSelect.value || "type-in-chat";
 					setInterval(function() {
-						var current = isCheckboxChecked(useViewedCarCheckbox);
-						if (current !== lastChecked) {
-							lastChecked = current;
+						var current = driverTargetSelect.value;
+						if (current && current !== lastTarget) {
+							lastTarget = current;
 							updateCarNumberVisibility();
 						}
 					}, 100);
 				}
-			}
-
-			function isCheckboxChecked(el) {
-				// sdpi-checkbox value can be boolean or string
-				var val = el.value;
-				return val === true || val === "true";
 			}
 
 			function updateModeVisibility(mode) {
@@ -222,18 +221,19 @@
 					toggle(meta.extra[j], true);
 				}
 
-				// Update car number visibility based on checkbox state
+				// Update car number visibility based on driver-target selection
 				if (meta.driver) {
 					updateCarNumberVisibility();
 				}
 			}
 
 			function updateCarNumberVisibility() {
-				var checkbox = document.getElementById("use-viewed-car");
+				var select = document.getElementById("driver-target-select");
 				var carNumberItem = document.getElementById("car-number-item");
-				if (checkbox && carNumberItem) {
-					var useViewed = isCheckboxChecked(checkbox);
-					carNumberItem.classList.toggle("hidden", useViewed);
+				if (select && carNumberItem) {
+					// Car number field is only relevant when a specific number is configured.
+					// Hidden for "viewed-car" (auto from telemetry) and "type-in-chat" (typed live).
+					carNumberItem.classList.toggle("hidden", select.value !== "specific");
 				}
 			}
 

--- a/packages/iracing-actions/src/actions/race-admin/race-admin.test.ts
+++ b/packages/iracing-actions/src/actions/race-admin/race-admin.test.ts
@@ -668,5 +668,36 @@ describe("RaceAdmin", () => {
       const persisted = setSettings.mock.calls[0]![0] as Record<string, unknown>;
       expect(persisted.driverTarget).toBe("viewed-car");
     });
+
+    it("backfills driverTarget=viewed-car for pre-existing buttons that never wrote useViewedCar", async () => {
+      // Regression for CodeRabbit catch on PR #495: v1.15 buttons whose users
+      // never toggled the "Use Viewed Car" checkbox have neither useViewedCar
+      // nor driverTarget in saved settings. Without backfill they'd silently
+      // flip to the new "type-in-chat" default.
+      const action = new RaceAdmin();
+      const ev = makeWillAppearEvent({ mode: "dq-driver", addedWithVersion: "1.15.0" });
+
+      await action.onWillAppear(ev);
+
+      const setSettings = ev.action.setSettings as unknown as ReturnType<typeof vi.fn>;
+      expect(setSettings).toHaveBeenCalledTimes(1);
+      const persisted = setSettings.mock.calls[0]![0] as Record<string, unknown>;
+      expect(persisted.driverTarget).toBe("viewed-car");
+      expect(persisted.useViewedCar).toBeUndefined();
+    });
+
+    it("does not persist for a fresh button with no addedWithVersion and no useViewedCar", async () => {
+      // Brand-new button — addedWithVersion is missing on first appear, so we
+      // fall through to the schema default ("type-in-chat") without writing.
+      // (Note: base-action's own onWillAppear may persist addedWithVersion, but
+      // race-admin's persistMigratedSettings does not.)
+      const action = new RaceAdmin();
+      const ev = makeWillAppearEvent({ mode: "yellow" });
+
+      await action.onWillAppear(ev);
+
+      const setSettings = ev.action.setSettings as unknown as ReturnType<typeof vi.fn>;
+      expect(setSettings).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/iracing-actions/src/actions/race-admin/race-admin.test.ts
+++ b/packages/iracing-actions/src/actions/race-admin/race-admin.test.ts
@@ -1,9 +1,9 @@
 import { buildTemplateContext, resolveTemplate } from "@iracedeck/iracing-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { buildAdminCommand, resolveDriverTarget } from "./race-admin-commands.js";
+import { buildAdminCommand, buildAdminCommandPrefix, resolveDriverTarget } from "./race-admin-commands.js";
 import { getModesByOptgroup, RACE_ADMIN_MODE_META, RACE_ADMIN_MODES } from "./race-admin-modes.js";
-import { generateRaceAdminSvg } from "./race-admin.js";
+import { generateRaceAdminSvg, RaceAdmin } from "./race-admin.js";
 
 // Mock SDK
 // Mock iracing-sdk
@@ -99,6 +99,11 @@ vi.mock("@iracedeck/icons/race-admin/rc-message.svg", () => ({
 }));
 
 // Mock shared utilities
+const mockSendMessage = vi.fn(async () => true);
+const mockBeginChat = vi.fn(() => true);
+const mockSetClipboardText = vi.fn(() => true);
+const mockSendKeyCombination = vi.fn(async () => true);
+
 vi.mock("@iracedeck/deck-core", () => ({
   CommonSettings: {
     extend: (_fields: unknown) => {
@@ -121,11 +126,16 @@ vi.mock("@iracedeck/deck-core", () => ({
     updateConnectionState = vi.fn();
     setKeyImage = vi.fn();
     setRegenerateCallback = vi.fn();
+    async onWillAppear(_ev: unknown): Promise<void> {}
+    async onWillDisappear(_ev: unknown): Promise<void> {}
+    async onDidReceiveSettings(_ev: unknown): Promise<void> {}
   },
   getCommands: vi.fn(() => ({
-    chat: { sendMessage: vi.fn(async () => true) },
+    chat: { sendMessage: mockSendMessage, beginChat: mockBeginChat },
     camera: { switchNum: vi.fn(() => true) },
   })),
+  getClipboard: vi.fn(() => ({ setClipboardText: mockSetClipboardText })),
+  getKeyboard: vi.fn(() => ({ sendKeyCombination: mockSendKeyCombination })),
   generateBorderParts: vi.fn(() => ({ defs: "", rects: "" })),
   getGlobalBorderSettings: vi.fn(() => ({})),
   getGlobalColors: vi.fn(() => ({})),
@@ -202,7 +212,7 @@ describe("RaceAdmin", () => {
   describe("resolveDriverTarget", () => {
     const baseSettings = {
       mode: "black-flag" as const,
-      useViewedCar: true,
+      driverTarget: "viewed-car" as const,
       carNumber: "",
       message: "",
       penaltyType: "time",
@@ -213,27 +223,33 @@ describe("RaceAdmin", () => {
       trackStatePercent: "50",
     };
 
-    it("should return viewed car number when useViewedCar is true", () => {
+    it("should return viewed car number when driverTarget is viewed-car", () => {
       const meta = RACE_ADMIN_MODE_META["black-flag"];
-      const result = resolveDriverTarget({ ...baseSettings, useViewedCar: true }, "42", meta);
+      const result = resolveDriverTarget({ ...baseSettings, driverTarget: "viewed-car" }, "42", meta);
       expect(result).toBe("42");
     });
 
-    it("should return null when useViewedCar is true but no viewed car", () => {
+    it("should return null when driverTarget is viewed-car but no viewed car", () => {
       const meta = RACE_ADMIN_MODE_META["black-flag"];
-      const result = resolveDriverTarget({ ...baseSettings, useViewedCar: true }, null, meta);
+      const result = resolveDriverTarget({ ...baseSettings, driverTarget: "viewed-car" }, null, meta);
       expect(result).toBeNull();
     });
 
-    it("should return pre-defined car number when useViewedCar is false", () => {
+    it("should return pre-defined car number when driverTarget is specific", () => {
       const meta = RACE_ADMIN_MODE_META["black-flag"];
-      const result = resolveDriverTarget({ ...baseSettings, useViewedCar: false, carNumber: "7" }, null, meta);
+      const result = resolveDriverTarget({ ...baseSettings, driverTarget: "specific", carNumber: "7" }, null, meta);
       expect(result).toBe("7");
     });
 
-    it("should return null when useViewedCar is false and carNumber is empty", () => {
+    it("should return null when driverTarget is specific and carNumber is empty", () => {
       const meta = RACE_ADMIN_MODE_META["black-flag"];
-      const result = resolveDriverTarget({ ...baseSettings, useViewedCar: false, carNumber: "" }, null, meta);
+      const result = resolveDriverTarget({ ...baseSettings, driverTarget: "specific", carNumber: "" }, null, meta);
+      expect(result).toBeNull();
+    });
+
+    it("should return null when driverTarget is type-in-chat (handled by executeMode)", () => {
+      const meta = RACE_ADMIN_MODE_META["black-flag"];
+      const result = resolveDriverTarget({ ...baseSettings, driverTarget: "type-in-chat" }, "42", meta);
       expect(result).toBeNull();
     });
 
@@ -250,7 +266,7 @@ describe("RaceAdmin", () => {
     const mockSdkController = {} as unknown;
     const baseSettings = {
       mode: "yellow" as const,
-      useViewedCar: true,
+      driverTarget: "viewed-car" as const,
       carNumber: "",
       message: "",
       penaltyType: "time",
@@ -280,7 +296,7 @@ describe("RaceAdmin", () => {
     });
 
     it("should build commands with driver target (pre-defined)", () => {
-      const settings = { ...baseSettings, useViewedCar: false, carNumber: "7" };
+      const settings = { ...baseSettings, driverTarget: "specific" as const, carNumber: "7" };
       const result = buildAdminCommand("dq-driver", settings, null, mockSdkController as never);
       expect(result).toBe("!dq #7");
     });
@@ -404,7 +420,7 @@ describe("RaceAdmin", () => {
   describe("generateRaceAdminSvg", () => {
     const defaultSettings = {
       mode: "yellow" as const,
-      useViewedCar: true,
+      driverTarget: "viewed-car" as const,
       carNumber: "",
       message: "",
       penaltyType: "time" as const,
@@ -427,24 +443,230 @@ describe("RaceAdmin", () => {
       expect(decoded).toContain("CAUTION");
     });
 
-    it("should show car number when pre-defined car is set", () => {
-      const settings = { ...defaultSettings, useViewedCar: false, carNumber: "42" };
+    it("should show car number when driverTarget is specific", () => {
+      const settings = { ...defaultSettings, driverTarget: "specific" as const, carNumber: "42" };
       const result = generateRaceAdminSvg("black-flag", settings);
       const decoded = decodeURIComponent(result);
       expect(decoded).toContain("#42");
     });
 
     it("should show default sub label when using viewed car", () => {
-      const settings = { ...defaultSettings, useViewedCar: true };
+      const settings = { ...defaultSettings, driverTarget: "viewed-car" as const };
       const result = generateRaceAdminSvg("black-flag", settings);
       const decoded = decodeURIComponent(result);
       expect(decoded).toContain("FLAG");
+    });
+
+    it("should show default sub label for type-in-chat (no fixed number)", () => {
+      const settings = { ...defaultSettings, driverTarget: "type-in-chat" as const, carNumber: "999" };
+      const result = generateRaceAdminSvg("black-flag", settings);
+      const decoded = decodeURIComponent(result);
+      // Falls through to the default subLabel; the carNumber is irrelevant here.
+      expect(decoded).toContain("FLAG");
+      expect(decoded).not.toContain("#999");
     });
 
     it("should produce different icons for different modes", () => {
       const yellowSvg = generateRaceAdminSvg("yellow", defaultSettings);
       const pitCloseSvg = generateRaceAdminSvg("pit-close", defaultSettings);
       expect(yellowSvg).not.toBe(pitCloseSvg);
+    });
+  });
+
+  // ── Command Prefix (type-in-chat) ───────────────────────────
+
+  describe("buildAdminCommandPrefix", () => {
+    it("returns the meta.command with a trailing space for driver-targeted modes", () => {
+      expect(buildAdminCommandPrefix("dq-driver")).toBe("!dq ");
+      expect(buildAdminCommandPrefix("clear-penalties")).toBe("!clear ");
+      expect(buildAdminCommandPrefix("black-flag")).toBe("!black ");
+      expect(buildAdminCommandPrefix("wave-around")).toBe("!waveby ");
+      expect(buildAdminCommandPrefix("eol")).toBe("!eol ");
+    });
+
+    it("returns the prefix even for non-driver modes (caller filters by needsDriver)", () => {
+      expect(buildAdminCommandPrefix("yellow")).toBe("!yellow ");
+      expect(buildAdminCommandPrefix("clear-all")).toBe("!clearall ");
+    });
+
+    it("never returns a prefix without trailing whitespace", () => {
+      for (const mode of RACE_ADMIN_MODES) {
+        const prefix = buildAdminCommandPrefix(mode);
+
+        if (prefix !== null) {
+          expect(prefix.endsWith(" ")).toBe(true);
+        }
+      }
+    });
+  });
+
+  // ── Action Class: type-in-chat fire path ────────────────────
+
+  describe("RaceAdmin.executeMode (via onKeyDown)", () => {
+    const baseSettings = {
+      mode: "dq-driver" as const,
+      driverTarget: "type-in-chat" as const,
+      carNumber: "",
+      message: "",
+      penaltyType: "time",
+      penaltyValue: "30",
+      paceLapsOperation: "+",
+      paceLapsValue: "1",
+      gridSetMinutes: "5",
+      trackStatePercent: "50",
+    };
+
+    function makeKeyDownEvent(settings: Record<string, unknown>) {
+      return {
+        action: { id: "ctx-1", setSettings: vi.fn(async () => {}) },
+        payload: { settings },
+      } as never;
+    }
+
+    beforeEach(() => {
+      mockSetClipboardText.mockClear();
+      mockSendKeyCombination.mockClear();
+      mockBeginChat.mockClear();
+      mockSendMessage.mockClear();
+      mockSetClipboardText.mockReturnValue(true);
+      mockBeginChat.mockReturnValue(true);
+      mockSendKeyCombination.mockResolvedValue(true);
+    });
+
+    it("type-in-chat: writes prefix, opens chat, pastes Ctrl+V, never sends Enter", async () => {
+      const action = new RaceAdmin();
+      const ev = makeKeyDownEvent(baseSettings);
+
+      await action.onKeyDown(ev);
+      // Wait past the 100ms internal delay so the keyboard call has fired.
+      await new Promise((r) => setTimeout(r, 150));
+
+      expect(mockSetClipboardText).toHaveBeenCalledTimes(1);
+      expect(mockSetClipboardText).toHaveBeenCalledWith("!dq ");
+
+      expect(mockBeginChat).toHaveBeenCalledTimes(1);
+
+      expect(mockSendKeyCombination).toHaveBeenCalledTimes(1);
+      expect(mockSendKeyCombination).toHaveBeenCalledWith({ key: "v", code: "KeyV", modifiers: ["ctrl"] });
+
+      // Crucially: no Enter key sent and no SDK chat.sendMessage call.
+      const enterCalls = mockSendKeyCombination.mock.calls.filter((c) => {
+        const arg = c[0] as { key?: string };
+
+        return arg?.key === "enter" || arg?.key === "Enter";
+      });
+      expect(enterCalls).toHaveLength(0);
+      expect(mockSendMessage).not.toHaveBeenCalled();
+    });
+
+    it("type-in-chat: clipboard write failure aborts before opening chat", async () => {
+      mockSetClipboardText.mockReturnValueOnce(false);
+      const action = new RaceAdmin();
+
+      await action.onKeyDown(makeKeyDownEvent(baseSettings));
+      await new Promise((r) => setTimeout(r, 150));
+
+      expect(mockSetClipboardText).toHaveBeenCalledTimes(1);
+      expect(mockBeginChat).not.toHaveBeenCalled();
+      expect(mockSendKeyCombination).not.toHaveBeenCalled();
+    });
+
+    it("type-in-chat: beginChat() failure aborts before sending Ctrl+V", async () => {
+      mockBeginChat.mockReturnValueOnce(false);
+      const action = new RaceAdmin();
+
+      await action.onKeyDown(makeKeyDownEvent(baseSettings));
+      await new Promise((r) => setTimeout(r, 150));
+
+      expect(mockSetClipboardText).toHaveBeenCalledTimes(1);
+      expect(mockBeginChat).toHaveBeenCalledTimes(1);
+      expect(mockSendKeyCombination).not.toHaveBeenCalled();
+    });
+
+    it("non-driver mode + leftover driverTarget=type-in-chat falls through to chat.sendMessage", async () => {
+      const action = new RaceAdmin();
+      const ev = makeKeyDownEvent({
+        ...baseSettings,
+        mode: "yellow", // needsDriver=false
+        driverTarget: "type-in-chat",
+        message: "Caution!",
+      });
+
+      await action.onKeyDown(ev);
+
+      expect(mockSendMessage).toHaveBeenCalledTimes(1);
+      expect(mockSendMessage).toHaveBeenCalledWith("!yellow Caution!");
+      expect(mockSetClipboardText).not.toHaveBeenCalled();
+      expect(mockBeginChat).not.toHaveBeenCalled();
+    });
+
+    it("type-in-chat: re-entrant fires while one is in flight are dropped", async () => {
+      const action = new RaceAdmin();
+      const ev = makeKeyDownEvent(baseSettings);
+
+      // Fire two in rapid succession; the second should bail before clipboard write.
+      const first = action.onKeyDown(ev);
+      const second = action.onKeyDown(ev);
+      await Promise.all([first, second]);
+      await new Promise((r) => setTimeout(r, 150));
+
+      expect(mockSetClipboardText).toHaveBeenCalledTimes(1);
+      expect(mockBeginChat).toHaveBeenCalledTimes(1);
+      expect(mockSendKeyCombination).toHaveBeenCalledTimes(1);
+    });
+
+    it("driverTarget=specific dispatches via SDK chat.sendMessage as before", async () => {
+      const action = new RaceAdmin();
+      await action.onKeyDown(makeKeyDownEvent({ ...baseSettings, driverTarget: "specific", carNumber: "42" }));
+
+      expect(mockSendMessage).toHaveBeenCalledTimes(1);
+      expect(mockSendMessage).toHaveBeenCalledWith("!dq #42");
+      expect(mockSetClipboardText).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Action Class: settings migration ────────────────────────
+
+  describe("RaceAdmin settings migration (useViewedCar → driverTarget)", () => {
+    function makeWillAppearEvent(settings: Record<string, unknown>) {
+      return {
+        action: { id: "ctx-1", setSettings: vi.fn(async () => {}) },
+        payload: { settings },
+      } as never;
+    }
+
+    it("persists migrated payload (without useViewedCar) when legacy key present", async () => {
+      const action = new RaceAdmin();
+      const ev = makeWillAppearEvent({ mode: "dq-driver", useViewedCar: false, carNumber: "7" });
+
+      await action.onWillAppear(ev);
+
+      const setSettings = ev.action.setSettings as unknown as ReturnType<typeof vi.fn>;
+      expect(setSettings).toHaveBeenCalledTimes(1);
+      const persisted = setSettings.mock.calls[0]![0] as Record<string, unknown>;
+      expect(persisted).toMatchObject({ mode: "dq-driver", driverTarget: "specific", carNumber: "7" });
+      expect(persisted.useViewedCar).toBeUndefined();
+    });
+
+    it("does not call setSettings when settings already use driverTarget", async () => {
+      const action = new RaceAdmin();
+      const ev = makeWillAppearEvent({ mode: "dq-driver", driverTarget: "viewed-car" });
+
+      await action.onWillAppear(ev);
+
+      const setSettings = ev.action.setSettings as unknown as ReturnType<typeof vi.fn>;
+      expect(setSettings).not.toHaveBeenCalled();
+    });
+
+    it("maps legacy useViewedCar=true to driverTarget=viewed-car", async () => {
+      const action = new RaceAdmin();
+      const ev = makeWillAppearEvent({ mode: "dq-driver", useViewedCar: true });
+
+      await action.onWillAppear(ev);
+
+      const setSettings = ev.action.setSettings as unknown as ReturnType<typeof vi.fn>;
+      const persisted = setSettings.mock.calls[0]![0] as Record<string, unknown>;
+      expect(persisted.driverTarget).toBe("viewed-car");
     });
   });
 });

--- a/packages/iracing-actions/src/actions/race-admin/race-admin.ts
+++ b/packages/iracing-actions/src/actions/race-admin/race-admin.ts
@@ -9,11 +9,13 @@ import {
   assembleIcon,
   CommonSettings,
   ConnectionStateAwareAction,
+  getClipboard,
   getCommands,
   getGlobalBorderSettings,
   getGlobalColors,
   getGlobalGraphicSettings,
   getGlobalTitleSettings,
+  getKeyboard,
   type IDeckDialDownEvent,
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
@@ -54,17 +56,15 @@ import yellowIconSvg from "@iracedeck/icons/race-admin/yellow.svg";
 import { getCarNumberFromSessionInfo, type TelemetryData } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
-import { buildAdminCommand } from "./race-admin-commands.js";
+import { migrateUseViewedCarToDriverTarget } from "./migrate-use-viewed-car.js";
+import { buildAdminCommand, buildAdminCommandPrefix } from "./race-admin-commands.js";
 import { RACE_ADMIN_MODE_META, RACE_ADMIN_MODES, type RaceAdminMode } from "./race-admin-modes.js";
 
 // ── Settings Schema ─────────────────────────────────────────────
 
 const RaceAdminSettings = CommonSettings.extend({
   mode: z.enum(RACE_ADMIN_MODES).default("yellow"),
-  useViewedCar: z
-    .union([z.boolean(), z.string()])
-    .transform((val) => val === true || val === "true")
-    .default(true),
+  driverTarget: z.enum(["viewed-car", "specific", "type-in-chat"]).default("type-in-chat"),
   carNumber: z.string().default(""),
   message: z.string().default(""),
   penaltyType: z.enum(["time", "laps", "drivethrough"]).default("time"),
@@ -122,8 +122,10 @@ export function generateRaceAdminSvg(mode: RaceAdminMode, settings: RaceAdminSet
   // Build default title from meta labels (subLabel on top, mainLabel on bottom)
   let subLabel = meta.subLabel;
 
-  // When pre-defined car number is set, show it on the icon instead of subLabel
-  if (meta.needsDriver && !settings.useViewedCar && settings.carNumber?.trim()) {
+  // When a specific car number is configured, show it on the icon instead of the
+  // generic subLabel. For the "viewed-car" and "type-in-chat" targets there's no
+  // fixed number to display, so fall through to the default subLabel.
+  if (meta.needsDriver && settings.driverTarget === "specific" && settings.carNumber?.trim()) {
     subLabel = `#${settings.carNumber.trim()}`;
   }
 
@@ -146,17 +148,40 @@ export const RACE_ADMIN_UUID = "com.iracedeck.sd.core.race-admin" as const;
 export class RaceAdmin extends ConnectionStateAwareAction<RaceAdminSettings> {
   private activeContexts = new Map<string, RaceAdminSettings>();
   private viewedCarNumbers = new Map<string, string | null>();
+  private typeInChatInFlight = new Set<string>();
 
   private parseSettings(raw: unknown): RaceAdminSettings {
-    const result = RaceAdminSettings.safeParse(raw);
+    const { migrated } = migrateUseViewedCarToDriverTarget(raw);
+    const result = RaceAdminSettings.safeParse(migrated);
 
     return result.success ? result.data : RaceAdminSettings.parse({});
+  }
+
+  /**
+   * Detect a legacy `useViewedCar` setting and persist the migrated shape to
+   * Stream Deck storage so the legacy key is permanently dropped. Logs and
+   * swallows persist failures — the runtime always reads via `parseSettings`,
+   * so a failed persist doesn't block functionality.
+   */
+  private async persistMigratedSettings(
+    ev: IDeckWillAppearEvent<RaceAdminSettings> | IDeckDidReceiveSettingsEvent<RaceAdminSettings>,
+  ): Promise<void> {
+    const { migrated, changed } = migrateUseViewedCarToDriverTarget(ev.payload.settings);
+
+    if (!changed) return;
+
+    try {
+      await ev.action.setSettings(migrated);
+    } catch (err) {
+      this.logger.warn(`Failed to persist migrated race-admin settings: ${err instanceof Error ? err.message : err}`);
+    }
   }
 
   // ── Lifecycle ───────────────────────────────────────────────
 
   override async onWillAppear(ev: IDeckWillAppearEvent<RaceAdminSettings>): Promise<void> {
     await super.onWillAppear(ev);
+    await this.persistMigratedSettings(ev);
     const settings = this.parseSettings(ev.payload.settings);
     this.activeContexts.set(ev.action.id, settings);
 
@@ -173,10 +198,12 @@ export class RaceAdmin extends ConnectionStateAwareAction<RaceAdminSettings> {
     this.sdkController.unsubscribe(ev.action.id);
     this.activeContexts.delete(ev.action.id);
     this.viewedCarNumbers.delete(ev.action.id);
+    this.typeInChatInFlight.delete(ev.action.id);
   }
 
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<RaceAdminSettings>): Promise<void> {
     await super.onDidReceiveSettings(ev);
+    await this.persistMigratedSettings(ev);
     const settings = this.parseSettings(ev.payload.settings);
     this.activeContexts.set(ev.action.id, settings);
     await this.updateDisplay(ev, settings);
@@ -200,6 +227,17 @@ export class RaceAdmin extends ConnectionStateAwareAction<RaceAdminSettings> {
 
   private async executeMode(contextId: string, settings: RaceAdminSettings): Promise<void> {
     const { mode } = settings;
+    const meta = RACE_ADMIN_MODE_META[mode];
+
+    // "Type in chat" only applies to driver-targeted modes — for non-driver
+    // modes a leftover `driverTarget: "type-in-chat"` setting is ignored and
+    // the command is dispatched normally via the SDK.
+    if (meta.needsDriver && settings.driverTarget === "type-in-chat") {
+      await this.executeTypeInChat(contextId, mode);
+
+      return;
+    }
+
     const viewedCarNumber = this.viewedCarNumbers.get(contextId) ?? null;
     const command = buildAdminCommand(mode, settings, viewedCarNumber, this.sdkController);
 
@@ -219,6 +257,64 @@ export class RaceAdmin extends ConnectionStateAwareAction<RaceAdminSettings> {
     }
 
     this.logger.debug(`Command: "${command}", result: ${success}`);
+  }
+
+  /**
+   * "Type in chat" driver-target mode (issue #491).
+   *
+   * Writes the command prefix (e.g. `"!clear "` with trailing space) to the
+   * OS clipboard, opens iRacing chat via the SDK, waits ~100ms for the input
+   * box to focus, and sends Ctrl+V to paste. **Does NOT send Enter** — the
+   * admin types the driver number themselves and submits manually.
+   *
+   * Re-entrancy: a per-context guard drops back-to-back fires while one is
+   * still in flight, preventing the second fire from clobbering the clipboard
+   * before the first paste lands.
+   */
+  private async executeTypeInChat(contextId: string, mode: RaceAdminMode): Promise<void> {
+    if (this.typeInChatInFlight.has(contextId)) {
+      this.logger.debug(`type-in-chat: dropping concurrent fire for ${contextId}`);
+
+      return;
+    }
+
+    this.typeInChatInFlight.add(contextId);
+
+    try {
+      const prefix = buildAdminCommandPrefix(mode);
+
+      if (!prefix) {
+        this.logger.warn(`type-in-chat: no command prefix for mode: ${mode}`);
+
+        return;
+      }
+
+      if (!getClipboard().setClipboardText(prefix)) {
+        this.logger.warn(`type-in-chat: clipboard write failed, aborting (mode: ${mode})`);
+
+        return;
+      }
+
+      const opened = getCommands().chat.beginChat();
+
+      if (!opened) {
+        this.logger.warn("type-in-chat: chat.beginChat() failed, aborting");
+
+        return;
+      }
+
+      // Match the chat-send pipeline's kChatStepDelayMs (addon.cc:352): give
+      // iRacing a couple frames to actually focus the chat input box before
+      // pasting. Without this, Ctrl+V lands on an empty viewport.
+      await new Promise<void>((resolve) => setTimeout(resolve, 100));
+
+      await getKeyboard().sendKeyCombination({ key: "v", code: "KeyV", modifiers: ["ctrl"] });
+
+      this.logger.info("Type-in-chat prefix pasted");
+      this.logger.debug(`Prefix: "${prefix}" (${prefix.length} chars)`);
+    } finally {
+      this.typeInChatInFlight.delete(contextId);
+    }
   }
 
   // ── Display ─────────────────────────────────────────────────

--- a/packages/iracing-native/CLAUDE.md
+++ b/packages/iracing-native/CLAUDE.md
@@ -68,6 +68,13 @@ All functions accept an array of PS/2 scan codes (modifiers first, then main key
 ### Internal helper: `sendScanKey(scanCode, isDown)`
 Static C++ function used by all three public functions. Sends a single key event via `SendInput()`. Derives `wVk` from scan code using `MapVirtualKeyW()` for compatibility.
 
+## Clipboard Functions
+
+### `setClipboardText(text: string): boolean`
+Writes a UTF-16 string to the Windows clipboard as `CF_UNICODETEXT`. Returns `true` on success, `false` if `OpenClipboard`/`GlobalAlloc`/`GlobalLock` fail. Internally reuses the same `copyToClipboard()` helper that backs the chat-send pipeline.
+
+Pasting is the caller's responsibility — `setClipboardText` only writes. Send `Ctrl+V` via `getKeyboard().sendKeyCombination(...)` from `@iracedeck/deck-core` to paste. Used by race-admin's "Type in Chat" driver-target mode and any future flows that need to put text on the clipboard without going through the full chat-send sequence.
+
 ## Cross-Package Sync
 
 The TypeScript wrapper in `src/index.ts` must mirror every function exported from `addon.cc`. When adding or modifying native keyboard functions:

--- a/packages/iracing-native/src/addon.cc
+++ b/packages/iracing-native/src/addon.cc
@@ -722,6 +722,35 @@ Napi::Value SendScanKeyUp(const Napi::CallbackInfo &info)
 }
 
 // ============================================================================
+// Clipboard
+// ============================================================================
+
+/**
+ * Write text to the Windows clipboard as CF_UNICODETEXT.
+ * Returns true on success.
+ *
+ * The implementation reuses the static `copyToClipboard()` helper used by the
+ * chat-send pipeline. Unlike `sendChatMessage`, this exposes the bare clipboard
+ * write so callers can compose paste flows themselves (e.g. race-admin's
+ * "Type in Chat" mode pastes a command prefix and lets the user finish typing).
+ */
+Napi::Value SetClipboardText(const Napi::CallbackInfo &info)
+{
+    Napi::Env env = info.Env();
+
+    if (info.Length() < 1 || !info[0].IsString())
+    {
+        Napi::TypeError::New(env, "Expected (text: string)").ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+
+    std::u16string text = info[0].As<Napi::String>().Utf16Value();
+    bool ok = copyToClipboard(text);
+
+    return Napi::Boolean::New(env, ok);
+}
+
+// ============================================================================
 // Module Initialization
 // ============================================================================
 
@@ -753,6 +782,9 @@ Napi::Object Init(Napi::Env env, Napi::Object exports)
     exports.Set("sendScanKeys", Napi::Function::New(env, SendScanKeys));
     exports.Set("sendScanKeyDown", Napi::Function::New(env, SendScanKeyDown));
     exports.Set("sendScanKeyUp", Napi::Function::New(env, SendScanKeyUp));
+
+    // Clipboard
+    exports.Set("setClipboardText", Napi::Function::New(env, SetClipboardText));
 
     return exports;
 }

--- a/packages/iracing-native/src/index.ts
+++ b/packages/iracing-native/src/index.ts
@@ -257,4 +257,21 @@ export class IRacingNative {
       this.getMock().sendScanKeyUp(scanCodes);
     }
   }
+
+  // ============================================================================
+  // Clipboard
+  // ============================================================================
+
+  /**
+   * Write text to the OS clipboard as Unicode text.
+   *
+   * Used by paste-based action flows (e.g. race-admin's "Type in Chat" mode).
+   * Pasting (Ctrl+V) is the caller's responsibility — use the keyboard service.
+   *
+   * @param text - The text to place on the clipboard
+   * @returns true on success
+   */
+  setClipboardText(text: string): boolean {
+    return addon ? addon.setClipboardText(text) : this.getMock().setClipboardText(text);
+  }
 }

--- a/packages/iracing-native/src/mock-impl.ts
+++ b/packages/iracing-native/src/mock-impl.ts
@@ -114,6 +114,12 @@ export class IRacingNativeMock {
     console.debug(`[IRacingNativeMock] sendScanKeyUp([${scanCodes.join(", ")}])`);
   }
 
+  setClipboardText(text: string): boolean {
+    console.debug(`[IRacingNativeMock] setClipboardText("${text}")`);
+
+    return true;
+  }
+
   private maybeRotateSnapshot(): void {
     const now = Date.now();
 

--- a/packages/iracing-plugin-mirabox/src/plugin.ts
+++ b/packages/iracing-plugin-mirabox/src/plugin.ts
@@ -24,6 +24,7 @@ import {
   initAppMonitor,
   initGlobalSettings,
   initializeBindingDispatcher,
+  initializeClipboard,
   initializeKeyboard,
   initializeSDK,
   initializeSimHub,
@@ -140,6 +141,10 @@ initializeKeyboard(
   (scanCodes) => native.sendScanKeyDown(scanCodes),
   (scanCodes) => native.sendScanKeyUp(scanCodes),
 );
+
+// Initialize clipboard for paste-based action flows (e.g. race-admin "Type in Chat").
+// Pasting itself uses the keyboard service above (Ctrl+V).
+initializeClipboard(adapter.createLogger("Clipboard"), (text) => native.setClipboardText(text));
 
 // Initialize audio engine for pit crew voice playback.
 // Base path lets scenarios emit manifest-relative clip paths (e.g.

--- a/packages/iracing-plugin-stream-deck/src/plugin.ts
+++ b/packages/iracing-plugin-stream-deck/src/plugin.ts
@@ -17,6 +17,7 @@ import {
   initAppMonitor,
   initGlobalSettings,
   initializeBindingDispatcher,
+  initializeClipboard,
   initializeKeyboard,
   initializeSDK,
   initializeSimHub,
@@ -136,6 +137,10 @@ initializeKeyboard(
   (scanCodes) => native.sendScanKeyDown(scanCodes),
   (scanCodes) => native.sendScanKeyUp(scanCodes),
 );
+
+// Initialize clipboard for paste-based action flows (e.g. race-admin "Type in Chat").
+// Pasting itself uses the keyboard service above (Ctrl+V).
+initializeClipboard(adapter.createLogger("Clipboard"), (text) => native.setClipboardText(text));
 
 // Initialize audio engine for pit crew voice playback.
 // Base path lets scenarios emit manifest-relative clip paths (e.g.

--- a/packages/website/src/content/docs/docs/actions/communication/race-admin.md
+++ b/packages/website/src/content/docs/docs/actions/communication/race-admin.md
@@ -493,10 +493,15 @@ Required. Supports template variables.
 
 ### Driver Target
 
-Every mode that accepts a `<driver>` parameter shares a single targeting setting with two options:
+Every mode that accepts a `<driver>` parameter shares a single targeting setting with three options:
 
-- **Use Viewed Car** (default) — The action reads the car number of the car currently being followed in the replay / broadcast view at send time. View a car and press the button; the command targets that car.
-- **Pre-defined Car Number** — Unchecking **Use Viewed Car** reveals a number input. The same car number is used on every press, regardless of which car is being viewed, and is also rendered on the button icon so you can tell which car the button targets.
+- **Type in Chat** (default) — One-tap "open chat with the right command pre-filled, let me type the number myself". The action opens iRacing chat, pastes the command prefix (e.g. `!clear `, with a trailing space), and **stops** — it does not press Enter. You type the car number off the standings sheet and press Enter to submit. Useful for league admins who handle a different driver each lap and don't want to pre-bind a specific number.
+- **Use Viewed Car** — The action reads the car number of the car currently being followed in the replay / broadcast view at send time. View a car and press the button; the command targets that car.
+- **Specific Car Number** — Selecting this reveals a number input. The same car number is used on every press, regardless of which car is being viewed, and is also rendered on the button icon so you can tell which car the button targets.
+
+:::caution
+**Type in Chat** leaves the command prefix on your OS clipboard after firing — same trade-off as the existing chat-send pipeline. If you have a clipboard manager that pops up on every change, you'll see the prefix queued there. Restoring the previous clipboard contents was deliberately skipped because clipboard-manager apps that watch `WM_CLIPBOARDUPDATE` can steal focus away from iRacing during the paste.
+:::
 
 ### Message templates
 


### PR DESCRIPTION
## Related Issue

Fixes #491

## What changed?

Adds a third **Driver Target** option (alongside "Use Viewed Car" and "Specific Car Number") for Race Admin's 11 driver-targeted modes — `!black`, `!dq`, `!clear`, `!waveby`, `!eol`, `!chat`, `!nchat`, `!admin`, `!nadmin`, `!remove`, `!showdqs`.

When a button in **Type in Chat** mode is pressed:

1. Writes the command prefix (e.g. `"!clear "` with trailing space) to the OS clipboard.
2. Opens iRacing chat via the SDK (`getCommands().chat.beginChat()`).
3. Waits 100 ms (matches `kChatStepDelayMs` in `addon.cc`) for the input box to focus.
4. Sends `Ctrl+V` via the existing keyboard service.
5. **Stops.** No Enter key is sent — the admin types the driver number themselves and submits manually.

Useful for league admins who handle a different driver each lap and don't want to pre-bind a specific car number; "Use Viewed Car" only works when the relevant driver is currently on screen.

**Settings migration.** `useViewedCar: boolean` → `driverTarget: "viewed-car" | "specific" | "type-in-chat"`. A new `migrate-use-viewed-car.ts` helper (modeled on `migrateLegacyActionToMode`) detects the legacy key, derives the new value, drops the legacy key, and the action persists the upgraded shape via `ev.action.setSettings()` on first appearance — so existing buttons keep their configured target without any user action and the legacy key never lingers in storage.

**New default.** Type in Chat is the default for brand-new buttons. Existing buttons are unaffected (the migration preserves their saved target).

**Clipboard service.** New `setClipboardText` native export in `@iracedeck/iracing-native` (wraps the existing static `copyToClipboard` helper used by the chat-send pipeline — no new C++ logic). New `@iracedeck/deck-core` `clipboard-service` singleton mirroring the `keyboard-service` pattern (`initializeClipboard()`, `getClipboard()`, `IClipboardService`). Wired into both plugins. Ctrl+V is dispatched through the existing keyboard service — no separate native paste call.

**Re-entrancy guard.** A per-context in-flight `Set<string>` drops back-to-back fires while one is still in flight, preventing the second fire from clobbering the clipboard before the first paste lands.

**Trade-offs (documented).** The clipboard is left containing the command prefix after fire — same trade-off as the existing chat-send pipeline (deliberate; clipboard-manager apps that watch `WM_CLIPBOARDUPDATE` can steal focus during a save/restore). Called out in the website docs alongside the existing chat-send caveat.

## How to test

- [ ] `pnpm install && pnpm build` — build green (17/17), `iracing_native.node` rebuilds with the new `setClipboardText` export.
- [ ] `pnpm test` — 115 files / 3609 tests pass.
- [ ] `pnpm lint` and `pnpm format` clean.
- [ ] **Manual on Stream Deck (Windows):**
  - [ ] Place a Race Admin action; pick a `needsDriver` mode (e.g. "Black Flag Driver"); confirm Driver Target shows three options and defaults to "Type in Chat".
  - [ ] Join an iRacing test session as admin; press the button. Chat opens, `!black ` is pasted with trailing space, cursor sits after the space, **no Enter is sent**.
  - [ ] Type `42`, press Enter manually — black flag issued for car 42.
  - [ ] Switch to a non-driver mode (e.g. "Throw Yellow Flag") — confirm the existing SDK `chat.sendMessage` path still fires immediately.
  - [ ] Verify Driver Target dropdown is hidden for non-driver modes.
  - [ ] Switch Driver Target to "Specific Car Number"; enter `42`; confirm the icon shows `#42` and the command sends as before.
  - [ ] Switch Driver Target to "Use Viewed Car"; view a car in replay/broadcast; press the button — command targets the viewed car as before.
- [ ] **Settings migration:** with an existing v1.15 setup that has saved `useViewedCar: false`, install the new build and confirm the PI shows "Specific Car Number" selected. Inspect the saved settings in Stream Deck storage and verify the legacy `useViewedCar` key is gone after first appearance.
- [ ] **Manual on Mirabox:** repeat the core flow to confirm parity.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clipboard support for writing text to the OS clipboard and native integrations wired in plugins.
  * Replaced "Use Viewed Car" with a new "Driver Target" setting: viewed-car, specific, type-in-chat (opens chat with prefix pre-filled).
  * Automatic migration/backfill from legacy settings to the new driver-target format.

* **Behavior**
  * "Type in Chat" writes a prefix to the clipboard, pastes into chat, and intentionally does not submit.

* **Documentation**
  * Updated docs describing the new Driver Target options and clipboard behavior.

* **Tests**
  * Added test coverage for clipboard and migration behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->