### PR TITLE
feat(actions): add Driving Line toggle to Toggle UI Elements (#543)

### DIFF
--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -9,7 +9,7 @@ description: Use when looking up Stream Deck actions, sub-actions, modes, catego
 
 Complete action definitions: `docs/reference/actions.json`
 
-The website currently documents **31 actions with 259 modes** (the totals used in this file and in user-facing docs). `docs/reference/actions.json` has not yet been re-synced to the new per-mode counting convention; use this skill file or the website as the source of truth for action and mode counts, and treat `actions.json` as a detailed inventory of individual mode values that is occasionally out of date.
+The website currently documents **31 actions with 260 modes** (the totals used in this file and in user-facing docs). `docs/reference/actions.json` has not yet been re-synced to the new per-mode counting convention; use this skill file or the website as the source of truth for action and mode counts, and treat `actions.json` as a detailed inventory of individual mode values that is occasionally out of date.
 
 Each action entry:
 ```json
@@ -39,13 +39,13 @@ When asked about actions or controls:
 |----------|---------|-------|-------------|
 | Display & Session | 2 | 8 | Live session data: incidents, laps, position, fuel, flags, track wetness |
 | Driving Controls | 6 | 30 | AI spotter, audio, black boxes, look direction, car control, pit crew (radar + radar-volume; Race Engineer voice mode planned) |
-| Cockpit & Interface | 5 | 33 | Wipers, force feedback, splits & reference, telemetry, UI toggles |
+| Cockpit & Interface | 5 | 34 | Wipers, force feedback, splits & reference, telemetry, UI toggles |
 | View & Camera | 5 | 88 | FOV, replay, camera controls, broadcast tools |
 | Media | 1 | 7 | Video recording, screenshots, texture management |
 | Pit Service | 3 | 15 | Fuel, tires, compounds, tearoff, fast repair |
 | Car Setup | 7 | 44 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control |
 | Communication | 2 | 34 | Chat, macros (15), whisper, toggle, reply, race admin commands |
-| **Total** | **31** | **259** | |
+| **Total** | **31** | **260** | |
 
 Mode counts reflect the PI Mode/Setting dropdown choices documented in each action page. Directional variants (Increase/Decrease) are treated as a single mode with a Direction sub-setting, matching the per-mode website format. Legacy replay actions (Replay Transport, Replay Speed, Replay Navigation) and Camera Cycle (Legacy) still exist in the plugin manifest for backward compatibility but are not counted as documented actions.
 
@@ -77,7 +77,7 @@ Mode counts reflect the PI Mode/Setting dropdown choices documented in each acti
 | Splits & Reference | 6 | cycle (+/- direction), toggle-ref-car, custom-sector-start, custom-sector-end, active-reset-set, active-reset-run |
 | Telemetry Control | 5 | toggle-logging, mark-event, start/stop/restart recording (SDK) |
 | Force Feedback | 6 | auto-compute-ffb-force, ffb-force (+/-), wheel-lfe (+/-), bass-shaker-lfe (+/-), wheel-lfe-intensity (+/-), haptic-lfe-intensity (+/-) |
-| Toggle UI Elements | 9 | dash-box, speed/gear/pedals, radio, FPS/network, weather, virtual mirror, UI edit, display-ref-car (deprecated), replay-ui (SDK) |
+| Toggle UI Elements | 10 | dash-box, speed/gear/pedals, radio, FPS/network, weather, virtual mirror, UI edit, driving-line, display-ref-car (deprecated), replay-ui (SDK) |
 
 ### View & Camera
 

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -96,6 +96,7 @@
 | Toggle Weather Radar | Shift+Alt+R | No | Toggle Weather Radar |
 | Toggle Virtual Mirror | Alt+M | No | Toggle Virtual Mirror |
 | Toggle UI Edit | Alt+K | No | Toggle UI Edit |
+| Toggle Driving Line | Ctrl+Alt+L | No | Driving Line |
 | Adjust UI Size | Ctrl+PageDown / Ctrl+PageUp | No | Scale UI Up / Scale UI Down |
 | Toggle UI Visibility | Space | No | Toggle UI Visibility |
 | Pause Sim | Shift+P | No | Pause Sim |

--- a/docs/reference/actions.json
+++ b/docs/reference/actions.json
@@ -266,6 +266,7 @@
             { "value": "weather-radar", "label": "Weather Radar" },
             { "value": "virtual-mirror", "label": "Virtual Mirror" },
             { "value": "ui-edit-mode", "label": "UI Edit Mode" },
+            { "value": "driving-line", "label": "Driving Line" },
             {
               "value": "display-ref-car",
               "label": "Display Reference Car",

--- a/packages/icons/preview/toggle-ui-elements/driving-line.svg
+++ b/packages/icons/preview/toggle-ui-elements/driving-line.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 70 70" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#1a3a3a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"TOGGLE\nDRIVING LINE"},"border":{"color":"#3a6a6a"}}</desc>
+
+
+    <path d="M5,70 L5,40 A35,35 0 0 1 40,5 L70,5" fill="none" stroke="#888888" stroke-width="3"/>
+    <path d="M25,70 L25,40 A15,15 0 0 1 40,25 L70,25" fill="none" stroke="#888888" stroke-width="3"/>
+    <path d="M15,70 L15,42 Q15,22 38,16 L62,15" fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round"/>
+    <path d="M68,15 l-9,-4 v8 z" fill="#ffffff" stroke="none"/>
+
+</svg>

--- a/packages/icons/toggle-ui-elements/driving-line.svg
+++ b/packages/icons/toggle-ui-elements/driving-line.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 70 70" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#1a3a3a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"TOGGLE\nDRIVING LINE"},"border":{"color":"#3a6a6a"}}</desc>
+
+
+    <path d="M5,70 L5,40 A35,35 0 0 1 40,5 L70,5" fill="none" stroke="#888888" stroke-width="3"/>
+    <path d="M25,70 L25,40 A15,15 0 0 1 40,25 L70,25" fill="none" stroke="#888888" stroke-width="3"/>
+    <path d="M15,70 L15,42 Q15,22 38,16 L62,15" fill="none" stroke="{{graphic1Color}}" stroke-width="4" stroke-linecap="round"/>
+    <path d="M68,15 l-9,-4 v8 z" fill="{{graphic1Color}}" stroke="none"/>
+
+</svg>

--- a/packages/iracing-actions/src/actions/data/key-bindings.json
+++ b/packages/iracing-actions/src/actions/data/key-bindings.json
@@ -50,7 +50,8 @@
     },
     { "id": "weatherRadar", "label": "Weather Radar", "default": "Shift+Alt+R", "setting": "toggleUiWeatherRadar" },
     { "id": "virtualMirror", "label": "Virtual Mirror", "default": "Alt+M", "setting": "toggleUiVirtualMirror" },
-    { "id": "uiEditMode", "label": "UI Edit Mode", "default": "Alt+K", "setting": "toggleUiEditMode" }
+    { "id": "uiEditMode", "label": "UI Edit Mode", "default": "Alt+K", "setting": "toggleUiEditMode" },
+    { "id": "drivingLine", "label": "Driving Line", "default": "Ctrl+Alt+L", "setting": "toggleUiDrivingLine" }
   ],
   "lookDirection": [
     { "id": "left", "label": "Look Left", "default": "Z", "setting": "lookDirectionLeft" },

--- a/packages/iracing-actions/src/actions/toggle-ui-elements/toggle-ui-elements.ejs
+++ b/packages/iracing-actions/src/actions/toggle-ui-elements/toggle-ui-elements.ejs
@@ -15,6 +15,7 @@
 				<option value="weather-radar">Weather Radar</option>
 				<option value="virtual-mirror">Virtual Mirror</option>
 				<option value="ui-edit-mode">UI Edit Mode</option>
+				<option value="driving-line">Driving Line</option>
 				<option value="replay-ui">Replay UI</option>
 			</sdpi-select>
 		</sdpi-item>

--- a/packages/iracing-actions/src/actions/toggle-ui-elements/toggle-ui-elements.test.ts
+++ b/packages/iracing-actions/src/actions/toggle-ui-elements/toggle-ui-elements.test.ts
@@ -23,6 +23,9 @@ vi.mock("@iracedeck/icons/toggle-ui-elements/virtual-mirror.svg", () => ({
 vi.mock("@iracedeck/icons/toggle-ui-elements/ui-edit-mode.svg", () => ({
   default: '<svg xmlns="http://www.w3.org/2000/svg">{{mainLabel}} {{subLabel}}</svg>',
 }));
+vi.mock("@iracedeck/icons/toggle-ui-elements/driving-line.svg", () => ({
+  default: '<svg xmlns="http://www.w3.org/2000/svg">{{mainLabel}} {{subLabel}}</svg>',
+}));
 vi.mock("@iracedeck/icons/toggle-ui-elements/display-ref-car.svg", () => ({
   default: '<svg xmlns="http://www.w3.org/2000/svg">{{mainLabel}} {{subLabel}}</svg>',
 }));
@@ -154,6 +157,10 @@ describe("ToggleUiElements", () => {
       expect(UI_ELEMENT_GLOBAL_KEYS["ui-edit-mode"]).toBe("toggleUiEditMode");
     });
 
+    it("should have correct mapping for driving-line", () => {
+      expect(UI_ELEMENT_GLOBAL_KEYS["driving-line"]).toBe("toggleUiDrivingLine");
+    });
+
     it("should have correct mapping for display-ref-car", () => {
       expect(UI_ELEMENT_GLOBAL_KEYS["display-ref-car"]).toBe("toggleUiDisplayRefCar");
     });
@@ -162,8 +169,8 @@ describe("ToggleUiElements", () => {
       expect(UI_ELEMENT_GLOBAL_KEYS["replay-ui"]).toBeUndefined();
     });
 
-    it("should have exactly 8 entries", () => {
-      expect(Object.keys(UI_ELEMENT_GLOBAL_KEYS)).toHaveLength(8);
+    it("should have exactly 9 entries", () => {
+      expect(Object.keys(UI_ELEMENT_GLOBAL_KEYS)).toHaveLength(9);
     });
   });
 
@@ -189,6 +196,7 @@ describe("ToggleUiElements", () => {
         "weather-radar",
         "virtual-mirror",
         "ui-edit-mode",
+        "driving-line",
         "display-ref-car",
         "replay-ui",
       ] as const;
@@ -233,6 +241,7 @@ describe("ToggleUiElements", () => {
         "weather-radar": { mainLabel: "WEATHER", subLabel: "RADAR" },
         "virtual-mirror": { mainLabel: "VIRTUAL", subLabel: "MIRROR" },
         "ui-edit-mode": { mainLabel: "UI EDIT", subLabel: "MODE" },
+        "driving-line": { mainLabel: "DRIVING LINE", subLabel: "TOGGLE" },
         "display-ref-car": { mainLabel: "REFERENCE", subLabel: "CAR" },
         "replay-ui": { mainLabel: "REPLAY UI", subLabel: "TOGGLE" },
       };

--- a/packages/iracing-actions/src/actions/toggle-ui-elements/toggle-ui-elements.ts
+++ b/packages/iracing-actions/src/actions/toggle-ui-elements/toggle-ui-elements.ts
@@ -18,6 +18,7 @@ import {
 } from "@iracedeck/deck-core";
 import dashBoxIconSvg from "@iracedeck/icons/toggle-ui-elements/dash-box.svg";
 import displayRefCarIconSvg from "@iracedeck/icons/toggle-ui-elements/display-ref-car.svg";
+import drivingLineIconSvg from "@iracedeck/icons/toggle-ui-elements/driving-line.svg";
 import fpsNetworkDisplayIconSvg from "@iracedeck/icons/toggle-ui-elements/fps-network-display.svg";
 import radioDisplayIconSvg from "@iracedeck/icons/toggle-ui-elements/radio-display.svg";
 import replayUiIconSvg from "@iracedeck/icons/toggle-ui-elements/replay-ui.svg";
@@ -36,6 +37,7 @@ type UiElement =
   | "weather-radar"
   | "virtual-mirror"
   | "ui-edit-mode"
+  | "driving-line"
   | "display-ref-car"
   | "replay-ui";
 
@@ -47,6 +49,7 @@ const ELEMENT_ICONS: Record<UiElement, string> = {
   "weather-radar": weatherRadarIconSvg,
   "virtual-mirror": virtualMirrorIconSvg,
   "ui-edit-mode": uiEditModeIconSvg,
+  "driving-line": drivingLineIconSvg,
   "display-ref-car": displayRefCarIconSvg,
   "replay-ui": replayUiIconSvg,
 };
@@ -62,6 +65,7 @@ const UI_ELEMENT_TITLES: Record<UiElement, string> = {
   "weather-radar": "RADAR\nWEATHER",
   "virtual-mirror": "MIRROR\nVIRTUAL",
   "ui-edit-mode": "MODE\nUI EDIT",
+  "driving-line": "TOGGLE\nDRIVING LINE",
   "display-ref-car": "CAR\nREFERENCE",
   "replay-ui": "TOGGLE\nREPLAY UI",
 };
@@ -80,6 +84,7 @@ export const UI_ELEMENT_GLOBAL_KEYS: Record<string, string> = {
   "weather-radar": "toggleUiWeatherRadar",
   "virtual-mirror": "toggleUiVirtualMirror",
   "ui-edit-mode": "toggleUiEditMode",
+  "driving-line": "toggleUiDrivingLine",
   "display-ref-car": "toggleUiDisplayRefCar",
 };
 
@@ -93,6 +98,7 @@ const ToggleUiElementsSettings = CommonSettings.extend({
       "weather-radar",
       "virtual-mirror",
       "ui-edit-mode",
+      "driving-line",
       "display-ref-car",
       "replay-ui",
     ])

--- a/packages/website/src/content/docs/docs/actions/cockpit/toggle-ui-elements.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/toggle-ui-elements.md
@@ -3,7 +3,7 @@ title: Toggle UI Elements
 description: Show or hide iRacing's on-screen UI elements.
 sidebar:
   badge:
-    text: "9 modes"
+    text: "10 modes"
     variant: tip
 ---
 
@@ -117,6 +117,26 @@ Enter or exit UI edit mode for repositioning overlays.
 
 - **Dial:** No rotation support
 - **Default binding:** `Alt+K`
+- **Telemetry-aware icon:** No
+
+#### Settings
+
+- No additional settings
+
+---
+
+### Driving Line
+
+Toggle the in-car driving-line overlay. Handy for reference laps when learning a track and turning it off again for clean laps.
+
+:::note
+The driving line must first be enabled in iRacing's options (Settings → Driving → Driving Aids → Driving Line). The toggle only switches the overlay on and off — if Driving Line is turned off in iRacing settings, the keybind cannot turn it on.
+:::
+
+#### Details
+
+- **Dial:** No rotation support
+- **Default binding:** `Ctrl+Alt+L`
 - **Telemetry-aware icon:** No
 
 #### Settings

--- a/packages/website/src/content/docs/index.mdx
+++ b/packages/website/src/content/docs/index.mdx
@@ -29,7 +29,7 @@ hero:
   </div>
   <div class="stat-divider" />
   <div class="stat">
-    <span class="stat-value">255</span>
+    <span class="stat-value">256</span>
     <span class="stat-label">Modes</span>
   </div>
   <div class="stat-divider" />


### PR DESCRIPTION
## Related Issue

Fixes #543

## What changed?

Adds a tenth **Driving Line** mode to the Toggle UI Elements action so drivers can show/hide the in-car racing-line overlay from the Stream Deck without pausing into iRacing's settings menu.

Per the answer in plan-mode questions, the user-facing label and all internal names use **Driving Line** (iRacing's actual terminology under Settings → Driving → Driving Aids → Driving Line), even though issue #543's body says "Racing Line". The issue title should be renamed manually to match.

Touched:

- **Action wiring** (`toggle-ui-elements.ts`) — new `"driving-line"` member of `UiElement`, plus the icon, title (`TOGGLE\nDRIVING LINE`), and global-key (`toggleUiDrivingLine`) maps and Zod enum entry. No new dispatch logic — `sendKeyBindingForElement` already covers every non-`replay-ui` mode.
- **Property Inspector** (`toggle-ui-elements.ejs`) — new `<option>` after UI Edit Mode.
- **Key binding** (`data/key-bindings.json`) — appended `{ id: drivingLine, label: "Driving Line", default: "Ctrl+Alt+L", setting: "toggleUiDrivingLine" }`.
- **Icon** (`packages/icons/toggle-ui-elements/driving-line.svg`) — 70×70 viewBox; gray 90° track-corner outline with a curving white driving line through the apex and a small direction arrow at the exit. Cross-platform-safe (basic shapes only, SVG Tiny 1.2 static for Mirabox QT5 compatibility).
- **Tests** (`toggle-ui-elements.test.ts`) — SVG mock, `UI_ELEMENT_GLOBAL_KEYS["driving-line"]` case, count assertion bumped 8 → 9, `expectedLabels` entry (`{ mainLabel: "DRIVING LINE", subLabel: "TOGGLE" }`), and the new mode in the `elements` round-trip array.
- **Auto-generated** — preview regenerated via `scripts/generate-icon-previews.mjs`. `icon-defaults.json` unchanged (it stores per-category defaults; the new icon reuses the existing toggle-ui-elements palette).
- **Docs** —
  - `docs/keyboard-shortcuts.md` — Interface section row for "Toggle Driving Line".
  - Website action page — modes badge 9 → 10 plus a new "Driving Line" section. Includes a `:::note` that the driving-line setting itself must be enabled in iRacing (Settings → Driving → Driving Aids → Driving Line) before the keybind can toggle the overlay.
  - Website index — Modes stat 255 → 256.
  - `.claude/skills/iracedeck-actions/SKILL.md` — totals 259 → 260, Cockpit & Interface 33 → 34, Toggle UI Elements row 9 → 10 with `driving-line` in the mode-values list.
  - `docs/reference/actions.json` — new mode entry.

Plugin code untouched — both Stream Deck and Mirabox plugins already register Toggle UI Elements; the new icon and PI option are picked up automatically by their Rollup builds.

## How to test

- [x] `pnpm install && pnpm build` — 17/17 packages green.
- [x] `pnpm test` — 3863/3863 vitest cases pass.
- [x] `pnpm lint:fix && pnpm format:fix` — clean.
- [x] Visually inspect `packages/icons/preview/toggle-ui-elements/driving-line.svg` — racing-line motif reads at key size.
- [x] Manual iRacing test — load the rebuilt Stream Deck plugin, add Toggle UI Elements → Driving Line, press the key, confirm the in-car driving line toggles. Rebind via PI to a different combo; confirm dispatch routes correctly.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for toggling the Driving Line overlay in-game with the keyboard shortcut `Ctrl+Alt+L`.

* **Documentation**
  * Updated action documentation to include the new Driving Line toggle option and its default keyboard binding.
  * Updated action statistics to reflect the addition of the new toggle mode.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niklam/iracedeck/pull/544)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->