### PR TITLE
feat(actions): add chat on/off toggle mode (#244)

### DIFF
--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -9,7 +9,7 @@ description: Use when looking up Stream Deck actions, sub-actions, modes, catego
 
 Complete action definitions: `docs/reference/actions.json`
 
-The website currently documents **31 actions with 257 modes** (the totals used in this file and in user-facing docs). `docs/reference/actions.json` has not yet been re-synced to the new per-mode counting convention; use this skill file or the website as the source of truth for action and mode counts, and treat `actions.json` as a detailed inventory of individual mode values that is occasionally out of date.
+The website currently documents **31 actions with 258 modes** (the totals used in this file and in user-facing docs). `docs/reference/actions.json` has not yet been re-synced to the new per-mode counting convention; use this skill file or the website as the source of truth for action and mode counts, and treat `actions.json` as a detailed inventory of individual mode values that is occasionally out of date.
 
 Each action entry:
 ```json
@@ -44,8 +44,8 @@ When asked about actions or controls:
 | Media | 1 | 7 | Video recording, screenshots, texture management |
 | Pit Service | 3 | 15 | Fuel, tires, compounds, tearoff, fast repair |
 | Car Setup | 7 | 44 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control |
-| Communication | 2 | 34 | Chat, macros (15), whisper, reply, race admin commands |
-| **Total** | **31** | **257** | |
+| Communication | 2 | 35 | Chat, macros (15), whisper, toggle, reply, race admin commands |
+| **Total** | **31** | **258** | |
 
 Mode counts reflect the PI Mode/Setting dropdown choices documented in each action page. Directional variants (Increase/Decrease) are treated as a single mode with a Direction sub-setting, matching the per-mode website format. Legacy replay actions (Replay Transport, Replay Speed, Replay Navigation) and Camera Cycle (Legacy) still exist in the plugin manifest for backward compatibility but are not counted as documented actions.
 
@@ -119,7 +119,7 @@ Mode counts reflect the PI Mode/Setting dropdown choices documented in each acti
 
 | Action | Modes | Mode values |
 |--------|-------|-------------|
-| Chat | 7 | send-message, macro (1-15), reply, respond-pm, whisper (keyboard), open-chat, cancel |
+| Chat | 8 | send-message, macro (1-15), reply, respond-pm, whisper (keyboard), toggle (keyboard), open-chat, cancel |
 | Race Admin | 27 | yellow, black-flag, dq-driver, show-dqs-field, show-dqs-driver, clear-penalties, clear-all, wave-around, eol, pit-close, pit-open, pace-laps, single/double-file-restart, advance-session, grid-set, grid-start, track-state, grant/revoke-admin, remove-driver, enable/disable-chat (all/driver), message-all, rc-message |
 
 ## Control Patterns

--- a/docs/reference/actions.json
+++ b/docs/reference/actions.json
@@ -740,6 +740,7 @@
             { "value": "reply", "label": "Reply" },
             { "value": "respond-pm", "label": "Respond to Last PM" },
             { "value": "whisper", "label": "Whisper" },
+            { "value": "toggle", "label": "Toggle Chat On/Off" },
             { "value": "open-chat", "label": "Open Chat" },
             { "value": "cancel", "label": "Cancel" }
           ]

--- a/packages/icons/chat/toggle.svg
+++ b/packages/icons/chat/toggle.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a3a4a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"CHAT\nON/OFF"},"border":{"color":"#5a6a7a"},"artworkBounds":{"x":23,"y":19,"width":98,"height":68}}</desc>
+
+    <path d="M32 20 h80 a8 8 0 0 1 8 8 v40 a8 8 0 0 1-8 8 H76 l-6 10 l-6-10 H32 a8 8 0 0 1-8-8 V28 a8 8 0 0 1 8-8 z"
+          fill="none" stroke="{{graphic1Color}}" stroke-width="4" stroke-linejoin="round"/>
+    <circle cx="72" cy="52" r="14" fill="none" stroke="{{color}}" stroke-width="4"/>
+    <line x1="72" y1="32" x2="72" y2="52" stroke="{{color}}" stroke-width="5" stroke-linecap="round"/>
+
+</svg>

--- a/packages/icons/preview/chat/toggle.svg
+++ b/packages/icons/preview/chat/toggle.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a3a4a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"CHAT\nON/OFF"},"border":{"color":"#5a6a7a"},"artworkBounds":{"x":23,"y":19,"width":98,"height":68}}</desc>
+
+    <path d="M32 20 h80 a8 8 0 0 1 8 8 v40 a8 8 0 0 1-8 8 H76 l-6 10 l-6-10 H32 a8 8 0 0 1-8-8 V28 a8 8 0 0 1 8-8 z"
+          fill="none" stroke="#ffffff" stroke-width="4" stroke-linejoin="round"/>
+    <circle cx="72" cy="52" r="14" fill="none" stroke="{{color}}" stroke-width="4"/>
+    <line x1="72" y1="32" x2="72" y2="52" stroke="{{color}}" stroke-width="5" stroke-linecap="round"/>
+
+</svg>

--- a/packages/iracing-actions/src/actions/chat/chat.ejs
+++ b/packages/iracing-actions/src/actions/chat/chat.ejs
@@ -13,6 +13,7 @@
 				<option value="reply">Reply to Chat</option>
 				<option value="respond-pm">Respond to Last PM</option>
 				<option value="whisper">Whisper</option>
+				<option value="toggle">Toggle Chat On/Off</option>
 				<option value="open-chat">Open Chat</option>
 				<option value="cancel">Cancel Chat</option>
 			</sdpi-select>

--- a/packages/iracing-actions/src/actions/chat/chat.test.ts
+++ b/packages/iracing-actions/src/actions/chat/chat.test.ts
@@ -56,6 +56,9 @@ vi.mock("@iracedeck/icons/chat/respond-pm.svg", () => ({
 vi.mock("@iracedeck/icons/chat/cancel.svg", () => ({
   default: "<svg>cancel-icon</svg>",
 }));
+vi.mock("@iracedeck/icons/chat/toggle.svg", () => ({
+  default: "<svg>toggle-icon</svg>",
+}));
 
 vi.mock("@iracedeck/deck-core", () => ({
   CommonSettings: {
@@ -174,7 +177,7 @@ function fakeEvent(actionId: string, settings: Record<string, unknown> = {}) {
   };
 }
 
-type ChatMode = "send-message" | "macro" | "reply" | "respond-pm" | "whisper" | "open-chat" | "cancel";
+type ChatMode = "send-message" | "macro" | "reply" | "respond-pm" | "whisper" | "toggle" | "open-chat" | "cancel";
 
 /** Helper to build chat settings for test functions */
 function chatSettings(
@@ -205,6 +208,7 @@ describe("Chat", () => {
   describe("constants", () => {
     it("should map keyboard modes to correct global settings keys", () => {
       expect(CHAT_GLOBAL_KEYS["whisper"]).toBe("chatWhisper");
+      expect(CHAT_GLOBAL_KEYS["toggle"]).toBe("chatToggle");
     });
 
     it("should not contain SDK-based modes", () => {
@@ -267,6 +271,7 @@ describe("Chat", () => {
       "open-chat",
       "reply",
       "whisper",
+      "toggle",
       "respond-pm",
       "cancel",
       "send-message",
@@ -297,6 +302,7 @@ describe("Chat", () => {
         "open-chat": { line1: "OPEN", line2: "CHAT" },
         reply: { line1: "REPLY", line2: "CHAT" },
         whisper: { line1: "WHISPER", line2: "CHAT" },
+        toggle: { line1: "ON/OFF", line2: "CHAT" },
         "respond-pm": { line1: "RESPOND", line2: "LAST PM" },
         cancel: { line1: "CANCEL", line2: "CHAT" },
       };
@@ -588,8 +594,23 @@ describe("Chat", () => {
       expect(mockTapBinding).toHaveBeenCalledWith("chatWhisper");
     });
 
+    it("should call tapGlobalBinding for toggle", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { mode: "toggle" }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("chatToggle");
+    });
+
+    it("should call tapGlobalBinding even when no key binding is configured for toggle", async () => {
+      mockParseKeyBinding.mockReturnValue(null);
+
+      await action.onKeyDown(fakeEvent("action-1", { mode: "toggle" }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("chatToggle");
+    });
+
     it("should not call SDK commands for keyboard modes", async () => {
       await action.onKeyDown(fakeEvent("action-1", { mode: "whisper" }) as any);
+      await action.onKeyDown(fakeEvent("action-1", { mode: "toggle" }) as any);
 
       expect(mockBeginChat).not.toHaveBeenCalled();
       expect(mockReply).not.toHaveBeenCalled();

--- a/packages/iracing-actions/src/actions/chat/chat.ts
+++ b/packages/iracing-actions/src/actions/chat/chat.ts
@@ -25,6 +25,7 @@ import cancelIcon from "@iracedeck/icons/chat/cancel.svg";
 import openChatIcon from "@iracedeck/icons/chat/open-chat.svg";
 import replyIcon from "@iracedeck/icons/chat/reply.svg";
 import respondPmIcon from "@iracedeck/icons/chat/respond-pm.svg";
+import toggleIcon from "@iracedeck/icons/chat/toggle.svg";
 import whisperIcon from "@iracedeck/icons/chat/whisper.svg";
 import { buildTemplateContext, resolveTemplate } from "@iracedeck/iracing-sdk";
 import z from "zod";
@@ -57,7 +58,7 @@ const MACRO_TEMPLATE = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144
   </g>
 </svg>`;
 
-type ChatMode = "send-message" | "macro" | "reply" | "respond-pm" | "whisper" | "open-chat" | "cancel";
+type ChatMode = "send-message" | "macro" | "reply" | "respond-pm" | "whisper" | "toggle" | "open-chat" | "cancel";
 
 /**
  * Title configuration for each static chat mode (icon modes only, not send-message/macro)
@@ -66,6 +67,7 @@ const CHAT_TITLES: Partial<Record<ChatMode, string>> = {
   "open-chat": "CHAT\nOPEN",
   reply: "CHAT\nREPLY",
   whisper: "CHAT\nWHISPER",
+  toggle: "CHAT\nON/OFF",
   "respond-pm": "LAST PM\nRESPOND",
   cancel: "CHAT\nCANCEL",
 };
@@ -78,6 +80,7 @@ const CHAT_ICONS: Partial<Record<ChatMode, string>> = {
   "open-chat": openChatIcon,
   reply: replyIcon,
   whisper: whisperIcon,
+  toggle: toggleIcon,
   "respond-pm": respondPmIcon,
   cancel: cancelIcon,
 };
@@ -90,11 +93,12 @@ const CHAT_ICONS: Partial<Record<ChatMode, string>> = {
  */
 export const CHAT_GLOBAL_KEYS: Record<string, string> = {
   whisper: "chatWhisper",
+  toggle: "chatToggle",
 };
 
 const ChatSettings = CommonSettings.extend({
   mode: z
-    .enum(["send-message", "macro", "reply", "respond-pm", "whisper", "open-chat", "cancel"])
+    .enum(["send-message", "macro", "reply", "respond-pm", "whisper", "toggle", "open-chat", "cancel"])
     .default("send-message"),
   message: z.string().default(""),
   macroNumber: z.coerce.number().min(1).max(15).default(1),
@@ -360,8 +364,9 @@ export class Chat extends ConnectionStateAwareAction<ChatSettings> {
         this.executeSdkMacro(settings.macroNumber);
         break;
 
-      // Keyboard-based mode
-      case "whisper": {
+      // Keyboard-based modes
+      case "whisper":
+      case "toggle": {
         const settingKey = CHAT_GLOBAL_KEYS[mode];
 
         if (!settingKey) {

--- a/packages/iracing-actions/src/actions/data/key-bindings.json
+++ b/packages/iracing-actions/src/actions/data/key-bindings.json
@@ -671,7 +671,9 @@
     }
   ],
   "chat": [
-    { "id": "whisper", "label": "Whisper", "default": "", "setting": "chatWhisper" }],
+    { "id": "whisper", "label": "Whisper", "default": "", "setting": "chatWhisper" },
+    { "id": "toggle", "label": "Toggle Chat On/Off", "default": "", "setting": "chatToggle" }
+  ],
   "cameraEditorAdjustments": [
     { "id": "latitudeIncrease", "label": "Latitude +", "default": "D", "setting": "camEditLatitudeIncrease" },
     { "id": "latitudeDecrease", "label": "Latitude -", "default": "A", "setting": "camEditLatitudeDecrease" },

--- a/packages/website/src/content/docs/docs/actions/communication/chat.md
+++ b/packages/website/src/content/docs/docs/actions/communication/chat.md
@@ -3,11 +3,11 @@ title: Chat
 description: Send chat messages, macros, replies, whispers, and manage the chat window.
 sidebar:
   badge:
-    text: "7 modes"
+    text: "8 modes"
     variant: tip
 ---
 
-Send chat messages and interact with iRacing's chat system. Includes sending custom messages, triggering built-in chat macros, replying to messages, whispering a specific driver, and managing the chat window.
+Send chat messages and interact with iRacing's chat system. Includes sending custom messages, triggering built-in chat macros, replying to messages, whispering a specific driver, toggling the chat window, and managing the chat window.
 
 :::note
 Chat macros correspond to iRacing's built-in macro slots 1 through 15. Configure the macro text inside iRacing's chat macro settings.
@@ -98,6 +98,22 @@ Send a private whisper to a specific driver. Whisper has no SDK command in iRaci
 - **Dial:** No rotation support
 - **Default binding:** No default key binding — Whisper has no default iRacing hotkey, so you must configure it in both iRacing and the Property Inspector
 - **Telemetry-aware icon:** No
+
+#### Settings
+
+- No additional settings
+
+---
+
+### Toggle Chat On/Off
+
+Show or hide the chat window. iRacing's `Text Chat Toggle` control has no SDK command and ships with no default key, so this mode falls back to a keyboard binding.
+
+#### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No default key binding — `Text Chat Toggle` has no default iRacing hotkey, so you must bind a key in iRacing's *Options → Controls → Text Chat Toggle* and the matching key in the Property Inspector
+- **Telemetry-aware icon:** No — iRacing does not expose chat-window state via telemetry, so the button cannot reflect whether chat is currently visible
 
 #### Settings
 


### PR DESCRIPTION
## Related Issue

Fixes #244

## What changed?

Adds an 8th mode to the Chat action: **Toggle Chat On/Off**. Mirrors the existing `whisper` keyboard-only pattern — iRacing exposes no SDK command for chat visibility and the `Text Chat Toggle` controls binding ships with no default key, so the user binds a key in iRacing *Options → Controls → Text Chat Toggle* and the matching key in the Property Inspector under Global Settings → Chat → Toggle Chat On/Off.

The 429-variable telemetry catalogue has no chat-state variable, so the icon cannot reflect actual chat visibility.

- New `toggle` mode in `Chat` action and `chatToggle` global key binding
- New static icon `packages/icons/chat/toggle.svg` (chat bubble + power glyph)
- Tests cover toggle dispatch, global-key mapping, and label rendering
- Website chat page bumped to "8 modes" with a new Toggle Chat On/Off section
- `actions.json` and the `iracedeck-actions` skill counts updated (Chat 7→8, Communication 34→35, Total 257→258)

## How to test

1. In iRacing, bind a free key (e.g. `Ctrl+Shift+T`) to *Options → Controls → Text Chat Toggle*.
2. In Stream Deck, drop a Chat action onto a key, choose mode **Toggle Chat On/Off**.
3. Open Global Settings → Chat → Toggle Chat On/Off and bind the same key.
4. Press the Stream Deck button in-session — the chat window toggles.
5. Repeat the flow on Mirabox to confirm the same option and key-binding row are rendered there.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Toggle Chat On/Off" mode, enabling users to toggle chat window visibility via keyboard binding.

* **Documentation**
  * Updated Chat action reference and documentation to reflect the new toggle mode and expanded feature descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->