### PR TITLE
feat(deck-core): global setting for flag-flash duration (#490)

### DIFF
--- a/.claude/rules/pi-templates.md
+++ b/.claude/rules/pi-templates.md
@@ -114,7 +114,7 @@ Located in `packages/pi-components/partials/`:
 - **global-title-defaults.ejs** - Global title defaults (show/hide, bold, font size, position) in accordion
 - **global-border-defaults.ejs** - Global border defaults (enable, width, color, glow) in accordion
 - **global-graphic-defaults.ejs** - Global graphic scale default (50-150%, default 100%) in accordion
-- **global-flag-flash.ejs** - Global flag-flash duration default (0-15000 ms, default 5000, step 500; `0` = flash forever) in accordion. See issue #490.
+- **global-flag-flash.ejs** - Global flag-flash duration default (0-30 seconds, default 15, step 1; `0` = flash forever) in accordion. See issue #490.
 - **global-common-settings.ejs** - Global common settings (window focus, SimHub server) in accordion
 - **docs-link.ejs** - Documentation link to the action's page on iracedeck.com (conditional, hidden when no URL mapped)
 - **version.ejs** - Version footer with downloads link

--- a/.claude/rules/pi-templates.md
+++ b/.claude/rules/pi-templates.md
@@ -84,6 +84,7 @@ Template `require('./data/...')` resolves relative to the shared data directory 
     <%- include('global-color-defaults') %>
     <%- include('global-border-defaults') %>
     <%- include('global-graphic-defaults') %>
+    <%- include('global-flag-flash') %>
     <%- include('global-common-settings') %>
 
     <script>
@@ -113,6 +114,7 @@ Located in `packages/pi-components/partials/`:
 - **global-title-defaults.ejs** - Global title defaults (show/hide, bold, font size, position) in accordion
 - **global-border-defaults.ejs** - Global border defaults (enable, width, color, glow) in accordion
 - **global-graphic-defaults.ejs** - Global graphic scale default (50-150%, default 100%) in accordion
+- **global-flag-flash.ejs** - Global flag-flash duration default (0-15000 ms, default 5000, step 500; `0` = flash forever) in accordion. See issue #490.
 - **global-common-settings.ejs** - Global common settings (window focus, SimHub server) in accordion
 - **docs-link.ejs** - Documentation link to the action's page on iracedeck.com (conditional, hidden when no URL mapped)
 - **version.ejs** - Version footer with downloads link

--- a/docs/superpowers/plans/2026-05-02-flag-flash-duration.md
+++ b/docs/superpowers/plans/2026-05-02-flag-flash-duration.md
@@ -1,0 +1,850 @@
+# Flag Flash Duration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `flagFlashDurationMs` global setting (default 5000 ms, range 0-15000, step 500) that auto-stops the flag-overlay flash after the configured duration. `0` = flash forever (today's behaviour). New flag transitions restart the timer.
+
+**Architecture:** The Zod schema gains one numeric field. `BaseAction` gains a sibling auto-stop `setTimeout` next to its existing flash interval. A new private `endFlagFlashVisual()` stops the visual without clearing the cached `lastFlagStateKey`, so the same flag continuing in telemetry doesn't immediately re-trigger the flash. A new `global-flag-flash.ejs` accordion partial is included by every per-action template that already includes `global-common-settings`.
+
+**Tech Stack:** TypeScript, Zod, Vitest with fake timers, EJS, sdpi-components (`<sdpi-range>`).
+
+**Spec:** `docs/superpowers/specs/2026-05-02-flag-flash-duration-design.md`.
+
+---
+
+## File Structure
+
+| File | Responsibility | New/Modify |
+|------|---------------|------------|
+| `packages/deck-core/src/global-settings.ts` | Zod schema field for `flagFlashDurationMs`. | Modify |
+| `packages/deck-core/src/global-settings.test.ts` | Schema cases (default, bounds, string coercion). | Modify |
+| `packages/deck-core/src/base-action.ts` | Auto-stop timer field + `endFlagFlashVisual()` + modified `startFlagFlash`/`stopFlagFlash`. | Modify |
+| `packages/deck-core/src/base-action.test.ts` | Five timer-behaviour tests with `vi.useFakeTimers()`. | New |
+| `packages/pi-components/partials/global-flag-flash.ejs` | New "Flag Flash" accordion partial. | New |
+| `packages/iracing-actions/src/actions/<each>/<each>.ejs` (×34) | Add `<%- include('global-flag-flash') %>` between `global-graphic-defaults` and `global-common-settings`. | Modify |
+| `packages/website/src/content/docs/docs/features/flags-overlay.md` | Document the new setting. | Modify |
+
+---
+
+## Working directory
+
+All work happens inside the existing worktree:
+
+```text
+C:/Users/nikla/Coding/iRaceDeck/ir-490
+```
+
+Branch: `490-flag-flash-duration`. The worktree was created off `master` (commit `1ee4c736`) and the spec is already committed (`a5c6267c`). All `git` commands below assume the working directory is `C:/Users/nikla/Coding/iRaceDeck/ir-490`.
+
+---
+
+## Build / verification commands
+
+Workspace root commands (run from any directory inside the worktree):
+
+```bash
+pnpm --filter @iracedeck/deck-core test
+pnpm --filter @iracedeck/deck-core test -- base-action.test.ts
+pnpm --filter @iracedeck/deck-core test -- global-settings.test.ts
+pnpm build
+pnpm lint:fix
+pnpm format:fix
+```
+
+**Build strategy:** Before running `pnpm build` manually, ask the user whether a watcher (`pnpm dev` or `rollup -w`) is already running — running `pnpm build` while a watcher is active interferes with the watcher's incremental state and the watcher already produces fresh output. If the watcher is running, skip the manual build and verify by checking watcher output instead. (See user feedback `feedback_ask_about_build.md`.)
+
+---
+
+## Task 1: Add `flagFlashDurationMs` to the global settings schema (TDD)
+
+**Files:**
+- Modify: `packages/deck-core/src/global-settings.ts:62-279` (`GlobalSettingsSchema` block)
+- Test: `packages/deck-core/src/global-settings.test.ts` (append a new `describe` block)
+
+- [ ] **Step 1.1: Write the failing schema tests**
+
+Append this block to `packages/deck-core/src/global-settings.test.ts` (after the last existing `describe` block):
+
+```typescript
+describe("flagFlashDurationMs (issue #490)", () => {
+  it("defaults to 5000 when not specified", () => {
+    const parsed = GlobalSettingsSchema.parse({}) as Record<string, unknown>;
+    expect(parsed.flagFlashDurationMs).toBe(5000);
+  });
+
+  it("accepts the lower bound (0 = flash forever)", () => {
+    const parsed = GlobalSettingsSchema.parse({ flagFlashDurationMs: 0 }) as Record<string, unknown>;
+    expect(parsed.flagFlashDurationMs).toBe(0);
+  });
+
+  it("accepts the upper bound (15000 ms)", () => {
+    const parsed = GlobalSettingsSchema.parse({ flagFlashDurationMs: 15000 }) as Record<string, unknown>;
+    expect(parsed.flagFlashDurationMs).toBe(15000);
+  });
+
+  it("coerces a numeric string from the Property Inspector slider", () => {
+    const parsed = GlobalSettingsSchema.parse({ flagFlashDurationMs: "7500" }) as Record<string, unknown>;
+    expect(parsed.flagFlashDurationMs).toBe(7500);
+  });
+
+  it("rejects values below 0", () => {
+    expect(() => GlobalSettingsSchema.parse({ flagFlashDurationMs: -1 })).toThrow();
+  });
+
+  it("rejects values above 15000", () => {
+    expect(() => GlobalSettingsSchema.parse({ flagFlashDurationMs: 15001 })).toThrow();
+  });
+});
+```
+
+- [ ] **Step 1.2: Run the new tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @iracedeck/deck-core test -- global-settings.test.ts
+```
+
+Expected: the new `flagFlashDurationMs` tests fail (default test expects `5000` but field is missing → `undefined`; the bounds tests pass trivially because `passthrough()` accepts any value as-is rather than validating).
+
+- [ ] **Step 1.3: Add the schema field**
+
+In `packages/deck-core/src/global-settings.ts`, inside `GlobalSettingsSchema` (the `z.object({ ... })` block that ends at line 278 with `.passthrough()`), add the field after `calloutEnabledPitServiceRequests` (around line 277):
+
+```typescript
+    /**
+     * Duration in milliseconds the flag overlay flashes after a new flag
+     * transition (issue #490). The flash auto-stops after this duration even
+     * while the underlying iRacing flag is still raised, so long full-course
+     * yellows don't turn into sustained visual noise. A new flag transition
+     * during or after the window starts a fresh timer.
+     *
+     * `0` disables the auto-stop and reverts to the original behaviour
+     * (flash continuously while the flag is raised). Range 0–15000, default
+     * 5000 (5 seconds). The blink rate (`FLAG_FLASH_INTERVAL_MS`) is a
+     * separate concept and stays a constant.
+     */
+    flagFlashDurationMs: z.coerce.number().min(0).max(15000).default(5000),
+```
+
+- [ ] **Step 1.4: Run the schema tests again — they should pass**
+
+Run:
+
+```bash
+pnpm --filter @iracedeck/deck-core test -- global-settings.test.ts
+```
+
+Expected: all `flagFlashDurationMs` cases pass; all pre-existing tests still pass.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add packages/deck-core/src/global-settings.ts packages/deck-core/src/global-settings.test.ts
+git commit -m "feat(deck-core): add flagFlashDurationMs global setting (#490)"
+```
+
+---
+
+## Task 2: Refactor `BaseAction` flag flash with a duration auto-stop (TDD)
+
+**Files:**
+- Modify: `packages/deck-core/src/base-action.ts:80-95` (private fields), `:447-494` (`startFlagFlash`/`stopFlagFlash`)
+- Test: `packages/deck-core/src/base-action.test.ts` (NEW)
+
+This is the largest task. It is structured TDD-first: each behaviour gets a failing test, then the minimal change to pass.
+
+### Step 2.1: Create the test scaffolding (no production code yet)
+
+- [ ] **Create `packages/deck-core/src/base-action.test.ts` with this content:**
+
+```typescript
+/**
+ * Tests for BaseAction flag-overlay duration auto-stop (issue #490).
+ *
+ * The harness mocks getController so the flag-overlay subscription
+ * registers a callback the test can drive directly via fake timers.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BaseAction } from "./base-action.js";
+import type { IDeckActionContext, IDeckDidReceiveSettingsEvent, IDeckWillAppearEvent } from "./types.js";
+
+type TelemetryCallback = (telemetry: { SessionFlags?: number } | undefined, isConnected: boolean) => void;
+
+const { mockSubscribe, mockUnsubscribe, getCapturedCallback } = vi.hoisted(() => {
+  let captured: TelemetryCallback | null = null;
+  return {
+    mockSubscribe: vi.fn((_id: string, cb: TelemetryCallback) => {
+      captured = cb;
+    }),
+    mockUnsubscribe: vi.fn(() => {
+      captured = null;
+    }),
+    getCapturedCallback: () => captured,
+  };
+});
+
+const { mockGetGlobalSettings } = vi.hoisted(() => ({
+  mockGetGlobalSettings: vi.fn<() => Record<string, unknown>>(() => ({})),
+}));
+
+vi.mock("./sdk-singleton.js", () => ({
+  getController: () => ({
+    subscribe: mockSubscribe,
+    unsubscribe: mockUnsubscribe,
+  }),
+}));
+
+vi.mock("./global-settings.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    getGlobalSettings: mockGetGlobalSettings,
+    onGlobalSettingsChange: vi.fn(() => () => {}),
+  };
+});
+
+// iRacing flag bitfield values used by resolveAllActiveFlags.
+// Mirrors @iracedeck/iracing-native Flags enum (Yellow = 0x08, Blue = 0x20).
+const FLAG_YELLOW = 0x08;
+const FLAG_BLUE = 0x20;
+
+class TestAction extends BaseAction {
+  // Expose the protected `flagOverlayActive` set for assertions.
+  getOverlayActive(): Set<string> {
+    return (this as unknown as { flagOverlayActive: Set<string> }).flagOverlayActive;
+  }
+
+  // Expose protected setKeyImage so tests can register a context — the
+  // overlay code skips contexts that aren't in `this.contexts`.
+  registerKey(ev: IDeckWillAppearEvent<Record<string, unknown>>, svg: string): Promise<void> {
+    return (this as unknown as { setKeyImage: (e: unknown, s: string) => Promise<void> }).setKeyImage(ev, svg);
+  }
+}
+
+interface TestContext {
+  action: TestAction;
+  fakeAction: IDeckActionContext;
+  setImageSpy: ReturnType<typeof vi.fn>;
+  driveTelemetry: (sessionFlags: number | undefined) => void;
+}
+
+function createTestContext(): TestContext {
+  const action = new TestAction();
+  const setImageSpy = vi.fn().mockResolvedValue(undefined);
+  const fakeAction: IDeckActionContext = {
+    id: "ctx-1",
+    isKey: () => true,
+    setImage: setImageSpy,
+    setTitle: vi.fn().mockResolvedValue(undefined),
+    setSettings: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const willAppear = {
+    action: fakeAction,
+    payload: { settings: {} },
+  } as unknown as IDeckWillAppearEvent<Record<string, unknown>>;
+
+  // Synchronous part of onWillAppear runs before the function's first await
+  // (skipped here because plugin-config is not initialized in tests). Safe
+  // to fire-and-forget.
+  void action.onWillAppear(willAppear);
+
+  // Register the context in `this.contexts` so applyFlagOverlayToContexts
+  // can find it. Synchronous side effect (contexts.set) happens before the
+  // awaited setImage call, so void-await is safe here too.
+  void action.registerKey(willAppear, "<svg/>");
+
+  // Opt the context into flag overlay + ensure telemetry subscription registers.
+  const settingsEvent = {
+    action: fakeAction,
+    payload: { settings: { flagsOverlay: true } },
+  } as unknown as IDeckDidReceiveSettingsEvent<Record<string, unknown>>;
+
+  void action.onDidReceiveSettings(settingsEvent);
+
+  return {
+    action,
+    fakeAction,
+    setImageSpy,
+    driveTelemetry: (sessionFlags) => {
+      const cb = getCapturedCallback();
+      if (!cb) throw new Error("Telemetry callback was never captured — subscription did not register");
+      cb(sessionFlags === undefined ? undefined : { SessionFlags: sessionFlags }, sessionFlags !== undefined);
+    },
+  };
+}
+
+describe("BaseAction flag flash duration (issue #490)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockGetGlobalSettings.mockReturnValue({ flagFlashDurationMs: 5000 });
+  });
+
+  it("auto-stops the flash after flagFlashDurationMs", () => {
+    const ctx = createTestContext();
+
+    ctx.driveTelemetry(FLAG_YELLOW);
+    expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(true);
+
+    vi.advanceTimersByTime(5000);
+
+    expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2.2: Run the scaffolding test to verify it fails for the right reason**
+
+Run:
+
+```bash
+pnpm --filter @iracedeck/deck-core test -- base-action.test.ts
+```
+
+Expected: the test fails because `flagOverlayActive.has("ctx-1")` is still `true` after 5000 ms — there is no auto-stop yet.
+
+- [ ] **Step 2.3: Add the auto-stop timer field**
+
+In `packages/deck-core/src/base-action.ts`, after the existing `flagFlashTimer` field declaration (line 80), add:
+
+```typescript
+  /** Auto-stop timer that ends the flash visual after the configured duration */
+  private flagFlashAutoStopTimer: ReturnType<typeof setTimeout> | null = null;
+```
+
+- [ ] **Step 2.4: Schedule the auto-stop in `startFlagFlash`**
+
+In `startFlagFlash()` (currently at line 447), modify the body so it:
+
+1. Clears any existing `flagFlashAutoStopTimer` alongside the existing `flagFlashTimer` clear.
+2. After starting the blink interval, schedules `setTimeout(() => this.endFlagFlashVisual(), durationMs)` when `durationMs > 0`.
+
+Replace the existing `startFlagFlash` method (the whole `private startFlagFlash(): void { ... }` block) with:
+
+```typescript
+  /**
+   * Start or restart the flag flash timer.
+   * Schedules an auto-stop after `flagFlashDurationMs` (issue #490).
+   */
+  private startFlagFlash(): void {
+    // Clear existing timers to prevent leaks
+    if (this.flagFlashTimer) {
+      clearInterval(this.flagFlashTimer);
+    }
+    if (this.flagFlashAutoStopTimer) {
+      clearTimeout(this.flagFlashAutoStopTimer);
+      this.flagFlashAutoStopTimer = null;
+    }
+
+    this.logger.debug(
+      `Starting flag flash: flags=[${this.currentFlags.map((f) => f.label).join(",")}], contexts=${this.flagOverlayContexts.size}`,
+    );
+
+    // Immediately show first flag
+    this.applyFlagOverlayToContexts();
+
+    this.flagFlashTimer = setInterval(() => {
+      this.flagFlashTick++;
+
+      if (this.flagFlashTick % 2 === 0) {
+        // Even tick: show flag color
+        this.applyFlagOverlayToContexts();
+      } else {
+        // Odd tick: restore original image
+        this.restoreAllFlagOverlayImages();
+      }
+    }, BaseAction.FLAG_FLASH_INTERVAL_MS);
+
+    // Auto-stop after configured duration. `0` keeps the flash running
+    // indefinitely (issue #490 escape hatch — backwards-compat).
+    const durationMs = getGlobalSettings().flagFlashDurationMs;
+    if (durationMs > 0) {
+      this.flagFlashAutoStopTimer = setTimeout(() => {
+        this.flagFlashAutoStopTimer = null;
+        this.endFlagFlashVisual();
+      }, durationMs);
+    }
+  }
+```
+
+- [ ] **Step 2.5: Add the `endFlagFlashVisual` method**
+
+Insert this method directly before the existing `stopFlagFlash` method (currently around line 476):
+
+```typescript
+  /**
+   * Stop the visual flash without clearing the cached flag state.
+   * Called by the duration auto-stop (issue #490): subsequent telemetry
+   * ticks with the same flag set are short-circuited by `lastFlagStateKey`,
+   * so the flash doesn't immediately retrigger.
+   */
+  private endFlagFlashVisual(): void {
+    if (this.flagFlashTimer) {
+      clearInterval(this.flagFlashTimer);
+      this.flagFlashTimer = null;
+    }
+
+    for (const contextId of this.flagOverlayActive) {
+      this.restoreFlagOverlayImage(contextId);
+    }
+
+    this.flagOverlayActive.clear();
+    this.flagFlashTick = 0;
+
+    // INTENTIONAL: lastFlagStateKey and currentFlags stay set so the same
+    // flag still in telemetry doesn't retrigger the flash via
+    // onFlagTelemetryUpdate's state-key short-circuit. stopFlagFlash() is
+    // the only path that wipes that cache (called when flags actually clear).
+    this.logger.debug("Flag flash auto-stopped after duration");
+  }
+```
+
+- [ ] **Step 2.6: Update `stopFlagFlash` to delegate visual cleanup and clear the auto-stop timer**
+
+Replace the existing `stopFlagFlash` method body so it calls `endFlagFlashVisual()` for the visual cleanup, then resets the cached state. Replace the whole `private stopFlagFlash(): void { ... }` block with:
+
+```typescript
+  /**
+   * Stop the flag flash and reset cached state.
+   * Called when flags clear (`flags.length === 0`) or the action
+   * unsubscribes from telemetry — anywhere a fresh transition should
+   * be allowed to retrigger the flash next.
+   */
+  private stopFlagFlash(): void {
+    if (this.flagFlashAutoStopTimer) {
+      clearTimeout(this.flagFlashAutoStopTimer);
+      this.flagFlashAutoStopTimer = null;
+    }
+
+    this.endFlagFlashVisual();
+
+    // Reset cached state so the next transition (including the same flag
+    // re-appearing later) restarts the flash.
+    this.lastFlagStateKey = "";
+    this.currentFlags = [];
+  }
+```
+
+- [ ] **Step 2.7: Run the auto-stop test — it should pass**
+
+Run:
+
+```bash
+pnpm --filter @iracedeck/deck-core test -- base-action.test.ts
+```
+
+Expected: the "auto-stops the flash after flagFlashDurationMs" test passes.
+
+- [ ] **Step 2.8: Add the "forever (0)" test**
+
+Append to the `describe("BaseAction flag flash duration (issue #490)", ...)` block in `base-action.test.ts`:
+
+```typescript
+  it("does not auto-stop when flagFlashDurationMs is 0 (forever)", () => {
+    mockGetGlobalSettings.mockReturnValue({ flagFlashDurationMs: 0 });
+
+    const ctx = createTestContext();
+    ctx.driveTelemetry(FLAG_YELLOW);
+
+    // Advance well past the default duration; flash must still be active.
+    vi.advanceTimersByTime(60_000);
+
+    expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(true);
+  });
+```
+
+- [ ] **Step 2.9: Run — it should pass on the first try**
+
+Run:
+
+```bash
+pnpm --filter @iracedeck/deck-core test -- base-action.test.ts
+```
+
+Expected: both tests pass. The implementation already gates the `setTimeout` on `durationMs > 0`.
+
+- [ ] **Step 2.10: Add the "retrigger restarts the window" test**
+
+Append:
+
+```typescript
+  it("restarts the auto-stop timer on a new flag transition", () => {
+    const ctx = createTestContext();
+
+    ctx.driveTelemetry(FLAG_YELLOW);
+    vi.advanceTimersByTime(4000);
+    expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(true);
+
+    // New transition (Yellow + Blue is a different state-key than Yellow alone).
+    ctx.driveTelemetry(FLAG_YELLOW | FLAG_BLUE);
+
+    // 4000 ms after the FIRST trigger, but only 0 ms into the SECOND window.
+    vi.advanceTimersByTime(4000);
+    expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(true);
+
+    // Another 1500 ms (5500 ms into the second window) — now past the limit.
+    vi.advanceTimersByTime(1500);
+    expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(false);
+  });
+```
+
+- [ ] **Step 2.11: Run — it should pass on the first try**
+
+Run:
+
+```bash
+pnpm --filter @iracedeck/deck-core test -- base-action.test.ts
+```
+
+Expected: pass. `startFlagFlash` already clears the existing auto-stop timer before scheduling a new one.
+
+- [ ] **Step 2.12: Add the "same-flag tick after auto-stop is a no-op" test**
+
+This is the test that validates the `endFlagFlashVisual` design (state preservation):
+
+```typescript
+  it("does not retrigger when the same flag continues in telemetry after auto-stop", () => {
+    const ctx = createTestContext();
+
+    ctx.driveTelemetry(FLAG_YELLOW);
+    vi.advanceTimersByTime(5000);
+    expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(false);
+
+    const callsBeforeRetick = ctx.setImageSpy.mock.calls.length;
+
+    // Same telemetry value comes in again — onFlagTelemetryUpdate should
+    // short-circuit because lastFlagStateKey is still "YELLOW".
+    ctx.driveTelemetry(FLAG_YELLOW);
+
+    expect(ctx.setImageSpy.mock.calls.length).toBe(callsBeforeRetick);
+    expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(false);
+  });
+```
+
+- [ ] **Step 2.13: Run — it should pass**
+
+Run:
+
+```bash
+pnpm --filter @iracedeck/deck-core test -- base-action.test.ts
+```
+
+Expected: pass. `endFlagFlashVisual` deliberately keeps `lastFlagStateKey` set, so the next telemetry update with the same bitfield short-circuits in `onFlagTelemetryUpdate` (the `if (stateKey === this.lastFlagStateKey) return;` guard).
+
+If this test fails, the most likely cause is that `endFlagFlashVisual` was inadvertently resetting `lastFlagStateKey` or `currentFlags` — fix by removing those resets from `endFlagFlashVisual` (they belong only in `stopFlagFlash`).
+
+- [ ] **Step 2.14: Add the "clear-then-restart fully resets" test**
+
+```typescript
+  it("restarts the flash when the same flag returns after a clear", () => {
+    const ctx = createTestContext();
+
+    ctx.driveTelemetry(FLAG_YELLOW);
+    vi.advanceTimersByTime(5000); // auto-stop fires
+
+    ctx.driveTelemetry(0); // flags clear → stopFlagFlash() resets cache
+
+    ctx.driveTelemetry(FLAG_YELLOW); // fresh transition — should retrigger
+    expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(true);
+  });
+```
+
+- [ ] **Step 2.15: Run — it should pass**
+
+Run:
+
+```bash
+pnpm --filter @iracedeck/deck-core test -- base-action.test.ts
+```
+
+Expected: pass. The `flags.length === 0` branch of `onFlagTelemetryUpdate` calls `stopFlagFlash()`, which resets `lastFlagStateKey` to `""`, so the subsequent `FLAG_YELLOW` is recognised as a transition.
+
+- [ ] **Step 2.16: Run the full deck-core suite to make sure nothing else regressed**
+
+Run:
+
+```bash
+pnpm --filter @iracedeck/deck-core test
+```
+
+Expected: all tests pass (existing + 5 new BaseAction tests + 6 new schema tests).
+
+- [ ] **Step 2.17: Commit**
+
+```bash
+git add packages/deck-core/src/base-action.ts packages/deck-core/src/base-action.test.ts
+git commit -m "feat(deck-core): auto-stop flag flash after configured duration (#490)"
+```
+
+---
+
+## Task 3: Create the `global-flag-flash` PI partial
+
+**Files:**
+- Create: `packages/pi-components/partials/global-flag-flash.ejs`
+
+- [ ] **Step 3.1: Create the partial**
+
+Create `packages/pi-components/partials/global-flag-flash.ejs` with this content:
+
+```ejs
+<!--
+  Global Flag Flash Settings
+
+  Plugin-wide flag-flash behaviour in a collapsible "Flag Flash" accordion.
+  Settings are stored in global settings (shared across all action instances).
+  Collapsed by default. See issue #490.
+-->
+<%- include('accordion', {
+  title: 'Flag Flash',
+  accordionId: 'Global Flag Flash',
+  open: false,
+  content: `
+    <sdpi-item label="Duration (ms)">
+      <sdpi-range setting="flagFlashDurationMs" default="5000" min="0" max="15000" step="500" global showlabels></sdpi-range>
+    </sdpi-item>
+    <div style="padding: 0 16px 8px; font-size: 11px; color: #999;">
+      How long the flag overlay flashes after a new flag transition.
+      Set to 0 to flash continuously while the flag is raised.
+    </div>
+  `
+}) %>
+```
+
+- [ ] **Step 3.2: Verify EJS partial syntax matches the existing global accordions**
+
+Read `packages/pi-components/partials/global-graphic-defaults.ejs` and confirm the structure matches (accordion call signature, content string format). Adjust if anything differs (e.g., quote style).
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add packages/pi-components/partials/global-flag-flash.ejs
+git commit -m "feat(pi-components): add global-flag-flash accordion partial (#490)"
+```
+
+---
+
+## Task 4: Include the new partial in every per-action template
+
+**Files (modify, all 34):**
+- `packages/iracing-actions/src/actions/ai-spotter-controls/ai-spotter-controls.ejs`
+- `packages/iracing-actions/src/actions/audio-controls/audio-controls.ejs`
+- `packages/iracing-actions/src/actions/black-box-selector/black-box-selector.ejs`
+- `packages/iracing-actions/src/actions/camera-editor-adjustments/camera-editor-adjustments.ejs`
+- `packages/iracing-actions/src/actions/camera-editor-controls/camera-editor-controls.ejs`
+- `packages/iracing-actions/src/actions/camera-focus/camera-focus.ejs`
+- `packages/iracing-actions/src/actions/car-control/car-control.ejs`
+- `packages/iracing-actions/src/actions/chat/chat.ejs`
+- `packages/iracing-actions/src/actions/cockpit-misc/cockpit-misc.ejs`
+- `packages/iracing-actions/src/actions/force-feedback/force-feedback.ejs`
+- `packages/iracing-actions/src/actions/fuel-service/fuel-service.ejs`
+- `packages/iracing-actions/src/actions/look-direction/look-direction.ejs`
+- `packages/iracing-actions/src/actions/media-capture/media-capture.ejs`
+- `packages/iracing-actions/src/actions/pit-crew/pit-crew.ejs`
+- `packages/iracing-actions/src/actions/pit-quick-actions/pit-quick-actions.ejs`
+- `packages/iracing-actions/src/actions/race-admin/race-admin.ejs`
+- `packages/iracing-actions/src/actions/replay-control/replay-control.ejs`
+- `packages/iracing-actions/src/actions/replay-navigation/replay-navigation.ejs`
+- `packages/iracing-actions/src/actions/replay-speed/replay-speed.ejs`
+- `packages/iracing-actions/src/actions/replay-transport/replay-transport.ejs`
+- `packages/iracing-actions/src/actions/session-info/session-info.ejs`
+- `packages/iracing-actions/src/actions/setup-aero/setup-aero.ejs`
+- `packages/iracing-actions/src/actions/setup-brakes/setup-brakes.ejs`
+- `packages/iracing-actions/src/actions/setup-chassis/setup-chassis.ejs`
+- `packages/iracing-actions/src/actions/setup-engine/setup-engine.ejs`
+- `packages/iracing-actions/src/actions/setup-fuel/setup-fuel.ejs`
+- `packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.ejs`
+- `packages/iracing-actions/src/actions/setup-traction/setup-traction.ejs`
+- `packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ejs`
+- `packages/iracing-actions/src/actions/telemetry-control/telemetry-control.ejs`
+- `packages/iracing-actions/src/actions/telemetry-display/telemetry-display.ejs`
+- `packages/iracing-actions/src/actions/tire-service/tire-service.ejs`
+- `packages/iracing-actions/src/actions/toggle-ui-elements/toggle-ui-elements.ejs`
+- `packages/iracing-actions/src/actions/view-adjustment/view-adjustment.ejs`
+
+- [ ] **Step 4.1: Insert the include in each template**
+
+For each file in the list above, add a single line `<%- include('global-flag-flash') %>` immediately after the existing `<%- include('global-graphic-defaults') %>` line and before `<%- include('global-common-settings') %>`.
+
+The standard pattern after the change should look like (taken from `look-direction.ejs`, lines 31-35):
+
+```ejs
+		<%- include('global-title-defaults') %>
+		<%- include('global-color-defaults') %>
+		<%- include('global-border-defaults') %>
+		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
+		<%- include('global-common-settings') %>
+```
+
+Match the existing indentation in each file (some use tabs, some may differ).
+
+If any of the 34 files does **not** have a `global-graphic-defaults` line (unlikely but possible), insert the new include directly before `global-common-settings` instead. If a file has neither, do not modify it — flag the discrepancy and stop the task to ask the user.
+
+- [ ] **Step 4.2: Verify the count of inclusions**
+
+Run:
+
+```bash
+grep -rl "global-flag-flash" packages/iracing-actions/src/actions/ | wc -l
+```
+
+Expected output: `34`.
+
+Also confirm that no per-action template double-includes the partial:
+
+```bash
+grep -c "global-flag-flash" packages/iracing-actions/src/actions/look-direction/look-direction.ejs
+```
+
+Expected output: `1`.
+
+- [ ] **Step 4.3: Build the plugins to confirm the EJS templates compile**
+
+Ask the user first whether a `pnpm dev` watcher is already running. If not, run:
+
+```bash
+pnpm build
+```
+
+Expected: build succeeds. Both Stream Deck and Mirabox plugin `ui/` outputs include the new "Flag Flash" accordion in every action's compiled HTML.
+
+- [ ] **Step 4.4: Spot-check the compiled HTML**
+
+```bash
+grep -l "Flag Flash" packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/ui/*.html | wc -l
+```
+
+Expected output: `34` (one HTML per action template).
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add packages/iracing-actions/src/actions/
+git commit -m "feat(actions): include global-flag-flash partial in every PI (#490)"
+```
+
+---
+
+## Task 5: Update the website documentation
+
+**Files:**
+- Modify: `packages/website/src/content/docs/docs/features/flags-overlay.md`
+
+- [ ] **Step 5.1: Append the new section to flags-overlay.md**
+
+After the existing "How It Works" section (the last paragraph ends with "while the flag is flashing."), append:
+
+```markdown
+
+## Flash Duration
+
+By default the flash plays for **5 seconds** after a new flag transition, then stops automatically — even if the flag is still raised. The intent is to give a clear "new event happened" beat without the sustained distraction of a flag flashing for the entire duration of a long full-course yellow.
+
+A new flag transition during the window starts a fresh timer, so the driver always gets the announcement when something changes.
+
+You can change the duration in the **Flag Flash** section under any action's Global Settings (the slider ranges from 0 to 15 000 ms in 500 ms steps). Setting it to **0** disables the auto-stop and reverts to the original behaviour: the flash continues for as long as the flag is raised.
+```
+
+- [ ] **Step 5.2: Commit**
+
+```bash
+git add packages/website/src/content/docs/docs/features/flags-overlay.md
+git commit -m "docs(website): document flag flash duration setting (#490)"
+```
+
+---
+
+## Task 6: Final verification
+
+- [ ] **Step 6.1: Run lint and format**
+
+Run:
+
+```bash
+pnpm lint:fix
+pnpm format:fix
+```
+
+Expected: no errors. If anything was auto-fixed, commit:
+
+```bash
+git add -u
+git commit -m "chore: apply lint/format fixes (#490)"
+```
+
+(Skip the commit if `git diff --quiet` reports no changes after the fixes.)
+
+- [ ] **Step 6.2: Run the full test suite**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6.3: Run the full build (ask first about the watcher)**
+
+Ask the user whether a watcher is running. If not, run:
+
+```bash
+pnpm build
+```
+
+Expected: build succeeds for every package.
+
+- [ ] **Step 6.4: Verify the worktree branch is ready to push**
+
+Run:
+
+```bash
+git log --oneline master..HEAD
+```
+
+Expected: 5–6 commits — spec doc, schema field, BaseAction refactor, PI partial, per-action template includes, website docs (and optional lint/format commit).
+
+---
+
+## Task 7: Open the pull request
+
+This task involves an external action (creating a PR). **Do not run any of these commands without confirming with the user first.** (See user feedback `feedback_confirm_before_external_actions.md`.)
+
+- [ ] **Step 7.1: Confirm with the user before pushing or opening the PR.**
+
+- [ ] **Step 7.2: Push the branch**
+
+```bash
+git push -u origin 490-flag-flash-duration
+```
+
+- [ ] **Step 7.3: Open the PR using the repo template**
+
+Read `.github/pull_request_template.md` first and use the same section structure (per `feedback_pr_template.md`). Title: `feat(deck-core): global setting for flag-flash duration (#490)` (conventional-commit prefix matches the issue label flow per `.claude/rules/build-and-commit.md`).
+
+```bash
+gh pr create --title "feat(deck-core): global setting for flag-flash duration (#490)" --body "$(cat <<'EOF'
+<!-- Use the structure from .github/pull_request_template.md verbatim -->
+EOF
+)"
+```
+
+- [ ] **Step 7.4: Report the PR URL to the user.**
+
+---
+
+## Post-merge
+
+After the PR merges, clean up the worktree per the user feedback `feedback_clean_before_worktree_remove.md`:
+
+```bash
+cd C:/Users/nikla/Coding/iRaceDeck/ir-490
+git clean -fdx
+cd C:/Users/nikla/Coding/iRaceDeck/dev
+git worktree remove ../ir-490
+git worktree list   # verify ir-490 is gone
+```

--- a/docs/superpowers/specs/2026-05-02-flag-flash-duration-design.md
+++ b/docs/superpowers/specs/2026-05-02-flag-flash-duration-design.md
@@ -1,0 +1,166 @@
+# Flag Flash Duration — Design
+
+Issue: [#490](https://github.com/niklam/iRaceDeck/issues/490) — `feat(deck-core): global setting for flag-flash duration`.
+
+## Problem
+
+`BaseAction.startFlagFlash()` runs the flag-overlay flash for as long as the underlying iRacing flag is raised. On long full-course yellows or sustained debris flags this means the button flashes for minutes, becoming visual noise the driver tunes out. The intent of the feature is "a new event happened" — once the driver has noticed it, the flash should stop.
+
+## Goal
+
+Make the flash a **finite beat** by default. After a user-configurable duration (default 5 s) the flash auto-stops even when the underlying flag is still active. A new flag transition during or after the flash window starts a fresh window. `0` disables the auto-stop (= today's behaviour, kept as an escape hatch).
+
+The blink rate (`FLAG_FLASH_INTERVAL_MS = 500`) is unchanged — that's a separate concept.
+
+## Setting
+
+| Field | Value |
+|-------|-------|
+| Schema key | `flagFlashDurationMs` |
+| Type | number (ms) |
+| Range | `0`–`15000` |
+| Default | `5000` |
+| `0` semantics | Flash continuously while the flag is raised (today's behaviour) |
+| Storage location | `GlobalSettingsSchema` (`packages/deck-core/src/global-settings.ts`) |
+| PI control | `<sdpi-range step="500">` — slider step 500 ms (≈ 0.5 s) |
+
+Naming follows the codebase convention of an explicit-unit suffix (`OVERTAKE_HOLD_MS`, `FLAG_FLASH_INTERVAL_MS`). The slider stores raw ms; tick labels show the ms value (no unit conversion in `sdpi-range`).
+
+## Timer logic
+
+`BaseAction` gains a sibling timer next to the existing `flagFlashTimer`:
+
+```ts
+private flagFlashAutoStopTimer: ReturnType<typeof setTimeout> | null = null;
+```
+
+### `startFlagFlash()` (modified)
+
+1. Clear any existing `flagFlashTimer` and `flagFlashAutoStopTimer` (existing pattern: prevent leaks on retrigger).
+2. Show the first flag image and start the blink interval (unchanged).
+3. Read `getGlobalSettings().flagFlashDurationMs`.
+4. If `> 0`, schedule `flagFlashAutoStopTimer = setTimeout(() => endFlagFlashVisual(), durationMs)`.
+5. If `0`, skip the auto-stop (= forever).
+
+The duration is read at flash start time, not via `onGlobalSettingsChange` — the user adjusts the slider, it takes effect on the **next** transition. No mid-flash retiming. Simpler, and makes the timer's lifetime obviously bounded by the transition that started it.
+
+### `endFlagFlashVisual()` (new private method)
+
+Called only by the auto-stop timer. Stops the **visual** without clearing the cached flag state.
+
+```ts
+private endFlagFlashVisual(): void {
+  if (this.flagFlashTimer) {
+    clearInterval(this.flagFlashTimer);
+    this.flagFlashTimer = null;
+  }
+  this.flagFlashAutoStopTimer = null;
+
+  for (const contextId of this.flagOverlayActive) {
+    this.restoreFlagOverlayImage(contextId);
+  }
+  this.flagOverlayActive.clear();
+  this.flagFlashTick = 0;
+
+  // INTENTIONAL: lastFlagStateKey and currentFlags stay set so the same
+  // flag continuing in telemetry doesn't retrigger the flash.
+}
+```
+
+The load-bearing detail: `lastFlagStateKey` is **not** reset. `onFlagTelemetryUpdate` already short-circuits when `stateKey === this.lastFlagStateKey`, so subsequent telemetry ticks with the same flag set are no-ops. Only a real change (different flag list) re-enters `startFlagFlash`.
+
+### `stopFlagFlash()` (modified)
+
+Real stop, called when flags clear (`flags.length === 0`) or the action unsubscribes. Calls `endFlagFlashVisual()` then resets the cached state (`lastFlagStateKey = ""`, `currentFlags = []`). Also clears `flagFlashAutoStopTimer` defensively (already cleared by `endFlagFlashVisual`, but explicit at the visible call site).
+
+### Why two methods rather than `stopFlagFlash(preserveState: boolean)`
+
+Three call sites today: `onFlagTelemetryUpdate` (flags cleared), `cleanupFlagSubscriptionIfUnneeded` (last overlay context removed), and the new auto-stop. Two of the three need the full reset, one needs the partial. Named methods read better than a boolean flag at the call site; the partial reset is a distinct concept worth its own name.
+
+### Retrigger semantics
+
+"New transition" = any change to the resolved flag-list state key. This matches today's transition detection (`onFlagTelemetryUpdate` already short-circuits on unchanged state key). Examples within a duration window:
+
+| Scenario | Behaviour |
+|----------|-----------|
+| `[Yellow]` → `[Yellow]` (same telemetry) | No-op (state-key match, short-circuit). |
+| `[Yellow]` → `[Yellow, Debris]` | State key changes → `startFlagFlash` retriggers, fresh duration window starts. |
+| `[Yellow]` → `[]` | State key changes → `stopFlagFlash` (full reset). |
+| `[Yellow]` (auto-stop fires) → `[Yellow]` later in same telemetry session | No-op — `lastFlagStateKey` is still `"Yellow"`. |
+| `[Yellow]` (auto-stop fires) → `[]` → `[Yellow]` | Two transitions: first stops fully, second restarts. |
+
+## Property Inspector
+
+New partial: `packages/pi-components/partials/global-flag-flash.ejs`.
+
+```ejs
+<%- include('accordion', {
+  title: 'Flag Flash',
+  accordionId: 'Global Flag Flash',
+  open: false,
+  content: `
+    <sdpi-item label="Duration (ms)">
+      <sdpi-range setting="flagFlashDurationMs" default="5000" min="0" max="15000" step="500" global showlabels></sdpi-range>
+    </sdpi-item>
+    <div style="padding: 0 16px 8px; font-size: 11px; color: #999;">
+      How long the flag flash plays after a new flag transition.
+      Set to 0 to flash continuously while the flag is raised.
+    </div>
+  `
+}) %>
+```
+
+Included from every per-action `.ejs` that already includes `global-common-settings`, matching the existing convention (every other global accordion partial is listed explicitly per action). Mechanical addition across the per-action templates; one extra line each.
+
+## Tests
+
+### `global-settings.test.ts` (existing file)
+
+Append a `flagFlashDurationMs` block:
+
+- Default is `5000` when not specified.
+- Parses `0` (escape hatch).
+- Parses `15000` (max).
+- Coerces `"7500"` (string from PI) to `7500`.
+- Rejects out-of-range values via Zod.
+
+### `base-action.test.ts` (new file)
+
+`BaseAction` has no existing test file. The new tests use `vi.useFakeTimers()` and a minimal harness that:
+
+- Mocks `getController()` so `ensureFlagTelemetrySubscription` registers a callback the test can drive directly.
+- Mocks `getGlobalSettings()` to return controllable `flagFlashDurationMs`.
+- Provides a fake `IDeckPlatformAction` with `setImage` recording calls and `isKey() === true`.
+
+Cases:
+
+1. **Auto-stop** — `flagFlashDurationMs = 5000`, drive a Yellow flag, advance fake timers by 5000 ms, assert `setImage` called with the original (restored) icon and no further blink ticks.
+2. **Forever (0)** — `flagFlashDurationMs = 0`, drive a Yellow flag, advance timers by 60 s, assert blink ticks continue (interval is still firing).
+3. **Retrigger restarts the window** — duration 5000, drive Yellow, advance 4000 ms, drive Yellow+Debris (new state key), advance another 4000 ms (8000 ms total since first trigger), assert flash still running. Advance another 1500 ms, assert auto-stopped.
+4. **Same-flag tick after auto-stop is a no-op** — drive Yellow, advance 5000 ms (auto-stops), drive another telemetry tick with `[Yellow]`, assert no new `setImage` calls (state-key short-circuit).
+5. **Flags clear after auto-stop fully resets** — drive Yellow, advance 5000 ms, drive `[]`, then drive Yellow again, assert flash restarts (fresh transition).
+
+## Documentation
+
+`packages/website/src/content/docs/docs/features/flags-overlay.md` — add a section describing the duration setting and its `0 = forever` semantics. Append after the existing "How It Works" section.
+
+## Files Affected
+
+| File | Change |
+|------|--------|
+| `packages/deck-core/src/global-settings.ts` | Add `flagFlashDurationMs` to `GlobalSettingsSchema`. |
+| `packages/deck-core/src/global-settings.test.ts` | Add schema cases. |
+| `packages/deck-core/src/base-action.ts` | Add `flagFlashAutoStopTimer`, modify `startFlagFlash`/`stopFlagFlash`, add `endFlagFlashVisual`. |
+| `packages/deck-core/src/base-action.test.ts` | New file with the five cases above. |
+| `packages/pi-components/partials/global-flag-flash.ejs` | New partial. |
+| `packages/iracing-actions/src/actions/*/<action>.ejs` | Add `<%- include('global-flag-flash') %>` to every per-action template that includes `global-common-settings`. |
+| `packages/website/src/content/docs/docs/features/flags-overlay.md` | Document the new setting. |
+
+No per-plugin registration needed — schema changes flow automatically via `GlobalSettingsSchema` to both Stream Deck and Mirabox plugins.
+
+## Out of scope
+
+- Mid-flash retiming when the slider changes (takes effect on the next transition instead — simpler, edge case unlikely to matter in practice).
+- Per-flag duration overrides (one duration applies to all flags).
+- Configuring the blink rate (`FLAG_FLASH_INTERVAL_MS` stays a constant).
+- Changing the storage unit to seconds (kept ms per the codebase convention).

--- a/packages/deck-core/src/base-action.test.ts
+++ b/packages/deck-core/src/base-action.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for BaseAction flag-overlay duration auto-stop (issue #490).
+ *
+ * The harness mocks getController so the flag-overlay subscription
+ * registers a callback the test can drive directly via fake timers.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BaseAction } from "./base-action.js";
+import type { IDeckActionContext, IDeckDidReceiveSettingsEvent, IDeckWillAppearEvent } from "./types.js";
+
+type TelemetryCallback = (telemetry: { SessionFlags?: number } | undefined, isConnected: boolean) => void;
+
+const { mockSubscribe, mockUnsubscribe, getCapturedCallback } = vi.hoisted(() => {
+  let captured: TelemetryCallback | null = null;
+
+  return {
+    mockSubscribe: vi.fn((_id: string, cb: TelemetryCallback) => {
+      captured = cb;
+    }),
+    mockUnsubscribe: vi.fn(() => {
+      captured = null;
+    }),
+    getCapturedCallback: () => captured,
+  };
+});
+
+const { mockGetGlobalSettings } = vi.hoisted(() => ({
+  mockGetGlobalSettings: vi.fn<() => Record<string, unknown>>(() => ({})),
+}));
+
+vi.mock("./sdk-singleton.js", () => ({
+  getController: () => ({
+    subscribe: mockSubscribe,
+    unsubscribe: mockUnsubscribe,
+  }),
+}));
+
+vi.mock("./global-settings.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    getGlobalSettings: mockGetGlobalSettings,
+    onGlobalSettingsChange: vi.fn(() => () => {}),
+  };
+});
+
+// iRacing flag bitfield values used by resolveAllActiveFlags.
+// Mirrors @iracedeck/iracing-native Flags enum (Yellow = 0x08, Blue = 0x20).
+const FLAG_YELLOW = 0x08;
+const FLAG_BLUE = 0x20;
+
+class TestAction extends BaseAction {
+  // Expose the protected `flagOverlayActive` set for assertions.
+  getOverlayActive(): Set<string> {
+    return (this as unknown as { flagOverlayActive: Set<string> }).flagOverlayActive;
+  }
+
+  // Expose protected setKeyImage so tests can register a context — the
+  // overlay code skips contexts that aren't in `this.contexts`.
+  registerKey(ev: IDeckWillAppearEvent<Record<string, unknown>>, svg: string): Promise<void> {
+    return (this as unknown as { setKeyImage: (e: unknown, s: string) => Promise<void> }).setKeyImage(ev, svg);
+  }
+}
+
+interface TestContext {
+  action: TestAction;
+  fakeAction: IDeckActionContext;
+  setImageSpy: ReturnType<typeof vi.fn>;
+  driveTelemetry: (sessionFlags: number | undefined) => void;
+}
+
+function createTestContext(): TestContext {
+  const action = new TestAction();
+  const setImageSpy = vi.fn().mockResolvedValue(undefined);
+  const fakeAction: IDeckActionContext = {
+    id: "ctx-1",
+    isKey: () => true,
+    setImage: setImageSpy,
+    setTitle: vi.fn().mockResolvedValue(undefined),
+    setSettings: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const willAppear = {
+    action: fakeAction,
+    payload: { settings: {} },
+  } as unknown as IDeckWillAppearEvent<Record<string, unknown>>;
+
+  // Synchronous part of onWillAppear runs before the function's first await
+  // (skipped here because plugin-config is not initialized in tests). Safe
+  // to fire-and-forget.
+  void action.onWillAppear(willAppear);
+
+  // Register the context in `this.contexts` so applyFlagOverlayToContexts
+  // can find it. Synchronous side effect (contexts.set) happens before the
+  // awaited setImage call, so void-await is safe here too.
+  void action.registerKey(willAppear, "<svg/>");
+
+  // Opt the context into flag overlay + ensure telemetry subscription registers.
+  const settingsEvent = {
+    action: fakeAction,
+    payload: { settings: { flagsOverlay: true } },
+  } as unknown as IDeckDidReceiveSettingsEvent<Record<string, unknown>>;
+
+  void action.onDidReceiveSettings(settingsEvent);
+
+  return {
+    action,
+    fakeAction,
+    setImageSpy,
+    driveTelemetry: (sessionFlags) => {
+      const cb = getCapturedCallback();
+
+      if (!cb) throw new Error("Telemetry callback was never captured — subscription did not register");
+
+      cb(sessionFlags === undefined ? undefined : { SessionFlags: sessionFlags }, sessionFlags !== undefined);
+    },
+  };
+}
+
+describe("BaseAction flag flash duration (issue #490)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockGetGlobalSettings.mockReturnValue({ flagFlashDurationMs: 5000 });
+  });
+
+  it("auto-stops the flash after flagFlashDurationMs", () => {
+    const ctx = createTestContext();
+
+    ctx.driveTelemetry(FLAG_YELLOW);
+    expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(true);
+
+    vi.advanceTimersByTime(5000);
+
+    expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(false);
+  });
+
+  it("does not auto-stop when flagFlashDurationMs is 0 (forever)", () => {
+    mockGetGlobalSettings.mockReturnValue({ flagFlashDurationMs: 0 });
+
+    const ctx = createTestContext();
+    ctx.driveTelemetry(FLAG_YELLOW);
+
+    // Advance well past the default duration; flash must still be active.
+    vi.advanceTimersByTime(60_000);
+
+    expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(true);
+  });
+
+  it("restarts the auto-stop timer on a new flag transition", () => {
+    const ctx = createTestContext();
+
+    ctx.driveTelemetry(FLAG_YELLOW);
+    vi.advanceTimersByTime(4000);
+    expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(true);
+
+    // New transition (Yellow + Blue is a different state-key than Yellow alone).
+    ctx.driveTelemetry(FLAG_YELLOW | FLAG_BLUE);
+
+    // 4000 ms after the FIRST trigger, but only 0 ms into the SECOND window.
+    vi.advanceTimersByTime(4000);
+    expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(true);
+
+    // Another 1500 ms (5500 ms into the second window) — now past the limit.
+    vi.advanceTimersByTime(1500);
+    expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(false);
+  });
+
+  it("does not retrigger when the same flag continues in telemetry after auto-stop", () => {
+    const ctx = createTestContext();
+
+    ctx.driveTelemetry(FLAG_YELLOW);
+    vi.advanceTimersByTime(5000);
+    expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(false);
+
+    const callsBeforeRetick = ctx.setImageSpy.mock.calls.length;
+
+    // Same telemetry value comes in again — onFlagTelemetryUpdate should
+    // short-circuit because lastFlagStateKey is still "YELLOW".
+    ctx.driveTelemetry(FLAG_YELLOW);
+
+    expect(ctx.setImageSpy.mock.calls.length).toBe(callsBeforeRetick);
+    expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(false);
+  });
+
+  it("restarts the flash when the same flag returns after a clear", () => {
+    const ctx = createTestContext();
+
+    ctx.driveTelemetry(FLAG_YELLOW);
+    vi.advanceTimersByTime(5000); // auto-stop fires
+
+    ctx.driveTelemetry(0); // flags clear → stopFlagFlash() resets cache
+
+    ctx.driveTelemetry(FLAG_YELLOW); // fresh transition — should retrigger
+    expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(true);
+  });
+});

--- a/packages/deck-core/src/base-action.test.ts
+++ b/packages/deck-core/src/base-action.test.ts
@@ -4,7 +4,7 @@
  * The harness mocks getController so the flag-overlay subscription
  * registers a callback the test can drive directly via fake timers.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { BaseAction } from "./base-action.js";
 import type { IDeckActionContext, IDeckDidReceiveSettingsEvent, IDeckWillAppearEvent } from "./types.js";
@@ -124,6 +124,10 @@ describe("BaseAction flag flash duration (issue #490)", () => {
     vi.useFakeTimers();
     vi.clearAllMocks();
     mockGetGlobalSettings.mockReturnValue({ flagFlashDurationMs: 5000 });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("auto-stops the flash after flagFlashDurationMs", () => {

--- a/packages/deck-core/src/base-action.test.ts
+++ b/packages/deck-core/src/base-action.test.ts
@@ -123,14 +123,14 @@ describe("BaseAction flag flash duration (issue #490)", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
-    mockGetGlobalSettings.mockReturnValue({ flagFlashDurationMs: 5000 });
+    mockGetGlobalSettings.mockReturnValue({ flagFlashDurationSeconds: 5 });
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it("auto-stops the flash after flagFlashDurationMs", () => {
+  it("auto-stops the flash after flagFlashDurationSeconds", () => {
     const ctx = createTestContext();
 
     ctx.driveTelemetry(FLAG_YELLOW);
@@ -141,8 +141,8 @@ describe("BaseAction flag flash duration (issue #490)", () => {
     expect(ctx.action.getOverlayActive().has("ctx-1")).toBe(false);
   });
 
-  it("does not auto-stop when flagFlashDurationMs is 0 (forever)", () => {
-    mockGetGlobalSettings.mockReturnValue({ flagFlashDurationMs: 0 });
+  it("does not auto-stop when flagFlashDurationSeconds is 0 (forever)", () => {
+    mockGetGlobalSettings.mockReturnValue({ flagFlashDurationSeconds: 0 });
 
     const ctx = createTestContext();
     ctx.driveTelemetry(FLAG_YELLOW);

--- a/packages/deck-core/src/base-action.ts
+++ b/packages/deck-core/src/base-action.ts
@@ -79,6 +79,9 @@ export abstract class BaseAction<T = Record<string, unknown>> implements IDeckAc
   /** Shared flash timer for all overlay contexts */
   private flagFlashTimer: ReturnType<typeof setInterval> | null = null;
 
+  /** Auto-stop timer that ends the flash visual after the configured duration */
+  private flagFlashAutoStopTimer: ReturnType<typeof setTimeout> | null = null;
+
   /** Current active flags from telemetry */
   private currentFlags: FlagInfo[] = [];
 
@@ -443,11 +446,17 @@ export abstract class BaseAction<T = Record<string, unknown>> implements IDeckAc
 
   /**
    * Start or restart the flag flash timer.
+   * Schedules an auto-stop after `flagFlashDurationMs` (issue #490).
    */
   private startFlagFlash(): void {
-    // Clear existing timer to prevent leaks
+    // Clear existing timers to prevent leaks
     if (this.flagFlashTimer) {
       clearInterval(this.flagFlashTimer);
+    }
+
+    if (this.flagFlashAutoStopTimer) {
+      clearTimeout(this.flagFlashAutoStopTimer);
+      this.flagFlashAutoStopTimer = null;
     }
 
     this.logger.debug(
@@ -468,29 +477,63 @@ export abstract class BaseAction<T = Record<string, unknown>> implements IDeckAc
         this.restoreAllFlagOverlayImages();
       }
     }, BaseAction.FLAG_FLASH_INTERVAL_MS);
+
+    // Auto-stop after configured duration. `0` keeps the flash running
+    // indefinitely (issue #490 escape hatch — backwards-compat).
+    const durationMs = getGlobalSettings().flagFlashDurationMs;
+
+    if (durationMs > 0) {
+      this.flagFlashAutoStopTimer = setTimeout(() => {
+        this.flagFlashAutoStopTimer = null;
+        this.endFlagFlashVisual();
+      }, durationMs);
+    }
   }
 
   /**
-   * Stop the flag flash timer and restore original images.
+   * Stop the visual flash without clearing the cached flag state.
+   * Called by the duration auto-stop (issue #490): subsequent telemetry
+   * ticks with the same flag set are short-circuited by `lastFlagStateKey`,
+   * so the flash doesn't immediately retrigger.
    */
-  private stopFlagFlash(): void {
+  private endFlagFlashVisual(): void {
     if (this.flagFlashTimer) {
       clearInterval(this.flagFlashTimer);
       this.flagFlashTimer = null;
-      this.logger.debug("Flag flash stopped");
     }
 
-    // Restore all overlay-active contexts
     for (const contextId of this.flagOverlayActive) {
       this.restoreFlagOverlayImage(contextId);
     }
 
     this.flagOverlayActive.clear();
+    this.flagFlashTick = 0;
 
-    // Reset state so flash restarts correctly if re-enabled
+    // INTENTIONAL: lastFlagStateKey and currentFlags stay set so the same
+    // flag still in telemetry doesn't retrigger the flash via
+    // onFlagTelemetryUpdate's state-key short-circuit. stopFlagFlash() is
+    // the only path that wipes that cache (called when flags actually clear).
+    this.logger.debug("Flag flash auto-stopped after duration");
+  }
+
+  /**
+   * Stop the flag flash and reset cached state.
+   * Called when flags clear (`flags.length === 0`) or the action
+   * unsubscribes from telemetry — anywhere a fresh transition should
+   * be allowed to retrigger the flash next.
+   */
+  private stopFlagFlash(): void {
+    if (this.flagFlashAutoStopTimer) {
+      clearTimeout(this.flagFlashAutoStopTimer);
+      this.flagFlashAutoStopTimer = null;
+    }
+
+    this.endFlagFlashVisual();
+
+    // Reset cached state so the next transition (including the same flag
+    // re-appearing later) restarts the flash.
     this.lastFlagStateKey = "";
     this.currentFlags = [];
-    this.flagFlashTick = 0;
   }
 
   /**

--- a/packages/deck-core/src/base-action.ts
+++ b/packages/deck-core/src/base-action.ts
@@ -446,7 +446,7 @@ export abstract class BaseAction<T = Record<string, unknown>> implements IDeckAc
 
   /**
    * Start or restart the flag flash timer.
-   * Schedules an auto-stop after `flagFlashDurationMs` (issue #490).
+   * Schedules an auto-stop after `flagFlashDurationSeconds` (issue #490).
    */
   private startFlagFlash(): void {
     // Clear existing timers to prevent leaks
@@ -480,13 +480,13 @@ export abstract class BaseAction<T = Record<string, unknown>> implements IDeckAc
 
     // Auto-stop after configured duration. `0` keeps the flash running
     // indefinitely (issue #490 escape hatch — backwards-compat).
-    const durationMs = getGlobalSettings().flagFlashDurationMs;
+    const durationSeconds = getGlobalSettings().flagFlashDurationSeconds;
 
-    if (durationMs > 0) {
+    if (durationSeconds > 0) {
       this.flagFlashAutoStopTimer = setTimeout(() => {
         this.flagFlashAutoStopTimer = null;
         this.endFlagFlashVisual();
-      }, durationMs);
+      }, durationSeconds * 1000);
     }
   }
 

--- a/packages/deck-core/src/global-settings.test.ts
+++ b/packages/deck-core/src/global-settings.test.ts
@@ -293,32 +293,32 @@ describe("resolveActiveDriverName", () => {
   });
 });
 
-describe("flagFlashDurationMs (issue #490)", () => {
-  it("defaults to 5000 when not specified", () => {
+describe("flagFlashDurationSeconds (issue #490)", () => {
+  it("defaults to 15 when not specified", () => {
     const parsed = GlobalSettingsSchema.parse({}) as Record<string, unknown>;
-    expect(parsed.flagFlashDurationMs).toBe(5000);
+    expect(parsed.flagFlashDurationSeconds).toBe(15);
   });
 
   it("accepts the lower bound (0 = flash forever)", () => {
-    const parsed = GlobalSettingsSchema.parse({ flagFlashDurationMs: 0 }) as Record<string, unknown>;
-    expect(parsed.flagFlashDurationMs).toBe(0);
+    const parsed = GlobalSettingsSchema.parse({ flagFlashDurationSeconds: 0 }) as Record<string, unknown>;
+    expect(parsed.flagFlashDurationSeconds).toBe(0);
   });
 
-  it("accepts the upper bound (15000 ms)", () => {
-    const parsed = GlobalSettingsSchema.parse({ flagFlashDurationMs: 15000 }) as Record<string, unknown>;
-    expect(parsed.flagFlashDurationMs).toBe(15000);
+  it("accepts the upper bound (30 seconds)", () => {
+    const parsed = GlobalSettingsSchema.parse({ flagFlashDurationSeconds: 30 }) as Record<string, unknown>;
+    expect(parsed.flagFlashDurationSeconds).toBe(30);
   });
 
   it("coerces a numeric string from the Property Inspector slider", () => {
-    const parsed = GlobalSettingsSchema.parse({ flagFlashDurationMs: "7500" }) as Record<string, unknown>;
-    expect(parsed.flagFlashDurationMs).toBe(7500);
+    const parsed = GlobalSettingsSchema.parse({ flagFlashDurationSeconds: "12" }) as Record<string, unknown>;
+    expect(parsed.flagFlashDurationSeconds).toBe(12);
   });
 
   it("rejects values below 0", () => {
-    expect(() => GlobalSettingsSchema.parse({ flagFlashDurationMs: -1 })).toThrow();
+    expect(() => GlobalSettingsSchema.parse({ flagFlashDurationSeconds: -1 })).toThrow();
   });
 
-  it("rejects values above 15000", () => {
-    expect(() => GlobalSettingsSchema.parse({ flagFlashDurationMs: 15001 })).toThrow();
+  it("rejects values above 30", () => {
+    expect(() => GlobalSettingsSchema.parse({ flagFlashDurationSeconds: 31 })).toThrow();
   });
 });

--- a/packages/deck-core/src/global-settings.test.ts
+++ b/packages/deck-core/src/global-settings.test.ts
@@ -292,3 +292,33 @@ describe("resolveActiveDriverName", () => {
     expect(resolveActiveDriverName(["adam", "driver"], "driver")).toBe("driver");
   });
 });
+
+describe("flagFlashDurationMs (issue #490)", () => {
+  it("defaults to 5000 when not specified", () => {
+    const parsed = GlobalSettingsSchema.parse({}) as Record<string, unknown>;
+    expect(parsed.flagFlashDurationMs).toBe(5000);
+  });
+
+  it("accepts the lower bound (0 = flash forever)", () => {
+    const parsed = GlobalSettingsSchema.parse({ flagFlashDurationMs: 0 }) as Record<string, unknown>;
+    expect(parsed.flagFlashDurationMs).toBe(0);
+  });
+
+  it("accepts the upper bound (15000 ms)", () => {
+    const parsed = GlobalSettingsSchema.parse({ flagFlashDurationMs: 15000 }) as Record<string, unknown>;
+    expect(parsed.flagFlashDurationMs).toBe(15000);
+  });
+
+  it("coerces a numeric string from the Property Inspector slider", () => {
+    const parsed = GlobalSettingsSchema.parse({ flagFlashDurationMs: "7500" }) as Record<string, unknown>;
+    expect(parsed.flagFlashDurationMs).toBe(7500);
+  });
+
+  it("rejects values below 0", () => {
+    expect(() => GlobalSettingsSchema.parse({ flagFlashDurationMs: -1 })).toThrow();
+  });
+
+  it("rejects values above 15000", () => {
+    expect(() => GlobalSettingsSchema.parse({ flagFlashDurationMs: 15001 })).toThrow();
+  });
+});

--- a/packages/deck-core/src/global-settings.ts
+++ b/packages/deck-core/src/global-settings.ts
@@ -276,18 +276,18 @@ export const GlobalSettingsSchema = z
       .transform((val) => val === true || val === "true")
       .default(true),
     /**
-     * Duration in milliseconds the flag overlay flashes after a new flag
+     * Duration in seconds the flag overlay flashes after a new flag
      * transition (issue #490). The flash auto-stops after this duration even
      * while the underlying iRacing flag is still raised, so long full-course
      * yellows don't turn into sustained visual noise. A new flag transition
      * during or after the window starts a fresh timer.
      *
      * `0` disables the auto-stop and reverts to the original behaviour
-     * (flash continuously while the flag is raised). Range 0–15000, default
-     * 5000 (5 seconds). The blink rate (`FLAG_FLASH_INTERVAL_MS`) is a
-     * separate concept and stays a constant.
+     * (flash continuously while the flag is raised). Range 0–30 seconds,
+     * default 15. The blink rate (`FLAG_FLASH_INTERVAL_MS`) is a separate
+     * concept and stays a constant.
      */
-    flagFlashDurationMs: z.coerce.number().min(0).max(15000).default(5000),
+    flagFlashDurationSeconds: z.coerce.number().min(0).max(30).default(15),
   })
   .passthrough();
 

--- a/packages/deck-core/src/global-settings.ts
+++ b/packages/deck-core/src/global-settings.ts
@@ -275,6 +275,19 @@ export const GlobalSettingsSchema = z
       .union([z.boolean(), z.string()])
       .transform((val) => val === true || val === "true")
       .default(true),
+    /**
+     * Duration in milliseconds the flag overlay flashes after a new flag
+     * transition (issue #490). The flash auto-stops after this duration even
+     * while the underlying iRacing flag is still raised, so long full-course
+     * yellows don't turn into sustained visual noise. A new flag transition
+     * during or after the window starts a fresh timer.
+     *
+     * `0` disables the auto-stop and reverts to the original behaviour
+     * (flash continuously while the flag is raised). Range 0–15000, default
+     * 5000 (5 seconds). The blink rate (`FLAG_FLASH_INTERVAL_MS`) is a
+     * separate concept and stays a constant.
+     */
+    flagFlashDurationMs: z.coerce.number().min(0).max(15000).default(5000),
   })
   .passthrough();
 

--- a/packages/deck-core/src/simhub-service.test.ts
+++ b/packages/deck-core/src/simhub-service.test.ts
@@ -65,7 +65,7 @@ describe("SimHub Service", () => {
       calloutEnabledPitReadbackEntry: true,
       calloutEnabledPitReadbackExit: true,
       calloutEnabledPitServiceRequests: true,
-      flagFlashDurationMs: 5000,
+      flagFlashDurationSeconds: 15,
     });
   });
 
@@ -180,7 +180,7 @@ describe("SimHub Service", () => {
         calloutEnabledPitReadbackEntry: true,
         calloutEnabledPitReadbackExit: true,
         calloutEnabledPitServiceRequests: true,
-        flagFlashDurationMs: 5000,
+        flagFlashDurationSeconds: 15,
       });
 
       initializeSimHub(mockLogger);

--- a/packages/deck-core/src/simhub-service.test.ts
+++ b/packages/deck-core/src/simhub-service.test.ts
@@ -65,6 +65,7 @@ describe("SimHub Service", () => {
       calloutEnabledPitReadbackEntry: true,
       calloutEnabledPitReadbackExit: true,
       calloutEnabledPitServiceRequests: true,
+      flagFlashDurationMs: 5000,
     });
   });
 
@@ -179,6 +180,7 @@ describe("SimHub Service", () => {
         calloutEnabledPitReadbackEntry: true,
         calloutEnabledPitReadbackExit: true,
         calloutEnabledPitServiceRequests: true,
+        flagFlashDurationMs: 5000,
       });
 
       initializeSimHub(mockLogger);

--- a/packages/iracing-actions/src/actions/ai-spotter-controls/ai-spotter-controls.ejs
+++ b/packages/iracing-actions/src/actions/ai-spotter-controls/ai-spotter-controls.ejs
@@ -35,6 +35,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<%- include('docs-link') %>

--- a/packages/iracing-actions/src/actions/audio-controls/audio-controls.ejs
+++ b/packages/iracing-actions/src/actions/audio-controls/audio-controls.ejs
@@ -39,6 +39,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<script>

--- a/packages/iracing-actions/src/actions/black-box-selector/black-box-selector.ejs
+++ b/packages/iracing-actions/src/actions/black-box-selector/black-box-selector.ejs
@@ -48,6 +48,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<script>

--- a/packages/iracing-actions/src/actions/camera-editor-adjustments/camera-editor-adjustments.ejs
+++ b/packages/iracing-actions/src/actions/camera-editor-adjustments/camera-editor-adjustments.ejs
@@ -50,6 +50,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<script>

--- a/packages/iracing-actions/src/actions/camera-editor-controls/camera-editor-controls.ejs
+++ b/packages/iracing-actions/src/actions/camera-editor-controls/camera-editor-controls.ejs
@@ -58,6 +58,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<%- include('docs-link') %>

--- a/packages/iracing-actions/src/actions/camera-focus/camera-focus.ejs
+++ b/packages/iracing-actions/src/actions/camera-focus/camera-focus.ejs
@@ -160,6 +160,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<script>

--- a/packages/iracing-actions/src/actions/car-control/car-control.ejs
+++ b/packages/iracing-actions/src/actions/car-control/car-control.ejs
@@ -96,6 +96,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<%- include('docs-link') %>

--- a/packages/iracing-actions/src/actions/chat/chat.ejs
+++ b/packages/iracing-actions/src/actions/chat/chat.ejs
@@ -65,6 +65,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<script>

--- a/packages/iracing-actions/src/actions/cockpit-misc/cockpit-misc.ejs
+++ b/packages/iracing-actions/src/actions/cockpit-misc/cockpit-misc.ejs
@@ -42,6 +42,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<script>

--- a/packages/iracing-actions/src/actions/force-feedback/force-feedback.ejs
+++ b/packages/iracing-actions/src/actions/force-feedback/force-feedback.ejs
@@ -47,6 +47,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<script>

--- a/packages/iracing-actions/src/actions/fuel-service/fuel-service.ejs
+++ b/packages/iracing-actions/src/actions/fuel-service/fuel-service.ejs
@@ -71,6 +71,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<script>

--- a/packages/iracing-actions/src/actions/look-direction/look-direction.ejs
+++ b/packages/iracing-actions/src/actions/look-direction/look-direction.ejs
@@ -32,6 +32,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<%- include('docs-link') %>

--- a/packages/iracing-actions/src/actions/media-capture/media-capture.ejs
+++ b/packages/iracing-actions/src/actions/media-capture/media-capture.ejs
@@ -35,6 +35,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<%- include('docs-link') %>

--- a/packages/iracing-actions/src/actions/pit-crew/pit-crew.ejs
+++ b/packages/iracing-actions/src/actions/pit-crew/pit-crew.ejs
@@ -172,6 +172,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<%- include('docs-link') %>

--- a/packages/iracing-actions/src/actions/pit-quick-actions/pit-quick-actions.ejs
+++ b/packages/iracing-actions/src/actions/pit-quick-actions/pit-quick-actions.ejs
@@ -27,6 +27,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<%- include('docs-link') %>

--- a/packages/iracing-actions/src/actions/race-admin/race-admin.ejs
+++ b/packages/iracing-actions/src/actions/race-admin/race-admin.ejs
@@ -116,6 +116,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<script>

--- a/packages/iracing-actions/src/actions/replay-control/replay-control.ejs
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.ejs
@@ -100,6 +100,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<script>

--- a/packages/iracing-actions/src/actions/replay-navigation/replay-navigation.ejs
+++ b/packages/iracing-actions/src/actions/replay-navigation/replay-navigation.ejs
@@ -98,6 +98,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<%- include('docs-link') %>

--- a/packages/iracing-actions/src/actions/replay-speed/replay-speed.ejs
+++ b/packages/iracing-actions/src/actions/replay-speed/replay-speed.ejs
@@ -26,6 +26,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<%- include('docs-link') %>

--- a/packages/iracing-actions/src/actions/replay-transport/replay-transport.ejs
+++ b/packages/iracing-actions/src/actions/replay-transport/replay-transport.ejs
@@ -32,6 +32,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<%- include('docs-link') %>

--- a/packages/iracing-actions/src/actions/session-info/session-info.ejs
+++ b/packages/iracing-actions/src/actions/session-info/session-info.ejs
@@ -86,6 +86,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<%- include('docs-link') %>

--- a/packages/iracing-actions/src/actions/setup-aero/setup-aero.ejs
+++ b/packages/iracing-actions/src/actions/setup-aero/setup-aero.ejs
@@ -39,6 +39,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<script>

--- a/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.ejs
+++ b/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.ejs
@@ -42,6 +42,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<script>

--- a/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.ejs
+++ b/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.ejs
@@ -48,6 +48,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<%- include('docs-link') %>

--- a/packages/iracing-actions/src/actions/setup-engine/setup-engine.ejs
+++ b/packages/iracing-actions/src/actions/setup-engine/setup-engine.ejs
@@ -39,6 +39,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<%- include('docs-link') %>

--- a/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.ejs
+++ b/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.ejs
@@ -40,6 +40,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<script>

--- a/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.ejs
+++ b/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.ejs
@@ -41,6 +41,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<script>

--- a/packages/iracing-actions/src/actions/setup-traction/setup-traction.ejs
+++ b/packages/iracing-actions/src/actions/setup-traction/setup-traction.ejs
@@ -40,6 +40,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<script>

--- a/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ejs
+++ b/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ejs
@@ -41,6 +41,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<script>

--- a/packages/iracing-actions/src/actions/telemetry-control/telemetry-control.ejs
+++ b/packages/iracing-actions/src/actions/telemetry-control/telemetry-control.ejs
@@ -33,6 +33,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<%- include('docs-link') %>

--- a/packages/iracing-actions/src/actions/telemetry-display/telemetry-display.ejs
+++ b/packages/iracing-actions/src/actions/telemetry-display/telemetry-display.ejs
@@ -41,6 +41,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<%- include('docs-link') %>

--- a/packages/iracing-actions/src/actions/tire-service/tire-service.ejs
+++ b/packages/iracing-actions/src/actions/tire-service/tire-service.ejs
@@ -93,6 +93,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<%- include('docs-link') %>

--- a/packages/iracing-actions/src/actions/toggle-ui-elements/toggle-ui-elements.ejs
+++ b/packages/iracing-actions/src/actions/toggle-ui-elements/toggle-ui-elements.ejs
@@ -36,6 +36,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<%- include('docs-link') %>

--- a/packages/iracing-actions/src/actions/view-adjustment/view-adjustment.ejs
+++ b/packages/iracing-actions/src/actions/view-adjustment/view-adjustment.ejs
@@ -40,6 +40,7 @@
 		<%- include('global-color-defaults') %>
 		<%- include('global-border-defaults') %>
 		<%- include('global-graphic-defaults') %>
+		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
 
 		<script>

--- a/packages/pi-components/partials/global-flag-flash.ejs
+++ b/packages/pi-components/partials/global-flag-flash.ejs
@@ -1,0 +1,21 @@
+<!--
+  Global Flag Flash Settings
+
+  Plugin-wide flag-flash behaviour in a collapsible "Flag Flash" accordion.
+  Settings are stored in global settings (shared across all action instances).
+  Collapsed by default. See issue #490.
+-->
+<%- include('accordion', {
+  title: 'Flag Flash',
+  accordionId: 'Global Flag Flash',
+  open: false,
+  content: `
+    <sdpi-item label="Duration (ms)">
+      <ird-range-input setting="flagFlashDurationMs" min="0" max="15000" step="500" default="5000" global showlabels></ird-range-input>
+    </sdpi-item>
+    <div style="padding: 0 16px 8px; font-size: 11px; color: #999;">
+      How long the flag overlay flashes after a new flag transition.
+      Set to 0 to flash continuously while the flag is raised.
+    </div>
+  `
+}) %>

--- a/packages/pi-components/partials/global-flag-flash.ejs
+++ b/packages/pi-components/partials/global-flag-flash.ejs
@@ -10,8 +10,8 @@
   accordionId: 'Global Flag Flash',
   open: false,
   content: `
-    <sdpi-item label="Duration (ms)">
-      <ird-range-input setting="flagFlashDurationMs" min="0" max="15000" step="500" default="5000" global showlabels></ird-range-input>
+    <sdpi-item label="Duration (s)">
+      <ird-range-input setting="flagFlashDurationSeconds" min="0" max="30" step="1" default="15" global showlabels></ird-range-input>
     </sdpi-item>
     <div style="padding: 0 16px 8px; font-size: 11px; color: #999;">
       How long the flag overlay flashes after a new flag transition.

--- a/packages/pi-components/partials/global-flag-flash.ejs
+++ b/packages/pi-components/partials/global-flag-flash.ejs
@@ -13,7 +13,7 @@
     <sdpi-item label="Duration (s)">
       <ird-range-input setting="flagFlashDurationSeconds" min="0" max="30" step="1" default="15" global showlabels></ird-range-input>
     </sdpi-item>
-    <div style="padding: 0 16px 8px; font-size: 11px; color: #999;">
+    <div style="padding: 0 16px 8px; font-family: 'Segoe UI', Arial, Roboto, Helvetica, sans-serif; font-size: 9pt; color: #888;">
       How long the flag overlay flashes after a new flag transition.
       Set to 0 to flash continuously while the flag is raised.
     </div>

--- a/packages/website/src/content/docs/docs/features/flags-overlay.md
+++ b/packages/website/src/content/docs/docs/features/flags-overlay.md
@@ -22,8 +22,8 @@ When a flag becomes active during racing, the selected buttons flash the flag co
 
 ## Flash Duration
 
-By default the flash plays for **5 seconds** after a new flag transition, then stops automatically — even if the flag is still raised. The intent is to give a clear "new event happened" beat without the sustained distraction of a flag flashing for the entire duration of a long full-course yellow.
+By default the flash plays for **15 seconds** after a new flag transition, then stops automatically — even if the flag is still raised. The intent is to give a clear "new event happened" beat without the sustained distraction of a flag flashing for the entire duration of a long full-course yellow.
 
 A new flag transition during the window starts a fresh timer, so the driver always gets the announcement when something changes.
 
-You can change the duration in the **Flag Flash** section under any action's Global Settings (the slider ranges from 0 to 15 000 ms in 500 ms steps). Setting it to **0** disables the auto-stop and reverts to the original behaviour: the flash continues for as long as the flag is raised.
+You can change the duration in the **Flag Flash** section under any action's Global Settings (the slider ranges from 0 to 30 seconds in 1 second steps). Setting it to **0** disables the auto-stop and reverts to the original behaviour: the flash continues for as long as the flag is raised.

--- a/packages/website/src/content/docs/docs/features/flags-overlay.md
+++ b/packages/website/src/content/docs/docs/features/flags-overlay.md
@@ -19,3 +19,11 @@ You can enable it on as many or as few buttons as you like — for example, only
 ## How It Works
 
 When a flag becomes active during racing, the selected buttons flash the flag color on top of their normal icon. When the flag clears, the buttons return to their normal appearance. The overlay does not interfere with the button's action — you can still press it as usual while the flag is flashing.
+
+## Flash Duration
+
+By default the flash plays for **5 seconds** after a new flag transition, then stops automatically — even if the flag is still raised. The intent is to give a clear "new event happened" beat without the sustained distraction of a flag flashing for the entire duration of a long full-course yellow.
+
+A new flag transition during the window starts a fresh timer, so the driver always gets the announcement when something changes.
+
+You can change the duration in the **Flag Flash** section under any action's Global Settings (the slider ranges from 0 to 15 000 ms in 500 ms steps). Setting it to **0** disables the auto-stop and reverts to the original behaviour: the flash continues for as long as the flag is raised.

--- a/packages/website/src/content/docs/docs/features/flags-overlay.md
+++ b/packages/website/src/content/docs/docs/features/flags-overlay.md
@@ -26,4 +26,4 @@ By default the flash plays for **15 seconds** after a new flag transition, then 
 
 A new flag transition during the window starts a fresh timer, so the driver always gets the announcement when something changes.
 
-You can change the duration in the **Flag Flash** section under any action's Global Settings (the slider ranges from 0 to 30 seconds in 1 second steps). Setting it to **0** disables the auto-stop and reverts to the original behaviour: the flash continues for as long as the flag is raised.
+You can change the duration in the **Flag Flash** section under any action's Global Settings (the slider ranges from 0 to 30 seconds in 1-second steps). Setting it to **0** disables the auto-stop and reverts to the original behaviour: the flash continues for as long as the flag is raised.


### PR DESCRIPTION
## Related Issue

Fixes #490

## What changed?

Adds a new global setting `flagFlashDurationSeconds` (default `15`, range `0`–`30`, step `1`) that auto-stops the flag-overlay flash after the configured duration. A new flag transition during or after the window restarts the timer. Setting the value to `0` keeps today's behaviour: the flash continues for as long as the underlying iRacing flag is raised.

Implementation:

- **Schema** — `packages/deck-core/src/global-settings.ts`: new `flagFlashDurationSeconds` field, `z.coerce.number().min(0).max(30).default(15)`.
- **Timer logic** — `packages/deck-core/src/base-action.ts`: new `flagFlashAutoStopTimer` sibling to the existing flash interval. `startFlagFlash()` reads `getGlobalSettings().flagFlashDurationSeconds`, multiplies by 1000, and schedules `setTimeout` (skipped when `0`). New private `endFlagFlashVisual()` stops the visual but **keeps `lastFlagStateKey` and `currentFlags` intact** so the same flag continuing in telemetry doesn't immediately retrigger the flash via the existing state-key short-circuit. `stopFlagFlash()` (called when flags actually clear) delegates the visual cleanup to `endFlagFlashVisual()` then wipes the cached state.
- **Property Inspector** — new `packages/pi-components/partials/global-flag-flash.ejs` accordion ("Flag Flash" / "Duration (s)") included by every per-action template that already includes `global-common-settings` (34 templates).
- **Docs & rules** — `flags-overlay.md` describes the new setting; `.claude/rules/pi-templates.md` lists the new partial in both the Available Partials list and the basic template snippet.

The new field flows automatically to both the Stream Deck and Mirabox plugins via `GlobalSettingsSchema` — no per-plugin registration needed.

## How to test

- [ ] Open any iRaceDeck action's Property Inspector → "Flag Flash" accordion in the Global Settings region. Confirm the slider shows `0`–`30 s` in `1 s` steps with `15` as the default.
- [ ] In a session, trigger a yellow flag (or any active flag): the configured button should flash for ~15 s and then stop, even while the flag is still raised in iRacing.
- [ ] Within the flash window, force a new transition (e.g., yellow → yellow + debris): the flash should restart with a fresh duration.
- [ ] After the flash auto-stops while the flag is still active, the same flag continuing in telemetry should NOT retrigger the flash. Clearing then re-raising the flag should restart it.
- [ ] Set the duration slider to `0`: the flash should run continuously for as long as the flag is raised (matches previous behaviour).
- [ ] Verify the help text under the slider renders in the same font/size/color as the Version footer.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests (5 BaseAction timer cases + 6 schema cases; full suite 3594/3594 green)
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox — via shared `GlobalSettingsSchema` and the `global-flag-flash` partial included in all 34 per-action templates)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global "Flag Flash Duration" setting (slider 0–30s, 1s steps, default 15s)
  * Duration controls how long flag overlays flash after transitions; timer resets on new transitions
  * Setting 0 disables auto-stop so flash remains while the flag is raised
  * "Flag Flash" control added across action settings pages

* **Documentation**
  * Updated docs to describe Flash Duration behavior and controls
<!-- end of auto-generated comment: release notes by coderabbit.ai -->