### PR TITLE
feat(sdk): poll telemetry at ~70 Hz with SessionTick dedupe (#493)

### DIFF
--- a/packages/audio-scenarios/src/catalog/pit-crew/radar-engine.ts
+++ b/packages/audio-scenarios/src/catalog/pit-crew/radar-engine.ts
@@ -27,10 +27,12 @@ const RADAR_AUDIO: Record<ActiveState, string> = {
   "two-right": "sfx/radar/IRD-radar-right.mp3",
 };
 
-// Single-car states tick at 250 ms (matches the legacy 4 Hz cadence).
-// Two-cars-same-side is faster (180 ms) because being sandwiched on one
-// side is the highest-risk position. Both-sides is 230 ms — locked between
-// cars but the driver is holding a straight line.
+// Single-car states tick at 250 ms — the radar engine has its own
+// `setInterval` for audio playback gaps and is independent of the SDK's
+// telemetry poll rate, so bumping that rate (issue #493) does not change
+// radar cadence. Two-cars-same-side is faster (180 ms) because being
+// sandwiched on one side is the highest-risk position. Both-sides is
+// 230 ms — locked between cars but the driver is holding a straight line.
 const RADAR_TICK_INTERVALS: Readonly<Record<ActiveState, number>> = {
   left: 250,
   right: 250,

--- a/packages/iracing-actions/src/actions/car-control/car-control.ts
+++ b/packages/iracing-actions/src/actions/car-control/car-control.ts
@@ -43,6 +43,7 @@ import drsTemplate from "../../../icons/car-control-drs.svg";
 import pushToPassTemplate from "../../../icons/car-control-push-to-pass.svg";
 import carControlTemplate from "../../../icons/car-control.svg";
 import { borderColorForState, statusBarNA, statusBarOff, statusBarOn } from "../../icons/status-bar.js";
+import { IconUpdateThrottle } from "../../shared/icon-update-throttle.js";
 
 const WHITE = "#ffffff";
 const GRAY = "#888888";
@@ -500,6 +501,14 @@ export class CarControl extends ConnectionStateAwareAction<CarControlSettings> {
   /** Auto-hold release timers per action context (escape auto-hold mode) */
   private autoHoldTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
+  /**
+   * Caps per-key icon updates at 10 Hz with a trailing-edge coalescer
+   * (issue #493). The SDK now ticks at ~70 Hz with SessionTick dedupe;
+   * a fast-changing telemetry-driven control (DRS, push-to-pass blinking)
+   * would otherwise flood `setKeyImage` calls.
+   */
+  private readonly imageThrottle = new IconUpdateThrottle();
+
   override async onWillAppear(ev: IDeckWillAppearEvent<CarControlSettings>): Promise<void> {
     await super.onWillAppear(ev);
     const settings = this.parseSettings(ev.payload.settings);
@@ -538,6 +547,7 @@ export class CarControl extends ConnectionStateAwareAction<CarControlSettings> {
     this.sdkController.unsubscribe(ev.action.id);
     this.activeContexts.delete(ev.action.id);
     this.lastState.delete(ev.action.id);
+    this.imageThrottle.clear(ev.action.id);
   }
 
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<CarControlSettings>): Promise<void> {
@@ -815,16 +825,29 @@ export class CarControl extends ConnectionStateAwareAction<CarControlSettings> {
     const stateKey = this.buildStateKey(settings, telemetryState);
     const lastStateKey = this.lastState.get(contextId);
 
-    if (lastStateKey !== stateKey) {
-      this.lastState.set(contextId, stateKey);
-      const svgDataUri = generateCarControlSvg(settings, telemetryState);
+    if (lastStateKey === stateKey) return;
+
+    this.lastState.set(contextId, stateKey);
+
+    // Route through the 10 Hz throttle (issue #493). The render closure
+    // re-resolves from current telemetry at flush time so a trailing-edge
+    // fire reflects the latest state, not the state we had when the
+    // throttle scheduled it.
+    this.imageThrottle.schedule(contextId, async () => {
+      const storedSettings = this.activeContexts.get(contextId);
+
+      if (!storedSettings || !TELEMETRY_AWARE_CONTROLS.has(storedSettings.control)) return;
+
+      const currentTelemetry = this.sdkController.getCurrentTelemetry();
+      const currentState = this.getTelemetryState(currentTelemetry, storedSettings.control);
+      const svgDataUri = generateCarControlSvg(storedSettings, currentState);
       await this.updateKeyImage(contextId, svgDataUri);
       this.setRegenerateCallback(contextId, () => {
-        const currentTelemetry = this.sdkController.getCurrentTelemetry();
-        const currentState = this.getTelemetryState(currentTelemetry, settings.control);
+        const t = this.sdkController.getCurrentTelemetry();
+        const s = this.getTelemetryState(t, storedSettings.control);
 
-        return generateCarControlSvg(settings, currentState);
+        return generateCarControlSvg(storedSettings, s);
       });
-    }
+    });
   }
 }

--- a/packages/iracing-actions/src/actions/car-control/car-control.ts
+++ b/packages/iracing-actions/src/actions/car-control/car-control.ts
@@ -531,6 +531,13 @@ export class CarControl extends ConnectionStateAwareAction<CarControlSettings> {
   }
 
   override async onWillDisappear(ev: IDeckWillDisappearEvent<CarControlSettings>): Promise<void> {
+    // Clear pending throttle + per-context state BEFORE awaiting any keyboard
+    // release / super so a queued trailing flush (up to 100 ms) can't fire
+    // and call `updateKeyImage` for a context that's mid-teardown.
+    this.imageThrottle.clear(ev.action.id);
+    this.activeContexts.delete(ev.action.id);
+    this.lastState.delete(ev.action.id);
+
     const settings = this.parseSettings(ev.payload.settings);
 
     if (settings.control === "escape") {
@@ -545,9 +552,6 @@ export class CarControl extends ConnectionStateAwareAction<CarControlSettings> {
 
     await super.onWillDisappear(ev);
     this.sdkController.unsubscribe(ev.action.id);
-    this.activeContexts.delete(ev.action.id);
-    this.lastState.delete(ev.action.id);
-    this.imageThrottle.clear(ev.action.id);
   }
 
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<CarControlSettings>): Promise<void> {

--- a/packages/iracing-actions/src/actions/telemetry-display/telemetry-display.ts
+++ b/packages/iracing-actions/src/actions/telemetry-display/telemetry-display.ts
@@ -130,11 +130,15 @@ export class TelemetryDisplay extends ConnectionStateAwareAction<TelemetryDispla
   }
 
   override async onWillDisappear(ev: IDeckWillDisappearEvent<TelemetryDisplaySettings>): Promise<void> {
-    await super.onWillDisappear(ev);
-    this.sdkController.unsubscribe(ev.action.id);
+    // Clear pending throttle + per-context state BEFORE awaiting super so a
+    // queued trailing flush (up to 100 ms) can't fire and call
+    // `updateKeyImage` for a context that's mid-teardown.
+    this.imageThrottle.clear(ev.action.id);
     this.activeContexts.delete(ev.action.id);
     this.lastState.delete(ev.action.id);
-    this.imageThrottle.clear(ev.action.id);
+
+    await super.onWillDisappear(ev);
+    this.sdkController.unsubscribe(ev.action.id);
   }
 
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<TelemetryDisplaySettings>): Promise<void> {

--- a/packages/iracing-actions/src/actions/telemetry-display/telemetry-display.ts
+++ b/packages/iracing-actions/src/actions/telemetry-display/telemetry-display.ts
@@ -20,6 +20,7 @@ import { resolveTemplate } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
 import telemetryDisplayTemplate from "../../../icons/telemetry-display.svg";
+import { IconUpdateThrottle } from "../../shared/icon-update-throttle.js";
 
 const TelemetryDisplaySettings = CommonSettings.extend({
   template: z.string().default("#{{self.car_number}}\n{{self.first_name}}"),
@@ -105,6 +106,13 @@ export const TELEMETRY_DISPLAY_UUID = "com.iracedeck.sd.core.telemetry-display" 
 export class TelemetryDisplay extends ConnectionStateAwareAction<TelemetryDisplaySettings> {
   private activeContexts = new Map<string, TelemetryDisplaySettings>();
   private lastState = new Map<string, string>();
+  /**
+   * Caps per-key icon updates at 10 Hz with a trailing-edge coalescer
+   * (issue #493). The SDK now ticks at ~70 Hz with SessionTick dedupe (so
+   * up to ~60 unique frames per second can reach this action); a fast-
+   * changing template like RPM would otherwise flood `setKeyImage` calls.
+   */
+  private readonly imageThrottle = new IconUpdateThrottle();
 
   override async onWillAppear(ev: IDeckWillAppearEvent<TelemetryDisplaySettings>): Promise<void> {
     await super.onWillAppear(ev);
@@ -126,6 +134,7 @@ export class TelemetryDisplay extends ConnectionStateAwareAction<TelemetryDispla
     this.sdkController.unsubscribe(ev.action.id);
     this.activeContexts.delete(ev.action.id);
     this.lastState.delete(ev.action.id);
+    this.imageThrottle.clear(ev.action.id);
   }
 
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<TelemetryDisplaySettings>): Promise<void> {
@@ -184,10 +193,22 @@ export class TelemetryDisplay extends ConnectionStateAwareAction<TelemetryDispla
     const stateKey = this.buildStateKey(title, value, settings);
     const lastStateKey = this.lastState.get(contextId);
 
-    if (lastStateKey !== stateKey) {
-      this.lastState.set(contextId, stateKey);
-      const svgDataUri = generateTelemetryDisplaySvg(title, value, settings);
+    if (lastStateKey === stateKey) return;
+
+    this.lastState.set(contextId, stateKey);
+
+    // Route through the 10 Hz throttle (issue #493). The render closure
+    // re-resolves from current telemetry/settings at flush time so a
+    // trailing-edge fire reflects the latest state, not the state we
+    // had when the throttle scheduled it.
+    this.imageThrottle.schedule(contextId, async () => {
+      const storedSettings = this.activeContexts.get(contextId);
+
+      if (!storedSettings) return;
+
+      const display = this.resolveDisplay(storedSettings);
+      const svgDataUri = generateTelemetryDisplaySvg(display.title, display.value, storedSettings);
       await this.updateKeyImage(contextId, svgDataUri);
-    }
+    });
   }
 }

--- a/packages/iracing-actions/src/shared/icon-update-throttle.test.ts
+++ b/packages/iracing-actions/src/shared/icon-update-throttle.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { IconUpdateThrottle } from "./icon-update-throttle.js";
+
+describe("IconUpdateThrottle", () => {
+  let throttle: IconUpdateThrottle;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    throttle = new IconUpdateThrottle(100);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the first call immediately", () => {
+    const render = vi.fn();
+    throttle.schedule("ctx", render);
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces rapid calls into a single trailing flush within the window", async () => {
+    const render = vi.fn();
+
+    // 10 changes within 100 ms — first fires immediately, rest are coalesced
+    // into one trailing flush at the window boundary.
+    throttle.schedule("ctx", render);
+
+    for (let i = 0; i < 9; i++) {
+      vi.advanceTimersByTime(10);
+      throttle.schedule("ctx", render);
+    }
+
+    // Immediate render only so far.
+    expect(render).toHaveBeenCalledTimes(1);
+
+    // Advance past the throttle window. The pending timer fires.
+    await vi.advanceTimersByTimeAsync(100);
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-evaluates the render closure at flush time so the latest state always wins", async () => {
+    let currentValue = "initial";
+    const calls: string[] = [];
+
+    throttle.schedule("ctx", () => {
+      calls.push(currentValue);
+    });
+    expect(calls).toEqual(["initial"]);
+
+    vi.advanceTimersByTime(20);
+    currentValue = "second";
+    throttle.schedule("ctx", () => {
+      calls.push(currentValue);
+    });
+
+    vi.advanceTimersByTime(20);
+    currentValue = "final";
+    throttle.schedule("ctx", () => {
+      calls.push(currentValue);
+    });
+
+    // Trailing flush picks up `final`, not `second`.
+    await vi.advanceTimersByTimeAsync(200);
+    expect(calls).toEqual(["initial", "final"]);
+  });
+
+  it("never fires the trailing flush if no calls arrived inside the window", async () => {
+    const render = vi.fn();
+
+    throttle.schedule("ctx", render);
+    expect(render).toHaveBeenCalledTimes(1);
+
+    // No further calls, but plenty of time passes.
+    await vi.advanceTimersByTimeAsync(500);
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders immediately again once the window has elapsed since the last send", async () => {
+    const render = vi.fn();
+
+    throttle.schedule("ctx", render);
+    expect(render).toHaveBeenCalledTimes(1);
+
+    // Wait past the window, then call again — should be immediate, not coalesced.
+    await vi.advanceTimersByTimeAsync(150);
+    throttle.schedule("ctx", render);
+    expect(render).toHaveBeenCalledTimes(2);
+    // No pending timer scheduled.
+    expect(throttle.pendingFlush.size).toBe(0);
+  });
+
+  it("isolates contexts — one key's throttle window does not affect another", async () => {
+    const renderA = vi.fn();
+    const renderB = vi.fn();
+
+    throttle.schedule("a", renderA);
+    throttle.schedule("b", renderB);
+    expect(renderA).toHaveBeenCalledTimes(1);
+    expect(renderB).toHaveBeenCalledTimes(1);
+
+    // Both contexts get their own coalesce window.
+    vi.advanceTimersByTime(20);
+    throttle.schedule("a", renderA);
+    throttle.schedule("b", renderB);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(renderA).toHaveBeenCalledTimes(2);
+    expect(renderB).toHaveBeenCalledTimes(2);
+  });
+
+  it("clear cancels the pending flush so no late render fires after disappear", async () => {
+    const render = vi.fn();
+
+    throttle.schedule("ctx", render);
+    vi.advanceTimersByTime(20);
+    throttle.schedule("ctx", render); // schedules a trailing flush
+
+    expect(throttle.pendingFlush.has("ctx")).toBe(true);
+    throttle.clear("ctx");
+    expect(throttle.pendingFlush.has("ctx")).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(500);
+    // Only the immediate render — the trailing one was cancelled.
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it("clearAll cancels every pending flush", () => {
+    throttle.schedule("a", vi.fn());
+    throttle.schedule("b", vi.fn());
+    vi.advanceTimersByTime(10);
+    throttle.schedule("a", vi.fn());
+    throttle.schedule("b", vi.fn());
+
+    expect(throttle.pendingFlush.size).toBe(2);
+    throttle.clearAll();
+    expect(throttle.pendingFlush.size).toBe(0);
+    expect(throttle.lastImageSentAt.size).toBe(0);
+  });
+});

--- a/packages/iracing-actions/src/shared/icon-update-throttle.ts
+++ b/packages/iracing-actions/src/shared/icon-update-throttle.ts
@@ -1,0 +1,99 @@
+/**
+ * Per-context throttle + trailing-edge coalescer for Stream Deck icon
+ * updates (issue #493).
+ *
+ * Built for actions that subscribe directly to the SDK at 60 Hz and re-render
+ * their key image when a derived state changes. Without a throttle, a
+ * fast-moving telemetry value (RPM, speed) would fire 60 `setKeyImage`
+ * calls per second per key — risks USB / WebSocket saturation and visible
+ * hitching, even though the device cannot meaningfully display 60 frames
+ * per second on a single key.
+ *
+ * Behavior per context id:
+ *   - First call OR call >= `windowMs` since the last send: render
+ *     immediately, record the send time, cancel any pending flush.
+ *   - Call inside the window: replace any pending timer with a fresh one
+ *     scheduled for the moment the window expires. Re-rendering at flush
+ *     time means the *latest* state always wins; we never need to remember
+ *     intermediate values.
+ *
+ * The render closure is re-evaluated at every call (immediate or trailing),
+ * so callers can pass a closure that resolves from current state — no need
+ * to capture and update an intermediate "pending state".
+ */
+export class IconUpdateThrottle {
+  /** @internal Exposed so tests can inspect throttle state. */
+  readonly lastImageSentAt = new Map<string, number>();
+  /** @internal Exposed so tests can inspect pending timers. */
+  readonly pendingFlush = new Map<string, ReturnType<typeof setTimeout>>();
+
+  /** Minimum gap between sends for the same context (default 100 ms — 10 Hz). */
+  constructor(private readonly windowMs = 100) {}
+
+  /**
+   * Either render immediately or coalesce into a trailing flush.
+   *
+   * `render` errors are swallowed (logged via the host's normal logger if
+   * the action wraps the call); the throttle stays in a clean state so the
+   * next change still gets through.
+   */
+  schedule(contextId: string, render: () => Promise<void> | void): void {
+    const now = Date.now();
+    const last = this.lastImageSentAt.get(contextId) ?? 0;
+    const elapsed = now - last;
+
+    if (elapsed >= this.windowMs) {
+      // Outside the window — fire immediately. Drop any pending flush
+      // because this immediate render supersedes it.
+      this.lastImageSentAt.set(contextId, now);
+      this.cancelPending(contextId);
+      void Promise.resolve(render()).catch(() => {});
+
+      return;
+    }
+
+    // Inside the window — coalesce. Replace any pending timer so the
+    // flush time stays anchored to the last arrival, and re-resolution
+    // at flush time picks up the latest state.
+    this.cancelPending(contextId);
+
+    const delay = this.windowMs - elapsed;
+
+    this.pendingFlush.set(
+      contextId,
+      setTimeout(() => {
+        this.pendingFlush.delete(contextId);
+        this.lastImageSentAt.set(contextId, Date.now());
+        void Promise.resolve(render()).catch(() => {});
+      }, delay),
+    );
+  }
+
+  /**
+   * Cancel any pending flush and forget the context. Call from
+   * `onWillDisappear` (and any teardown that drops the context) so timers
+   * never fire after the action is gone.
+   */
+  clear(contextId: string): void {
+    this.cancelPending(contextId);
+    this.lastImageSentAt.delete(contextId);
+  }
+
+  /** Cancel everything. */
+  clearAll(): void {
+    for (const id of [...this.pendingFlush.keys()]) {
+      this.cancelPending(id);
+    }
+
+    this.lastImageSentAt.clear();
+  }
+
+  private cancelPending(contextId: string): void {
+    const timer = this.pendingFlush.get(contextId);
+
+    if (timer) {
+      clearTimeout(timer);
+      this.pendingFlush.delete(contextId);
+    }
+  }
+}

--- a/packages/iracing-sdk/src/SDKController.test.ts
+++ b/packages/iracing-sdk/src/SDKController.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { IRacingSDK } from "./IRacingSDK.js";
-import { SDKController, TelemetryCallback } from "./SDKController.js";
+import { SDKController, TELEMETRY_INTERVAL_MS, TelemetryCallback } from "./SDKController.js";
 import { TelemetryData } from "./types.js";
 
 // Create mock SDK factory
@@ -33,6 +33,52 @@ describe("SDKController", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
+  });
+
+  describe("TELEMETRY_INTERVAL_MS", () => {
+    it("polls slightly faster than iRacing's 60 Hz to never miss a frame", () => {
+      // Pinned literally so any future drift surfaces visibly. We poll at
+      // ~70 Hz (14 ms) and dedupe by SessionTick — see issue #493 and the
+      // module-level docstring on TELEMETRY_INTERVAL_MS for the rationale.
+      expect(TELEMETRY_INTERVAL_MS).toBe(14);
+      // Sanity: must be strictly faster than iRacing's 60 Hz write rate
+      // (16.67 ms) for the dedupe approach to never miss a frame.
+      expect(TELEMETRY_INTERVAL_MS).toBeLessThan(1000 / 60);
+    });
+  });
+
+  describe("SessionTick dedupe", () => {
+    it("notifies subscribers only when SessionTick advances", () => {
+      const callback = vi.fn();
+      const telemetry: TelemetryData = { Speed: 100, SessionTick: 1000 } as TelemetryData;
+      vi.mocked(mockSdk.getTelemetry).mockReturnValue(telemetry);
+
+      controller.subscribe("test", callback);
+      // Prime: let the first poll establish lastSessionTick = 1000, then
+      // ignore the bookkeeping notifications from subscribe()/first poll.
+      vi.advanceTimersByTime(TELEMETRY_INTERVAL_MS);
+      callback.mockClear();
+
+      // Three more polls reading the SAME tick — dedupe should suppress all.
+      vi.advanceTimersByTime(TELEMETRY_INTERVAL_MS * 3);
+      expect(callback).not.toHaveBeenCalled();
+
+      // Tick advances — next poll fires the callback exactly once.
+      vi.mocked(mockSdk.getTelemetry).mockReturnValue({ Speed: 100, SessionTick: 1001 } as TelemetryData);
+      vi.advanceTimersByTime(TELEMETRY_INTERVAL_MS);
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it("notifies on every poll when SessionTick is undefined (legacy SDK builds)", () => {
+      const callback = vi.fn();
+      vi.mocked(mockSdk.getTelemetry).mockReturnValue({ Speed: 100 } as TelemetryData);
+
+      controller.subscribe("test", callback);
+      callback.mockClear();
+
+      vi.advanceTimersByTime(TELEMETRY_INTERVAL_MS * 3);
+      expect(callback).toHaveBeenCalledTimes(3);
+    });
   });
 
   describe("subscribe", () => {

--- a/packages/iracing-sdk/src/SDKController.ts
+++ b/packages/iracing-sdk/src/SDKController.ts
@@ -249,6 +249,9 @@ export class SDKController {
       this.lastValidTelemetry = null;
       this.lastTemplateContext = null;
       this.templateContextDirty = true;
+      // Reset dedupe state so the first frame of the next iRacing session
+      // is never suppressed by a stale tick value (issue #493 follow-up).
+      this.lastSessionTick = -1;
       this.notifySubscribers(null);
     } else if (enabled && this.subscribers.size > 0 && !this.isConnected) {
       // Re-enabling and we have subscribers - try to connect immediately

--- a/packages/iracing-sdk/src/SDKController.ts
+++ b/packages/iracing-sdk/src/SDKController.ts
@@ -10,6 +10,22 @@ import { SessionInfo, TelemetryData } from "./types.js";
 
 export type TelemetryCallback = (telemetry: TelemetryData | null, isConnected: boolean) => void;
 
+/**
+ * Telemetry poll interval in milliseconds. iRacing writes shared memory at
+ * ~60 Hz; we poll slightly faster (~70 Hz, 14 ms) and dedupe by
+ * `SessionTick` so subscribers see exactly one notification per real
+ * iRacing frame — never a duplicate, never a drop. Polling at
+ * `Math.round(1000 / 60) = 17 ms` would drift slightly slower than 60 Hz
+ * and silently miss ~1.6 frames per second; the small extra poll work
+ * here is cheap because the dedupe short-circuits before any subscriber
+ * callback or template-context rebuild fires.
+ *
+ * Sub-100 ms features (sector timing, precise pit/lap edges, transient
+ * `PlayerIncidents` flag detection) all depend on this cadence — see
+ * issue #493.
+ */
+export const TELEMETRY_INTERVAL_MS = 14;
+
 export class SDKController {
   private readonly sdk: IRacingSDK;
   private readonly logger: ILogger;
@@ -21,6 +37,15 @@ export class SDKController {
   private reconnectEnabled = true;
   private templateContextDirty = true;
   private lastTemplateContext: TemplateContext | null = null;
+  /**
+   * iRacing's `SessionTick` value at the last notified frame. We poll
+   * faster than iRacing's native write rate (see TELEMETRY_INTERVAL_MS)
+   * and skip notifying subscribers when the tick hasn't advanced, so each
+   * real iRacing frame produces exactly one downstream notification. Reset
+   * to `-1` on disconnect / stop so the next connection's first frame
+   * always notifies.
+   */
+  private lastSessionTick = -1;
 
   constructor(sdk: IRacingSDK, logger: ILogger = silentLogger) {
     this.sdk = sdk;
@@ -78,12 +103,13 @@ export class SDKController {
       }
     }, 2000);
 
-    // Start telemetry update loop (faster - 4Hz when connected)
+    // Start telemetry update loop. 60 Hz matches iRacing's shared-memory
+    // write rate so consumers see every fresh value (issue #493).
     this.updateInterval = setInterval(() => {
       if (this.sdk.isConnected()) {
         this.update();
       }
-    }, 250);
+    }, TELEMETRY_INTERVAL_MS);
   }
 
   /**
@@ -104,6 +130,7 @@ export class SDKController {
     this.isConnected = false;
     this.lastTemplateContext = null;
     this.templateContextDirty = true;
+    this.lastSessionTick = -1;
   }
 
   /**
@@ -143,6 +170,7 @@ export class SDKController {
         this.lastValidTelemetry = null;
         this.lastTemplateContext = null;
         this.templateContextDirty = true;
+        this.lastSessionTick = -1;
         this.notifySubscribers(null);
       }
 
@@ -161,6 +189,22 @@ export class SDKController {
 
       return;
     }
+
+    // Dedupe by iRacing's `SessionTick`. We poll faster than iRacing's
+    // 60 Hz write rate (see TELEMETRY_INTERVAL_MS) so the same tick will
+    // be read by 1–2 polls in a row; firing subscribers only on a tick
+    // change keeps downstream work (template context rebuild, action
+    // re-renders) at iRacing's native cadence regardless of poll rate.
+    // `SessionTick` undefined falls through (no field on this build of
+    // the SDK headers) — we still notify so we don't silently break
+    // legacy paths.
+    const tick = telemetry.SessionTick;
+
+    if (tick !== undefined && tick === this.lastSessionTick) {
+      return;
+    }
+
+    this.lastSessionTick = tick ?? -1;
 
     // Cache the valid telemetry
     this.lastValidTelemetry = telemetry;

--- a/packages/iracing-sdk/src/index.ts
+++ b/packages/iracing-sdk/src/index.ts
@@ -8,7 +8,7 @@
 export { IRacingSDK } from "./IRacingSDK.js";
 
 // SDK Controller (manages connections and subscribers)
-export { SDKController, TelemetryCallback } from "./SDKController.js";
+export { SDKController, TELEMETRY_INTERVAL_MS, TelemetryCallback } from "./SDKController.js";
 
 // Interfaces for dependency injection
 export type { INativeSDK } from "./interfaces.js";

--- a/packages/scenario-harness/src/mock-sdk-controller.ts
+++ b/packages/scenario-harness/src/mock-sdk-controller.ts
@@ -31,11 +31,15 @@ export type MockSDKControllerOptions = {
    * flags / off-track" so the harness boots without firing spurious events.
    */
   initialTelemetry?: TelemetryData;
-  /** Tick interval in ms when running. Default 250 (matches the real loop). */
+  /**
+   * Tick interval in ms when running. Defaults to 14 ms to match the real
+   * SDKController's poll rate (issue #493 — slightly faster than iRacing's
+   * 60 Hz write rate).
+   */
   tickIntervalMs?: number;
 };
 
-const DEFAULT_TICK_INTERVAL_MS = 250;
+const DEFAULT_TICK_INTERVAL_MS = 14;
 
 /**
  * Minimum-viable telemetry snapshot. Field set covers everything the


### PR DESCRIPTION
## Related Issue

Fixes #493

## What changed?

Raises the iRacing telemetry poll cadence from 4 Hz to ~70 Hz with `SessionTick` deduplication, and caps per-key icon updates at 10 Hz so the higher tick rate can't flood the Stream Deck.

**Why ~70 Hz with dedupe instead of exactly 60 Hz:** `Math.round(1000/60) = 17 ms` is slightly slower than iRacing's 60 Hz write rate (~16.67 ms), which would silently drop ~1.6 frames per second. Polling at 14 ms (~70 Hz) and deduping by iRacing's `SessionTick` guarantees exactly one downstream notification per real iRacing frame — never duplicates, never drops.

**Why this matters:** sub-100 ms features (sector timing, precise pit/lap edges, transient `PlayerIncidents` flag detection — see #530) were all gated by the 4 Hz cadence. The transient flag in particular is cleared within a frame or two by iRacing, so at 4 Hz we missed the non-zero window almost every time.

**Throttle on actions:** `telemetry-display` and `car-control` subscribe directly to the SDK and re-render on state change. Without a throttle, a fast-moving template like RPM would fire 60 `setKeyImage` calls per second per key (USB / WebSocket saturation, visible hitching). New `IconUpdateThrottle` utility in `packages/iracing-actions/src/shared/` provides a per-context trailing-edge coalescer with a 100 ms window. The render closure re-resolves at flush time so the latest state always wins.

**Out of scope (per the issue):**
- A user-facing 30/60 Hz toggle — 60 Hz for everyone keeps the change tight; revisit only if a real user reports CPU pressure.
- Sector timing itself.
- Switching from `setInterval` polling to a worker thread blocking on `irsdk_waitForDataReady`.

## How to test

- `pnpm install && pnpm build && pnpm test` (3821 tests, all green; 11 new).
- `pnpm lint:fix && pnpm format:fix` clean.

Manual:

- [ ] Set up a Telemetry Display key showing live RPM or Speed. Was 4 fps before — should look visibly smoother (10 fps cap from the throttle, vs the old 4 fps).
- [ ] Drive into a wall in iRacing while running #530 stacked on top — engineer should now actually call out "collision wall / two points" because the higher poll rate catches the brief `PlayerIncidents` non-zero window.
- [ ] CPU sanity: the node sibling process should sit < 5 % of one core during normal driving.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — N/A, SDK + action package change, both plugins consume the updated SDK transparently
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Telemetry polling accelerated to 14 ms and frame-level deduplication added for more timely, non-duplicated updates
  * Icon updates now rate-limited/coalesced (10 Hz) to reduce unnecessary re-renders

* **Tests**
  * Added tests covering icon update throttling and telemetry polling/deduplication behavior

* **Chores**
  * Test harness/mock controller default tick cadence updated to match the faster polling rate

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niklam/iracedeck/pull/532)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->