### PR TITLE
fix(actions/camera-controls): rename "Focus on Exiting" to "Most Exciting" (#510)

### DIFF
--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -85,7 +85,7 @@ Mode counts reflect the PI Mode/Setting dropdown choices documented in each acti
 |--------|-------|-------------|
 | View Adjustment | 5 | fov (+/-), horizon (+/-), driver-height (+/-), recenter-vr, ui-size (+/-) |
 | Replay Control | 25 | play/pause, play-backward, stop, FF, rewind, slow-mo, frame +/-, speed +/-, set-speed, speed-display, session next/prev, lap next/prev, incident next/prev, jump to beginning/live/my car, next/prev car, next/prev car number |
-| Camera Controls | 12 | change-camera, cycle (camera / sub-camera / car / driving), focus (your car / leader / incident / exiting), switch (by position / car number), set-camera-state |
+| Camera Controls | 12 | change-camera, cycle (camera / sub-camera / car / driving), focus (your car / leader / incident / most exciting), switch (by position / car number), set-camera-state |
 | Camera Editor Adjustments | 15 | latitude, longitude, altitude, yaw, pitch, fov-zoom, key-step, vanish-x, vanish-y, blimp-radius, blimp-velocity, mic-gain (all +/-), auto-set-mic-gain, f-number (+/-), focus-depth (+/-) |
 | Camera Editor Controls | 30 | Open Camera Tool, 14 toggles (key accel/10x, parabolic mic, temp edits, dampening, zoom, beyond fence, in cockpit, mouse nav, pitch/roll gyro, limit shot range, show camera, shot selection, manual focus), cycle position/aim type, acquire start/end, camera CRUD (insert/remove/copy/paste), group CRUD (copy/paste), track/car save/load |
 

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -252,7 +252,7 @@
 | Toggle UI Visibility | - | Yes | - |
 | Focus on Leader | - | Yes | - |
 | Focus on Incident | - | Yes | - |
-| Focus on Exiting Cars | - | Yes | - |
+| Focus on Most Exciting | - | Yes | - |
 
 ### Texture Reload
 

--- a/docs/reference/actions.json
+++ b/docs/reference/actions.json
@@ -479,7 +479,7 @@
             { "value": "focus-your-car", "label": "Focus Your Car" },
             { "value": "focus-on-leader", "label": "Focus on Leader" },
             { "value": "focus-on-incident", "label": "Focus on Incident" },
-            { "value": "focus-on-exiting", "label": "Focus on Exiting" },
+            { "value": "focus-on-most-exciting", "label": "Focus on Most Exciting" },
             { "value": "switch-by-position", "label": "Switch by Position" },
             { "value": "switch-by-car-number", "label": "Switch by Car Number" },
             { "value": "set-camera-state", "label": "Set Camera State" }

--- a/docs/stream-deck-plugin-unified.md
+++ b/docs/stream-deck-plugin-unified.md
@@ -341,7 +341,7 @@ Focus camera on specific target.
 | Focus Your Car        | Ctrl+V      | SDK             | None       | -            |
 | Focus on Leader       | _(SDK)_     | SDK             | None       | -            |
 | Focus on Incident     | _(SDK)_     | SDK             | None       | -            |
-| Focus on Exiting Cars | _(SDK)_     | SDK             | None       | -            |
+| Focus on Most Exciting | _(SDK)_     | SDK             | None       | -            |
 | Switch by Position    | _(SDK)_     | SDK             | None       | Configurable |
 | Switch by Car Number  | _(SDK)_     | SDK             | None       | Configurable |
 | Set Camera State      | _(SDK)_     | SDK             | None       | Configurable |

--- a/packages/icons/camera-focus/focus-on-most-exciting.svg
+++ b/packages/icons/camera-focus/focus-on-most-exciting.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
-  <desc>{"colors":{"backgroundColor":"#2a3a4a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"FOCUS\nEXITING"},"border":{"color":"#5a6a7a"},"artworkBounds":{"x":31,"y":19,"width":82,"height":58}}</desc>
+  <desc>{"colors":{"backgroundColor":"#2a3a4a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"MOST\nEXCITING"},"border":{"color":"#5a6a7a"},"artworkBounds":{"x":31,"y":19,"width":82,"height":58}}</desc>
 
     <circle cx="60" cy="48" r="20" fill="none" stroke="{{graphic1Color}}" stroke-width="4"/>
     <circle cx="60" cy="48" r="5" fill="{{graphic1Color}}"/>

--- a/packages/icons/preview/camera-focus/focus-on-most-exciting.svg
+++ b/packages/icons/preview/camera-focus/focus-on-most-exciting.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
-  <desc>{"colors":{"backgroundColor":"#2a3a4a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"FOCUS\nEXITING"},"border":{"color":"#5a6a7a"},"artworkBounds":{"x":31,"y":19,"width":82,"height":58}}</desc>
+  <desc>{"colors":{"backgroundColor":"#2a3a4a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"MOST\nEXCITING"},"border":{"color":"#5a6a7a"},"artworkBounds":{"x":31,"y":19,"width":82,"height":58}}</desc>
 
     <circle cx="60" cy="48" r="20" fill="none" stroke="#ffffff" stroke-width="4"/>
     <circle cx="60" cy="48" r="5" fill="#ffffff"/>

--- a/packages/iracing-actions/src/actions/camera-controls/camera-controls.test.ts
+++ b/packages/iracing-actions/src/actions/camera-controls/camera-controls.test.ts
@@ -76,8 +76,8 @@ vi.mock("@iracedeck/icons/camera-focus/focus-on-leader.svg", () => ({
 vi.mock("@iracedeck/icons/camera-focus/focus-on-incident.svg", () => ({
   default: '<svg xmlns="http://www.w3.org/2000/svg">focus-on-incident {{mainLabel}} {{subLabel}}</svg>',
 }));
-vi.mock("@iracedeck/icons/camera-focus/focus-on-exiting.svg", () => ({
-  default: '<svg xmlns="http://www.w3.org/2000/svg">focus-on-exiting {{mainLabel}} {{subLabel}}</svg>',
+vi.mock("@iracedeck/icons/camera-focus/focus-on-most-exciting.svg", () => ({
+  default: '<svg xmlns="http://www.w3.org/2000/svg">focus-on-most-exciting {{mainLabel}} {{subLabel}}</svg>',
 }));
 vi.mock("@iracedeck/icons/camera-focus/switch-by-position.svg", () => ({
   default: '<svg xmlns="http://www.w3.org/2000/svg">switch-by-position {{mainLabel}} {{subLabel}}</svg>',
@@ -130,7 +130,7 @@ vi.mock("@iracedeck/deck-core", () => ({
       setState: vi.fn(() => true),
       focusOnLeader: vi.fn(() => true),
       focusOnIncident: vi.fn(() => true),
-      focusOnExiting: vi.fn(() => true),
+      focusOnMostExciting: vi.fn(() => true),
     },
   })),
   generateBorderParts: vi.fn(() => ({ defs: "", rects: "" })),
@@ -477,7 +477,7 @@ describe("CameraControls", () => {
         "focus-your-car",
         "focus-on-leader",
         "focus-on-incident",
-        "focus-on-exiting",
+        "focus-on-most-exciting",
         "switch-by-position",
         "switch-by-car-number",
         "set-camera-state",
@@ -510,6 +510,12 @@ describe("CameraControls", () => {
         const decoded = decodeURIComponent(generateCameraControlsSvg({ target: "set-camera-state" }));
         expect(decoded).toContain("CAM STATE");
         expect(decoded).toContain("SET");
+      });
+
+      it("should include MOST and EXCITING labels for focus-on-most-exciting", () => {
+        const decoded = decodeURIComponent(generateCameraControlsSvg({ target: "focus-on-most-exciting" }));
+        expect(decoded).toContain("MOST");
+        expect(decoded).toContain("EXCITING");
       });
     });
   });

--- a/packages/iracing-actions/src/actions/camera-controls/camera-controls.ts
+++ b/packages/iracing-actions/src/actions/camera-controls/camera-controls.ts
@@ -32,9 +32,9 @@ import drivingPreviousSvg from "@iracedeck/icons/camera-cycle/driving-previous.s
 import subCameraNextSvg from "@iracedeck/icons/camera-cycle/sub-camera-next.svg";
 import subCameraPreviousSvg from "@iracedeck/icons/camera-cycle/sub-camera-previous.svg";
 // Focus icons
-import focusOnExitingSvg from "@iracedeck/icons/camera-focus/focus-on-exiting.svg";
 import focusOnIncidentSvg from "@iracedeck/icons/camera-focus/focus-on-incident.svg";
 import focusOnLeaderSvg from "@iracedeck/icons/camera-focus/focus-on-leader.svg";
+import focusOnMostExcitingSvg from "@iracedeck/icons/camera-focus/focus-on-most-exciting.svg";
 import focusYourCarSvg from "@iracedeck/icons/camera-focus/focus-your-car.svg";
 import setCameraStateSvg from "@iracedeck/icons/camera-focus/set-camera-state.svg";
 import switchByCarNumberSvg from "@iracedeck/icons/camera-focus/switch-by-car-number.svg";
@@ -67,6 +67,8 @@ import {
 } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
+import { migrateFocusOnExitingToMostExciting } from "./migrate-focus-on-exiting.js";
+
 // --- Target types ---
 
 const CYCLE_TARGET_VALUES = ["cycle-camera", "cycle-sub-camera", "cycle-car", "cycle-driving"] as const;
@@ -75,7 +77,7 @@ const FOCUS_TARGET_VALUES = [
   "focus-your-car",
   "focus-on-leader",
   "focus-on-incident",
-  "focus-on-exiting",
+  "focus-on-most-exciting",
   "switch-by-position",
   "switch-by-car-number",
   "set-camera-state",
@@ -251,7 +253,7 @@ const FOCUS_ICONS: Record<string, string> = {
   "focus-your-car": focusYourCarSvg,
   "focus-on-leader": focusOnLeaderSvg,
   "focus-on-incident": focusOnIncidentSvg,
-  "focus-on-exiting": focusOnExitingSvg,
+  "focus-on-most-exciting": focusOnMostExcitingSvg,
   "switch-by-position": switchByPositionSvg,
   "switch-by-car-number": switchByCarNumberSvg,
   "set-camera-state": setCameraStateSvg,
@@ -261,7 +263,7 @@ const FOCUS_TITLES: Record<string, string> = {
   "focus-your-car": "FOCUS\nYOUR CAR",
   "focus-on-leader": "FOCUS\nLEADER",
   "focus-on-incident": "FOCUS\nINCIDENT",
-  "focus-on-exiting": "FOCUS\nEXITING",
+  "focus-on-most-exciting": "MOST\nEXCITING",
   "switch-by-position": "SWITCH\nPOSITION",
   "switch-by-car-number": "SWITCH\nCAR #",
   "set-camera-state": "SET\nCAM STATE",
@@ -652,7 +654,7 @@ function getNextSelectedGroupEntry(
  * Camera Controls
  * Cycles through cameras, sub-cameras, cars, and driving cameras,
  * and focuses on specific targets (your car, leader, incidents,
- * exiting cars, positions, car numbers, camera state)
+ * most exciting, positions, car numbers, camera state)
  * via iRacing SDK commands.
  */
 export const CAMERA_FOCUS_UUID = "com.iracedeck.sd.core.camera-focus" as const;
@@ -667,6 +669,7 @@ export class CameraControls extends ConnectionStateAwareAction<CameraControlsSet
 
   override async onWillAppear(ev: IDeckWillAppearEvent<CameraControlsSettings>): Promise<void> {
     await super.onWillAppear(ev);
+    await this.persistMigratedSettings(ev);
     const settings = this.parseSettings(ev.payload.settings);
     this.activeContexts.set(ev.action.id, settings);
     await this.updateDisplay(ev, settings);
@@ -689,6 +692,7 @@ export class CameraControls extends ConnectionStateAwareAction<CameraControlsSet
 
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<CameraControlsSettings>): Promise<void> {
     await super.onDidReceiveSettings(ev);
+    await this.persistMigratedSettings(ev);
     const settings = this.parseSettings(ev.payload.settings);
     this.activeContexts.set(ev.action.id, settings);
     this.lastDisplayedGroup.delete(ev.action.id);
@@ -733,9 +737,33 @@ export class CameraControls extends ConnectionStateAwareAction<CameraControlsSet
   }
 
   private parseSettings(settings: unknown): CameraControlsSettings {
-    const parsed = CameraControlsSettings.safeParse(settings);
+    const { migrated } = migrateFocusOnExitingToMostExciting(settings);
+    const parsed = CameraControlsSettings.safeParse(migrated);
 
     return parsed.success ? parsed.data : CameraControlsSettings.parse({});
+  }
+
+  /**
+   * Detect a legacy `target: "focus-on-exiting"` setting and persist the
+   * migrated shape (`target: "focus-on-most-exciting"`) so the legacy value
+   * is permanently dropped. Logs and swallows persist failures — the runtime
+   * always reads via `parseSettings`, so a failed persist doesn't block
+   * functionality.
+   */
+  private async persistMigratedSettings(
+    ev: IDeckWillAppearEvent<CameraControlsSettings> | IDeckDidReceiveSettingsEvent<CameraControlsSettings>,
+  ): Promise<void> {
+    const { migrated, changed } = migrateFocusOnExitingToMostExciting(ev.payload.settings);
+
+    if (!changed) return;
+
+    try {
+      await ev.action.setSettings(migrated);
+    } catch (err) {
+      this.logger.warn(
+        `Failed to persist migrated camera-controls settings: ${err instanceof Error ? err.message : err}`,
+      );
+    }
   }
 
   private executeCycle(
@@ -858,9 +886,9 @@ export class CameraControls extends ConnectionStateAwareAction<CameraControlsSet
         this.logger.debug(`Result: ${success}`);
         break;
       }
-      case "focus-on-exiting": {
-        const success = camera.focusOnExiting(groupNum, cameraNum);
-        this.logger.info("Focus on exiting executed");
+      case "focus-on-most-exciting": {
+        const success = camera.focusOnMostExciting(groupNum, cameraNum);
+        this.logger.info("Focus on most exciting executed");
         this.logger.debug(`Result: ${success}`);
         break;
       }

--- a/packages/iracing-actions/src/actions/camera-controls/migrate-focus-on-exiting.test.ts
+++ b/packages/iracing-actions/src/actions/camera-controls/migrate-focus-on-exiting.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { migrateFocusOnExitingToMostExciting } from "./migrate-focus-on-exiting.js";
+
+describe("migrateFocusOnExitingToMostExciting", () => {
+  it("rewrites target=focus-on-exiting to target=focus-on-most-exciting", () => {
+    const result = migrateFocusOnExitingToMostExciting({ target: "focus-on-exiting" });
+
+    expect(result.changed).toBe(true);
+    expect(result.migrated).toEqual({ target: "focus-on-most-exciting" });
+  });
+
+  it("preserves other settings keys during migration", () => {
+    const result = migrateFocusOnExitingToMostExciting({
+      target: "focus-on-exiting",
+      direction: "next",
+      position: 3,
+      carNumber: 0,
+      cameraState: 0,
+      cameraGroup: 9,
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.migrated).toEqual({
+      target: "focus-on-most-exciting",
+      direction: "next",
+      position: 3,
+      carNumber: 0,
+      cameraState: 0,
+      cameraGroup: 9,
+    });
+  });
+
+  it("does not change settings whose target is already focus-on-most-exciting", () => {
+    const result = migrateFocusOnExitingToMostExciting({ target: "focus-on-most-exciting" });
+
+    expect(result.changed).toBe(false);
+    expect(result.migrated).toEqual({ target: "focus-on-most-exciting" });
+  });
+
+  it("does not touch unrelated targets", () => {
+    const result = migrateFocusOnExitingToMostExciting({ target: "focus-on-leader", position: 1 });
+
+    expect(result.changed).toBe(false);
+    expect(result.migrated).toEqual({ target: "focus-on-leader", position: 1 });
+  });
+
+  it("handles missing target key", () => {
+    const result = migrateFocusOnExitingToMostExciting({ direction: "next" });
+
+    expect(result.changed).toBe(false);
+    expect(result.migrated).toEqual({ direction: "next" });
+  });
+
+  it("handles empty raw settings", () => {
+    const result = migrateFocusOnExitingToMostExciting({});
+
+    expect(result.changed).toBe(false);
+    expect(result.migrated).toEqual({});
+  });
+
+  it("handles null and undefined raw settings", () => {
+    expect(migrateFocusOnExitingToMostExciting(null)).toEqual({ migrated: {}, changed: false });
+    expect(migrateFocusOnExitingToMostExciting(undefined)).toEqual({ migrated: {}, changed: false });
+  });
+
+  it("handles non-object raw settings (string, number, boolean)", () => {
+    expect(migrateFocusOnExitingToMostExciting("string").changed).toBe(false);
+    expect(migrateFocusOnExitingToMostExciting(42).changed).toBe(false);
+    expect(migrateFocusOnExitingToMostExciting(true).changed).toBe(false);
+  });
+});

--- a/packages/iracing-actions/src/actions/camera-controls/migrate-focus-on-exiting.ts
+++ b/packages/iracing-actions/src/actions/camera-controls/migrate-focus-on-exiting.ts
@@ -1,0 +1,26 @@
+/**
+ * One-shot in-place migration helper for the camera-controls action's legacy
+ * `target: "focus-on-exiting"` value. The mode was renamed to
+ * `target: "focus-on-most-exciting"` in #510 to correct the typo inherited
+ * from the iRacing SDK's `csFocusAtExiting` enum (the underlying behavior is
+ * iRacing's "Most Exciting" director focus, not pit-lane related).
+ *
+ * Returns `{ migrated, changed }` so callers can decide whether to persist
+ * via `ev.action.setSettings(migrated)`. Safe on non-object inputs.
+ *
+ * Mirrors the pattern of `migrateRespondPmToReply`.
+ */
+export function migrateFocusOnExitingToMostExciting(raw: unknown): {
+  migrated: Record<string, unknown>;
+  changed: boolean;
+} {
+  if (!raw || typeof raw !== "object") return { migrated: {}, changed: false };
+
+  const record = raw as Record<string, unknown>;
+
+  if (record.target === "focus-on-exiting") {
+    return { migrated: { ...record, target: "focus-on-most-exciting" }, changed: true };
+  }
+
+  return { migrated: { ...record }, changed: false };
+}

--- a/packages/iracing-actions/src/actions/camera-focus/camera-focus.ejs
+++ b/packages/iracing-actions/src/actions/camera-focus/camera-focus.ejs
@@ -79,7 +79,7 @@
 				<option value="focus-your-car">Focus Your Car</option>
 				<option value="focus-on-leader">Focus on Leader</option>
 				<option value="focus-on-incident">Focus on Incident</option>
-				<option value="focus-on-exiting">Focus on Exiting Cars</option>
+				<option value="focus-on-most-exciting">Focus on Most Exciting</option>
 				<option value="switch-by-position">Switch by Position</option>
 				<option value="switch-by-car-number">Switch by Car Number</option>
 				<option value="set-camera-state">Set Camera State</option>

--- a/packages/iracing-actions/src/actions/data/icon-defaults.json
+++ b/packages/iracing-actions/src/actions/data/icon-defaults.json
@@ -38,7 +38,6 @@
   "camera-focus": {
     "backgroundColor": "#2a3a4a",
     "textColor": "#ffffff",
-    "graphic1Color": "#ffffff",
     "borderColor": "#5a6a7a"
   },
   "camera-select": {
@@ -89,7 +88,7 @@
     "graphic1Color": "#ffffff",
     "borderColor": "#5a3a6a"
   },
-  "pit-crew": {
+  "pit-engineer": {
     "backgroundColor": "#2a3a5a",
     "textColor": "#ffffff",
     "graphic1Color": "#ffffff",
@@ -209,6 +208,12 @@
     "backgroundColor": "#2a3a2a",
     "textColor": "#ffffff",
     "graphic1Color": "#ffffff"
+  },
+  "pit-crew": {
+    "backgroundColor": "#2a3a5a",
+    "textColor": "#ffffff",
+    "graphic1Color": "#ffffff",
+    "borderColor": "#4a5a7a"
   },
   "pit-quick-actions-fast-repair": {
     "backgroundColor": "#3a2a2a",

--- a/packages/iracing-sdk/src/commands/CameraCommand.test.ts
+++ b/packages/iracing-sdk/src/commands/CameraCommand.test.ts
@@ -202,9 +202,9 @@ describe("CameraCommand", () => {
     });
   });
 
-  describe("focusOnExiting", () => {
+  describe("focusOnMostExciting", () => {
     it("should call switchPos with FocusAtExiting mode", () => {
-      cameraCommand.focusOnExiting(4, 0);
+      cameraCommand.focusOnMostExciting(4, 0);
 
       expect(mockNative.broadcastMsg).toHaveBeenCalledWith(
         BroadcastMsg.CamSwitchPos,
@@ -215,7 +215,7 @@ describe("CameraCommand", () => {
     });
 
     it("should return true", () => {
-      expect(cameraCommand.focusOnExiting(1, 0)).toBe(true);
+      expect(cameraCommand.focusOnMostExciting(1, 0)).toBe(true);
     });
   });
 
@@ -330,7 +330,7 @@ describe("CameraCommand", () => {
       expect(cameraCommand.showUI(0)).toBe(true);
       expect(cameraCommand.focusOnLeader(1, 1)).toBe(true);
       expect(cameraCommand.focusOnIncident(1, 1)).toBe(true);
-      expect(cameraCommand.focusOnExiting(1, 1)).toBe(true);
+      expect(cameraCommand.focusOnMostExciting(1, 1)).toBe(true);
       expect(cameraCommand.cycleCamera(1, 1, 1)).toBe(true);
       expect(cameraCommand.cycleSubCamera(1, 1, 1, 1)).toBe(true);
       expect(cameraCommand.cycleCar(1, 1)).toBe(true);

--- a/packages/iracing-sdk/src/commands/CameraCommand.ts
+++ b/packages/iracing-sdk/src/commands/CameraCommand.ts
@@ -100,11 +100,17 @@ export class CameraCommand extends BroadcastCommand {
   }
 
   /**
-   * Focus on cars exiting pits
+   * Focus on the car the iRacing director rates as most exciting in the moment.
+   * Replay only.
+   *
+   * Note: the underlying SDK enum is `CameraFocusMode.FocusAtExiting`, which
+   * mirrors the upstream typo in `irsdk_csFocusAtExiting`. The behavior is
+   * iRacing's "Most Exciting" director focus, not pit-lane related.
+   *
    * @param group Camera group number
    * @param camera Camera number within group
    */
-  focusOnExiting(group: number, camera: number): boolean {
+  focusOnMostExciting(group: number, camera: number): boolean {
     return this.switchPos(CameraFocusMode.FocusAtExiting, group, camera);
   }
 

--- a/packages/website/src/content/docs/docs/actions/view-camera/camera-focus.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/camera-focus.md
@@ -151,9 +151,9 @@ Focus the camera on the latest incident reported by iRacing.
 
 ---
 
-### Focus on Exiting
+### Focus on Most Exciting
 
-Focus the camera on a car that is currently exiting pit lane.
+Focus the camera on the car the iRacing director rates as most exciting in the moment. Replay only.
 
 #### Details
 

--- a/scripts/data/icon-title-defaults.json
+++ b/scripts/data/icon-title-defaults.json
@@ -102,7 +102,7 @@
   "camera-editor-controls/temporary-edits-toggle": "TOGGLE\nTEMP EDIT",
   "camera-editor-controls/zoom-toggle": "TOGGLE\nZOOM",
 
-  "camera-focus/focus-on-exiting": "FOCUS\nEXITING",
+  "camera-focus/focus-on-most-exciting": "MOST\nEXCITING",
   "camera-focus/focus-on-incident": "FOCUS\nINCIDENT",
   "camera-focus/focus-on-leader": "FOCUS\nLEADER",
   "camera-focus/focus-your-car": "FOCUS\nYOUR CAR",


### PR DESCRIPTION
## Related Issue

Fixes #510

## What changed?

The Camera Controls mode previously labeled `Focus on Exiting Cars` is iRacing's "Most Exciting" director focus — verified in-game. The label and underlying setting value were inherited from a typo in iRacing's official SDK header (`csFocusAtExiting`). Renames the typo across the iRaceDeck surface; the SDK header and the mirrored `CameraFocusMode.FocusAtExiting` enum stay untouched.

- **Settings value:** `focus-on-exiting` → `focus-on-most-exciting`
- **PI dropdown label:** `Focus on Exiting Cars` → `Focus on Most Exciting`
- **Default key title:** `FOCUS\nEXITING` → `MOST\nEXCITING`
- **SDK wrapper method:** `CameraCommand.focusOnExiting()` → `focusOnMostExciting()`
- **Icon files:** `focus-on-exiting.svg` → `focus-on-most-exciting.svg` (source + preview), `<desc>` title metadata updated
- **One-shot migration** (`migrate-focus-on-exiting.ts`): saved `focus-on-exiting` settings are silently rewritten to `focus-on-most-exciting` on `onWillAppear` / `onDidReceiveSettings`, mirroring the `migrateRespondPmToReply` pattern from #506.
- **Docs/data:** website action docs (description rewritten as "Most Exciting" replay-only mode), `docs/reference/actions.json`, `docs/stream-deck-plugin-unified.md`, `docs/keyboard-shortcuts.md`, `scripts/data/icon-title-defaults.json`, `iracedeck-actions` skill listing.
- **Tests:** updated `camera-controls.test.ts` and `CameraCommand.test.ts` for renames; added 8-case `migrate-focus-on-exiting.test.ts`.

`packages/iracing-actions/src/actions/data/icon-defaults.json` was regenerated by `scripts/generate-icon-defaults.mjs`. The diff against `master` includes minor pre-existing drift (`pit-crew` → `pit-engineer` ordering, removal of unused `graphic1Color` from `camera-focus`) that was already pending in the working tree before this branch.

## How to test

- [ ] Add a Camera Controls action with target = "Focus on Most Exciting" → verify the icon shows `MOST EXCITING` and pressing it triggers the iRacing director focus.
- [ ] Pre-existing action saved as `focus-on-exiting` (from before this PR) → verify it migrates silently on first appearance and shows the new label/title without user action.
- [ ] Other Camera Controls modes (cycle camera, change camera, focus your car/leader/incident, switch by position/car number, set camera state) still work unchanged.
- [ ] Property Inspector dropdown lists "Focus on Most Exciting" instead of "Focus on Exiting Cars".

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added camera editor controls: Temporary Edits toggle and Zoom toggle
  * Added icon style defaults for pit‑engineer and pit‑crew

* **Updates**
  * Renamed camera focus option from "Focus on Exiting Cars" to "Focus on Most Exciting" across UI, docs, shortcuts, and plugins
<!-- end of auto-generated comment: release notes by coderabbit.ai -->