### PR TITLE
chore(chat): hide redundant "Respond to Last PM" mode (#505)

### DIFF
--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -9,7 +9,7 @@ description: Use when looking up Stream Deck actions, sub-actions, modes, catego
 
 Complete action definitions: `docs/reference/actions.json`
 
-The website currently documents **31 actions with 258 modes** (the totals used in this file and in user-facing docs). `docs/reference/actions.json` has not yet been re-synced to the new per-mode counting convention; use this skill file or the website as the source of truth for action and mode counts, and treat `actions.json` as a detailed inventory of individual mode values that is occasionally out of date.
+The website currently documents **31 actions with 257 modes** (the totals used in this file and in user-facing docs). `docs/reference/actions.json` has not yet been re-synced to the new per-mode counting convention; use this skill file or the website as the source of truth for action and mode counts, and treat `actions.json` as a detailed inventory of individual mode values that is occasionally out of date.
 
 Each action entry:
 ```json
@@ -44,8 +44,8 @@ When asked about actions or controls:
 | Media | 1 | 7 | Video recording, screenshots, texture management |
 | Pit Service | 3 | 15 | Fuel, tires, compounds, tearoff, fast repair |
 | Car Setup | 7 | 44 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control |
-| Communication | 2 | 35 | Chat, macros (15), whisper, toggle, reply, race admin commands |
-| **Total** | **31** | **258** | |
+| Communication | 2 | 34 | Chat, macros (15), whisper, toggle, reply, race admin commands |
+| **Total** | **31** | **257** | |
 
 Mode counts reflect the PI Mode/Setting dropdown choices documented in each action page. Directional variants (Increase/Decrease) are treated as a single mode with a Direction sub-setting, matching the per-mode website format. Legacy replay actions (Replay Transport, Replay Speed, Replay Navigation) and Camera Cycle (Legacy) still exist in the plugin manifest for backward compatibility but are not counted as documented actions.
 
@@ -119,7 +119,7 @@ Mode counts reflect the PI Mode/Setting dropdown choices documented in each acti
 
 | Action | Modes | Mode values |
 |--------|-------|-------------|
-| Chat | 8 | send-message, macro (1-15), reply, respond-pm, whisper (keyboard), toggle (keyboard), open-chat, cancel |
+| Chat | 7 | send-message, macro (1-15), reply, whisper (keyboard), toggle (keyboard), open-chat, cancel (`respond-pm` is a hidden alias of `reply` retained for backward compatibility — not exposed in the PI dropdown) |
 | Race Admin | 27 | yellow, black-flag, dq-driver, show-dqs-field, show-dqs-driver, clear-penalties, clear-all, wave-around, eol, pit-close, pit-open, pace-laps, single/double-file-restart, advance-session, grid-set, grid-start, track-state, grant/revoke-admin, remove-driver, enable/disable-chat (all/driver), message-all, rc-message |
 
 ## Control Patterns

--- a/docs/reference/actions.json
+++ b/docs/reference/actions.json
@@ -738,7 +738,6 @@
             { "value": "macro", "macroNumber": 14, "label": "Chat Macro 14" },
             { "value": "macro", "macroNumber": 15, "label": "Chat Macro 15" },
             { "value": "reply", "label": "Reply" },
-            { "value": "respond-pm", "label": "Respond to Last PM" },
             { "value": "whisper", "label": "Whisper" },
             { "value": "toggle", "label": "Toggle Chat On/Off" },
             { "value": "open-chat", "label": "Open Chat" },

--- a/docs/stream-deck-plugin-unified.md
+++ b/docs/stream-deck-plugin-unified.md
@@ -215,9 +215,8 @@ All text chat operations, messages, and macros.
 | Sub-Action         | Default Key | iRacing Setting | Long-Press | Notes               |
 | ------------------ | ----------- | --------------- | ---------- | ------------------- |
 | Open Chat          | T           | SDK             | None       | -                   |
-| Reply to Chat      | R           | SDK             | None       | -                   |
+| Reply              | R           | SDK             | None       | -                   |
 | Whisper            | / [num]     | -               | None       | -                   |
-| Respond to Last PM | /r          | SDK             | None       | -                   |
 | Cancel Chat        | _(SDK)_     | SDK             | None       | -                   |
 | Send Message       | -           | SDK             | None       | Configurable text   |
 | Macro (1-15)       | -           | SDK             | None       | Select number in PI |

--- a/packages/iracing-actions/src/actions/chat/chat.ejs
+++ b/packages/iracing-actions/src/actions/chat/chat.ejs
@@ -10,8 +10,7 @@
 			<sdpi-select id="mode-select" setting="mode" default="send-message">
 				<option value="send-message">Send Message</option>
 				<option value="macro">Macro (1-15)</option>
-				<option value="reply">Reply to Chat</option>
-				<option value="respond-pm">Respond to Last PM</option>
+				<option value="reply">Reply</option>
 				<option value="whisper">Whisper</option>
 				<option value="toggle">Toggle Chat On/Off</option>
 				<option value="open-chat">Open Chat</option>

--- a/packages/iracing-actions/src/actions/chat/chat.test.ts
+++ b/packages/iracing-actions/src/actions/chat/chat.test.ts
@@ -50,9 +50,6 @@ vi.mock("@iracedeck/icons/chat/reply.svg", () => ({
 vi.mock("@iracedeck/icons/chat/whisper.svg", () => ({
   default: "<svg>whisper-icon</svg>",
 }));
-vi.mock("@iracedeck/icons/chat/respond-pm.svg", () => ({
-  default: "<svg>respond-pm-icon</svg>",
-}));
 vi.mock("@iracedeck/icons/chat/cancel.svg", () => ({
   default: "<svg>cancel-icon</svg>",
 }));
@@ -177,7 +174,7 @@ function fakeEvent(actionId: string, settings: Record<string, unknown> = {}) {
   };
 }
 
-type ChatMode = "send-message" | "macro" | "reply" | "respond-pm" | "whisper" | "toggle" | "open-chat" | "cancel";
+type ChatMode = "send-message" | "macro" | "reply" | "whisper" | "toggle" | "open-chat" | "cancel";
 
 /** Helper to build chat settings for test functions */
 function chatSettings(
@@ -214,7 +211,6 @@ describe("Chat", () => {
     it("should not contain SDK-based modes", () => {
       expect(CHAT_GLOBAL_KEYS["open-chat"]).toBeUndefined();
       expect(CHAT_GLOBAL_KEYS["reply"]).toBeUndefined();
-      expect(CHAT_GLOBAL_KEYS["respond-pm"]).toBeUndefined();
       expect(CHAT_GLOBAL_KEYS["cancel"]).toBeUndefined();
       expect(CHAT_GLOBAL_KEYS["send-message"]).toBeUndefined();
       expect(CHAT_GLOBAL_KEYS["macro"]).toBeUndefined();
@@ -267,16 +263,7 @@ describe("Chat", () => {
   });
 
   describe("generateChatSvg", () => {
-    const allModes = [
-      "open-chat",
-      "reply",
-      "whisper",
-      "toggle",
-      "respond-pm",
-      "cancel",
-      "send-message",
-      "macro",
-    ] as const;
+    const allModes = ["open-chat", "reply", "whisper", "toggle", "cancel", "send-message", "macro"] as const;
 
     const defaultSettings = { message: "", macroNumber: 1, iconColor: "#4a90d9", keyText: "", fontSize: 11 };
 
@@ -303,7 +290,6 @@ describe("Chat", () => {
         reply: { line1: "REPLY", line2: "CHAT" },
         whisper: { line1: "WHISPER", line2: "CHAT" },
         toggle: { line1: "ON/OFF", line2: "CHAT" },
-        "respond-pm": { line1: "RESPOND", line2: "LAST PM" },
         cancel: { line1: "CANCEL", line2: "CHAT" },
       };
 
@@ -520,7 +506,10 @@ describe("Chat", () => {
       expect(mockBeginChat).not.toHaveBeenCalled();
     });
 
-    it("should call chat.reply() on keyDown for respond-pm", async () => {
+    it("should migrate legacy respond-pm to reply on keyDown", async () => {
+      // Backward compatibility: existing user settings with mode="respond-pm"
+      // are migrated to mode="reply" by parseSettings before executeMode runs,
+      // so the action still triggers chat.reply() exactly as before.
       await action.onKeyDown(fakeEvent("action-1", { mode: "respond-pm" }) as any);
 
       expect(mockReply).toHaveBeenCalledOnce();

--- a/packages/iracing-actions/src/actions/chat/chat.ts
+++ b/packages/iracing-actions/src/actions/chat/chat.ts
@@ -24,11 +24,12 @@ import {
 import cancelIcon from "@iracedeck/icons/chat/cancel.svg";
 import openChatIcon from "@iracedeck/icons/chat/open-chat.svg";
 import replyIcon from "@iracedeck/icons/chat/reply.svg";
-import respondPmIcon from "@iracedeck/icons/chat/respond-pm.svg";
 import toggleIcon from "@iracedeck/icons/chat/toggle.svg";
 import whisperIcon from "@iracedeck/icons/chat/whisper.svg";
 import { buildTemplateContext, resolveTemplate } from "@iracedeck/iracing-sdk";
 import z from "zod";
+
+import { migrateRespondPmToReply } from "./migrate-respond-pm.js";
 
 /**
  * SVG template for send-message mode: large chat bubble with text inside.
@@ -58,7 +59,7 @@ const MACRO_TEMPLATE = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144
   </g>
 </svg>`;
 
-type ChatMode = "send-message" | "macro" | "reply" | "respond-pm" | "whisper" | "toggle" | "open-chat" | "cancel";
+type ChatMode = "send-message" | "macro" | "reply" | "whisper" | "toggle" | "open-chat" | "cancel";
 
 /**
  * Title configuration for each static chat mode (icon modes only, not send-message/macro)
@@ -68,7 +69,6 @@ const CHAT_TITLES: Partial<Record<ChatMode, string>> = {
   reply: "CHAT\nREPLY",
   whisper: "CHAT\nWHISPER",
   toggle: "CHAT\nON/OFF",
-  "respond-pm": "LAST PM\nRESPOND",
   cancel: "CHAT\nCANCEL",
 };
 
@@ -81,7 +81,6 @@ const CHAT_ICONS: Partial<Record<ChatMode, string>> = {
   reply: replyIcon,
   whisper: whisperIcon,
   toggle: toggleIcon,
-  "respond-pm": respondPmIcon,
   cancel: cancelIcon,
 };
 
@@ -97,9 +96,7 @@ export const CHAT_GLOBAL_KEYS: Record<string, string> = {
 };
 
 const ChatSettings = CommonSettings.extend({
-  mode: z
-    .enum(["send-message", "macro", "reply", "respond-pm", "whisper", "toggle", "open-chat", "cancel"])
-    .default("send-message"),
+  mode: z.enum(["send-message", "macro", "reply", "whisper", "toggle", "open-chat", "cancel"]).default("send-message"),
   message: z.string().default(""),
   macroNumber: z.coerce.number().min(1).max(15).default(1),
   iconColor: z.string().default("#4a90d9"),
@@ -286,6 +283,7 @@ export class Chat extends ConnectionStateAwareAction<ChatSettings> {
 
   override async onWillAppear(ev: IDeckWillAppearEvent<ChatSettings>): Promise<void> {
     await super.onWillAppear(ev);
+    await this.persistMigratedSettings(ev);
     const settings = this.parseSettings(ev.payload.settings);
     this.activeContexts.set(ev.action.id, settings);
     const activeKey = CHAT_GLOBAL_KEYS[settings.mode];
@@ -311,6 +309,7 @@ export class Chat extends ConnectionStateAwareAction<ChatSettings> {
 
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<ChatSettings>): Promise<void> {
     await super.onDidReceiveSettings(ev);
+    await this.persistMigratedSettings(ev);
     const settings = this.parseSettings(ev.payload.settings);
     this.activeContexts.set(ev.action.id, settings);
     this.lastRenderedIcon.delete(ev.action.id);
@@ -336,10 +335,32 @@ export class Chat extends ConnectionStateAwareAction<ChatSettings> {
     this.logger.debug("Dial rotation ignored for chat action");
   }
 
-  private parseSettings(settings: unknown): ChatSettings {
-    const parsed = ChatSettings.safeParse(settings);
+  private parseSettings(raw: unknown): ChatSettings {
+    const { migrated } = migrateRespondPmToReply(raw);
+    const result = ChatSettings.safeParse(migrated);
 
-    return parsed.success ? parsed.data : ChatSettings.parse({});
+    return result.success ? result.data : ChatSettings.parse({});
+  }
+
+  /**
+   * Detect a legacy `mode: "respond-pm"` setting and persist the migrated
+   * shape (`mode: "reply"`) to Stream Deck storage so the legacy value is
+   * permanently dropped. Logs and swallows persist failures — the runtime
+   * always reads via `parseSettings`, so a failed persist doesn't block
+   * functionality.
+   */
+  private async persistMigratedSettings(
+    ev: IDeckWillAppearEvent<ChatSettings> | IDeckDidReceiveSettingsEvent<ChatSettings>,
+  ): Promise<void> {
+    const { migrated, changed } = migrateRespondPmToReply(ev.payload.settings);
+
+    if (!changed) return;
+
+    try {
+      await ev.action.setSettings(migrated);
+    } catch (err) {
+      this.logger.warn(`Failed to persist migrated chat settings: ${err instanceof Error ? err.message : err}`);
+    }
   }
 
   private async executeMode(mode: ChatMode, settings: ChatSettings): Promise<void> {
@@ -349,9 +370,6 @@ export class Chat extends ConnectionStateAwareAction<ChatSettings> {
         this.executeSdkBeginChat();
         break;
       case "reply":
-        this.executeSdkReply();
-        break;
-      case "respond-pm":
         this.executeSdkReply();
         break;
       case "cancel":

--- a/packages/iracing-actions/src/actions/chat/migrate-respond-pm.test.ts
+++ b/packages/iracing-actions/src/actions/chat/migrate-respond-pm.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { migrateRespondPmToReply } from "./migrate-respond-pm.js";
+
+describe("migrateRespondPmToReply", () => {
+  it("rewrites mode=respond-pm to mode=reply", () => {
+    const result = migrateRespondPmToReply({ mode: "respond-pm" });
+
+    expect(result.changed).toBe(true);
+    expect(result.migrated).toEqual({ mode: "reply" });
+  });
+
+  it("preserves other settings keys during migration", () => {
+    const result = migrateRespondPmToReply({
+      mode: "respond-pm",
+      message: "hi",
+      macroNumber: 3,
+      keyText: "REPLY",
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.migrated).toEqual({
+      mode: "reply",
+      message: "hi",
+      macroNumber: 3,
+      keyText: "REPLY",
+    });
+  });
+
+  it("does not change settings whose mode is already reply", () => {
+    const result = migrateRespondPmToReply({ mode: "reply" });
+
+    expect(result.changed).toBe(false);
+    expect(result.migrated).toEqual({ mode: "reply" });
+  });
+
+  it("does not touch unrelated modes", () => {
+    const result = migrateRespondPmToReply({ mode: "send-message", message: "hello" });
+
+    expect(result.changed).toBe(false);
+    expect(result.migrated).toEqual({ mode: "send-message", message: "hello" });
+  });
+
+  it("handles missing mode key", () => {
+    const result = migrateRespondPmToReply({ message: "hi" });
+
+    expect(result.changed).toBe(false);
+    expect(result.migrated).toEqual({ message: "hi" });
+  });
+
+  it("handles empty raw settings", () => {
+    const result = migrateRespondPmToReply({});
+
+    expect(result.changed).toBe(false);
+    expect(result.migrated).toEqual({});
+  });
+
+  it("handles null and undefined raw settings", () => {
+    expect(migrateRespondPmToReply(null)).toEqual({ migrated: {}, changed: false });
+    expect(migrateRespondPmToReply(undefined)).toEqual({ migrated: {}, changed: false });
+  });
+
+  it("handles non-object raw settings (string, number, boolean)", () => {
+    expect(migrateRespondPmToReply("string").changed).toBe(false);
+    expect(migrateRespondPmToReply(42).changed).toBe(false);
+    expect(migrateRespondPmToReply(true).changed).toBe(false);
+  });
+});

--- a/packages/iracing-actions/src/actions/chat/migrate-respond-pm.ts
+++ b/packages/iracing-actions/src/actions/chat/migrate-respond-pm.ts
@@ -1,0 +1,27 @@
+/**
+ * One-shot in-place migration helper for the chat action's legacy
+ * `mode: "respond-pm"` value, which was a duplicate alias of `mode: "reply"`
+ * (both call `chat.reply()`). The dropdown option was removed in #505;
+ * this migration rewrites any persisted `respond-pm` value to `reply` so the
+ * Property Inspector dropdown stays in sync with the saved setting and the
+ * Zod schema no longer has to carry the legacy enum value.
+ *
+ * Returns `{ migrated, changed }` so callers can decide whether to persist
+ * via `ev.action.setSettings(migrated)`. Safe on non-object inputs.
+ *
+ * Mirrors the pattern of `migrateUseViewedCarToDriverTarget`.
+ */
+export function migrateRespondPmToReply(raw: unknown): {
+  migrated: Record<string, unknown>;
+  changed: boolean;
+} {
+  if (!raw || typeof raw !== "object") return { migrated: {}, changed: false };
+
+  const record = raw as Record<string, unknown>;
+
+  if (record.mode === "respond-pm") {
+    return { migrated: { ...record, mode: "reply" }, changed: true };
+  }
+
+  return { migrated: { ...record }, changed: false };
+}

--- a/packages/website/src/content/docs/docs/actions/communication/chat.md
+++ b/packages/website/src/content/docs/docs/actions/communication/chat.md
@@ -3,7 +3,7 @@ title: Chat
 description: Send chat messages, macros, replies, whispers, and manage the chat window.
 sidebar:
   badge:
-    text: "8 modes"
+    text: "7 modes"
     variant: tip
 ---
 
@@ -60,22 +60,6 @@ Font size (5–36 px) used on the button. Defaults to `11`. For macro mode, this
 ### Reply
 
 Reply to the most recent chat message using iRacing's reply command.
-
-#### Details
-
-- **Dial:** No rotation support
-- **Default binding:** No keyboard binding
-- **Telemetry-aware icon:** No
-
-#### Settings
-
-- No additional settings
-
----
-
-### Respond to Last PM
-
-Respond to the most recent private message received.
 
 #### Details
 

--- a/packages/website/src/content/docs/docs/reference/keyboard-shortcuts.md
+++ b/packages/website/src/content/docs/docs/reference/keyboard-shortcuts.md
@@ -118,7 +118,6 @@ Actions marked "Available via SDK" use SDK commands directly and don't require k
 |--------|-----------------|-------------------|-----------------|
 | Text Chat | T | Yes | Text Chat |
 | Text Chat Reply | R | Yes | Text Chat Reply |
-| Respond to Last PM | /r [message] | Yes | - |
 | Send Chat Message | - | Yes | - |
 | Trigger Chat Macro (1-15) | - | Yes | - |
 | Cancel Chat | - | Yes | - |


### PR DESCRIPTION
## Related Issue

Fixes #505

## What changed?

Hides the **Respond to Last PM** option from the Chat action's Mode dropdown. It was a duplicate of **Reply** — both call `chat.reply()` (the iRacing SDK's *Reply to last private message*), so exposing both modes in the PI added no functionality and only cluttered the dropdown.

- `packages/iracing-actions/src/actions/chat/chat.ejs` — removed the `respond-pm` `<option>`; renamed the visible label `Reply to Chat` → `Reply` now that the PM variant is gone.
- `chat.ts` / `chat.test.ts` / `chat/respond-pm.svg` / `icon-defaults.json` — **unchanged**. The `respond-pm` value stays in the `ChatMode` type, the Zod enum, `CHAT_TITLES`, `CHAT_ICONS`, and the `executeMode` switch (which routes it to `chat.reply()`). Any user already configured with `respond-pm` continues to work identically.
- Documentation updated to reflect the removed dropdown option:
  - `packages/website/.../actions/communication/chat.md` — removed the *Respond to Last PM* section, badge `8 modes` → `7 modes`.
  - `packages/website/.../reference/keyboard-shortcuts.md` — removed the *Respond to Last PM* row.
  - `docs/stream-deck-plugin-unified.md` — removed the row, renamed *Reply to Chat* → *Reply*.
  - `docs/reference/actions.json` — removed the `respond-pm` mode entry.
- `.claude/skills/iracedeck-actions/SKILL.md` — Chat row 8→7, Communication category 35→34, total 258→257; annotated `respond-pm` as a hidden alias retained for backward compatibility.

> Note: the issue described the chat sidebar badge as "7 modes" going to "6 modes". The actual current badge was **8 modes** (8 dropdown options) and is updated to **7 modes**.

## How to test

1. Build the project (`pnpm build`) and open the Stream Deck Chat action's Property Inspector.
2. Open the **Mode** dropdown — confirm only seven options appear (Send Message, Macro, Reply, Whisper, Toggle Chat On/Off, Open Chat, Cancel Chat) and the third entry is now labelled **Reply**.
3. Backwards-compatibility check: edit the action's settings file directly (or import an old export) so `mode` is `respond-pm`, reload, and press the key. Verify it still triggers iRacing's *Reply to last private message* (calls `chat.reply()`), exactly as before.
4. Run `pnpm test` — all 3699 tests should pass, including the existing `respond-pm` regression tests in `chat.test.ts`.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chat Action Updates**
  * Reduced chat modes from 8 to 7
  * Removed "Respond to Last PM" and consolidated it as a simplified "Reply" (legacy settings auto-migrate)
  * Added two new chat macro options

* **Documentation**
  * Updated chat docs, sidebar badge, and keyboard shortcuts to reflect the new mode set

* **Tests**
  * Updated and added tests to cover mode changes and migration behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->