### PR TITLE
feat(actions/session-info): blank "--" placeholder in Race Flags mode (#511)

### DIFF
--- a/packages/iracing-actions/src/actions/session-info/session-info.ejs
+++ b/packages/iracing-actions/src/actions/session-info/session-info.ejs
@@ -32,6 +32,10 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<sdpi-item id="flags-settings" label="UI" class="hidden">
+			<sdpi-checkbox setting="blankWhenNoFlag" label="Blank when no flag"></sdpi-checkbox>
+		</sdpi-item>
+
 		<script>
 			async function initialize() {
 				await customElements.whenDefined("sdpi-select");
@@ -57,12 +61,16 @@
 			function updateVisibility(mode) {
 				const positionSettings = document.getElementById("position-settings");
 				const fuelSettings = document.getElementById("fuel-settings");
+				const flagsSettings = document.getElementById("flags-settings");
 
 				if (positionSettings) {
 					positionSettings.classList.toggle("hidden", mode !== "position");
 				}
 				if (fuelSettings) {
 					fuelSettings.classList.toggle("hidden", mode !== "fuel");
+				}
+				if (flagsSettings) {
+					flagsSettings.classList.toggle("hidden", mode !== "flags");
 				}
 			}
 

--- a/packages/iracing-actions/src/actions/session-info/session-info.test.ts
+++ b/packages/iracing-actions/src/actions/session-info/session-info.test.ts
@@ -20,14 +20,24 @@ vi.mock("@iracedeck/deck-core", () => ({
     extend: () => {
       const defaults = { mode: "incidents", positionShowTotal: false, fuelFormat: "amount", blankWhenNoFlag: false };
       const validModes = ["incidents", "time-remaining", "laps", "position", "fuel", "flags"];
+      const coerceBool = (v: unknown): boolean => v === true || v === "true";
+      const merge = (data: Record<string, unknown>) => {
+        const merged: Record<string, unknown> = { ...defaults, ...data };
+
+        if ("positionShowTotal" in merged) merged.positionShowTotal = coerceBool(merged.positionShowTotal);
+
+        if ("blankWhenNoFlag" in merged) merged.blankWhenNoFlag = coerceBool(merged.blankWhenNoFlag);
+
+        return merged;
+      };
       const schema = {
-        parse: (data: Record<string, unknown>) => ({ ...defaults, ...data }),
+        parse: (data: Record<string, unknown>) => merge(data),
         safeParse: (data: Record<string, unknown>) => {
           if (data?.mode && !validModes.includes(data.mode as string)) {
             return { success: false, error: new Error("Invalid mode") };
           }
 
-          return { success: true, data: { ...defaults, ...data } };
+          return { success: true, data: merge(data) };
         },
       };
 

--- a/packages/iracing-actions/src/actions/session-info/session-info.test.ts
+++ b/packages/iracing-actions/src/actions/session-info/session-info.test.ts
@@ -18,7 +18,7 @@ vi.mock("@iracedeck/iracing-sdk", async () => {
 vi.mock("@iracedeck/deck-core", () => ({
   CommonSettings: {
     extend: () => {
-      const defaults = { mode: "incidents", positionShowTotal: false, fuelFormat: "amount" };
+      const defaults = { mode: "incidents", positionShowTotal: false, fuelFormat: "amount", blankWhenNoFlag: false };
       const validModes = ["incidents", "time-remaining", "laps", "position", "fuel", "flags"];
       const schema = {
         parse: (data: Record<string, unknown>) => ({ ...defaults, ...data }),
@@ -92,9 +92,16 @@ function defaultSettings(
     fontSize: number;
     positionShowTotal: boolean;
     fuelFormat: "amount" | "percentage";
+    blankWhenNoFlag: boolean;
   }> = {},
 ) {
-  return { mode: "incidents" as const, positionShowTotal: false, fuelFormat: "amount" as const, ...overrides };
+  return {
+    mode: "incidents" as const,
+    positionShowTotal: false,
+    fuelFormat: "amount" as const,
+    blankWhenNoFlag: false,
+    ...overrides,
+  };
 }
 
 /** Create a minimal fake event with the given action ID and settings. */
@@ -639,6 +646,63 @@ describe("SessionInfo", () => {
       await action.onWillDisappear(fakeEvent("action-1") as any);
 
       expect(action["flagPulseTimers"].has("action-1")).toBe(false);
+    });
+
+    describe("flags mode display value", () => {
+      it("returns '--' when no telemetry and blankWhenNoFlag is false", () => {
+        const action = new SessionInfo();
+        const settings = defaultSettings({ mode: "flags", blankWhenNoFlag: false });
+
+        const result = action["extractDisplayValue"](settings as any, null);
+
+        expect(result).toBe("--");
+      });
+
+      it("returns '' when no telemetry and blankWhenNoFlag is true", () => {
+        const action = new SessionInfo();
+        const settings = defaultSettings({ mode: "flags", blankWhenNoFlag: true });
+
+        const result = action["extractDisplayValue"](settings as any, null);
+
+        expect(result).toBe("");
+      });
+
+      it("returns '--' when telemetry has no active flag and blankWhenNoFlag is false", () => {
+        const action = new SessionInfo();
+        const settings = defaultSettings({ mode: "flags", blankWhenNoFlag: false });
+        const telemetry = { SessionFlags: 0 } as any;
+
+        const result = action["extractDisplayValue"](settings as any, telemetry);
+
+        expect(result).toBe("--");
+      });
+
+      it("returns '' when telemetry has no active flag and blankWhenNoFlag is true", () => {
+        const action = new SessionInfo();
+        const settings = defaultSettings({ mode: "flags", blankWhenNoFlag: true });
+        const telemetry = { SessionFlags: 0 } as any;
+
+        const result = action["extractDisplayValue"](settings as any, telemetry);
+
+        expect(result).toBe("");
+      });
+
+      it("returns the flag label when a flag is active regardless of blankWhenNoFlag", () => {
+        const action = new SessionInfo();
+        const telemetry = { SessionFlags: 0x00000004 } as any; // Green
+
+        const blankFalse = action["extractDisplayValue"](
+          defaultSettings({ mode: "flags", blankWhenNoFlag: false }) as any,
+          telemetry,
+        );
+        const blankTrue = action["extractDisplayValue"](
+          defaultSettings({ mode: "flags", blankWhenNoFlag: true }) as any,
+          telemetry,
+        );
+
+        expect(blankFalse).toBe("GREEN");
+        expect(blankTrue).toBe("GREEN");
+      });
     });
 
     it("should cancel flag pulse on onDidReceiveSettings", async () => {

--- a/packages/iracing-actions/src/actions/session-info/session-info.ts
+++ b/packages/iracing-actions/src/actions/session-info/session-info.ts
@@ -53,6 +53,10 @@ const SessionInfoSettings = CommonSettings.extend({
     .transform((val) => val === true || val === "true")
     .default(false),
   fuelFormat: z.enum(["amount", "percentage"]).default("amount"),
+  blankWhenNoFlag: z
+    .union([z.boolean(), z.string()])
+    .transform((val) => val === true || val === "true")
+    .default(false),
 });
 
 type SessionInfoSettings = z.infer<typeof SessionInfoSettings>;
@@ -301,7 +305,7 @@ export class SessionInfo extends ConnectionStateAwareAction<SessionInfoSettings>
 
       if (settings.mode === "fuel") return settings.fuelFormat === "percentage" ? "--%" : "-- L";
 
-      if (settings.mode === "flags") return "--";
+      if (settings.mode === "flags") return settings.blankWhenNoFlag ? "" : "--";
 
       return "--:--";
     }
@@ -372,7 +376,9 @@ export class SessionInfo extends ConnectionStateAwareAction<SessionInfoSettings>
     if (settings.mode === "flags") {
       const flagInfo = resolveActiveFlag(telemetry.SessionFlags);
 
-      return flagInfo ? flagInfo.label : "--";
+      if (flagInfo) return flagInfo.label;
+
+      return settings.blankWhenNoFlag ? "" : "--";
     }
 
     // time-remaining (default)

--- a/packages/website/src/content/docs/docs/actions/display-session/session-info.md
+++ b/packages/website/src/content/docs/docs/actions/display-session/session-info.md
@@ -113,6 +113,10 @@ Display currently active flags with the corresponding colors and a pulsing anima
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the icon updates to reflect the active flag (green, yellow, white, checkered, etc.) and pulses when a new flag is raised
 
+#### Setting: UI
+
+- **Blank when no flag** — When enabled, the icon shows no value text while no flag is active, leaving the button visually empty (background color and title visibility are unaffected and remain configurable). When a flag becomes active, the flag label, color, and pulse/flash effects render as usual. Defaults to `Off` (the icon shows `--` when no flag is active).
+
 #### Setting: Font Size
 
 Size of the rendered value, in PI units (5–36, doubled for SVG render). Defaults to `14`.


### PR DESCRIPTION
## Related Issue

Fixes #511

## What changed?

Adds a **Blank when no flag** toggle to the Session Info → Flags mode (per-action setting, default off). When enabled, the value text is suppressed (`""` instead of `"--"`) on both no-flag paths in `extractDisplayValue`:

- No telemetry yet
- Telemetry present but no active flag

Active-flag rendering — label, background color override, and pulse/flash effects via `resolveFlagColorOverride` / `startFlagPulse` / `startFlagColorFlash` — is unchanged. Background color and title visibility were already independently configurable, so this fills the last gap and lets users park a Flags button next to content keys with no visual noise until a flag actually appears.

PI grouping: the new control lives in a `label="UI"` row with the toggle's own `label="Blank when no flag"` to the right of the checkbox, mode-conditional via the existing `mode-select` visibility toggler.

## How to test

- [ ] Add or open a Session Info action set to **Race Flags** mode.
- [ ] In the PI, locate the new **UI** row with the **Blank when no flag** checkbox under the Mode selector.
- [ ] **Default off:** with no flag active, the icon shows `--` (existing behavior).
- [ ] **Toggle on:** with no flag active, the icon shows no value text — only the background.
- [ ] Trigger a flag (e.g. start a race, drive to a yellow-flag zone, or use a flag overlay): icon renders the flag label, color override, and pulse/flash exactly as before, regardless of the toggle.
- [ ] Switch the mode dropdown to **Position** / **Fuel** / etc. — the **UI** row hides; switching back to **Race Flags** restores it.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — action lives in shared `@iracedeck/iracing-actions`; both plugins consume the same source
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a UI setting for Flags mode to optionally blank the display when no active flag is present while preserving background color and title customization.

* **Documentation**
  * Updated Flags mode docs to describe the new UI option and default behavior.

* **Tests**
  * Added tests covering Flags display behavior, including cases for telemetry absence, no-flag, and active-flag with the new setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->