### PR TITLE
feat(actions): add Track Wetness mode to Session Info (#526)

### DIFF
--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -9,7 +9,7 @@ description: Use when looking up Stream Deck actions, sub-actions, modes, catego
 
 Complete action definitions: `docs/reference/actions.json`
 
-The website currently documents **31 actions with 258 modes** (the totals used in this file and in user-facing docs). `docs/reference/actions.json` has not yet been re-synced to the new per-mode counting convention; use this skill file or the website as the source of truth for action and mode counts, and treat `actions.json` as a detailed inventory of individual mode values that is occasionally out of date.
+The website currently documents **31 actions with 259 modes** (the totals used in this file and in user-facing docs). `docs/reference/actions.json` has not yet been re-synced to the new per-mode counting convention; use this skill file or the website as the source of truth for action and mode counts, and treat `actions.json` as a detailed inventory of individual mode values that is occasionally out of date.
 
 Each action entry:
 ```json

--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -37,7 +37,7 @@ When asked about actions or controls:
 
 | Category | Actions | Modes | Description |
 |----------|---------|-------|-------------|
-| Display & Session | 2 | 7 | Live session data: incidents, laps, position, fuel, flags |
+| Display & Session | 2 | 8 | Live session data: incidents, laps, position, fuel, flags, track wetness |
 | Driving Controls | 6 | 30 | AI spotter, audio, black boxes, look direction, car control, pit crew (radar + radar-volume; Race Engineer voice mode planned) |
 | Cockpit & Interface | 5 | 33 | Wipers, force feedback, splits & reference, telemetry, UI toggles |
 | View & Camera | 5 | 88 | FOV, replay, camera controls, broadcast tools |
@@ -45,7 +45,7 @@ When asked about actions or controls:
 | Pit Service | 3 | 15 | Fuel, tires, compounds, tearoff, fast repair |
 | Car Setup | 7 | 44 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control |
 | Communication | 2 | 34 | Chat, macros (15), whisper, toggle, reply, race admin commands |
-| **Total** | **31** | **258** | |
+| **Total** | **31** | **259** | |
 
 Mode counts reflect the PI Mode/Setting dropdown choices documented in each action page. Directional variants (Increase/Decrease) are treated as a single mode with a Direction sub-setting, matching the per-mode website format. Legacy replay actions (Replay Transport, Replay Speed, Replay Navigation) and Camera Cycle (Legacy) still exist in the plugin manifest for backward compatibility but are not counted as documented actions.
 
@@ -55,7 +55,7 @@ Mode counts reflect the PI Mode/Setting dropdown choices documented in each acti
 
 | Action | Modes | Mode values |
 |--------|-------|-------------|
-| Session Info | 6 | incidents, time-remaining, laps, position, fuel, flags |
+| Session Info | 7 | incidents, time-remaining, laps, position, fuel, flags, track-wetness |
 | Telemetry Display | 1 | template (Mustache-driven display, no Mode dropdown) |
 
 ### Driving Controls

--- a/docs/reference/actions.json
+++ b/docs/reference/actions.json
@@ -24,7 +24,12 @@
             { "value": "laps", "label": "Laps", "description": "Current lap number" },
             { "value": "position", "label": "Position", "description": "Race position, optionally shows total cars" },
             { "value": "fuel", "label": "Fuel", "description": "Fuel level as amount or percentage" },
-            { "value": "flags", "label": "Flags", "description": "Active race flags with colors and pulsing" }
+            { "value": "flags", "label": "Flags", "description": "Active race flags with colors and pulsing" },
+            {
+              "value": "track-wetness",
+              "label": "Track Wetness",
+              "description": "Track wetness state with a centered vertical 6-segment bar; the current state is the icon title"
+            }
           ]
         },
         {

--- a/packages/iracing-actions/icons/session-info.svg
+++ b/packages/iracing-actions/icons/session-info.svg
@@ -6,10 +6,13 @@
     <rect x="0" y="0" width="144" height="144" rx="24" fill="{{backgroundColor}}"/>
 {{borderContent}}
 
+    <!-- Optional mode-specific graphic (e.g., track wetness drop + bar). Empty for text modes. -->
+    {{graphicContent}}
+
     <!-- Title label (position and style controlled by title settings) -->
     {{titleContent}}
 
-    <!-- Large centered value -->
+    <!-- Large centered value (empty when graphicContent carries the display) -->
     <text x="72" y="{{valueY}}" text-anchor="middle" dominant-baseline="central"
           fill="{{textColor}}" font-family="Arial, sans-serif" font-size="{{valueFontSize}}" font-weight="bold">{{value}}</text>
   </g>

--- a/packages/iracing-actions/src/actions/session-info/session-info.ejs
+++ b/packages/iracing-actions/src/actions/session-info/session-info.ejs
@@ -14,6 +14,7 @@
 				<option value="position">Position</option>
 				<option value="fuel">Fuel</option>
 				<option value="flags">Race Flags</option>
+				<option value="track-wetness">Track Wetness</option>
 			</sdpi-select>
 		</sdpi-item>
 

--- a/packages/iracing-actions/src/actions/session-info/session-info.test.ts
+++ b/packages/iracing-actions/src/actions/session-info/session-info.test.ts
@@ -1,4 +1,4 @@
-import { FLAG_DEFINITIONS, resolveActiveFlag } from "@iracedeck/iracing-sdk";
+import { FLAG_DEFINITIONS, resolveActiveFlag, TrackWetness } from "@iracedeck/iracing-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -6,7 +6,9 @@ import {
   formatFuelAmount,
   formatSessionTime,
   generateSessionInfoSvg,
+  generateTrackWetnessGraphic,
   SessionInfo,
+  trackWetnessLabel,
 } from "./session-info.js";
 
 vi.mock("@iracedeck/iracing-sdk", async () => {
@@ -19,7 +21,7 @@ vi.mock("@iracedeck/deck-core", () => ({
   CommonSettings: {
     extend: () => {
       const defaults = { mode: "incidents", positionShowTotal: false, fuelFormat: "amount", blankWhenNoFlag: false };
-      const validModes = ["incidents", "time-remaining", "laps", "position", "fuel", "flags"];
+      const validModes = ["incidents", "time-remaining", "laps", "position", "fuel", "flags", "track-wetness"];
       const coerceBool = (v: unknown): boolean => v === true || v === "true";
       const merge = (data: Record<string, unknown>) => {
         const merged: Record<string, unknown> = { ...defaults, ...data };
@@ -90,7 +92,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     textColor: "#ffffff",
   })),
   renderIconTemplate: vi.fn((_template: string, data: Record<string, string>) => {
-    return `<svg>${data.backgroundColor || ""}|${data.titleContent || ""}|<text font-size="${data.valueFontSize || ""}" y="${data.valueY || ""}" fill="${data.textColor || ""}">${data.value || ""}</text></svg>`;
+    return `<svg>${data.backgroundColor || ""}|${data.titleContent || ""}|${data.graphicContent || ""}|<text font-size="${data.valueFontSize || ""}" y="${data.valueY || ""}" fill="${data.textColor || ""}">${data.value || ""}</text></svg>`;
   }),
   svgToDataUri: vi.fn((svg: string) => `data:image/svg+xml,${encodeURIComponent(svg)}`),
 }));
@@ -98,7 +100,7 @@ vi.mock("@iracedeck/deck-core", () => ({
 /** Default settings factory for tests */
 function defaultSettings(
   overrides: Partial<{
-    mode: "incidents" | "time-remaining" | "laps" | "position" | "fuel" | "flags";
+    mode: "incidents" | "time-remaining" | "laps" | "position" | "fuel" | "flags" | "track-wetness";
     fontSize: number;
     positionShowTotal: boolean;
     fuelFormat: "amount" | "percentage";
@@ -568,6 +570,209 @@ describe("SessionInfo", () => {
       // Should use override color, not flash red
       expect(decoded).toContain("#2ecc71");
       expect(decoded).not.toContain("#e74c3c");
+    });
+
+    it("should use the live state name as the title for track-wetness mode", () => {
+      const dry = decodeURIComponent(
+        generateSessionInfoSvg(defaultSettings({ mode: "track-wetness" }), "DRY", false, undefined, TrackWetness.Dry),
+      );
+      const wet = decodeURIComponent(
+        generateSessionInfoSvg(
+          defaultSettings({ mode: "track-wetness" }),
+          "MOSTLY DRY",
+          false,
+          undefined,
+          TrackWetness.MostlyDry,
+        ),
+      );
+
+      expect(dry).toContain("DRY");
+      expect(dry).not.toContain("WETNESS");
+      expect(wet).toContain("MOSTLY DRY");
+    });
+
+    it("should leave the value text slot empty for track-wetness", () => {
+      const result = generateSessionInfoSvg(
+        defaultSettings({ mode: "track-wetness" }),
+        "MOSTLY DRY",
+        false,
+        undefined,
+        TrackWetness.MostlyDry,
+      );
+      const decoded = decodeURIComponent(result);
+
+      // Title (from generateTitleText mock) is the only place the state label appears.
+      const matches = decoded.match(/MOSTLY DRY/g) ?? [];
+
+      expect(matches.length).toBe(1);
+      // Value-slot <text> exists but is empty between > and </text>.
+      expect(decoded).toMatch(/y="\d[\d.]*"[^>]*>(<\/text>|\s*<\/text>)/);
+    });
+
+    it("should include bar segments in the graphicContent for track-wetness", () => {
+      const result = generateSessionInfoSvg(
+        defaultSettings({ mode: "track-wetness" }),
+        "DRY",
+        false,
+        undefined,
+        TrackWetness.Dry,
+      );
+      const decoded = decodeURIComponent(result);
+
+      expect(decoded).toContain("<rect");
+    });
+
+    it("should not include any graphicContent for non-track-wetness modes", () => {
+      const result = generateSessionInfoSvg(defaultSettings({ mode: "incidents" }), "3x", false);
+      const decoded = decodeURIComponent(result);
+
+      // No bar rects in incidents mode (border rects are stripped by the mock)
+      expect(decoded).not.toContain("<rect");
+    });
+  });
+
+  describe("trackWetnessLabel", () => {
+    it("returns '--' for Unknown", () => {
+      expect(trackWetnessLabel(TrackWetness.Unknown)).toBe("--");
+    });
+
+    it("returns '--' for undefined", () => {
+      expect(trackWetnessLabel(undefined)).toBe("--");
+    });
+
+    it("returns 'DRY' for Dry", () => {
+      expect(trackWetnessLabel(TrackWetness.Dry)).toBe("DRY");
+    });
+
+    it("returns 'MOSTLY DRY' for MostlyDry", () => {
+      expect(trackWetnessLabel(TrackWetness.MostlyDry)).toBe("MOSTLY DRY");
+    });
+
+    it("returns 'V. LIGHT' for VeryLightlyWet", () => {
+      expect(trackWetnessLabel(TrackWetness.VeryLightlyWet)).toBe("V. LIGHT");
+    });
+
+    it("returns 'LIGHT' for LightlyWet", () => {
+      expect(trackWetnessLabel(TrackWetness.LightlyWet)).toBe("LIGHT");
+    });
+
+    it("returns 'MODERATE' for ModeratelyWet", () => {
+      expect(trackWetnessLabel(TrackWetness.ModeratelyWet)).toBe("MODERATE");
+    });
+
+    it("returns 'VERY WET' for VeryWet", () => {
+      expect(trackWetnessLabel(TrackWetness.VeryWet)).toBe("VERY WET");
+    });
+
+    it("returns 'EXTREME' for ExtremelyWet", () => {
+      expect(trackWetnessLabel(TrackWetness.ExtremelyWet)).toBe("EXTREME");
+    });
+  });
+
+  describe("generateTrackWetnessGraphic", () => {
+    const LIT_COLORS = ["#a8e6f0", "#6dc9e3", "#3b9bc4", "#1f7eb0", "#15639a", "#0e4c80"];
+
+    function countSegmentRects(svg: string): { lit: number; total: number } {
+      const rectMatches = svg.match(/<rect[^/]*\/>/g) ?? [];
+      const lit = rectMatches.filter((rect) => LIT_COLORS.some((c) => rect.includes(c))).length;
+
+      return { lit, total: rectMatches.length };
+    }
+
+    it("renders 6 segments total regardless of state", () => {
+      for (const state of [
+        TrackWetness.Unknown,
+        TrackWetness.Dry,
+        TrackWetness.MostlyDry,
+        TrackWetness.VeryLightlyWet,
+        TrackWetness.LightlyWet,
+        TrackWetness.ModeratelyWet,
+        TrackWetness.VeryWet,
+        TrackWetness.ExtremelyWet,
+      ]) {
+        const svg = generateTrackWetnessGraphic(state);
+        const counts = countSegmentRects(svg);
+
+        expect(counts.total).toBe(6);
+      }
+    });
+
+    it("lights 0 segments for Unknown", () => {
+      expect(countSegmentRects(generateTrackWetnessGraphic(TrackWetness.Unknown)).lit).toBe(0);
+    });
+
+    it("lights 0 segments for undefined", () => {
+      expect(countSegmentRects(generateTrackWetnessGraphic(undefined)).lit).toBe(0);
+    });
+
+    it("lights 0 segments for Dry", () => {
+      expect(countSegmentRects(generateTrackWetnessGraphic(TrackWetness.Dry)).lit).toBe(0);
+    });
+
+    it("lights segments according to state (MostlyDry=1 … ExtremelyWet=6)", () => {
+      const cases: Array<[TrackWetness, number]> = [
+        [TrackWetness.MostlyDry, 1],
+        [TrackWetness.VeryLightlyWet, 2],
+        [TrackWetness.LightlyWet, 3],
+        [TrackWetness.ModeratelyWet, 4],
+        [TrackWetness.VeryWet, 5],
+        [TrackWetness.ExtremelyWet, 6],
+      ];
+
+      for (const [state, expectedLit] of cases) {
+        const svg = generateTrackWetnessGraphic(state);
+
+        expect(countSegmentRects(svg).lit).toBe(expectedLit);
+      }
+    });
+
+    it("uses the unlit color for all segments when state is Unknown or Dry", () => {
+      for (const state of [TrackWetness.Unknown, TrackWetness.Dry]) {
+        const svg = generateTrackWetnessGraphic(state);
+
+        for (const c of LIT_COLORS) expect(svg).not.toContain(c);
+
+        expect(svg).toContain("#3a3a3a");
+      }
+    });
+
+    it("does not render any text inside the graphic (the title carries the state name)", () => {
+      const svg = generateTrackWetnessGraphic(TrackWetness.MostlyDry);
+
+      expect(svg).not.toContain("<text");
+    });
+  });
+
+  describe("track-wetness mode display value", () => {
+    it("returns 'DRY' label when telemetry reports Dry", () => {
+      const action = new SessionInfo();
+      const settings = defaultSettings({ mode: "track-wetness" });
+      const telemetry = { TrackWetness: TrackWetness.Dry } as any;
+
+      expect(action["extractDisplayValue"](settings as any, telemetry)).toBe("DRY");
+    });
+
+    it("returns 'EXTREME' label when telemetry reports ExtremelyWet", () => {
+      const action = new SessionInfo();
+      const settings = defaultSettings({ mode: "track-wetness" });
+      const telemetry = { TrackWetness: TrackWetness.ExtremelyWet } as any;
+
+      expect(action["extractDisplayValue"](settings as any, telemetry)).toBe("EXTREME");
+    });
+
+    it("returns '--' label when telemetry is null", () => {
+      const action = new SessionInfo();
+      const settings = defaultSettings({ mode: "track-wetness" });
+
+      expect(action["extractDisplayValue"](settings as any, null)).toBe("--");
+    });
+
+    it("returns '--' label when TrackWetness is missing from telemetry", () => {
+      const action = new SessionInfo();
+      const settings = defaultSettings({ mode: "track-wetness" });
+      const telemetry = {} as any;
+
+      expect(action["extractDisplayValue"](settings as any, telemetry)).toBe("--");
     });
   });
 

--- a/packages/iracing-actions/src/actions/session-info/session-info.ts
+++ b/packages/iracing-actions/src/actions/session-info/session-info.ts
@@ -22,6 +22,7 @@ import {
   type SessionInfo as IRacingSessionInfo,
   resolveActiveFlag,
   type TelemetryData,
+  TrackWetness,
 } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
@@ -43,7 +44,9 @@ const UNLIMITED_LAPS = 32767;
 const LITERS_PER_GALLON = 3.78541;
 
 const SessionInfoSettings = CommonSettings.extend({
-  mode: z.enum(["incidents", "time-remaining", "laps", "position", "fuel", "flags"]).default("incidents"),
+  mode: z
+    .enum(["incidents", "time-remaining", "laps", "position", "fuel", "flags", "track-wetness"])
+    .default("incidents"),
   fontSize: z.preprocess(
     (val) => (val === "" || val === null || val === undefined ? undefined : val),
     z.coerce.number().min(5).max(36).optional(),
@@ -118,6 +121,81 @@ export function countActiveDrivers(sessionInfo: IRacingSessionInfo | null): numb
 }
 
 /**
+ * Lit-segment colors for the track-wetness bar (cyan → deep blue gradient across 6 states).
+ * Index 0 is the bottom-most segment (lit at MostlyDry), index 5 is the top (lit at ExtremelyWet).
+ * Dry shows zero lit segments. Semantic colors — fixed across platforms (see
+ * `.claude/rules/icons.md` "What stays fixed").
+ */
+const TRACK_WETNESS_SEGMENT_COLORS = [
+  "#a8e6f0", // MostlyDry
+  "#6dc9e3", // VeryLightlyWet
+  "#3b9bc4", // LightlyWet
+  "#1f7eb0", // ModeratelyWet
+  "#15639a", // VeryWet
+  "#0e4c80", // ExtremelyWet
+] as const;
+
+const TRACK_WETNESS_UNLIT_COLOR = "#3a3a3a";
+
+/**
+ * @internal Exported for testing
+ *
+ * Maps a TrackWetness enum value to a short upper-case label rendered as the
+ * action title at the bottom of the icon. Returns "--" for Unknown / undefined.
+ */
+export function trackWetnessLabel(state: TrackWetness | undefined): string {
+  switch (state) {
+    case TrackWetness.Dry:
+      return "DRY";
+    case TrackWetness.MostlyDry:
+      return "MOSTLY DRY";
+    case TrackWetness.VeryLightlyWet:
+      return "V. LIGHT";
+    case TrackWetness.LightlyWet:
+      return "LIGHT";
+    case TrackWetness.ModeratelyWet:
+      return "MODERATE";
+    case TrackWetness.VeryWet:
+      return "VERY WET";
+    case TrackWetness.ExtremelyWet:
+      return "EXTREME";
+    default:
+      return "--";
+  }
+}
+
+/**
+ * @internal Exported for testing
+ *
+ * Generates an inline SVG fragment showing a centered vertical 6-segment bar that
+ * fills cumulatively from the bottom using a cyan→deep-blue gradient. Dry and
+ * Unknown render zero lit segments; ExtremelyWet renders all six. The state label
+ * is rendered separately as the icon title (see `generateSessionInfoSvg`).
+ */
+export function generateTrackWetnessGraphic(state: TrackWetness | undefined): string {
+  // Dry → 0 lit, MostlyDry → 1, …, ExtremelyWet → 6.
+  const lit =
+    state !== undefined && state >= TrackWetness.MostlyDry && state <= TrackWetness.ExtremelyWet ? state - 1 : 0;
+
+  // Centered vertical 6-segment bar: 6 × 14 high + 5 × 3 gap = 99.
+  // Bottom at y=110, top at y=11; horizontally centered at x=72 with width=80 (x=32..112).
+  const segH = 14;
+  const gap = 3;
+  const barX = 32;
+  const barW = 80;
+  const barBottom = 110;
+  const segments: string[] = [];
+
+  for (let i = 0; i < 6; i++) {
+    const y = barBottom - segH - i * (segH + gap);
+    const fill = i < lit ? TRACK_WETNESS_SEGMENT_COLORS[i] : TRACK_WETNESS_UNLIT_COLOR;
+    segments.push(`<rect x="${barX}" y="${y}" width="${barW}" height="${segH}" rx="2" fill="${fill}"/>`);
+  }
+
+  return segments.join("\n    ");
+}
+
+/**
  * @internal Exported for testing
  *
  * Generates an SVG data URI for the session info display.
@@ -127,6 +205,7 @@ export function generateSessionInfoSvg(
   value: string,
   isFlashing: boolean,
   colorOverride?: { background: string; text: string },
+  trackWetnessState?: TrackWetness,
 ): string {
   const titleLabels: Record<string, string> = {
     incidents: "INCIDENTS",
@@ -136,7 +215,12 @@ export function generateSessionInfoSvg(
     fuel: "FUEL",
     flags: "FLAGS",
   };
-  const actionDefaultTitle = titleLabels[settings.mode] ?? "INCIDENTS";
+  // Track-wetness uses the live state name as its title so the icon shows the
+  // current state in one line. All other modes use a fixed category label.
+  const actionDefaultTitle =
+    settings.mode === "track-wetness"
+      ? trackWetnessLabel(trackWetnessState)
+      : (titleLabels[settings.mode] ?? "INCIDENTS");
   const valueFontSizeNum = settings.fontSize !== undefined ? settings.fontSize * 2 : 28;
   const valueFontSize = String(valueFontSizeNum);
   const valueY = String(88 + (valueFontSizeNum - 44) / 3);
@@ -175,12 +259,19 @@ export function generateSessionInfoSvg(
   const border = resolveBorderSettings(sessionInfoTemplate, getGlobalBorderSettings(), settings.borderOverrides);
   const borderSvg = generateBorderParts(border);
 
+  const graphicContent = settings.mode === "track-wetness" ? generateTrackWetnessGraphic(trackWetnessState) : "";
+
+  // The graphic content carries its own label for track-wetness, so clear the value
+  // text slot to avoid drawing the label twice.
+  const valueText = settings.mode === "track-wetness" ? "" : value;
+
   const svg = renderIconTemplate(sessionInfoTemplate, {
     backgroundColor,
     titleContent,
     borderDefs: borderSvg.defs,
     borderContent: borderSvg.rects,
-    value,
+    graphicContent,
+    value: valueText,
     valueFontSize,
     valueY,
     textColor,
@@ -275,8 +366,9 @@ export class SessionInfo extends ConnectionStateAwareAction<SessionInfoSettings>
 
     // Resolve flag colors for flags mode
     const colorOverride = this.resolveFlagColorOverride(settings, telemetry);
+    const trackWetnessState = telemetry?.TrackWetness as TrackWetness | undefined;
 
-    const svgDataUri = generateSessionInfoSvg(settings, value, isFlashing, colorOverride);
+    const svgDataUri = generateSessionInfoSvg(settings, value, isFlashing, colorOverride, trackWetnessState);
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
 
@@ -296,6 +388,13 @@ export class SessionInfo extends ConnectionStateAwareAction<SessionInfoSettings>
   }
 
   private extractDisplayValue(settings: SessionInfoSettings, telemetry: TelemetryData | null): string {
+    // Track wetness renders its label inside the graphic content. The label is still
+    // returned here so the state-key cache busts on state transitions; generateSessionInfoSvg
+    // clears the value text slot for this mode to avoid drawing it twice.
+    if (settings.mode === "track-wetness") {
+      return trackWetnessLabel(telemetry?.TrackWetness as TrackWetness | undefined);
+    }
+
     if (!telemetry) {
       if (settings.mode === "incidents") return "--";
 
@@ -495,12 +594,13 @@ export class SessionInfo extends ConnectionStateAwareAction<SessionInfoSettings>
     const value = this.extractDisplayValue(settings, telemetry);
     const isFlashing = this.flashStates.get(contextId) ?? false;
     const colorOverride = this.resolveFlagColorOverride(settings, telemetry);
+    const trackWetnessState = telemetry?.TrackWetness as TrackWetness | undefined;
     const stateKey = this.buildStateKey(settings, value, isFlashing, colorOverride?.background);
     const lastStateKey = this.lastState.get(contextId);
 
     if (lastStateKey !== stateKey) {
       this.lastState.set(contextId, stateKey);
-      const svgDataUri = generateSessionInfoSvg(settings, value, isFlashing, colorOverride);
+      const svgDataUri = generateSessionInfoSvg(settings, value, isFlashing, colorOverride, trackWetnessState);
       await this.updateKeyImage(contextId, svgDataUri);
     }
   }

--- a/packages/iracing-native/src/mock-data/snapshots.ts
+++ b/packages/iracing-native/src/mock-data/snapshots.ts
@@ -5,7 +5,7 @@
  * driving around the track. These are placeholder values — replace
  * with real telemetry captures for more accurate simulation.
  */
-import { Flags, PitSvFlags, PitSvStatus, SessionState, TrkLoc } from "../defines.js";
+import { Flags, PitSvFlags, PitSvStatus, SessionState, TrackWetness, TrkLoc } from "../defines.js";
 import type { MockSnapshotValues } from "./telemetry.js";
 
 /** Create a 64-element array with default value, setting specific car values */
@@ -126,6 +126,7 @@ export const SNAPSHOT_MID_STRAIGHT: MockSnapshotValues = {
   AirTemp: 25.56,
   TrackTempCrew: 32.22,
   Skies: 1, // Partly Cloudy
+  TrackWetness: TrackWetness.Dry,
 };
 
 /**
@@ -157,6 +158,8 @@ export const SNAPSHOT_BRAKING: MockSnapshotValues = {
 
   P2P_Status: false,
   DRS_Status: 0,
+
+  TrackWetness: TrackWetness.VeryLightlyWet,
 };
 
 /**
@@ -198,6 +201,8 @@ export const SNAPSHOT_PIT_ENTRY: MockSnapshotValues = {
 
   P2P_Status: false,
   DRS_Status: 0,
+
+  TrackWetness: TrackWetness.ModeratelyWet,
 };
 
 /**
@@ -212,6 +217,7 @@ export const SNAPSHOT_YELLOW_FLAG: MockSnapshotValues = {
   Throttle: 0.4,
   P2P_Status: false,
   DRS_Status: 0,
+  TrackWetness: TrackWetness.VeryWet,
 };
 
 /**
@@ -224,6 +230,7 @@ export const SNAPSHOT_BLUE_FLAG: MockSnapshotValues = {
   SessionFlags: Flags.Green | Flags.Blue,
   PlayerCarPosition: 3,
   PlayerCarClassPosition: 3,
+  TrackWetness: TrackWetness.MostlyDry,
 };
 
 /**
@@ -240,6 +247,7 @@ export const SNAPSHOT_YELLOW_BLUE_FLAG: MockSnapshotValues = {
   PlayerCarClassPosition: 3,
   P2P_Status: false,
   DRS_Status: 0,
+  TrackWetness: TrackWetness.ExtremelyWet,
 };
 
 /**

--- a/packages/iracing-native/src/mock-data/telemetry.ts
+++ b/packages/iracing-native/src/mock-data/telemetry.ts
@@ -297,6 +297,14 @@ function buildVarHeaders(): VarHeader[] {
     { type: VarType.Float, count: 1, countAsTime: false, name: "AirTemp", desc: "Air temperature", unit: "C" },
     { type: VarType.Float, count: 1, countAsTime: false, name: "TrackTempCrew", desc: "Track temperature", unit: "C" },
     { type: VarType.Int, count: 1, countAsTime: false, name: "Skies", desc: "Sky condition", unit: "irsdk_Skies" },
+    {
+      type: VarType.Int,
+      count: 1,
+      countAsTime: false,
+      name: "TrackWetness",
+      desc: "Track wetness",
+      unit: "irsdk_TrackWetness",
+    },
   ];
 
   let offset = 0;

--- a/packages/website/src/content/docs/docs/actions/display-session/session-info.md
+++ b/packages/website/src/content/docs/docs/actions/display-session/session-info.md
@@ -1,9 +1,9 @@
 ---
 title: Session Info
-description: Display live session information — incidents, time, laps, position, fuel, and flags.
+description: Display live session information — incidents, time, laps, position, fuel, flags, and track wetness.
 sidebar:
   badge:
-    text: "6 modes"
+    text: "7 modes"
     variant: tip
 ---
 
@@ -120,3 +120,30 @@ Display currently active flags with the corresponding colors and a pulsing anima
 #### Setting: Font Size
 
 Size of the rendered value, in PI units (5–36, doubled for SVG render). Defaults to `14`.
+
+---
+
+### Track Wetness
+
+Show the current track-wetness state with a centered vertical 6-segment bar that fills cumulatively as the track gets wetter using a cyan→deep-blue gradient. The current state name is rendered as the icon title. Maps to iRacing's `irsdk_TrackWetness` telemetry.
+
+| State | Bar | Title |
+|-------|-----|-------|
+| Unknown | empty | `--` |
+| Dry | empty | `DRY` |
+| Mostly Dry | 1 segment | `MOSTLY DRY` |
+| Very Lightly Wet | 2 segments | `V. LIGHT` |
+| Lightly Wet | 3 segments | `LIGHT` |
+| Moderately Wet | 4 segments | `MODERATE` |
+| Very Wet | 5 segments | `VERY WET` |
+| Extremely Wet | 6 segments | `EXTREME` |
+
+#### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — the bar and label update live as track conditions shift through the eight states
+
+#### Settings
+
+- No additional settings. The Font Size slider does not apply (the graphic carries its own label).

--- a/packages/website/src/content/docs/docs/actions/overview.md
+++ b/packages/website/src/content/docs/docs/actions/overview.md
@@ -3,14 +3,14 @@ title: Actions Overview
 description: All iRaceDeck actions organized by category
 ---
 
-iRaceDeck provides 31 actions with 257 modes for iRacing, organized into 9 categories.
+iRaceDeck provides 31 actions with 258 modes for iRacing, organized into 9 categories.
 
 ## Categories
 
 | Category | Actions | Modes | Description |
 |----------|---------|-------|-------------|
 | [Audio & Voice](/docs/actions/audio-voice/ai-spotter-controls/) | 3 | 12 | AI spotter, audio controls, race engineer & radar |
-| [Display & Session](/docs/actions/display-session/session-info/) | 2 | 7 | Live session data: incidents, laps, position, fuel, flags |
+| [Display & Session](/docs/actions/display-session/session-info/) | 2 | 8 | Live session data: incidents, laps, position, fuel, flags, track wetness |
 | [Driving Controls](/docs/actions/driving/black-box-selector/) | 3 | 17 | Black boxes, look direction, car control |
 | [Cockpit & Interface](/docs/actions/cockpit/cockpit-misc/) | 5 | 33 | Wipers, force feedback, splits & reference, telemetry, UI toggles |
 | [View & Camera](/docs/actions/view-camera/view-adjustment/) | 5 | 88 | FOV, replay, camera controls, broadcast tools |

--- a/packages/website/src/content/docs/docs/actions/overview.md
+++ b/packages/website/src/content/docs/docs/actions/overview.md
@@ -10,7 +10,7 @@ iRaceDeck provides 31 actions with 258 modes for iRacing, organized into 9 categ
 | Category | Actions | Modes | Description |
 |----------|---------|-------|-------------|
 | [Audio & Voice](/docs/actions/audio-voice/ai-spotter-controls/) | 3 | 12 | AI spotter, audio controls, race engineer & radar |
-| [Display & Session](/docs/actions/display-session/session-info/) | 2 | 8 | Live session data: incidents, laps, position, fuel, flags, track wetness |
+| [Display & Session](/docs/actions/display-session/session-info/) | 2 | 8 | Live session data: incidents, time remaining, laps, position, fuel, flags, track wetness |
 | [Driving Controls](/docs/actions/driving/black-box-selector/) | 3 | 17 | Black boxes, look direction, car control |
 | [Cockpit & Interface](/docs/actions/cockpit/cockpit-misc/) | 5 | 33 | Wipers, force feedback, splits & reference, telemetry, UI toggles |
 | [View & Camera](/docs/actions/view-camera/view-adjustment/) | 5 | 88 | FOV, replay, camera controls, broadcast tools |

--- a/packages/website/src/content/docs/docs/index.md
+++ b/packages/website/src/content/docs/docs/index.md
@@ -19,7 +19,7 @@ Welcome to the iRaceDeck documentation. Here you'll find guides for getting star
 
 ## Actions
 
-iRaceDeck provides **31 actions** with **257 modes** across 9 categories. See the [Actions Overview](/docs/actions/overview/) for a full breakdown, or jump to a category:
+iRaceDeck provides **31 actions** with **258 modes** across 9 categories. See the [Actions Overview](/docs/actions/overview/) for a full breakdown, or jump to a category:
 
 - [Audio & Voice](/docs/actions/audio-voice/ai-spotter-controls/) — AI spotter, audio controls, race engineer & radar
 - [Display & Session](/docs/actions/display-session/session-info/) — Live session data and telemetry displays


### PR DESCRIPTION
## Related Issue

Refs #526 (Part 1 of 2 — display only; the Race Engineer callout follows in a separate PR.)

## What changed?

Adds a **Track Wetness** mode to the Session Info action under Display & Session, surfacing iRacing's `TrackWetness` telemetry (already in the SDK snapshot, never previously consumed).

- New `{{graphicContent}}` slot in `session-info.svg` so visual modes can plug in custom artwork. The 6 existing text-based modes (Incidents, Time Remaining, Laps, Position, Fuel, Flags) leave the slot empty and behave byte-identical to today.
- New `track-wetness` mode renders a **centered vertical 6-segment bar** with a cyan→deep-blue gradient that fills cumulatively as the track gets wetter:
  - **Dry / Unknown** → 0 lit
  - **Mostly Dry** → 1 lit · **Very Lightly Wet** → 2 · **Lightly Wet** → 3 · **Moderately Wet** → 4 · **Very Wet** → 5 · **Extremely Wet** → 6
- The **current state name is the icon title** ("DRY", "MOSTLY DRY", "V. LIGHT", "LIGHT", "MODERATE", "VERY WET", "EXTREME", or "--" for Unknown) — single line, no separate label inside the graphic.
- Designed to QT5 / SVG Tiny 1.2 static so it renders identically on Mirabox and Elgato.
- Mock telemetry (`packages/iracing-native/src/mock-data/`) now seeds `TrackWetness` across the rotating snapshots so the dev mock cycles through visible states (Dry → VeryLightlyWet → ModeratelyWet → VeryWet → MostlyDry → ExtremelyWet).
- Tests cover label mapping for all enum values, segment count (6 always), correct lit count per state (Unknown/Dry → 0, ExtremelyWet → 6), unlit-only colors for Unknown/Dry, and that no `<text>` is rendered inside the graphic.
- Website action page, overview, top-level docs index, `docs/reference/actions.json`, and the `iracedeck-actions` skill are all updated for the new mode and the bumped counts.

## How to test

- [x] In iRacing rain session, switch a Session Info button to **Track Wetness**; confirm the bar fills as conditions worsen and the title updates to the live state name (snapshot taken on a real session showed `TrackWetness: 6` → "VERY WET" with 5 of 6 segments lit, as expected).
- [ ] Cycle through the 6 existing modes and confirm they render identically to before.
- [ ] Verify on Mirabox that the bar renders without filters/clip-path (QT5 / SVG Tiny 1.2 static).
- [ ] `pnpm install && pnpm build && pnpm test` — clean.

## Checklist

- [x] Linked to an approved issue (#526)
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox — no plugin-side changes needed; the action lives in `@iracedeck/iracing-actions` and both plugins pick it up via the existing barrel)
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "Track Wetness" mode to Session Info: a 6-segment vertical cyan→deep‑blue bar that reflects live track wetness telemetry; Session Info modes increased from 7→8 (overall modes 258→259).

* **Documentation**
  * Updated Session Info and reference docs/overview to include the new Track Wetness mode and revised mode counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->