### PR TITLE
fix(audio-assets): restore radio filter gain stages from before #522 (#524)

### DIFF
--- a/packages/audio-assets/src/presets.mjs
+++ b/packages/audio-assets/src/presets.mjs
@@ -1,11 +1,12 @@
 /**
  * Canonical radio-effect filter applied to voice MP3s at build time.
  *
- * 250-3500 Hz bandpass shapes the radio character. A `tanh` soft-clip and
- * a brick-wall limiter at -0.5 dBFS sit at unity gain afterwards purely as
- * peak safety — they don't engage on a typical voice signal. No bake-in
- * makeup gain (issue #522): the user's `raceEngineerVolume` slider is the
- * sole loudness control, with full headroom in both directions.
+ * 250-3500 Hz bandpass + 8 dB pre-gain into a `tanh` soft-clip (smoother
+ * than `hard`), pulled back 6 dB to a working level and then bumped 6 dB
+ * makeup into a brick-wall limiter at -0.5 dBFS. The limiter catches the
+ * peaks the makeup gain pushes past 0 dBFS while the rest of the signal
+ * stays uncompressed — louder than dry TTS, but the voice's natural
+ * dynamics are preserved.
  *
  * Applied to every .mp3 under voice/ at build time. Anything outside voice/
  * (currently only sfx/) is copied unchanged — SFX tones, ticks and squelch
@@ -15,4 +16,5 @@
  * (the cache path embeds a hash of the filter chain), so the next plugin
  * or harness build reprocesses every voice clip from source.
  */
-export const RADIO_ENGINEER_FILTER = "highpass=f=250,lowpass=f=3500,asoftclip=type=tanh,alimiter=limit=0.95";
+export const RADIO_ENGINEER_FILTER =
+  "highpass=f=250,lowpass=f=3500,volume=8dB,asoftclip=type=tanh,volume=-6dB,volume=6dB,alimiter=limit=0.95";

--- a/packages/deck-core/src/global-settings.ts
+++ b/packages/deck-core/src/global-settings.ts
@@ -167,9 +167,9 @@ export const GlobalSettingsSchema = z
     /**
      * Volume for the Race Engineer voice, 0–100 (mapped to 0.0–1.0 on
      * `AudioBus.Voice`). Sliding to 0 silences voice scenarios without
-     * disabling the feature. Default: 50 (issue #522 — paired with the
-     * removal of bake-in gain from the radio filter so the slider has
-     * headroom in both directions).
+     * disabling the feature. Default: 50 (issue #522 — first-run mix
+     * sits below full-tilt so the slider has headroom in both
+     * directions).
      */
     raceEngineerVolume: z.coerce.number().min(0).max(100).default(50),
     /**


### PR DESCRIPTION
## Related Issue

Fixes #524

## What changed?

Restore the +8 dB pre-gain and the cancelling -6/+6 dB pair around the brick-wall limiter in `RADIO_ENGINEER_FILTER` (`packages/audio-assets/src/presets.mjs`) plus the JSDoc that describes the chain. The post-#522 unity-gain chain produced a quieter, dryer voice than intended — the pre-#522 chain is the radio character we want back.

Volume defaults stay at 50 / 25 / 50 — they're a UX-driven headroom choice, not a compensation for the missing filter gain. Reworded the `raceEngineerVolume` JSDoc rationale in `packages/deck-core/src/global-settings.ts` that explicitly attributed the lower default to the bake-in-gain removal so it matches the `radarVolume` UX framing. `backgroundVolume` and `radarVolume` JSDocs were already filter-independent and stay as written.

The cache hash flips back to the pre-#522 value (`cc829e8b`), so any clips processed for #522 are still on disk under their own hash and the restored chain reuses the still-cached pre-#522 outputs as instant hits — no ffmpeg reprocessing on next build.

## How to test

1. `pnpm install && pnpm build` in this branch — the audio-assets stage should report `0 processed, 163 cache-hit, 6 copied as-is (filter hash cc829e8b)`, confirming the pre-#522 cache is reused.
2. Link the rebuilt plugin (`pnpm relink:stream-deck`) and trigger any Race Engineer scenario in iRacing or the harness.
3. Voice should have the loud broadcast-radio character back — noticeably louder and more saturated than the post-#522 unity-gain output. With `raceEngineerVolume` at the new default (50), level should match what you'd get from #522 at ~100.
4. `radarVolume` and `backgroundVolume` defaults are unchanged at 50 / 25; the Pit Crew PI defaults and `global-settings.test.ts` assertions also stay as-is.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted audio filter preset code for improved readability and maintainability.

* **Documentation**
  * Updated internal documentation for audio volume settings to reflect system constraints and related configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->