### PR TITLE
improve(release): use HEAD commit count for manifest build number (#536)

### DIFF
--- a/scripts/release-hooks.mjs
+++ b/scripts/release-hooks.mjs
@@ -39,12 +39,22 @@ const packageJsonPaths = readdirSync(packagesDir, { withFileTypes: true })
 // Bump Version in manifest.json files. Elgato's manifest schema requires a
 // strict 4-part numeric format `{major}.{minor}.{patch}.{build}`
 // (^(0|[1-9]\d*)(\.(0|[1-9]\d*)){3}$), so semver pre-release / build metadata
-// suffixes must be stripped. Every 1.15.0 pre-release and the final 1.15.0
-// therefore ship with the same manifest Version "1.15.0.0".
+// suffixes must be stripped. The build slot is populated from
+// `git rev-list --count HEAD` so each release (pre or final alike) gets a
+// unique 4-part version; the final naturally outranks its preceding
+// pre-releases because release-it commits the version bump between runs,
+// which advances the commit count.
 const manifestPaths = [
   "packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/manifest.json",
   "packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/manifest.json",
 ];
+
+const numericVersion = version.replace(/[-+].*$/, "");
+const buildNumber = execFileSync("git", ["rev-list", "--count", "HEAD"], {
+  cwd: root,
+  encoding: "utf-8",
+}).trim();
+const manifestVersion = `${numericVersion}.${buildNumber}`;
 
 // release-it runs before:bump hooks even in dry-run mode, which would otherwise
 // modify real package.json / manifest.json files and stage them with `git add`.
@@ -52,9 +62,7 @@ const manifestPaths = [
 if (process.env.RELEASE_IT_DRY_RUN === "1") {
   console.log(`  [dry-run] Would bump ${packageJsonPaths.length} package.json files to version ${version}:`);
   for (const rel of packageJsonPaths) console.log(`    - ${rel}`);
-  console.log(
-    `  [dry-run] Would bump ${manifestPaths.length} manifest.json files to version ${version.replace(/[-+].*$/, "")}.0:`,
-  );
+  console.log(`  [dry-run] Would bump ${manifestPaths.length} manifest.json files to version ${manifestVersion}:`);
   for (const rel of manifestPaths) console.log(`    - ${rel}`);
   process.exit(0);
 }
@@ -67,14 +75,12 @@ for (const rel of packageJsonPaths) {
   console.log(`  Updated ${rel} → ${version}`);
 }
 
-const numericVersion = version.replace(/[-+].*$/, "");
-
 for (const rel of manifestPaths) {
   const filePath = join(root, rel);
   const manifest = JSON.parse(readFileSync(filePath, "utf-8"));
-  manifest.Version = `${numericVersion}.0`;
+  manifest.Version = manifestVersion;
   writeFileSync(filePath, JSON.stringify(manifest, null, 2) + "\n");
-  console.log(`  Updated ${rel} → ${numericVersion}.0`);
+  console.log(`  Updated ${rel} → ${manifestVersion}`);
 }
 
 // Stage all modified files. Use argv form (no shell) so package directory


### PR DESCRIPTION
## Related Issue

Fixes #536

## What changed?

`scripts/release-hooks.mjs` now populates the 4th component of the plugin manifest `Version` field from `git rev-list --count HEAD` instead of hardcoding `.0`. Every release-it run (pre-release or final) produces a unique 4-part manifest version, so pre-releases of the same semver (e.g. `1.17.0-pre.1`, `1.17.0-pre.2`, `1.17.0` final) no longer collide on the Stream Deck side.

Monotonicity falls out naturally: release-it commits the version bump between runs, which advances the commit count by at least one, so the final always outranks its preceding pre-releases. Test releases cut from feature branches each get their own count progression (HEAD-based, not pinned to `origin/master`) so different branches don't share build numbers.

Block comment in the script refreshed to reflect the new behavior; dry-run preview now shows the actual build number it would write.

## How to test

```bash
# Direct hook dry-run (no side effects):
RELEASE_IT_DRY_RUN=1 node scripts/release-hooks.mjs 1.17.0-pre.1
# Expect the manifest preview line to read "version 1.17.0.<N>"
# where <N> matches `git rev-list --count HEAD`.

# Full release-it dry-run:
pnpm release -- minor --preRelease=pre --dry-run
```

## Checklist

- [x] Linked to an approved issue
- [ ] New code has unit tests — N/A, no existing test coverage for `scripts/release-hooks.mjs`; the change is verified via direct hook dry-run.
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — both manifests share the same hook; no per-plugin changes needed.
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version numbering has been updated to include unique build identifiers alongside standard version components, ensuring every release and pre-release build receives a distinct version string.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niklam/iracedeck/pull/538)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->