### PR TITLE
fix(actions): remove autofuel default key bindings (#374)

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -68,8 +68,8 @@
 | Push To Pass / Overtake | - | No | Push To Pass / Overtake |
 | DRS | - | No | DRS |
 | Traction Control Arm | - | No | Traction Control Arm |
-| Autofuel Toggle | Shift+Ctrl+A | No | Autofuel Toggle |
-| Adjust Autofuel Lap Margin | Shift+Alt+X / Shift+Alt+S | No | Autofuel Lap Margin Inc / Autofuel Lap Margin Dec |
+| Autofuel Toggle | - | No | Autofuel Toggle |
+| Adjust Autofuel Lap Margin | - | No | Autofuel Lap Margin Inc / Autofuel Lap Margin Dec |
 | Tear Off Visor | - | No | Tear Off Visor |
 | Toggle Windshield Wipers | Shift+W | No | Toggle Windshield Wipers |
 | Trigger Windshield Wipers | Ctrl+Alt+W | No | Trigger Windshield Wipers |

--- a/docs/plugins/core/actions/autofuel-lap-margin.md
+++ b/docs/plugins/core/actions/autofuel-lap-margin.md
@@ -34,8 +34,8 @@ Triggers the direction configured in Settings (increase or decrease).
 
 | Action | Default Key | iRacing Setting |
 |--------|-------------|-----------------|
-| Increase | Shift+Alt+X | Autofuel Lap Margin Inc |
-| Decrease | Shift+Alt+S | Autofuel Lap Margin Dec |
+| Increase | *(none)* | Autofuel Lap Margin Inc |
+| Decrease | *(none)* | Autofuel Lap Margin Dec |
 
 ## Icon States
 

--- a/docs/plugins/core/actions/autofuel-toggle.md
+++ b/docs/plugins/core/actions/autofuel-toggle.md
@@ -24,7 +24,7 @@ None.
 
 | Action | Default Key | iRacing Setting |
 |--------|-------------|-----------------|
-| Toggle | Shift+Ctrl+A | Autofuel Toggle |
+| Toggle | *(none)* | Autofuel Toggle |
 
 ## Icon States
 

--- a/docs/stream-deck-plugin-unified.md
+++ b/docs/stream-deck-plugin-unified.md
@@ -178,9 +178,9 @@ Complete fuel management for pit stops and autofuel.
 | Reduce Fuel         | -            | SDK             | Repeat     | Adjust amount |
 | Set Fuel Amount     | -            | SDK             | None       | Direct value  |
 | Clear Fuel Checkbox | _(SDK)_      | SDK             | None       | -             |
-| Toggle Autofuel     | Shift+Ctrl+A | -               | None       | -             |
-| Increase Lap Margin | Shift+Alt+X  | -               | Repeat     | -             |
-| Decrease Lap Margin | Shift+Alt+S  | -               | Repeat     | -             |
+| Toggle Autofuel     | -            | -               | None       | -             |
+| Increase Lap Margin | -            | -               | Repeat     | -             |
+| Decrease Lap Margin | -            | -               | Repeat     | -             |
 
 **Type:** Adjustment/Toggle (+/- or value input)
 **SDK Support:** Partial (pit commands via SDK, autofuel via keyboard)

--- a/packages/iracing-actions/src/actions/data/key-bindings.json
+++ b/packages/iracing-actions/src/actions/data/key-bindings.json
@@ -239,19 +239,19 @@
     {
       "id": "toggleAutofuel",
       "label": "Toggle Autofuel",
-      "default": "Shift+Ctrl+A",
+      "default": "",
       "setting": "fuelServiceToggleAutofuel"
     },
     {
       "id": "lapMarginIncrease",
       "label": "Lap Margin Increase",
-      "default": "Shift+Alt+X",
+      "default": "",
       "setting": "fuelServiceLapMarginIncrease"
     },
     {
       "id": "lapMarginDecrease",
       "label": "Lap Margin Decrease",
-      "default": "Shift+Alt+S",
+      "default": "",
       "setting": "fuelServiceLapMarginDecrease"
     }
   ],

--- a/packages/website/src/content/docs/docs/actions/pit-service/fuel-service.md
+++ b/packages/website/src/content/docs/docs/actions/pit-service/fuel-service.md
@@ -122,7 +122,7 @@ Toggle iRacing's autofuel checkbox on or off. The icon shows a green ON / red OF
 #### Details
 
 - **Dial:** No rotation support
-- **Default binding:** `Shift+Ctrl+A`
+- **Default binding:** No default key binding
 - **Telemetry-aware icon:** Yes — shows an on/off indicator driven by `dpFuelAutoFillActive`
 
 #### Settings
@@ -138,7 +138,7 @@ Raise the autofuel lap margin by one. Pressing the button taps the iRacing "Lap 
 #### Details
 
 - **Dial:** Rotation adjusts lap margin (clockwise = increase, counter-clockwise = decrease)
-- **Default binding:** `Shift+Alt+X`
+- **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
 #### Settings
@@ -154,7 +154,7 @@ Lower the autofuel lap margin by one. Pressing the button taps the iRacing "Lap 
 #### Details
 
 - **Dial:** Rotation adjusts lap margin (clockwise = decrease, counter-clockwise = increase)
-- **Default binding:** `Shift+Alt+S`
+- **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
 #### Settings

--- a/packages/website/src/content/docs/docs/reference/keyboard-shortcuts.md
+++ b/packages/website/src/content/docs/docs/reference/keyboard-shortcuts.md
@@ -21,8 +21,8 @@ Actions marked "Available via SDK" use SDK commands directly and don't require k
 | Ignition | I | No | Ignition |
 | Starter | S | No | Starter |
 | Pit Speed Limiter | A | No | Pit Speed Limiter |
-| Autofuel Toggle | Shift+Ctrl+A | No | Autofuel Toggle |
-| Adjust Autofuel Lap Margin | Shift+Alt+X / Shift+Alt+S | No | Autofuel Lap Margin Inc / Dec |
+| Autofuel Toggle | - | No | Autofuel Toggle |
+| Adjust Autofuel Lap Margin | - | No | Autofuel Lap Margin Inc / Dec |
 | Toggle Windshield Wipers | Shift+W | No | Toggle Windshield Wipers |
 | Trigger Windshield Wipers | Ctrl+Alt+W | No | Trigger Windshield Wipers |
 | Toggle Dash Box | D | No | Toggle Dash Box |


### PR DESCRIPTION
## Related Issue

Fixes #374

## What changed?

iRacing ships no defaults for Autofuel Toggle / Lap Margin Inc / Lap Margin Dec, so the PI's pre-filled `Shift+Ctrl+A` / `Shift+Alt+X` / `Shift+Alt+S` were misleading: out-of-the-box buttons either no-op (iRacing has nothing on those combos) or collide with whatever the user *does* have bound on them.

Changes (7 files, 16/+ 16/-):

- `packages/iracing-actions/src/actions/data/key-bindings.json` — `"default": "Shift+..."` → `"default": ""` for the three `fuelService` entries, matching the existing convention used by `tearOffVisor` / `pushToTalk`.
- Six docs files updated to reflect no-default state (`*(none)*` in the per-action docs, `-` in the keyboard-shortcuts tables, "No default key binding" in the website action page).

Two artifacts the issue listed turned out to be no-ops on inspection and were intentionally left alone:
- `packages/iracing-actions/src/actions/fuel-service/fuel-service.test.ts` — references setting names + mocked user-bound values, never the JSON defaults.
- `docs/plugins/core/actions/fuel-service.md` — already shows `*(none)*`.

One file the issue did not list was also updated: `docs/stream-deck-plugin-unified.md` (lines 181–183 had the old defaults).

No code change in `packages/pi-components/src/components/key-binding-input.ts`: the existing auto-persist-on-mount and SimHub→Keyboard repopulate paths handle empty `default=""` correctly (empty is falsy → first-mount persistence is skipped, mode-toggle resets to `null`).

Existing installs are unaffected — those values were already persisted into global settings on first PI mount and remain there.

## How to test

1. `pnpm install && pnpm build` — clean (verified: 17/17 tasks).
2. `pnpm test` — clean (verified: 3695/3695).
3. Open the generated `com.iracedeck.sd.core.sdPlugin/ui/fuel-service.html` and confirm the three `ird-key-binding` lines show `default=""` (verified).
4. Manual: clear stored values for `fuelServiceToggleAutofuel` / `fuelServiceLapMarginIncrease` / `fuelServiceLapMarginDecrease` in plugin global settings, open the fuel-service action's PI — the three inputs should be empty, not pre-filled.
5. Toggle one of them SimHub → Keyboard and back — field should stay empty rather than re-inserting the old default.
6. Smoke: with the three settings already populated by an existing user, the values should still display (defaults removal does not wipe persisted state).

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed default keyboard shortcuts for autofuel-related actions. Autofuel Toggle, Autofuel Lap Margin Increase, and Autofuel Lap Margin Decrease now have no pre-assigned key bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->