### PR TITLE
feat(simhub): sort SimHub roles alphabetically in binding picker (#501)

### DIFF
--- a/packages/deck-core/src/simhub-service.test.ts
+++ b/packages/deck-core/src/simhub-service.test.ts
@@ -258,6 +258,21 @@ describe("SimHub Service", () => {
       expect(result).toEqual([]);
       expect(mockLogger.warn).toHaveBeenCalled();
     });
+
+    it("should sort roles alphabetically (case-insensitive)", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve(["Zebra", "apple", "Banana", "cherry"]),
+        }),
+      );
+
+      initializeSimHub(mockLogger);
+      const result = await getSimHub().getRoles();
+
+      expect(result).toEqual(["apple", "Banana", "cherry", "Zebra"]);
+    });
   });
 
   describe("URL-encodes role names", () => {

--- a/packages/deck-core/src/simhub-service.ts
+++ b/packages/deck-core/src/simhub-service.ts
@@ -150,7 +150,7 @@ class SimHubService implements ISimHubService {
         return [];
       }
 
-      const roles = json as string[];
+      const roles = (json as string[]).slice().sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
       this.logger.debug(`Available roles: ${JSON.stringify(roles)}`);
       this.setReachable(true);
 

--- a/packages/pi-components/src/components/key-binding-input.ts
+++ b/packages/pi-components/src/components/key-binding-input.ts
@@ -189,7 +189,9 @@ async function ensureSimHubRolesFetched(): Promise<void> {
         const json: unknown = await response.json();
 
         if (Array.isArray(json) && json.every((item) => typeof item === "string")) {
-          simHubRoles = json as string[];
+          simHubRoles = (json as string[])
+            .slice()
+            .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
           simHubReachable = true;
         } else {
           console.warn("[ird-key-binding] SimHub GetRoles returned unexpected format");


### PR DESCRIPTION
## Summary

- Sort SimHub Control Mapper roles alphabetically wherever they're shown in the Property Inspector binding picker (the friend of key bindings).
- Sort once at fetch/storage time using case-insensitive `localeCompare` (`sensitivity: "base"`) so every consumer sees a stable ordering — no per-keystroke sort in the autocomplete.
- Two independent code paths get the same comparator: `SimHubService.getRoles()` (plugin runtime) and the in-page `simHubRoles` cache in `ird-key-binding` (PI browser context).

Closes #501.

## Test plan

- [x] `pnpm test` — all 3659 tests pass, including the new `getRoles()` sort test
- [x] `pnpm build` — clean
- [x] `pnpm lint:fix` / `pnpm format:fix` — no changes
- [ ] Manual: open the PI for any action with a key binding, switch to SimHub mode, confirm the role dropdown is alphabetical regardless of definition order in SimHub Control Mapper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SimHub roles are now consistently sorted alphabetically in a case-insensitive manner, ensuring predictable presentation across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->