### PR TITLE
feat(actions): add live-value View sub-modes to setup actions (#541)

### DIFF
--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -9,7 +9,7 @@ description: Use when looking up Stream Deck actions, sub-actions, modes, catego
 
 Complete action definitions: `docs/reference/actions.json`
 
-The website currently documents **31 actions with 260 modes** (the totals used in this file and in user-facing docs). `docs/reference/actions.json` has not yet been re-synced to the new per-mode counting convention; use this skill file or the website as the source of truth for action and mode counts, and treat `actions.json` as a detailed inventory of individual mode values that is occasionally out of date.
+The website currently documents **31 actions with 289 modes** (the totals used in this file and in user-facing docs). `docs/reference/actions.json` has not yet been re-synced to the new per-mode counting convention; use this skill file or the website as the source of truth for action and mode counts, and treat `actions.json` as a detailed inventory of individual mode values that is occasionally out of date.
 
 Each action entry:
 ```json

--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -43,9 +43,9 @@ When asked about actions or controls:
 | View & Camera | 5 | 88 | FOV, replay, camera controls, broadcast tools |
 | Media | 1 | 7 | Video recording, screenshots, texture management |
 | Pit Service | 3 | 15 | Fuel, tires, compounds, tearoff, fast repair |
-| Car Setup | 7 | 44 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control |
+| Car Setup | 7 | 73 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control — adjustment modes plus read-only "View …" sub-modes that display live dc* telemetry on the key |
 | Communication | 2 | 34 | Chat, macros (15), whisper, toggle, reply, race admin commands |
-| **Total** | **31** | **260** | |
+| **Total** | **31** | **289** | |
 
 Mode counts reflect the PI Mode/Setting dropdown choices documented in each action page. Directional variants (Increase/Decrease) are treated as a single mode with a Direction sub-setting, matching the per-mode website format. Legacy replay actions (Replay Transport, Replay Speed, Replay Navigation) and Camera Cycle (Legacy) still exist in the plugin manifest for backward compatibility but are not counted as documented actions.
 
@@ -107,13 +107,13 @@ Mode counts reflect the PI Mode/Setting dropdown choices documented in each acti
 
 | Action | Modes | Mode values |
 |--------|-------|-------------|
-| Setup Aero | 4 | front-wing (+/-), rear-wing (+/-), qualifying-tape (+/-), rf-brake-attached |
-| Setup Brakes | 7 | abs-toggle, abs-adjust (+/-), brake-bias (+/-), brake-bias-fine (+/-), peak-brake-bias (+/-), brake-misc (+/-), engine-braking (+/-) |
-| Setup Chassis | 13 | differential-preload/entry/middle/exit, front/rear ARB, left/right spring, LF/RF/LR/RR shock, power-steering (all +/-) |
-| Setup Engine | 4 | engine-power (+/-), throttle-shaping (+/-), boost-level (+/-), launch-rpm (+/-) |
-| Setup Fuel | 5 | fuel-mixture (+/-), fuel-cut-position (+/-), disable-fuel-cut, low-fuel-accept, fcy-mode-toggle |
-| Setup Hybrid | 6 | mguk-regen-gain (+/-), mguk-deploy-mode (+/-), mguk-fixed-deploy (+/-), hys-boost (hold), hys-regen (hold), hys-no-boost |
-| Setup Traction | 5 | tc-toggle, tc-slot-1/2/3/4 (all +/-) |
+| Setup Aero | 6 | view-{front-wing, rear-wing} (read-only, live dcFrontWing/dcRearWing), front-wing (+/-), rear-wing (+/-), qualifying-tape (+/-), rf-brake-attached |
+| Setup Brakes | 13 | view-{brake-bias, brake-bias-fine, peak-brake-bias, brake-misc, engine-braking, abs-adjust} (read-only, live dcBrakeBias/dcBrakeBiasFine/dcPeakBrakeBias/dcBrakeMisc/dcEngineBraking/dcABS), abs-toggle, abs-adjust (+/-), brake-bias (+/-), brake-bias-fine (+/-), peak-brake-bias (+/-), brake-misc (+/-), engine-braking (+/-) |
+| Setup Chassis | 22 | view-{diff-preload, diff-entry, diff-middle, diff-exit, anti-roll-front, anti-roll-rear, power-steering, weight-jacker-left, weight-jacker-right} (read-only, live dcDiffPreload/dcDiffEntry/dcDiffMiddle/dcDiffExit/dcAntiRollFront/dcAntiRollRear/dcPowerSteering/dcWeightJackerLeft/dcWeightJackerRight), differential-preload/entry/middle/exit, front/rear ARB, left/right spring, LF/RF/LR/RR shock, power-steering (all +/-) |
+| Setup Engine | 7 | view-{engine-power, throttle-shape, launch-rpm} (read-only, live dcEnginePower/dcThrottleShape/dcLaunchRPM), engine-power (+/-), throttle-shaping (+/-), boost-level (+/-), launch-rpm (+/-) |
+| Setup Fuel | 7 | view-{fuel-mixture, fuel-cut-position} (read-only, live dcFuelMixture/dcFuelCutPosition), fuel-mixture (+/-), fuel-cut-position (+/-), disable-fuel-cut, low-fuel-accept, fcy-mode-toggle |
+| Setup Hybrid | 9 | view-{mguk-deploy-mode, mguk-regen-gain, mguk-deploy-fixed} (read-only, live dcMGUKDeployMode/dcMGUKRegenGain/dcMGUKDeployFixed), mguk-regen-gain (+/-), mguk-deploy-mode (+/-), mguk-fixed-deploy (+/-), hys-boost (hold), hys-regen (hold), hys-no-boost |
+| Setup Traction | 9 | view-tc-slot-{1,2,3,4} = "TC1"…"TC4" (read-only, live dcTractionControl/dcTractionControl2/dcTractionControl3/dcTractionControl4), tc-toggle, tc-slot-1/2/3/4 (all +/-, labelled TC1–TC4 in the PI) |
 
 ### Communication
 
@@ -131,6 +131,7 @@ Mode counts reflect the PI Mode/Setting dropdown choices documented in each acti
 | Composite | Multiple dropdowns combine | Audio (category + action), black box (mode + box) |
 | Hold | Key held while button pressed | Look direction, HYS boost/regen |
 | Telemetry-aware | Icon updates from live data | Session info, car control (pit limiter), tire service |
+| Read-only View | Setting prefixed `view-…`; the action subscribes to telemetry and renders the live dc* value, with key presses suppressed | Setup actions' View sub-modes (issue #541) |
 
 ## Keeping in Sync
 

--- a/.claude/skills/iracing-telemetry/SKILL.md
+++ b/.claude/skills/iracing-telemetry/SKILL.md
@@ -50,7 +50,7 @@ This is the **source of truth** for which variables are available in Mustache te
 | Category | Pattern | Count | Examples |
 |----------|---------|-------|----------|
 | Tire/Shock | `LF*`, `RF*`, `LR*`, `RR*`, `CF*`, `CR*` | 88 | `LFtempCM`, `RRwearL`, `LFshockDefl` |
-| In-Car Adjustments | `dc*` | 42 | `dcBrakeBias`, `dcTractionControl`, `dcDRSToggle` |
+| In-Car Adjustments | `dc*` | 42 | `dcBrakeBias`, `dcTractionControl`, `dcDRSToggle`. The setup-* actions' "View …" sub-modes (issue #541) consume these directly — see `packages/iracing-actions/src/shared/setup-view.ts` for the registry mapping each view-* setting to its dc* field. |
 | Lap/Timing | `Lap*`, `Race*` | 28 | `Lap`, `LapBestLapTime`, `LapDistPct` |
 | Per-Car Arrays | `CarIdx*` | 27 | `CarIdxPosition`, `CarIdxLapDistPct`, `CarIdxGear` |
 | Pit Adjustments | `dp*` | 24 | `dpFuelAddKg`, `dpRFTireChange`, `dpWingFront` |

--- a/.claude/skills/iracing-telemetry/SKILL.md
+++ b/.claude/skills/iracing-telemetry/SKILL.md
@@ -50,7 +50,7 @@ This is the **source of truth** for which variables are available in Mustache te
 | Category | Pattern | Count | Examples |
 |----------|---------|-------|----------|
 | Tire/Shock | `LF*`, `RF*`, `LR*`, `RR*`, `CF*`, `CR*` | 88 | `LFtempCM`, `RRwearL`, `LFshockDefl` |
-| In-Car Adjustments | `dc*` | 42 | `dcBrakeBias`, `dcTractionControl`, `dcDRSToggle`. The setup-* actions' "View …" sub-modes (issue #541) consume these directly — see `packages/iracing-actions/src/shared/setup-view.ts` for the registry mapping each view-* setting to its dc* field. |
+| In-Car Adjustments | `dc*` | 42 | `dcBrakeBias`, `dcTractionControl`, `dcDRSToggle`. The `setup-*` actions' "View …" sub-modes (issue #541) consume these directly — see `packages/iracing-actions/src/shared/setup-view.ts` for the registry mapping each `view-*` setting to its `dc*` field. |
 | Lap/Timing | `Lap*`, `Race*` | 28 | `Lap`, `LapBestLapTime`, `LapDistPct` |
 | Per-Car Arrays | `CarIdx*` | 27 | `CarIdxPosition`, `CarIdxLapDistPct`, `CarIdxGear` |
 | Pit Adjustments | `dp*` | 24 | `dpFuelAddKg`, `dpRFTireChange`, `dpWingFront` |

--- a/docs/reference/actions.json
+++ b/docs/reference/actions.json
@@ -581,6 +581,12 @@
           "encoder": true,
           "settingsKeys": ["setting", "direction"],
           "modes": [
+            { "setting": "view-brake-bias", "label": "View Brake Bias", "controlType": "view" },
+            { "setting": "view-brake-bias-fine", "label": "View Brake Bias Fine", "controlType": "view" },
+            { "setting": "view-peak-brake-bias", "label": "View Peak Brake Bias", "controlType": "view" },
+            { "setting": "view-brake-misc", "label": "View Brake Misc", "controlType": "view" },
+            { "setting": "view-engine-braking", "label": "View Engine Braking", "controlType": "view" },
+            { "setting": "view-abs-adjust", "label": "View ABS Adjust", "controlType": "view" },
             { "setting": "abs-toggle", "label": "ABS Toggle" },
             { "setting": "abs-adjust", "direction": "increase", "label": "ABS Increase" },
             { "setting": "abs-adjust", "direction": "decrease", "label": "ABS Decrease" },
@@ -603,6 +609,15 @@
           "encoder": true,
           "settingsKeys": ["setting", "direction"],
           "modes": [
+            { "setting": "view-diff-preload", "label": "View Diff Preload", "controlType": "view" },
+            { "setting": "view-diff-entry", "label": "View Diff Entry", "controlType": "view" },
+            { "setting": "view-diff-middle", "label": "View Diff Middle", "controlType": "view" },
+            { "setting": "view-diff-exit", "label": "View Diff Exit", "controlType": "view" },
+            { "setting": "view-anti-roll-front", "label": "View Anti-Roll Front", "controlType": "view" },
+            { "setting": "view-anti-roll-rear", "label": "View Anti-Roll Rear", "controlType": "view" },
+            { "setting": "view-power-steering", "label": "View Power Steering", "controlType": "view" },
+            { "setting": "view-weight-jacker-left", "label": "View Weight Jacker Left", "controlType": "view" },
+            { "setting": "view-weight-jacker-right", "label": "View Weight Jacker Right", "controlType": "view" },
             { "setting": "front-anti-roll-bar", "direction": "increase", "label": "Front ARB Stiffer" },
             { "setting": "front-anti-roll-bar", "direction": "decrease", "label": "Front ARB Softer" },
             { "setting": "rear-anti-roll-bar", "direction": "increase", "label": "Rear ARB Stiffer" },
@@ -638,6 +653,8 @@
           "encoder": true,
           "settingsKeys": ["setting", "direction"],
           "modes": [
+            { "setting": "view-front-wing", "label": "View Front Wing", "controlType": "view" },
+            { "setting": "view-rear-wing", "label": "View Rear Wing", "controlType": "view" },
             { "setting": "front-wing", "direction": "increase", "label": "Front Wing More" },
             { "setting": "front-wing", "direction": "decrease", "label": "Front Wing Less" },
             { "setting": "rear-wing", "direction": "increase", "label": "Rear Wing More" },
@@ -654,6 +671,9 @@
           "encoder": true,
           "settingsKeys": ["setting", "direction"],
           "modes": [
+            { "setting": "view-engine-power", "label": "View Engine Power", "controlType": "view" },
+            { "setting": "view-throttle-shape", "label": "View Throttle Shape", "controlType": "view" },
+            { "setting": "view-launch-rpm", "label": "View Launch RPM", "controlType": "view" },
             { "setting": "engine-power", "direction": "increase", "label": "Engine Power Increase" },
             { "setting": "engine-power", "direction": "decrease", "label": "Engine Power Decrease" },
             { "setting": "throttle-shaping", "direction": "increase", "label": "Throttle Shaping Increase" },
@@ -671,6 +691,8 @@
           "encoder": true,
           "settingsKeys": ["setting", "direction"],
           "modes": [
+            { "setting": "view-fuel-mixture", "label": "View Fuel Mixture", "controlType": "view" },
+            { "setting": "view-fuel-cut-position", "label": "View Fuel Cut Position", "controlType": "view" },
             { "setting": "fuel-mixture", "direction": "increase", "label": "Fuel Mixture Richer" },
             { "setting": "fuel-mixture", "direction": "decrease", "label": "Fuel Mixture Leaner" },
             { "setting": "fuel-cut-position", "direction": "increase", "label": "Fuel Cut Position Increase" },
@@ -687,6 +709,9 @@
           "encoder": true,
           "settingsKeys": ["setting", "direction"],
           "modes": [
+            { "setting": "view-mguk-deploy-mode", "label": "View MGU-K Deploy Mode", "controlType": "view" },
+            { "setting": "view-mguk-regen-gain", "label": "View MGU-K Regen Gain", "controlType": "view" },
+            { "setting": "view-mguk-deploy-fixed", "label": "View MGU-K Deploy Fixed", "controlType": "view" },
             { "setting": "mguk-regen-gain", "direction": "increase", "label": "MGU-K Regen Gain Increase" },
             { "setting": "mguk-regen-gain", "direction": "decrease", "label": "MGU-K Regen Gain Decrease" },
             { "setting": "mguk-deploy-mode", "direction": "increase", "label": "MGU-K Deploy Mode Up" },
@@ -705,15 +730,19 @@
           "encoder": true,
           "settingsKeys": ["setting", "direction"],
           "modes": [
+            { "setting": "view-tc-slot-1", "label": "View TC1", "controlType": "view" },
+            { "setting": "view-tc-slot-2", "label": "View TC2", "controlType": "view" },
+            { "setting": "view-tc-slot-3", "label": "View TC3", "controlType": "view" },
+            { "setting": "view-tc-slot-4", "label": "View TC4", "controlType": "view" },
             { "setting": "tc-toggle", "label": "TC Toggle" },
-            { "setting": "tc-slot-1", "direction": "increase", "label": "TC Slot 1 Increase" },
-            { "setting": "tc-slot-1", "direction": "decrease", "label": "TC Slot 1 Decrease" },
-            { "setting": "tc-slot-2", "direction": "increase", "label": "TC Slot 2 Increase" },
-            { "setting": "tc-slot-2", "direction": "decrease", "label": "TC Slot 2 Decrease" },
-            { "setting": "tc-slot-3", "direction": "increase", "label": "TC Slot 3 Increase" },
-            { "setting": "tc-slot-3", "direction": "decrease", "label": "TC Slot 3 Decrease" },
-            { "setting": "tc-slot-4", "direction": "increase", "label": "TC Slot 4 Increase" },
-            { "setting": "tc-slot-4", "direction": "decrease", "label": "TC Slot 4 Decrease" }
+            { "setting": "tc-slot-1", "direction": "increase", "label": "TC1 Increase" },
+            { "setting": "tc-slot-1", "direction": "decrease", "label": "TC1 Decrease" },
+            { "setting": "tc-slot-2", "direction": "increase", "label": "TC2 Increase" },
+            { "setting": "tc-slot-2", "direction": "decrease", "label": "TC2 Decrease" },
+            { "setting": "tc-slot-3", "direction": "increase", "label": "TC3 Increase" },
+            { "setting": "tc-slot-3", "direction": "decrease", "label": "TC3 Decrease" },
+            { "setting": "tc-slot-4", "direction": "increase", "label": "TC4 Increase" },
+            { "setting": "tc-slot-4", "direction": "decrease", "label": "TC4 Decrease" }
           ]
         }
       ]

--- a/docs/stream-deck-plugin-unified.md
+++ b/docs/stream-deck-plugin-unified.md
@@ -510,10 +510,10 @@ Traction control adjustments.
 | Sub-Action    | Default Key | iRacing Setting | Long-Press | Notes |
 | ------------- | ----------- | --------------- | ---------- | ----- |
 | TC Toggle     | -           | -               | None       | -     |
-| TC Slot 1 +/- | -           | Adjustment      | Repeat     | -     |
-| TC Slot 2 +/- | -           | Adjustment      | Repeat     | -     |
-| TC Slot 3 +/- | -           | Adjustment      | Repeat     | -     |
-| TC Slot 4 +/- | -           | Adjustment      | Repeat     | -     |
+| TC1 +/- | -           | Adjustment      | Repeat     | -     |
+| TC2 +/- | -           | Adjustment      | Repeat     | -     |
+| TC3 +/- | -           | Adjustment      | Repeat     | -     |
+| TC4 +/- | -           | Adjustment      | Repeat     | -     |
 
 **Type:** Toggle or +/- (TC slot selector)
 

--- a/packages/icons/preview/setup-traction/tc-slot-1-decrease.svg
+++ b/packages/icons/preview/setup-traction/tc-slot-1-decrease.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 52" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC SLOT 1\nDECREASE"},"border":{"color":"#3a5a3a"}}</desc>
+  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC1\nDECREASE"},"border":{"color":"#3a5a3a"}}</desc>
 
 
     <circle cx="58" cy="26" r="24" fill="none" stroke="#ffffff" stroke-width="4"/>

--- a/packages/icons/preview/setup-traction/tc-slot-1-increase.svg
+++ b/packages/icons/preview/setup-traction/tc-slot-1-increase.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 52" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC SLOT 1\nINCREASE"},"border":{"color":"#3a5a3a"}}</desc>
+  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC1\nINCREASE"},"border":{"color":"#3a5a3a"}}</desc>
   
 
     <circle cx="26" cy="26" r="24" fill="none" stroke="#ffffff" stroke-width="4"/>

--- a/packages/icons/preview/setup-traction/tc-slot-2-decrease.svg
+++ b/packages/icons/preview/setup-traction/tc-slot-2-decrease.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 52" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC SLOT 2\nDECREASE"},"border":{"color":"#3a5a3a"}}</desc>
+  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC2\nDECREASE"},"border":{"color":"#3a5a3a"}}</desc>
 
 
     <circle cx="58" cy="26" r="24" fill="none" stroke="#ffffff" stroke-width="4"/>

--- a/packages/icons/preview/setup-traction/tc-slot-2-increase.svg
+++ b/packages/icons/preview/setup-traction/tc-slot-2-increase.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 52" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC SLOT 2\nINCREASE"},"border":{"color":"#3a5a3a"}}</desc>
+  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC2\nINCREASE"},"border":{"color":"#3a5a3a"}}</desc>
   
 
     <circle cx="26" cy="26" r="24" fill="none" stroke="#ffffff" stroke-width="4"/>

--- a/packages/icons/preview/setup-traction/tc-slot-3-decrease.svg
+++ b/packages/icons/preview/setup-traction/tc-slot-3-decrease.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 52" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC SLOT 3\nDECREASE"},"border":{"color":"#3a5a3a"}}</desc>
+  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC3\nDECREASE"},"border":{"color":"#3a5a3a"}}</desc>
 
 
     <circle cx="58" cy="26" r="24" fill="none" stroke="#ffffff" stroke-width="4"/>

--- a/packages/icons/preview/setup-traction/tc-slot-3-increase.svg
+++ b/packages/icons/preview/setup-traction/tc-slot-3-increase.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 52" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC SLOT 3\nINCREASE"},"border":{"color":"#3a5a3a"}}</desc>
+  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC3\nINCREASE"},"border":{"color":"#3a5a3a"}}</desc>
   
 
     <circle cx="26" cy="26" r="24" fill="none" stroke="#ffffff" stroke-width="4"/>

--- a/packages/icons/preview/setup-traction/tc-slot-4-decrease.svg
+++ b/packages/icons/preview/setup-traction/tc-slot-4-decrease.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 52" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC SLOT 4\nDECREASE"},"border":{"color":"#3a5a3a"}}</desc>
+  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC4\nDECREASE"},"border":{"color":"#3a5a3a"}}</desc>
 
 
     <circle cx="58" cy="26" r="24" fill="none" stroke="#ffffff" stroke-width="4"/>

--- a/packages/icons/preview/setup-traction/tc-slot-4-increase.svg
+++ b/packages/icons/preview/setup-traction/tc-slot-4-increase.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 52" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC SLOT 4\nINCREASE"},"border":{"color":"#3a5a3a"}}</desc>
+  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC4\nINCREASE"},"border":{"color":"#3a5a3a"}}</desc>
   
 
     <circle cx="26" cy="26" r="24" fill="none" stroke="#ffffff" stroke-width="4"/>

--- a/packages/icons/setup-traction/tc-slot-1-decrease.svg
+++ b/packages/icons/setup-traction/tc-slot-1-decrease.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 52" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC SLOT 1\nDECREASE"},"border":{"color":"#3a5a3a"}}</desc>
+  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC1\nDECREASE"},"border":{"color":"#3a5a3a"}}</desc>
 
 
     <circle cx="58" cy="26" r="24" fill="none" stroke="{{graphic1Color}}" stroke-width="4"/>

--- a/packages/icons/setup-traction/tc-slot-1-increase.svg
+++ b/packages/icons/setup-traction/tc-slot-1-increase.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 52" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC SLOT 1\nINCREASE"},"border":{"color":"#3a5a3a"}}</desc>
+  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC1\nINCREASE"},"border":{"color":"#3a5a3a"}}</desc>
   
 
     <circle cx="26" cy="26" r="24" fill="none" stroke="{{graphic1Color}}" stroke-width="4"/>

--- a/packages/icons/setup-traction/tc-slot-2-decrease.svg
+++ b/packages/icons/setup-traction/tc-slot-2-decrease.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 52" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC SLOT 2\nDECREASE"},"border":{"color":"#3a5a3a"}}</desc>
+  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC2\nDECREASE"},"border":{"color":"#3a5a3a"}}</desc>
 
 
     <circle cx="58" cy="26" r="24" fill="none" stroke="{{graphic1Color}}" stroke-width="4"/>

--- a/packages/icons/setup-traction/tc-slot-2-increase.svg
+++ b/packages/icons/setup-traction/tc-slot-2-increase.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 52" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC SLOT 2\nINCREASE"},"border":{"color":"#3a5a3a"}}</desc>
+  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC2\nINCREASE"},"border":{"color":"#3a5a3a"}}</desc>
   
 
     <circle cx="26" cy="26" r="24" fill="none" stroke="{{graphic1Color}}" stroke-width="4"/>

--- a/packages/icons/setup-traction/tc-slot-3-decrease.svg
+++ b/packages/icons/setup-traction/tc-slot-3-decrease.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 52" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC SLOT 3\nDECREASE"},"border":{"color":"#3a5a3a"}}</desc>
+  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC3\nDECREASE"},"border":{"color":"#3a5a3a"}}</desc>
 
 
     <circle cx="58" cy="26" r="24" fill="none" stroke="{{graphic1Color}}" stroke-width="4"/>

--- a/packages/icons/setup-traction/tc-slot-3-increase.svg
+++ b/packages/icons/setup-traction/tc-slot-3-increase.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 52" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC SLOT 3\nINCREASE"},"border":{"color":"#3a5a3a"}}</desc>
+  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC3\nINCREASE"},"border":{"color":"#3a5a3a"}}</desc>
   
 
     <circle cx="26" cy="26" r="24" fill="none" stroke="{{graphic1Color}}" stroke-width="4"/>

--- a/packages/icons/setup-traction/tc-slot-4-decrease.svg
+++ b/packages/icons/setup-traction/tc-slot-4-decrease.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 52" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC SLOT 4\nDECREASE"},"border":{"color":"#3a5a3a"}}</desc>
+  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC4\nDECREASE"},"border":{"color":"#3a5a3a"}}</desc>
 
 
     <circle cx="58" cy="26" r="24" fill="none" stroke="{{graphic1Color}}" stroke-width="4"/>

--- a/packages/icons/setup-traction/tc-slot-4-increase.svg
+++ b/packages/icons/setup-traction/tc-slot-4-increase.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 52" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC SLOT 4\nINCREASE"},"border":{"color":"#3a5a3a"}}</desc>
+  <desc>{"colors":{"backgroundColor":"#1a2a1a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TC4\nINCREASE"},"border":{"color":"#3a5a3a"}}</desc>
   
 
     <circle cx="26" cy="26" r="24" fill="none" stroke="{{graphic1Color}}" stroke-width="4"/>

--- a/packages/iracing-actions/icons/setup-view.svg
+++ b/packages/iracing-actions/icons/setup-view.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
+  <desc>{"colors":{"backgroundColor":"#2a3444","textColor":"#ffffff"}}</desc>
+  {{borderDefs}}
+  <g>
+    <!-- Main background -->
+    <rect x="0" y="0" width="144" height="144" rx="24" fill="{{backgroundColor}}"/>
+{{borderContent}}
+
+    <!-- Title label (position and style controlled by title settings) -->
+    {{titleContent}}
+
+    <!-- Large centered value (live dc* telemetry readout) -->
+    <text x="72" y="{{valueY}}" text-anchor="middle" dominant-baseline="central"
+          fill="{{textColor}}" font-family="Arial, sans-serif" font-size="{{valueFontSize}}" font-weight="bold">{{value}}</text>
+  </g>
+</svg>

--- a/packages/iracing-actions/src/actions/data/key-bindings.json
+++ b/packages/iracing-actions/src/actions/data/key-bindings.json
@@ -568,14 +568,14 @@
   ],
   "setupTraction": [
     { "id": "tcToggle", "label": "TC Toggle", "default": "", "setting": "setupTractionTcToggle" },
-    { "id": "tcSlot1Increase", "label": "TC Slot 1 +", "default": "", "setting": "setupTractionTcSlot1Increase" },
-    { "id": "tcSlot1Decrease", "label": "TC Slot 1 -", "default": "", "setting": "setupTractionTcSlot1Decrease" },
-    { "id": "tcSlot2Increase", "label": "TC Slot 2 +", "default": "", "setting": "setupTractionTcSlot2Increase" },
-    { "id": "tcSlot2Decrease", "label": "TC Slot 2 -", "default": "", "setting": "setupTractionTcSlot2Decrease" },
-    { "id": "tcSlot3Increase", "label": "TC Slot 3 +", "default": "", "setting": "setupTractionTcSlot3Increase" },
-    { "id": "tcSlot3Decrease", "label": "TC Slot 3 -", "default": "", "setting": "setupTractionTcSlot3Decrease" },
-    { "id": "tcSlot4Increase", "label": "TC Slot 4 +", "default": "", "setting": "setupTractionTcSlot4Increase" },
-    { "id": "tcSlot4Decrease", "label": "TC Slot 4 -", "default": "", "setting": "setupTractionTcSlot4Decrease" }
+    { "id": "tcSlot1Increase", "label": "TC1 +", "default": "", "setting": "setupTractionTcSlot1Increase" },
+    { "id": "tcSlot1Decrease", "label": "TC1 -", "default": "", "setting": "setupTractionTcSlot1Decrease" },
+    { "id": "tcSlot2Increase", "label": "TC2 +", "default": "", "setting": "setupTractionTcSlot2Increase" },
+    { "id": "tcSlot2Decrease", "label": "TC2 -", "default": "", "setting": "setupTractionTcSlot2Decrease" },
+    { "id": "tcSlot3Increase", "label": "TC3 +", "default": "", "setting": "setupTractionTcSlot3Increase" },
+    { "id": "tcSlot3Decrease", "label": "TC3 -", "default": "", "setting": "setupTractionTcSlot3Decrease" },
+    { "id": "tcSlot4Increase", "label": "TC4 +", "default": "", "setting": "setupTractionTcSlot4Increase" },
+    { "id": "tcSlot4Decrease", "label": "TC4 -", "default": "", "setting": "setupTractionTcSlot4Decrease" }
   ],
   "setupEngine": [
     {

--- a/packages/iracing-actions/src/actions/setup-aero/setup-aero.ejs
+++ b/packages/iracing-actions/src/actions/setup-aero/setup-aero.ejs
@@ -8,10 +8,16 @@
 
 		<sdpi-item label="Setting">
 			<sdpi-select id="setting-select" setting="setting" default="front-wing">
-				<option value="front-wing">Front Wing</option>
-				<option value="rear-wing">Rear Wing</option>
-				<option value="qualifying-tape">Qualifying Tape</option>
-				<option value="rf-brake-attached">RF Brake Attached</option>
+				<optgroup label="Adjust">
+					<option value="front-wing">Front Wing</option>
+					<option value="qualifying-tape">Qualifying Tape</option>
+					<option value="rear-wing">Rear Wing</option>
+					<option value="rf-brake-attached">RF Brake Attached</option>
+				</optgroup>
+				<optgroup label="Display value">
+					<option value="view-front-wing">View Front Wing</option>
+					<option value="view-rear-wing">View Rear Wing</option>
+				</optgroup>
 			</sdpi-select>
 		</sdpi-item>
 
@@ -43,11 +49,12 @@
 		<%- include('global-common-settings') %>
 
 		<script>
-			// RF Brake Attached is the only non-directional control
+			// RF Brake Attached is non-directional; View sub-modes are read-only — both hide Direction.
 			function updateVisibility(setting) {
 				const directionItem = document.getElementById("direction-item");
 				if (!directionItem) return;
-				directionItem.classList.toggle("hidden", setting === "rf-brake-attached");
+				const hide = setting === "rf-brake-attached" || setting.startsWith("view-");
+				directionItem.classList.toggle("hidden", hide);
 			}
 
 			async function initialize() {

--- a/packages/iracing-actions/src/actions/setup-aero/setup-aero.test.ts
+++ b/packages/iracing-actions/src/actions/setup-aero/setup-aero.test.ts
@@ -65,6 +65,15 @@ vi.mock("@iracedeck/deck-core", () => ({
     return b.key;
   }),
   generateBorderParts: vi.fn(() => ({ defs: "", rects: "" })),
+  generateTitleText: vi.fn(({ text, fill }: { text: string; fill: string }) => {
+    if (!text) return "";
+
+    return `<text fill="${fill}">${text}</text>`;
+  }),
+  renderIconTemplate: vi.fn((_template: string, data: Record<string, string>) => {
+    return `<svg>${data.value ?? ""} ${data.titleContent ?? ""}</svg>`;
+  }),
+  svgToDataUri: vi.fn((svg: string) => `data:image/svg+xml,${encodeURIComponent(svg)}`),
   getGlobalBorderSettings: vi.fn(() => ({})),
   getGlobalColors: vi.fn(() => ({})),
   getGlobalGraphicSettings: vi.fn(() => ({})),
@@ -360,6 +369,29 @@ describe("SetupAero", () => {
 
     it("should ignore rotation for non-directional controls (rf-brake-attached)", async () => {
       await action.onDialRotate(fakeDialRotateEvent("action-1", { setting: "rf-brake-attached" }, 1) as any);
+
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("view sub-modes (issue #541)", () => {
+    let action: SetupAero;
+
+    beforeEach(() => {
+      action = new SetupAero();
+      (action.sdkController.getCurrentTelemetry as any).mockReturnValue({ dcFrontWing: 4, dcRearWing: 6 });
+    });
+
+    it("renders the formatted telemetry value for View Front Wing", async () => {
+      const ev = fakeEvent("action-1", { setting: "view-front-wing" }) as any;
+      await action.onWillAppear(ev);
+      const calls = (action.setKeyImage as any).mock.calls;
+      const svg = decodeURIComponent(calls[0][1] as string);
+      expect(svg).toContain("4");
+    });
+
+    it("does not fire a binding when a View setting is pressed", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-rear-wing" }) as any);
 
       expect(mockTapBinding).not.toHaveBeenCalled();
     });

--- a/packages/iracing-actions/src/actions/setup-aero/setup-aero.ts
+++ b/packages/iracing-actions/src/actions/setup-aero/setup-aero.ts
@@ -11,6 +11,7 @@ import {
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
   type IDeckWillAppearEvent,
+  type IDeckWillDisappearEvent,
   resolveBorderSettings,
   resolveGraphicSettings,
   resolveIconColors,
@@ -23,18 +24,23 @@ import qualifyingTapeIncreaseIconSvg from "@iracedeck/icons/setup-aero/qualifyin
 import rearWingDecreaseIconSvg from "@iracedeck/icons/setup-aero/rear-wing-decrease.svg";
 import rearWingIncreaseIconSvg from "@iracedeck/icons/setup-aero/rear-wing-increase.svg";
 import rfBrakeAttachedIconSvg from "@iracedeck/icons/setup-aero/rf-brake-attached.svg";
+import type { TelemetryData } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
-type SetupAeroSetting = "front-wing" | "rear-wing" | "qualifying-tape" | "rf-brake-attached";
+import { formatViewValue, generateSetupViewSvg, isViewSetting } from "../../shared/setup-view.js";
+
+type SetupAeroAdjustSetting = "front-wing" | "rear-wing" | "qualifying-tape" | "rf-brake-attached";
+
+/**
+ * The combined `setting` type is the union of `SetupAeroAdjustSetting` and the two View
+ * IDs in `setup-view.ts`. Code paths narrow back to `SetupAeroAdjustSetting` after
+ * `isViewSetting` gates the View branch; nothing needs the full union as a name.
+ */
 
 type DirectionType = "increase" | "decrease";
 
 /** Controls that have +/- direction */
-const DIRECTIONAL_CONTROLS: Set<SetupAeroSetting> = new Set([
-  "front-wing",
-  "rear-wing",
-  "qualifying-tape",
-]);
+const DIRECTIONAL_CONTROLS: Set<SetupAeroAdjustSetting> = new Set(["front-wing", "rear-wing", "qualifying-tape"]);
 
 /**
  * Flat icon lookup record mapping setting + direction keys to imported SVGs.
@@ -79,7 +85,18 @@ export const SETUP_AERO_GLOBAL_KEYS: Record<string, string> = {
 };
 
 const SetupAeroSettings = CommonSettings.extend({
-  setting: z.enum(["front-wing", "rear-wing", "qualifying-tape", "rf-brake-attached"]).default("front-wing"),
+  setting: z
+    .enum([
+      // View sub-modes.
+      "view-front-wing",
+      "view-rear-wing",
+      // Adjustment sub-modes.
+      "front-wing",
+      "rear-wing",
+      "qualifying-tape",
+      "rf-brake-attached",
+    ])
+    .default("front-wing"),
   direction: z.enum(["increase", "decrease"]).default("increase"),
 });
 
@@ -88,10 +105,23 @@ type SetupAeroSettings = z.infer<typeof SetupAeroSettings>;
 /**
  * @internal Exported for testing
  *
- * Generates an SVG data URI icon for the setup aero action.
+ * Generates an SVG data URI icon for the setup aero action's adjustment sub-modes.
+ * View sub-modes use the shared `generateSetupViewSvg` render path.
  */
 export function generateSetupAeroSvg(settings: SetupAeroSettings): string {
-  const { setting, direction } = settings;
+  if (isViewSetting(settings.setting)) {
+    return generateSetupViewSvg({
+      viewId: settings.setting,
+      telemetry: null,
+      colorSourceSvg: frontWingIncreaseIconSvg,
+      colorOverrides: settings.colorOverrides,
+      titleOverrides: settings.titleOverrides,
+      borderOverrides: settings.borderOverrides,
+    });
+  }
+
+  const setting = settings.setting as SetupAeroAdjustSetting;
+  const { direction } = settings;
 
   const iconKey = DIRECTIONAL_CONTROLS.has(setting) ? `${setting}-${direction}` : setting;
   const iconSvg = SETUP_AERO_ICONS[iconKey] || SETUP_AERO_ICONS["rf-brake-attached"];
@@ -115,56 +145,84 @@ export function generateSetupAeroSvg(settings: SetupAeroSettings): string {
 export const SETUP_AERO_UUID = "com.iracedeck.sd.core.setup-aero" as const;
 
 export class SetupAero extends ConnectionStateAwareAction<SetupAeroSettings> {
+  /** Current settings per action context, used by the telemetry-tick callback for View sub-modes. */
+  private readonly activeContexts = new Map<string, SetupAeroSettings>();
+
+  /** Last rendered View value per context — memoizes the icon so we only re-emit on actual change. */
+  private readonly lastRenderedValue = new Map<string, string>();
+
   override async onWillAppear(ev: IDeckWillAppearEvent<SetupAeroSettings>): Promise<void> {
     await super.onWillAppear(ev);
     const settings = this.parseSettings(ev.payload.settings);
-    const activeKey = this.resolveGlobalKey(settings.setting, settings.direction);
-
-    if (activeKey) {
-      this.setActiveBinding(activeKey);
-    }
-
+    this.activeContexts.set(ev.action.id, settings);
+    this.applyActiveBinding(settings);
     await this.updateDisplay(ev, settings);
+
+    this.sdkController.subscribe(ev.action.id, (telemetry) => {
+      const stored = this.activeContexts.get(ev.action.id);
+
+      if (stored && isViewSetting(stored.setting)) {
+        void this.updateDisplayFromTelemetry(ev.action.id, telemetry, stored);
+      }
+    });
+  }
+
+  override async onWillDisappear(ev: IDeckWillDisappearEvent<SetupAeroSettings>): Promise<void> {
+    this.sdkController.unsubscribe(ev.action.id);
+    this.activeContexts.delete(ev.action.id);
+    this.lastRenderedValue.delete(ev.action.id);
+    await super.onWillDisappear(ev);
   }
 
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<SetupAeroSettings>): Promise<void> {
     await super.onDidReceiveSettings(ev);
     const settings = this.parseSettings(ev.payload.settings);
-    const activeKey = this.resolveGlobalKey(settings.setting, settings.direction);
-
-    if (activeKey) {
-      this.setActiveBinding(activeKey);
-    }
-
+    this.activeContexts.set(ev.action.id, settings);
+    this.lastRenderedValue.delete(ev.action.id);
+    this.applyActiveBinding(settings);
     await this.updateDisplay(ev, settings);
   }
 
   override async onKeyDown(ev: IDeckKeyDownEvent<SetupAeroSettings>): Promise<void> {
-    this.logger.info("Key down received");
     const settings = this.parseSettings(ev.payload.settings);
+
+    if (isViewSetting(settings.setting)) {
+      this.logger.debug("View sub-mode is read-only, ignoring key press");
+
+      return;
+    }
+
+    this.logger.info("Key down received");
     await this.executeSetting(settings.setting, settings.direction);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<SetupAeroSettings>): Promise<void> {
-    this.logger.info("Dial down received");
     const settings = this.parseSettings(ev.payload.settings);
+
+    if (isViewSetting(settings.setting)) return;
+
+    this.logger.info("Dial down received");
     await this.executeSetting(settings.setting, settings.direction);
   }
 
   override async onDialRotate(ev: IDeckDialRotateEvent<SetupAeroSettings>): Promise<void> {
-    this.logger.info("Dial rotated");
     const settings = this.parseSettings(ev.payload.settings);
 
+    if (isViewSetting(settings.setting)) return;
+
+    this.logger.info("Dial rotated");
+    const adjustSetting = settings.setting as SetupAeroAdjustSetting;
+
     // Non-directional controls have no +/- adjustment — ignore rotation
-    if (!DIRECTIONAL_CONTROLS.has(settings.setting)) {
-      this.logger.debug(`Rotation ignored for ${settings.setting}`);
+    if (!DIRECTIONAL_CONTROLS.has(adjustSetting)) {
+      this.logger.debug(`Rotation ignored for ${adjustSetting}`);
 
       return;
     }
 
     // Clockwise (ticks > 0) = increase, Counter-clockwise (ticks < 0) = decrease
     const direction: DirectionType = ev.payload.ticks > 0 ? "increase" : "decrease";
-    await this.executeSetting(settings.setting, direction);
+    await this.executeSetting(adjustSetting, direction);
   }
 
   private parseSettings(settings: unknown): SetupAeroSettings {
@@ -173,7 +231,21 @@ export class SetupAero extends ConnectionStateAwareAction<SetupAeroSettings> {
     return parsed.success ? parsed.data : SetupAeroSettings.parse({});
   }
 
-  private async executeSetting(setting: SetupAeroSetting, direction: DirectionType): Promise<void> {
+  private applyActiveBinding(settings: SetupAeroSettings): void {
+    if (isViewSetting(settings.setting)) {
+      this.setActiveBinding(null);
+
+      return;
+    }
+
+    const activeKey = this.resolveGlobalKey(settings.setting, settings.direction);
+
+    if (activeKey) {
+      this.setActiveBinding(activeKey);
+    }
+  }
+
+  private async executeSetting(setting: SetupAeroAdjustSetting, direction: DirectionType): Promise<void> {
     const settingKey = this.resolveGlobalKey(setting, direction);
 
     if (!settingKey) {
@@ -185,7 +257,7 @@ export class SetupAero extends ConnectionStateAwareAction<SetupAeroSettings> {
     await this.tapBinding(settingKey);
   }
 
-  private resolveGlobalKey(setting: SetupAeroSetting, direction: DirectionType): string | null {
+  private resolveGlobalKey(setting: SetupAeroAdjustSetting, direction: DirectionType): string | null {
     if (DIRECTIONAL_CONTROLS.has(setting)) {
       const key = `${setting}-${direction}`;
 
@@ -199,9 +271,53 @@ export class SetupAero extends ConnectionStateAwareAction<SetupAeroSettings> {
     ev: IDeckWillAppearEvent<SetupAeroSettings> | IDeckDidReceiveSettingsEvent<SetupAeroSettings>,
     settings: SetupAeroSettings,
   ): Promise<void> {
-    const svgDataUri = generateSetupAeroSvg(settings);
+    const svgDataUri = this.renderIcon(settings);
+
+    if (isViewSetting(settings.setting)) {
+      const telemetry = this.sdkController.getCurrentTelemetry();
+      this.lastRenderedValue.set(ev.action.id, formatViewValue(settings.setting, telemetry));
+    }
+
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateSetupAeroSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () => this.renderIcon(settings));
+  }
+
+  private renderIcon(settings: SetupAeroSettings): string {
+    if (isViewSetting(settings.setting)) {
+      return generateSetupViewSvg({
+        viewId: settings.setting,
+        telemetry: this.sdkController.getCurrentTelemetry(),
+        colorSourceSvg: frontWingIncreaseIconSvg,
+        colorOverrides: settings.colorOverrides,
+        titleOverrides: settings.titleOverrides,
+        borderOverrides: settings.borderOverrides,
+      });
+    }
+
+    return generateSetupAeroSvg(settings);
+  }
+
+  private async updateDisplayFromTelemetry(
+    contextId: string,
+    telemetry: TelemetryData | null,
+    settings: SetupAeroSettings,
+  ): Promise<void> {
+    if (!isViewSetting(settings.setting)) return;
+
+    const value = formatViewValue(settings.setting, telemetry);
+
+    if (this.lastRenderedValue.get(contextId) === value) return;
+
+    this.lastRenderedValue.set(contextId, value);
+    const svgDataUri = generateSetupViewSvg({
+      viewId: settings.setting,
+      telemetry,
+      colorSourceSvg: frontWingIncreaseIconSvg,
+      colorOverrides: settings.colorOverrides,
+      titleOverrides: settings.titleOverrides,
+      borderOverrides: settings.borderOverrides,
+    });
+    await this.updateKeyImage(contextId, svgDataUri);
   }
 }

--- a/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.ejs
+++ b/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.ejs
@@ -8,13 +8,23 @@
 
 		<sdpi-item label="Setting">
 			<sdpi-select id="setting-select" setting="setting" default="brake-bias">
-				<option value="abs-toggle">ABS Toggle</option>
-				<option value="abs-adjust">ABS Adjust</option>
-				<option value="brake-bias">Brake Bias</option>
-				<option value="brake-bias-fine">Brake Bias Fine</option>
-				<option value="peak-brake-bias">Peak Brake Bias</option>
-				<option value="brake-misc">Brake Misc</option>
-				<option value="engine-braking">Engine Braking</option>
+				<optgroup label="Adjust">
+					<option value="abs-adjust">ABS Adjust</option>
+					<option value="abs-toggle">ABS Toggle</option>
+					<option value="brake-bias">Brake Bias</option>
+					<option value="brake-bias-fine">Brake Bias Fine</option>
+					<option value="brake-misc">Brake Misc</option>
+					<option value="engine-braking">Engine Braking</option>
+					<option value="peak-brake-bias">Peak Brake Bias</option>
+				</optgroup>
+				<optgroup label="Display value">
+					<option value="view-abs-adjust">View ABS Adjust</option>
+					<option value="view-brake-bias">View Brake Bias</option>
+					<option value="view-brake-bias-fine">View Brake Bias Fine</option>
+					<option value="view-brake-misc">View Brake Misc</option>
+					<option value="view-engine-braking">View Engine Braking</option>
+					<option value="view-peak-brake-bias">View Peak Brake Bias</option>
+				</optgroup>
 			</sdpi-select>
 		</sdpi-item>
 
@@ -46,11 +56,12 @@
 		<%- include('global-common-settings') %>
 
 		<script>
-			// ABS Toggle is the only non-directional control
+			// ABS Toggle is non-directional; View sub-modes are read-only — both hide Direction.
 			function updateVisibility(setting) {
 				const directionItem = document.getElementById("direction-item");
 				if (!directionItem) return;
-				directionItem.classList.toggle("hidden", setting === "abs-toggle");
+				const hide = setting === "abs-toggle" || setting.startsWith("view-");
+				directionItem.classList.toggle("hidden", hide);
 			}
 
 			async function initialize() {

--- a/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.test.ts
+++ b/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.test.ts
@@ -84,6 +84,15 @@ vi.mock("@iracedeck/deck-core", () => ({
     return b.key;
   }),
   generateBorderParts: vi.fn(() => ({ defs: "", rects: "" })),
+  generateTitleText: vi.fn(({ text, fill }: { text: string; fill: string }) => {
+    if (!text) return "";
+
+    return `<text fill="${fill}">${text}</text>`;
+  }),
+  renderIconTemplate: vi.fn((_template: string, data: Record<string, string>) => {
+    return `<svg>${data.value ?? ""} ${data.titleContent ?? ""}</svg>`;
+  }),
+  svgToDataUri: vi.fn((svg: string) => `data:image/svg+xml,${encodeURIComponent(svg)}`),
   getGlobalBorderSettings: vi.fn(() => ({})),
   getGlobalColors: vi.fn(() => ({})),
   getGlobalGraphicSettings: vi.fn(() => ({})),
@@ -459,6 +468,54 @@ describe("SetupBrakes", () => {
       await action.onDialRotate(fakeDialRotateEvent("action-1", { setting: "abs-toggle" }, 1) as any);
 
       expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("view sub-modes (issue #541)", () => {
+    let action: SetupBrakes;
+
+    beforeEach(() => {
+      action = new SetupBrakes();
+      // iRacing exposes dcBrakeBias in percent units (54, not 0.54).
+      (action.sdkController.getCurrentTelemetry as any).mockReturnValue({ dcBrakeBias: 56 });
+    });
+
+    it("renders the formatted telemetry value for a View setting on willAppear", async () => {
+      const ev = fakeEvent("action-1", { setting: "view-brake-bias" }) as any;
+      await action.onWillAppear(ev);
+
+      // The icon SVG carries the formatted value via the {{value}} placeholder.
+      const calls = (action.setKeyImage as any).mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      const svg = decodeURIComponent(calls[0][1] as string);
+      expect(svg).toContain("56.0%");
+    });
+
+    it("does not call tapBinding when a View setting is pressed", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-brake-bias" }) as any);
+      await action.onDialDown(fakeEvent("action-1", { setting: "view-brake-bias" }) as any);
+      await action.onDialRotate(fakeDialRotateEvent("action-1", { setting: "view-brake-bias" }, 1) as any);
+
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("subscribes to telemetry on willAppear and unsubscribes on willDisappear", async () => {
+      const subscribe = action.sdkController.subscribe as any;
+      const unsubscribe = action.sdkController.unsubscribe as any;
+      await action.onWillAppear(fakeEvent("action-1", { setting: "view-brake-bias" }) as any);
+
+      expect(subscribe).toHaveBeenCalledWith("action-1", expect.any(Function));
+
+      await action.onWillDisappear({ action: { id: "action-1" }, payload: { settings: {} } } as any);
+      expect(unsubscribe).toHaveBeenCalledWith("action-1");
+    });
+
+    it("clears active binding when switching to a View setting", async () => {
+      const setActive = action.setActiveBinding as any;
+      await action.onWillAppear(fakeEvent("action-1", { setting: "view-brake-bias" }) as any);
+
+      // setActiveBinding is called with null for view sub-modes.
+      expect(setActive).toHaveBeenCalledWith(null);
     });
   });
 });

--- a/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.ts
+++ b/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.ts
@@ -11,6 +11,7 @@ import {
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
   type IDeckWillAppearEvent,
+  type IDeckWillDisappearEvent,
   resolveBorderSettings,
   resolveGraphicSettings,
   resolveIconColors,
@@ -29,9 +30,12 @@ import engineBrakingDecreaseIconSvg from "@iracedeck/icons/setup-brakes/engine-b
 import engineBrakingIncreaseIconSvg from "@iracedeck/icons/setup-brakes/engine-braking-increase.svg";
 import peakBrakeBiasDecreaseIconSvg from "@iracedeck/icons/setup-brakes/peak-brake-bias-decrease.svg";
 import peakBrakeBiasIncreaseIconSvg from "@iracedeck/icons/setup-brakes/peak-brake-bias-increase.svg";
+import type { TelemetryData } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
-type SetupBrakesSetting =
+import { formatViewValue, generateSetupViewSvg, isViewSetting } from "../../shared/setup-view.js";
+
+type SetupBrakesAdjustSetting =
   | "abs-toggle"
   | "abs-adjust"
   | "brake-bias"
@@ -40,10 +44,16 @@ type SetupBrakesSetting =
   | "brake-misc"
   | "engine-braking";
 
+/**
+ * The combined `setting` type is the union of `SetupBrakesAdjustSetting` and the six View
+ * IDs in `setup-view.ts`. Code paths narrow back to `SetupBrakesAdjustSetting` after
+ * `isViewSetting` gates the View branch; nothing needs the full union as a name.
+ */
+
 type DirectionType = "increase" | "decrease";
 
 /** Controls that have +/- direction */
-const DIRECTIONAL_CONTROLS: Set<SetupBrakesSetting> = new Set([
+const DIRECTIONAL_CONTROLS: Set<SetupBrakesAdjustSetting> = new Set([
   "abs-adjust",
   "brake-bias",
   "brake-bias-fine",
@@ -115,6 +125,14 @@ export const SETUP_BRAKES_GLOBAL_KEYS: Record<string, string> = {
 const SetupBrakesSettings = CommonSettings.extend({
   setting: z
     .enum([
+      // View sub-modes (read-only telemetry display) — listed first to appear at the top of the PI dropdown.
+      "view-brake-bias",
+      "view-brake-bias-fine",
+      "view-peak-brake-bias",
+      "view-brake-misc",
+      "view-engine-braking",
+      "view-abs-adjust",
+      // Adjustment sub-modes (existing).
       "abs-toggle",
       "abs-adjust",
       "brake-bias",
@@ -130,9 +148,10 @@ const SetupBrakesSettings = CommonSettings.extend({
 type SetupBrakesSettings = z.infer<typeof SetupBrakesSettings>;
 
 /**
- * Resolves the flat icon lookup key for a given setting and direction.
+ * Resolves the flat icon lookup key for a given adjustment setting and direction.
+ * View sub-modes use a separate render path (`generateSetupViewSvg`) and never reach this.
  */
-function resolveIconKey(setting: SetupBrakesSetting, direction: DirectionType): string {
+function resolveIconKey(setting: SetupBrakesAdjustSetting, direction: DirectionType): string {
   if (DIRECTIONAL_CONTROLS.has(setting)) {
     return `${setting}-${direction}`;
   }
@@ -143,10 +162,25 @@ function resolveIconKey(setting: SetupBrakesSetting, direction: DirectionType): 
 /**
  * @internal Exported for testing
  *
- * Generates an SVG data URI icon for the setup brakes action.
+ * Generates an SVG data URI icon for the setup brakes action's adjustment sub-modes.
+ * View sub-modes call `generateSetupViewSvg` via `renderSettingIcon` instead.
  */
 export function generateSetupBrakesSvg(settings: SetupBrakesSettings): string {
-  const { setting, direction } = settings;
+  if (isViewSetting(settings.setting)) {
+    // View sub-modes have no static icon — they render telemetry through the shared template.
+    // Return a placeholder so callers that ignore telemetry get a stable string.
+    return generateSetupViewSvg({
+      viewId: settings.setting,
+      telemetry: null,
+      colorSourceSvg: brakeBiasIncreaseIconSvg,
+      colorOverrides: settings.colorOverrides,
+      titleOverrides: settings.titleOverrides,
+      borderOverrides: settings.borderOverrides,
+    });
+  }
+
+  const setting = settings.setting as SetupBrakesAdjustSetting;
+  const { direction } = settings;
 
   const iconKey = resolveIconKey(setting, direction);
   const iconSvg = SETUP_BRAKES_ICONS[iconKey] || SETUP_BRAKES_ICONS["abs-toggle"];
@@ -170,56 +204,88 @@ export function generateSetupBrakesSvg(settings: SetupBrakesSettings): string {
 export const SETUP_BRAKES_UUID = "com.iracedeck.sd.core.setup-brakes" as const;
 
 export class SetupBrakes extends ConnectionStateAwareAction<SetupBrakesSettings> {
+  /** Current settings per action context, used by the telemetry-tick callback for View sub-modes. */
+  private readonly activeContexts = new Map<string, SetupBrakesSettings>();
+
+  /** Last rendered View value per context — memoizes the icon so we only re-emit on actual change. */
+  private readonly lastRenderedValue = new Map<string, string>();
+
   override async onWillAppear(ev: IDeckWillAppearEvent<SetupBrakesSettings>): Promise<void> {
     await super.onWillAppear(ev);
     const settings = this.parseSettings(ev.payload.settings);
-    const activeKey = this.resolveGlobalKey(settings.setting, settings.direction);
-
-    if (activeKey) {
-      this.setActiveBinding(activeKey);
-    }
-
+    this.activeContexts.set(ev.action.id, settings);
+    this.applyActiveBinding(settings);
     await this.updateDisplay(ev, settings);
+
+    // Subscribe always; the callback no-ops for non-View settings. View entries can be
+    // toggled in / out via `onDidReceiveSettings` without resubscribing.
+    this.sdkController.subscribe(ev.action.id, (telemetry) => {
+      const stored = this.activeContexts.get(ev.action.id);
+
+      if (stored && isViewSetting(stored.setting)) {
+        void this.updateDisplayFromTelemetry(ev.action.id, telemetry, stored);
+      }
+    });
+  }
+
+  override async onWillDisappear(ev: IDeckWillDisappearEvent<SetupBrakesSettings>): Promise<void> {
+    this.sdkController.unsubscribe(ev.action.id);
+    this.activeContexts.delete(ev.action.id);
+    this.lastRenderedValue.delete(ev.action.id);
+    await super.onWillDisappear(ev);
   }
 
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<SetupBrakesSettings>): Promise<void> {
     await super.onDidReceiveSettings(ev);
     const settings = this.parseSettings(ev.payload.settings);
-    const activeKey = this.resolveGlobalKey(settings.setting, settings.direction);
-
-    if (activeKey) {
-      this.setActiveBinding(activeKey);
-    }
-
+    this.activeContexts.set(ev.action.id, settings);
+    // Bust the memo cache so the next tick re-renders even if the new mode happens to
+    // resolve to the same display string as the previous mode.
+    this.lastRenderedValue.delete(ev.action.id);
+    this.applyActiveBinding(settings);
     await this.updateDisplay(ev, settings);
   }
 
   override async onKeyDown(ev: IDeckKeyDownEvent<SetupBrakesSettings>): Promise<void> {
-    this.logger.info("Key down received");
     const settings = this.parseSettings(ev.payload.settings);
+
+    if (isViewSetting(settings.setting)) {
+      this.logger.debug("View sub-mode is read-only, ignoring key press");
+
+      return;
+    }
+
+    this.logger.info("Key down received");
     await this.executeSetting(settings.setting, settings.direction);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<SetupBrakesSettings>): Promise<void> {
-    this.logger.info("Dial down received");
     const settings = this.parseSettings(ev.payload.settings);
+
+    if (isViewSetting(settings.setting)) return;
+
+    this.logger.info("Dial down received");
     await this.executeSetting(settings.setting, settings.direction);
   }
 
   override async onDialRotate(ev: IDeckDialRotateEvent<SetupBrakesSettings>): Promise<void> {
-    this.logger.info("Dial rotated");
     const settings = this.parseSettings(ev.payload.settings);
 
+    if (isViewSetting(settings.setting)) return;
+
+    this.logger.info("Dial rotated");
+    const adjustSetting = settings.setting as SetupBrakesAdjustSetting;
+
     // Non-directional controls have no +/- adjustment — ignore rotation
-    if (!DIRECTIONAL_CONTROLS.has(settings.setting)) {
-      this.logger.debug(`Rotation ignored for ${settings.setting}`);
+    if (!DIRECTIONAL_CONTROLS.has(adjustSetting)) {
+      this.logger.debug(`Rotation ignored for ${adjustSetting}`);
 
       return;
     }
 
     // Clockwise (ticks > 0) = increase, Counter-clockwise (ticks < 0) = decrease
     const direction: DirectionType = ev.payload.ticks > 0 ? "increase" : "decrease";
-    await this.executeSetting(settings.setting, direction);
+    await this.executeSetting(adjustSetting, direction);
   }
 
   private parseSettings(settings: unknown): SetupBrakesSettings {
@@ -228,7 +294,23 @@ export class SetupBrakes extends ConnectionStateAwareAction<SetupBrakesSettings>
     return parsed.success ? parsed.data : SetupBrakesSettings.parse({});
   }
 
-  private async executeSetting(setting: SetupBrakesSetting, direction: DirectionType): Promise<void> {
+  private applyActiveBinding(settings: SetupBrakesSettings): void {
+    if (isViewSetting(settings.setting)) {
+      // View sub-modes don't fire any binding — clear the active binding so the
+      // readiness overlay reflects "no binding" instead of carrying a stale key.
+      this.setActiveBinding(null);
+
+      return;
+    }
+
+    const activeKey = this.resolveGlobalKey(settings.setting, settings.direction);
+
+    if (activeKey) {
+      this.setActiveBinding(activeKey);
+    }
+  }
+
+  private async executeSetting(setting: SetupBrakesAdjustSetting, direction: DirectionType): Promise<void> {
     const settingKey = this.resolveGlobalKey(setting, direction);
 
     if (!settingKey) {
@@ -240,7 +322,7 @@ export class SetupBrakes extends ConnectionStateAwareAction<SetupBrakesSettings>
     await this.tapBinding(settingKey);
   }
 
-  private resolveGlobalKey(setting: SetupBrakesSetting, direction: DirectionType): string | null {
+  private resolveGlobalKey(setting: SetupBrakesAdjustSetting, direction: DirectionType): string | null {
     if (DIRECTIONAL_CONTROLS.has(setting)) {
       const key = `${setting}-${direction}`;
 
@@ -254,9 +336,53 @@ export class SetupBrakes extends ConnectionStateAwareAction<SetupBrakesSettings>
     ev: IDeckWillAppearEvent<SetupBrakesSettings> | IDeckDidReceiveSettingsEvent<SetupBrakesSettings>,
     settings: SetupBrakesSettings,
   ): Promise<void> {
-    const svgDataUri = generateSetupBrakesSvg(settings);
+    const svgDataUri = this.renderIcon(settings);
+
+    if (isViewSetting(settings.setting)) {
+      const telemetry = this.sdkController.getCurrentTelemetry();
+      this.lastRenderedValue.set(ev.action.id, formatViewValue(settings.setting, telemetry));
+    }
+
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateSetupBrakesSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () => this.renderIcon(settings));
+  }
+
+  private renderIcon(settings: SetupBrakesSettings): string {
+    if (isViewSetting(settings.setting)) {
+      return generateSetupViewSvg({
+        viewId: settings.setting,
+        telemetry: this.sdkController.getCurrentTelemetry(),
+        colorSourceSvg: brakeBiasIncreaseIconSvg,
+        colorOverrides: settings.colorOverrides,
+        titleOverrides: settings.titleOverrides,
+        borderOverrides: settings.borderOverrides,
+      });
+    }
+
+    return generateSetupBrakesSvg(settings);
+  }
+
+  private async updateDisplayFromTelemetry(
+    contextId: string,
+    telemetry: TelemetryData | null,
+    settings: SetupBrakesSettings,
+  ): Promise<void> {
+    if (!isViewSetting(settings.setting)) return;
+
+    const value = formatViewValue(settings.setting, telemetry);
+
+    if (this.lastRenderedValue.get(contextId) === value) return;
+
+    this.lastRenderedValue.set(contextId, value);
+    const svgDataUri = generateSetupViewSvg({
+      viewId: settings.setting,
+      telemetry,
+      colorSourceSvg: brakeBiasIncreaseIconSvg,
+      colorOverrides: settings.colorOverrides,
+      titleOverrides: settings.titleOverrides,
+      borderOverrides: settings.borderOverrides,
+    });
+    await this.updateKeyImage(contextId, svgDataUri);
   }
 }

--- a/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.ejs
+++ b/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.ejs
@@ -7,24 +7,37 @@
 		<%- include('section-header', { title: 'Action Settings' }) %>
 
 		<sdpi-item label="Component">
-			<sdpi-select setting="setting" default="differential-preload">
-				<option value="differential-preload">Differential Preload</option>
-				<option value="differential-entry">Differential Entry</option>
-				<option value="differential-middle">Differential Middle</option>
-				<option value="differential-exit">Differential Exit</option>
-				<option value="front-arb">Front ARB</option>
-				<option value="rear-arb">Rear ARB</option>
-				<option value="left-spring">Left Spring</option>
-				<option value="right-spring">Right Spring</option>
-				<option value="lf-shock">LF Shock</option>
-				<option value="rf-shock">RF Shock</option>
-				<option value="lr-shock">LR Shock</option>
-				<option value="rr-shock">RR Shock</option>
-				<option value="power-steering">Power Steering</option>
+			<sdpi-select id="setting-select" setting="setting" default="differential-preload">
+				<optgroup label="Adjust">
+					<option value="differential-entry">Differential Entry</option>
+					<option value="differential-exit">Differential Exit</option>
+					<option value="differential-middle">Differential Middle</option>
+					<option value="differential-preload">Differential Preload</option>
+					<option value="front-arb">Front ARB</option>
+					<option value="left-spring">Left Spring</option>
+					<option value="lf-shock">LF Shock</option>
+					<option value="lr-shock">LR Shock</option>
+					<option value="power-steering">Power Steering</option>
+					<option value="rear-arb">Rear ARB</option>
+					<option value="rf-shock">RF Shock</option>
+					<option value="right-spring">Right Spring</option>
+					<option value="rr-shock">RR Shock</option>
+				</optgroup>
+				<optgroup label="Display value">
+					<option value="view-anti-roll-front">View Anti-Roll Front</option>
+					<option value="view-anti-roll-rear">View Anti-Roll Rear</option>
+					<option value="view-diff-entry">View Diff Entry</option>
+					<option value="view-diff-exit">View Diff Exit</option>
+					<option value="view-diff-middle">View Diff Middle</option>
+					<option value="view-diff-preload">View Diff Preload</option>
+					<option value="view-power-steering">View Power Steering</option>
+					<option value="view-weight-jacker-left">View Weight Jacker Left</option>
+					<option value="view-weight-jacker-right">View Weight Jacker Right</option>
+				</optgroup>
 			</sdpi-select>
 		</sdpi-item>
 
-		<sdpi-item label="Direction">
+		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">
 				<option value="increase">Increase</option>
 				<option value="decrease">Decrease</option>
@@ -50,6 +63,53 @@
 		<%- include('global-graphic-defaults') %>
 		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
+
+		<script>
+			// View sub-modes are read-only — hide Direction when one is selected.
+			function updateVisibility(setting) {
+				const directionItem = document.getElementById("direction-item");
+				if (!directionItem) return;
+				directionItem.classList.toggle("hidden", setting.startsWith("view-"));
+			}
+
+			async function initialize() {
+				await customElements.whenDefined("sdpi-select");
+
+				const settingSelect = document.getElementById("setting-select");
+
+				if (settingSelect) {
+					const initialValue = settingSelect.value || "differential-preload";
+					updateVisibility(initialValue);
+
+					settingSelect.addEventListener("change", (ev) => {
+						updateVisibility(ev.target.value || "differential-preload");
+					});
+					settingSelect.addEventListener("input", (ev) => {
+						updateVisibility(ev.target.value || "differential-preload");
+					});
+
+					// Polling fallback for reliable detection
+					let lastValue = settingSelect.value || "differential-preload";
+					setInterval(() => {
+						const currentValue = settingSelect.value;
+						if (currentValue && currentValue !== lastValue) {
+							lastValue = currentValue;
+							updateVisibility(currentValue);
+						}
+					}, 100);
+				}
+			}
+
+			if (document.readyState === "loading") {
+				document.addEventListener("DOMContentLoaded", initialize);
+			} else {
+				initialize();
+			}
+		</script>
+
+		<style>
+			.hidden { display: none !important; }
+		</style>
 
 		<%- include('docs-link') %>
 

--- a/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.test.ts
+++ b/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.test.ts
@@ -122,6 +122,15 @@ vi.mock("@iracedeck/deck-core", () => ({
     return b.key;
   }),
   generateBorderParts: vi.fn(() => ({ defs: "", rects: "" })),
+  generateTitleText: vi.fn(({ text, fill }: { text: string; fill: string }) => {
+    if (!text) return "";
+
+    return `<text fill="${fill}">${text}</text>`;
+  }),
+  renderIconTemplate: vi.fn((_template: string, data: Record<string, string>) => {
+    return `<svg>${data.value ?? ""} ${data.titleContent ?? ""}</svg>`;
+  }),
+  svgToDataUri: vi.fn((svg: string) => `data:image/svg+xml,${encodeURIComponent(svg)}`),
   getGlobalBorderSettings: vi.fn(() => ({})),
   getGlobalColors: vi.fn(() => ({})),
   getGlobalGraphicSettings: vi.fn(() => ({})),
@@ -558,6 +567,40 @@ describe("SetupChassis", () => {
       );
 
       expect(mockTapBinding).toHaveBeenCalledWith("setupChassisFrontArbIncrease");
+    });
+  });
+
+  describe("view sub-modes (issue #541)", () => {
+    let action: SetupChassis;
+
+    beforeEach(() => {
+      action = new SetupChassis();
+      (action.sdkController.getCurrentTelemetry as any).mockReturnValue({
+        dcDiffEntry: 4,
+        dcWeightJackerRight: 0.06,
+      });
+    });
+
+    it("renders the formatted telemetry value for a View setting", async () => {
+      const ev = fakeEvent("action-1", { setting: "view-diff-entry" }) as any;
+      await action.onWillAppear(ev);
+      const calls = (action.setKeyImage as any).mock.calls;
+      const svg = decodeURIComponent(calls[0][1] as string);
+      expect(svg).toContain("4");
+    });
+
+    it("renders the signed-percent formatter for weight-jacker-right", async () => {
+      const ev = fakeEvent("action-1", { setting: "view-weight-jacker-right" }) as any;
+      await action.onWillAppear(ev);
+      const calls = (action.setKeyImage as any).mock.calls;
+      const svg = decodeURIComponent(calls[0][1] as string);
+      expect(svg).toContain("+6%");
+    });
+
+    it("does not fire a binding when a View setting is pressed", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-power-steering" }) as any);
+
+      expect(mockTapBinding).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.ts
+++ b/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.ts
@@ -11,6 +11,7 @@ import {
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
   type IDeckWillAppearEvent,
+  type IDeckWillDisappearEvent,
   resolveBorderSettings,
   resolveGraphicSettings,
   resolveIconColors,
@@ -42,7 +43,10 @@ import rightSpringDecreaseIconSvg from "@iracedeck/icons/setup-chassis/right-spr
 import rightSpringIncreaseIconSvg from "@iracedeck/icons/setup-chassis/right-spring-increase.svg";
 import rrShockDecreaseIconSvg from "@iracedeck/icons/setup-chassis/rr-shock-decrease.svg";
 import rrShockIncreaseIconSvg from "@iracedeck/icons/setup-chassis/rr-shock-increase.svg";
+import type { TelemetryData } from "@iracedeck/iracing-sdk";
 import z from "zod";
+
+import { formatViewValue, generateSetupViewSvg, isViewSetting } from "../../shared/setup-view.js";
 
 type DirectionType = "increase" | "decrease";
 
@@ -114,7 +118,7 @@ const SETUP_CHASSIS_TITLES: Record<string, string> = {
  * @internal Exported for testing
  *
  * Mapping from setting + direction to global settings keys.
- * All chassis settings are directional, using composite keys (e.g., "differential-preload-increase").
+ * All chassis adjustment settings are directional, using composite keys (e.g., "differential-preload-increase").
  */
 export const SETUP_CHASSIS_GLOBAL_KEYS: Record<string, string> = {
   "differential-preload-increase": "setupChassisDifferentialPreloadIncrease",
@@ -148,6 +152,17 @@ export const SETUP_CHASSIS_GLOBAL_KEYS: Record<string, string> = {
 const SetupChassisSettings = CommonSettings.extend({
   setting: z
     .enum([
+      // View sub-modes (read-only telemetry display).
+      "view-diff-preload",
+      "view-diff-entry",
+      "view-diff-middle",
+      "view-diff-exit",
+      "view-anti-roll-front",
+      "view-anti-roll-rear",
+      "view-power-steering",
+      "view-weight-jacker-left",
+      "view-weight-jacker-right",
+      // Adjustment sub-modes.
       "differential-preload",
       "differential-entry",
       "differential-middle",
@@ -171,9 +186,21 @@ type SetupChassisSettings = z.infer<typeof SetupChassisSettings>;
 /**
  * @internal Exported for testing
  *
- * Generates an SVG data URI icon for the setup chassis action.
+ * Generates an SVG data URI icon for the setup chassis action's adjustment sub-modes.
+ * View sub-modes use the shared `generateSetupViewSvg` render path.
  */
 export function generateSetupChassisSvg(settings: SetupChassisSettings): string {
+  if (isViewSetting(settings.setting)) {
+    return generateSetupViewSvg({
+      viewId: settings.setting,
+      telemetry: null,
+      colorSourceSvg: differentialPreloadIncreaseIconSvg,
+      colorOverrides: settings.colorOverrides,
+      titleOverrides: settings.titleOverrides,
+      borderOverrides: settings.borderOverrides,
+    });
+  }
+
   const { setting, direction } = settings;
   const key = `${setting}-${direction}`;
 
@@ -198,36 +225,72 @@ export function generateSetupChassisSvg(settings: SetupChassisSettings): string 
 export const SETUP_CHASSIS_UUID = "com.iracedeck.sd.core.setup-chassis" as const;
 
 export class SetupChassis extends ConnectionStateAwareAction<SetupChassisSettings> {
+  /** Current settings per action context, used by the telemetry-tick callback for View sub-modes. */
+  private readonly activeContexts = new Map<string, SetupChassisSettings>();
+
+  /** Last rendered View value per context — memoizes the icon so we only re-emit on actual change. */
+  private readonly lastRenderedValue = new Map<string, string>();
+
   override async onWillAppear(ev: IDeckWillAppearEvent<SetupChassisSettings>): Promise<void> {
     await super.onWillAppear(ev);
     const settings = this.parseSettings(ev.payload.settings);
-    this.setActiveBinding(SETUP_CHASSIS_GLOBAL_KEYS[`${settings.setting}-${settings.direction}`]);
+    this.activeContexts.set(ev.action.id, settings);
+    this.applyActiveBinding(settings);
     await this.updateDisplay(ev, settings);
+
+    this.sdkController.subscribe(ev.action.id, (telemetry) => {
+      const stored = this.activeContexts.get(ev.action.id);
+
+      if (stored && isViewSetting(stored.setting)) {
+        void this.updateDisplayFromTelemetry(ev.action.id, telemetry, stored);
+      }
+    });
+  }
+
+  override async onWillDisappear(ev: IDeckWillDisappearEvent<SetupChassisSettings>): Promise<void> {
+    this.sdkController.unsubscribe(ev.action.id);
+    this.activeContexts.delete(ev.action.id);
+    this.lastRenderedValue.delete(ev.action.id);
+    await super.onWillDisappear(ev);
   }
 
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<SetupChassisSettings>): Promise<void> {
     await super.onDidReceiveSettings(ev);
     const settings = this.parseSettings(ev.payload.settings);
-    this.setActiveBinding(SETUP_CHASSIS_GLOBAL_KEYS[`${settings.setting}-${settings.direction}`]);
+    this.activeContexts.set(ev.action.id, settings);
+    this.lastRenderedValue.delete(ev.action.id);
+    this.applyActiveBinding(settings);
     await this.updateDisplay(ev, settings);
   }
 
   override async onKeyDown(ev: IDeckKeyDownEvent<SetupChassisSettings>): Promise<void> {
-    this.logger.info("Key down received");
     const settings = this.parseSettings(ev.payload.settings);
+
+    if (isViewSetting(settings.setting)) {
+      this.logger.debug("View sub-mode is read-only, ignoring key press");
+
+      return;
+    }
+
+    this.logger.info("Key down received");
     await this.executeSetting(settings.setting, settings.direction);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<SetupChassisSettings>): Promise<void> {
-    this.logger.info("Dial down received");
     const settings = this.parseSettings(ev.payload.settings);
+
+    if (isViewSetting(settings.setting)) return;
+
+    this.logger.info("Dial down received");
     await this.executeSetting(settings.setting, settings.direction);
   }
 
   override async onDialRotate(ev: IDeckDialRotateEvent<SetupChassisSettings>): Promise<void> {
-    this.logger.info("Dial rotated");
     const settings = this.parseSettings(ev.payload.settings);
 
+    if (isViewSetting(settings.setting)) return;
+
+    this.logger.info("Dial rotated");
     // Clockwise (ticks > 0) = increase, Counter-clockwise (ticks < 0) = decrease
     const direction: DirectionType = ev.payload.ticks > 0 ? "increase" : "decrease";
     await this.executeSetting(settings.setting, direction);
@@ -237,6 +300,16 @@ export class SetupChassis extends ConnectionStateAwareAction<SetupChassisSetting
     const parsed = SetupChassisSettings.safeParse(settings);
 
     return parsed.success ? parsed.data : SetupChassisSettings.parse({});
+  }
+
+  private applyActiveBinding(settings: SetupChassisSettings): void {
+    if (isViewSetting(settings.setting)) {
+      this.setActiveBinding(null);
+
+      return;
+    }
+
+    this.setActiveBinding(SETUP_CHASSIS_GLOBAL_KEYS[`${settings.setting}-${settings.direction}`]);
   }
 
   private async executeSetting(setting: string, direction: DirectionType): Promise<void> {
@@ -255,9 +328,53 @@ export class SetupChassis extends ConnectionStateAwareAction<SetupChassisSetting
     ev: IDeckWillAppearEvent<SetupChassisSettings> | IDeckDidReceiveSettingsEvent<SetupChassisSettings>,
     settings: SetupChassisSettings,
   ): Promise<void> {
-    const svgDataUri = generateSetupChassisSvg(settings);
+    const svgDataUri = this.renderIcon(settings);
+
+    if (isViewSetting(settings.setting)) {
+      const telemetry = this.sdkController.getCurrentTelemetry();
+      this.lastRenderedValue.set(ev.action.id, formatViewValue(settings.setting, telemetry));
+    }
+
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateSetupChassisSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () => this.renderIcon(settings));
+  }
+
+  private renderIcon(settings: SetupChassisSettings): string {
+    if (isViewSetting(settings.setting)) {
+      return generateSetupViewSvg({
+        viewId: settings.setting,
+        telemetry: this.sdkController.getCurrentTelemetry(),
+        colorSourceSvg: differentialPreloadIncreaseIconSvg,
+        colorOverrides: settings.colorOverrides,
+        titleOverrides: settings.titleOverrides,
+        borderOverrides: settings.borderOverrides,
+      });
+    }
+
+    return generateSetupChassisSvg(settings);
+  }
+
+  private async updateDisplayFromTelemetry(
+    contextId: string,
+    telemetry: TelemetryData | null,
+    settings: SetupChassisSettings,
+  ): Promise<void> {
+    if (!isViewSetting(settings.setting)) return;
+
+    const value = formatViewValue(settings.setting, telemetry);
+
+    if (this.lastRenderedValue.get(contextId) === value) return;
+
+    this.lastRenderedValue.set(contextId, value);
+    const svgDataUri = generateSetupViewSvg({
+      viewId: settings.setting,
+      telemetry,
+      colorSourceSvg: differentialPreloadIncreaseIconSvg,
+      colorOverrides: settings.colorOverrides,
+      titleOverrides: settings.titleOverrides,
+      borderOverrides: settings.borderOverrides,
+    });
+    await this.updateKeyImage(contextId, svgDataUri);
   }
 }

--- a/packages/iracing-actions/src/actions/setup-engine/setup-engine.ejs
+++ b/packages/iracing-actions/src/actions/setup-engine/setup-engine.ejs
@@ -7,15 +7,22 @@
 		<%- include('section-header', { title: 'Action Settings' }) %>
 
 		<sdpi-item label="Setting">
-			<sdpi-select setting="setting" default="engine-power">
-				<option value="engine-power">Engine Power</option>
-				<option value="throttle-shaping">Throttle Shaping</option>
-				<option value="boost-level">Boost Level</option>
-				<option value="launch-rpm">Launch RPM</option>
+			<sdpi-select id="setting-select" setting="setting" default="engine-power">
+				<optgroup label="Adjust">
+					<option value="boost-level">Boost Level</option>
+					<option value="engine-power">Engine Power</option>
+					<option value="launch-rpm">Launch RPM</option>
+					<option value="throttle-shaping">Throttle Shaping</option>
+				</optgroup>
+				<optgroup label="Display value">
+					<option value="view-engine-power">View Engine Power</option>
+					<option value="view-launch-rpm">View Launch RPM</option>
+					<option value="view-throttle-shape">View Throttle Shape</option>
+				</optgroup>
 			</sdpi-select>
 		</sdpi-item>
 
-		<sdpi-item label="Direction">
+		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">
 				<option value="increase">Increase</option>
 				<option value="decrease">Decrease</option>
@@ -41,6 +48,53 @@
 		<%- include('global-graphic-defaults') %>
 		<%- include('global-flag-flash') %>
 		<%- include('global-common-settings') %>
+
+		<script>
+			// View sub-modes are read-only — hide Direction when one is selected.
+			function updateVisibility(setting) {
+				const directionItem = document.getElementById("direction-item");
+				if (!directionItem) return;
+				directionItem.classList.toggle("hidden", setting.startsWith("view-"));
+			}
+
+			async function initialize() {
+				await customElements.whenDefined("sdpi-select");
+
+				const settingSelect = document.getElementById("setting-select");
+
+				if (settingSelect) {
+					const initialValue = settingSelect.value || "engine-power";
+					updateVisibility(initialValue);
+
+					settingSelect.addEventListener("change", (ev) => {
+						updateVisibility(ev.target.value || "engine-power");
+					});
+					settingSelect.addEventListener("input", (ev) => {
+						updateVisibility(ev.target.value || "engine-power");
+					});
+
+					// Polling fallback for reliable detection
+					let lastValue = settingSelect.value || "engine-power";
+					setInterval(() => {
+						const currentValue = settingSelect.value;
+						if (currentValue && currentValue !== lastValue) {
+							lastValue = currentValue;
+							updateVisibility(currentValue);
+						}
+					}, 100);
+				}
+			}
+
+			if (document.readyState === "loading") {
+				document.addEventListener("DOMContentLoaded", initialize);
+			} else {
+				initialize();
+			}
+		</script>
+
+		<style>
+			.hidden { display: none !important; }
+		</style>
 
 		<%- include('docs-link') %>
 

--- a/packages/iracing-actions/src/actions/setup-engine/setup-engine.test.ts
+++ b/packages/iracing-actions/src/actions/setup-engine/setup-engine.test.ts
@@ -69,6 +69,15 @@ vi.mock("@iracedeck/deck-core", () => ({
     return b.key;
   }),
   generateBorderParts: vi.fn(() => ({ defs: "", rects: "" })),
+  generateTitleText: vi.fn(({ text, fill }: { text: string; fill: string }) => {
+    if (!text) return "";
+
+    return `<text fill="${fill}">${text}</text>`;
+  }),
+  renderIconTemplate: vi.fn((_template: string, data: Record<string, string>) => {
+    return `<svg>${data.value ?? ""} ${data.titleContent ?? ""}</svg>`;
+  }),
+  svgToDataUri: vi.fn((svg: string) => `data:image/svg+xml,${encodeURIComponent(svg)}`),
   getGlobalBorderSettings: vi.fn(() => ({})),
   getGlobalColors: vi.fn(() => ({})),
   getGlobalGraphicSettings: vi.fn(() => ({})),
@@ -365,6 +374,29 @@ describe("SetupEngine", () => {
       );
 
       expect(mockTapBinding).toHaveBeenCalledWith("setupEngineThrottleShapingIncrease");
+    });
+  });
+
+  describe("view sub-modes (issue #541)", () => {
+    let action: SetupEngine;
+
+    beforeEach(() => {
+      action = new SetupEngine();
+      (action.sdkController.getCurrentTelemetry as any).mockReturnValue({ dcEnginePower: 7 });
+    });
+
+    it("renders the formatted telemetry value for a View setting", async () => {
+      const ev = fakeEvent("action-1", { setting: "view-engine-power" }) as any;
+      await action.onWillAppear(ev);
+      const calls = (action.setKeyImage as any).mock.calls;
+      const svg = decodeURIComponent(calls[0][1] as string);
+      expect(svg).toContain("7");
+    });
+
+    it("does not fire a binding when a View setting is pressed", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-throttle-shape" }) as any);
+
+      expect(mockTapBinding).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/iracing-actions/src/actions/setup-engine/setup-engine.ts
+++ b/packages/iracing-actions/src/actions/setup-engine/setup-engine.ts
@@ -11,6 +11,7 @@ import {
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
   type IDeckWillAppearEvent,
+  type IDeckWillDisappearEvent,
   resolveBorderSettings,
   resolveGraphicSettings,
   resolveIconColors,
@@ -24,9 +25,18 @@ import launchRpmDecreaseIconSvg from "@iracedeck/icons/setup-engine/launch-rpm-d
 import launchRpmIncreaseIconSvg from "@iracedeck/icons/setup-engine/launch-rpm-increase.svg";
 import throttleShapingDecreaseIconSvg from "@iracedeck/icons/setup-engine/throttle-shaping-decrease.svg";
 import throttleShapingIncreaseIconSvg from "@iracedeck/icons/setup-engine/throttle-shaping-increase.svg";
+import type { TelemetryData } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
-type SetupEngineSetting = "engine-power" | "throttle-shaping" | "boost-level" | "launch-rpm";
+import { formatViewValue, generateSetupViewSvg, isViewSetting } from "../../shared/setup-view.js";
+
+type SetupEngineAdjustSetting = "engine-power" | "throttle-shaping" | "boost-level" | "launch-rpm";
+
+/**
+ * The combined `setting` type is the union of `SetupEngineAdjustSetting` and the three
+ * View IDs in `setup-view.ts`. Code paths narrow back to `SetupEngineAdjustSetting`
+ * after `isViewSetting` gates the View branch; nothing needs the full union as a name.
+ */
 
 type DirectionType = "increase" | "decrease";
 
@@ -76,7 +86,19 @@ export const SETUP_ENGINE_GLOBAL_KEYS: Record<string, string> = {
 };
 
 const SetupEngineSettings = CommonSettings.extend({
-  setting: z.enum(["engine-power", "throttle-shaping", "boost-level", "launch-rpm"]).default("engine-power"),
+  setting: z
+    .enum([
+      // View sub-modes.
+      "view-engine-power",
+      "view-throttle-shape",
+      "view-launch-rpm",
+      // Adjustment sub-modes.
+      "engine-power",
+      "throttle-shaping",
+      "boost-level",
+      "launch-rpm",
+    ])
+    .default("engine-power"),
   direction: z.enum(["increase", "decrease"]).default("increase"),
 });
 
@@ -85,10 +107,23 @@ type SetupEngineSettings = z.infer<typeof SetupEngineSettings>;
 /**
  * @internal Exported for testing
  *
- * Generates an SVG data URI icon for the setup engine action.
+ * Generates an SVG data URI icon for the setup engine action's adjustment sub-modes.
+ * View sub-modes use the shared `generateSetupViewSvg` render path.
  */
 export function generateSetupEngineSvg(settings: SetupEngineSettings): string {
-  const { setting, direction } = settings;
+  if (isViewSetting(settings.setting)) {
+    return generateSetupViewSvg({
+      viewId: settings.setting,
+      telemetry: null,
+      colorSourceSvg: enginePowerIncreaseIconSvg,
+      colorOverrides: settings.colorOverrides,
+      titleOverrides: settings.titleOverrides,
+      borderOverrides: settings.borderOverrides,
+    });
+  }
+
+  const setting = settings.setting as SetupEngineAdjustSetting;
+  const { direction } = settings;
 
   const iconKey = `${setting}-${direction}`;
   const iconSvg = SETUP_ENGINE_ICONS[iconKey] || SETUP_ENGINE_ICONS["engine-power-increase"];
@@ -112,36 +147,72 @@ export function generateSetupEngineSvg(settings: SetupEngineSettings): string {
 export const SETUP_ENGINE_UUID = "com.iracedeck.sd.core.setup-engine" as const;
 
 export class SetupEngine extends ConnectionStateAwareAction<SetupEngineSettings> {
+  /** Current settings per action context, used by the telemetry-tick callback for View sub-modes. */
+  private readonly activeContexts = new Map<string, SetupEngineSettings>();
+
+  /** Last rendered View value per context — memoizes the icon so we only re-emit on actual change. */
+  private readonly lastRenderedValue = new Map<string, string>();
+
   override async onWillAppear(ev: IDeckWillAppearEvent<SetupEngineSettings>): Promise<void> {
     await super.onWillAppear(ev);
     const settings = this.parseSettings(ev.payload.settings);
-    this.setActiveBinding(SETUP_ENGINE_GLOBAL_KEYS[`${settings.setting}-${settings.direction}`]);
+    this.activeContexts.set(ev.action.id, settings);
+    this.applyActiveBinding(settings);
     await this.updateDisplay(ev, settings);
+
+    this.sdkController.subscribe(ev.action.id, (telemetry) => {
+      const stored = this.activeContexts.get(ev.action.id);
+
+      if (stored && isViewSetting(stored.setting)) {
+        void this.updateDisplayFromTelemetry(ev.action.id, telemetry, stored);
+      }
+    });
+  }
+
+  override async onWillDisappear(ev: IDeckWillDisappearEvent<SetupEngineSettings>): Promise<void> {
+    this.sdkController.unsubscribe(ev.action.id);
+    this.activeContexts.delete(ev.action.id);
+    this.lastRenderedValue.delete(ev.action.id);
+    await super.onWillDisappear(ev);
   }
 
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<SetupEngineSettings>): Promise<void> {
     await super.onDidReceiveSettings(ev);
     const settings = this.parseSettings(ev.payload.settings);
-    this.setActiveBinding(SETUP_ENGINE_GLOBAL_KEYS[`${settings.setting}-${settings.direction}`]);
+    this.activeContexts.set(ev.action.id, settings);
+    this.lastRenderedValue.delete(ev.action.id);
+    this.applyActiveBinding(settings);
     await this.updateDisplay(ev, settings);
   }
 
   override async onKeyDown(ev: IDeckKeyDownEvent<SetupEngineSettings>): Promise<void> {
-    this.logger.info("Key down received");
     const settings = this.parseSettings(ev.payload.settings);
+
+    if (isViewSetting(settings.setting)) {
+      this.logger.debug("View sub-mode is read-only, ignoring key press");
+
+      return;
+    }
+
+    this.logger.info("Key down received");
     await this.executeSetting(settings.setting, settings.direction);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<SetupEngineSettings>): Promise<void> {
-    this.logger.info("Dial down received");
     const settings = this.parseSettings(ev.payload.settings);
+
+    if (isViewSetting(settings.setting)) return;
+
+    this.logger.info("Dial down received");
     await this.executeSetting(settings.setting, settings.direction);
   }
 
   override async onDialRotate(ev: IDeckDialRotateEvent<SetupEngineSettings>): Promise<void> {
-    this.logger.info("Dial rotated");
     const settings = this.parseSettings(ev.payload.settings);
 
+    if (isViewSetting(settings.setting)) return;
+
+    this.logger.info("Dial rotated");
     // Clockwise (ticks > 0) = increase, Counter-clockwise (ticks < 0) = decrease
     const direction: DirectionType = ev.payload.ticks > 0 ? "increase" : "decrease";
     await this.executeSetting(settings.setting, direction);
@@ -153,7 +224,17 @@ export class SetupEngine extends ConnectionStateAwareAction<SetupEngineSettings>
     return parsed.success ? parsed.data : SetupEngineSettings.parse({});
   }
 
-  private async executeSetting(setting: SetupEngineSetting, direction: DirectionType): Promise<void> {
+  private applyActiveBinding(settings: SetupEngineSettings): void {
+    if (isViewSetting(settings.setting)) {
+      this.setActiveBinding(null);
+
+      return;
+    }
+
+    this.setActiveBinding(SETUP_ENGINE_GLOBAL_KEYS[`${settings.setting}-${settings.direction}`]);
+  }
+
+  private async executeSetting(setting: SetupEngineAdjustSetting, direction: DirectionType): Promise<void> {
     const settingKey = SETUP_ENGINE_GLOBAL_KEYS[`${setting}-${direction}`];
 
     if (!settingKey) {
@@ -169,9 +250,53 @@ export class SetupEngine extends ConnectionStateAwareAction<SetupEngineSettings>
     ev: IDeckWillAppearEvent<SetupEngineSettings> | IDeckDidReceiveSettingsEvent<SetupEngineSettings>,
     settings: SetupEngineSettings,
   ): Promise<void> {
-    const svgDataUri = generateSetupEngineSvg(settings);
+    const svgDataUri = this.renderIcon(settings);
+
+    if (isViewSetting(settings.setting)) {
+      const telemetry = this.sdkController.getCurrentTelemetry();
+      this.lastRenderedValue.set(ev.action.id, formatViewValue(settings.setting, telemetry));
+    }
+
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateSetupEngineSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () => this.renderIcon(settings));
+  }
+
+  private renderIcon(settings: SetupEngineSettings): string {
+    if (isViewSetting(settings.setting)) {
+      return generateSetupViewSvg({
+        viewId: settings.setting,
+        telemetry: this.sdkController.getCurrentTelemetry(),
+        colorSourceSvg: enginePowerIncreaseIconSvg,
+        colorOverrides: settings.colorOverrides,
+        titleOverrides: settings.titleOverrides,
+        borderOverrides: settings.borderOverrides,
+      });
+    }
+
+    return generateSetupEngineSvg(settings);
+  }
+
+  private async updateDisplayFromTelemetry(
+    contextId: string,
+    telemetry: TelemetryData | null,
+    settings: SetupEngineSettings,
+  ): Promise<void> {
+    if (!isViewSetting(settings.setting)) return;
+
+    const value = formatViewValue(settings.setting, telemetry);
+
+    if (this.lastRenderedValue.get(contextId) === value) return;
+
+    this.lastRenderedValue.set(contextId, value);
+    const svgDataUri = generateSetupViewSvg({
+      viewId: settings.setting,
+      telemetry,
+      colorSourceSvg: enginePowerIncreaseIconSvg,
+      colorOverrides: settings.colorOverrides,
+      titleOverrides: settings.titleOverrides,
+      borderOverrides: settings.borderOverrides,
+    });
+    await this.updateKeyImage(contextId, svgDataUri);
   }
 }

--- a/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.ejs
+++ b/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.ejs
@@ -8,11 +8,17 @@
 
 		<sdpi-item label="Setting">
 			<sdpi-select id="setting-select" setting="setting" default="fuel-mixture">
-				<option value="fuel-mixture">Fuel Mixture</option>
-				<option value="fuel-cut-position">Fuel Cut Position</option>
-				<option value="disable-fuel-cut">Disable Fuel Cut</option>
-				<option value="low-fuel-accept">Low Fuel Accept</option>
-				<option value="fcy-mode-toggle">FCY Mode Toggle</option>
+				<optgroup label="Adjust">
+					<option value="disable-fuel-cut">Disable Fuel Cut</option>
+					<option value="fcy-mode-toggle">FCY Mode Toggle</option>
+					<option value="fuel-cut-position">Fuel Cut Position</option>
+					<option value="fuel-mixture">Fuel Mixture</option>
+					<option value="low-fuel-accept">Low Fuel Accept</option>
+				</optgroup>
+				<optgroup label="Display value">
+					<option value="view-fuel-cut-position">View Fuel Cut Position</option>
+					<option value="view-fuel-mixture">View Fuel Mixture</option>
+				</optgroup>
 			</sdpi-select>
 		</sdpi-item>
 
@@ -44,13 +50,14 @@
 		<%- include('global-common-settings') %>
 
 		<script>
-			// Non-directional controls: hide direction dropdown
+			// Non-directional controls: hide direction dropdown. View sub-modes also hide it (read-only).
 			const NON_DIRECTIONAL = new Set(["disable-fuel-cut", "low-fuel-accept", "fcy-mode-toggle"]);
 
 			function updateVisibility(setting) {
 				const directionItem = document.getElementById("direction-item");
 				if (!directionItem) return;
-				directionItem.classList.toggle("hidden", NON_DIRECTIONAL.has(setting));
+				const hide = NON_DIRECTIONAL.has(setting) || setting.startsWith("view-");
+				directionItem.classList.toggle("hidden", hide);
 			}
 
 			async function initialize() {

--- a/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.test.ts
+++ b/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.test.ts
@@ -65,6 +65,15 @@ vi.mock("@iracedeck/deck-core", () => ({
     return b.key;
   }),
   generateBorderParts: vi.fn(() => ({ defs: "", rects: "" })),
+  generateTitleText: vi.fn(({ text, fill }: { text: string; fill: string }) => {
+    if (!text) return "";
+
+    return `<text fill="${fill}">${text}</text>`;
+  }),
+  renderIconTemplate: vi.fn((_template: string, data: Record<string, string>) => {
+    return `<svg>${data.value ?? ""} ${data.titleContent ?? ""}</svg>`;
+  }),
+  svgToDataUri: vi.fn((svg: string) => `data:image/svg+xml,${encodeURIComponent(svg)}`),
   getGlobalBorderSettings: vi.fn(() => ({})),
   getGlobalColors: vi.fn(() => ({})),
   getGlobalGraphicSettings: vi.fn(() => ({})),
@@ -450,6 +459,29 @@ describe("SetupFuel", () => {
 
     it("should ignore rotation for non-directional controls (fcy-mode-toggle)", async () => {
       await action.onDialRotate(fakeDialRotateEvent("action-1", { setting: "fcy-mode-toggle" }, -1) as any);
+
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("view sub-modes (issue #541)", () => {
+    let action: SetupFuel;
+
+    beforeEach(() => {
+      action = new SetupFuel();
+      (action.sdkController.getCurrentTelemetry as any).mockReturnValue({ dcFuelMixture: 5 });
+    });
+
+    it("renders the formatted telemetry value for a View setting", async () => {
+      const ev = fakeEvent("action-1", { setting: "view-fuel-mixture" }) as any;
+      await action.onWillAppear(ev);
+      const calls = (action.setKeyImage as any).mock.calls;
+      const svg = decodeURIComponent(calls[0][1] as string);
+      expect(svg).toContain("5");
+    });
+
+    it("does not fire a binding when a View setting is pressed", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-fuel-cut-position" }) as any);
 
       expect(mockTapBinding).not.toHaveBeenCalled();
     });

--- a/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.ts
+++ b/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.ts
@@ -11,6 +11,7 @@ import {
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
   type IDeckWillAppearEvent,
+  type IDeckWillDisappearEvent,
   resolveBorderSettings,
   resolveGraphicSettings,
   resolveIconColors,
@@ -23,19 +24,28 @@ import fuelCutPositionIncreaseIconSvg from "@iracedeck/icons/setup-fuel/fuel-cut
 import fuelMixtureDecreaseIconSvg from "@iracedeck/icons/setup-fuel/fuel-mixture-decrease.svg";
 import fuelMixtureIncreaseIconSvg from "@iracedeck/icons/setup-fuel/fuel-mixture-increase.svg";
 import lowFuelAcceptIconSvg from "@iracedeck/icons/setup-fuel/low-fuel-accept.svg";
+import type { TelemetryData } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
-type SetupFuelSetting =
+import { formatViewValue, generateSetupViewSvg, isViewSetting } from "../../shared/setup-view.js";
+
+type SetupFuelAdjustSetting =
   | "fuel-mixture"
   | "fuel-cut-position"
   | "disable-fuel-cut"
   | "low-fuel-accept"
   | "fcy-mode-toggle";
 
+/**
+ * The combined `setting` type is the union of `SetupFuelAdjustSetting` and the two View
+ * IDs in `setup-view.ts`. Code paths narrow back to `SetupFuelAdjustSetting` after
+ * `isViewSetting` gates the View branch; nothing needs the full union as a name.
+ */
+
 type DirectionType = "increase" | "decrease";
 
 /** Controls that have +/- direction */
-const DIRECTIONAL_CONTROLS: Set<SetupFuelSetting> = new Set(["fuel-mixture", "fuel-cut-position"]);
+const DIRECTIONAL_CONTROLS: Set<SetupFuelAdjustSetting> = new Set(["fuel-mixture", "fuel-cut-position"]);
 
 /**
  * Flat icon lookup record mapping setting + direction keys to imported SVGs.
@@ -81,7 +91,17 @@ export const SETUP_FUEL_GLOBAL_KEYS: Record<string, string> = {
 
 const SetupFuelSettings = CommonSettings.extend({
   setting: z
-    .enum(["fuel-mixture", "fuel-cut-position", "disable-fuel-cut", "low-fuel-accept", "fcy-mode-toggle"])
+    .enum([
+      // View sub-modes.
+      "view-fuel-mixture",
+      "view-fuel-cut-position",
+      // Adjustment sub-modes.
+      "fuel-mixture",
+      "fuel-cut-position",
+      "disable-fuel-cut",
+      "low-fuel-accept",
+      "fcy-mode-toggle",
+    ])
     .default("fuel-mixture"),
   direction: z.enum(["increase", "decrease"]).default("increase"),
 });
@@ -91,10 +111,23 @@ type SetupFuelSettings = z.infer<typeof SetupFuelSettings>;
 /**
  * @internal Exported for testing
  *
- * Generates an SVG data URI icon for the setup fuel action.
+ * Generates an SVG data URI icon for the setup fuel action's adjustment sub-modes.
+ * View sub-modes use the shared `generateSetupViewSvg` render path.
  */
 export function generateSetupFuelSvg(settings: SetupFuelSettings): string {
-  const { setting, direction } = settings;
+  if (isViewSetting(settings.setting)) {
+    return generateSetupViewSvg({
+      viewId: settings.setting,
+      telemetry: null,
+      colorSourceSvg: fuelMixtureIncreaseIconSvg,
+      colorOverrides: settings.colorOverrides,
+      titleOverrides: settings.titleOverrides,
+      borderOverrides: settings.borderOverrides,
+    });
+  }
+
+  const setting = settings.setting as SetupFuelAdjustSetting;
+  const { direction } = settings;
 
   const iconKey = DIRECTIONAL_CONTROLS.has(setting) ? `${setting}-${direction}` : setting;
   const iconSvg = SETUP_FUEL_ICONS[iconKey] || SETUP_FUEL_ICONS["disable-fuel-cut"];
@@ -118,56 +151,84 @@ export function generateSetupFuelSvg(settings: SetupFuelSettings): string {
 export const SETUP_FUEL_UUID = "com.iracedeck.sd.core.setup-fuel" as const;
 
 export class SetupFuel extends ConnectionStateAwareAction<SetupFuelSettings> {
+  /** Current settings per action context, used by the telemetry-tick callback for View sub-modes. */
+  private readonly activeContexts = new Map<string, SetupFuelSettings>();
+
+  /** Last rendered View value per context — memoizes the icon so we only re-emit on actual change. */
+  private readonly lastRenderedValue = new Map<string, string>();
+
   override async onWillAppear(ev: IDeckWillAppearEvent<SetupFuelSettings>): Promise<void> {
     await super.onWillAppear(ev);
     const settings = this.parseSettings(ev.payload.settings);
-    const activeKey = this.resolveGlobalKey(settings.setting, settings.direction);
-
-    if (activeKey) {
-      this.setActiveBinding(activeKey);
-    }
-
+    this.activeContexts.set(ev.action.id, settings);
+    this.applyActiveBinding(settings);
     await this.updateDisplay(ev, settings);
+
+    this.sdkController.subscribe(ev.action.id, (telemetry) => {
+      const stored = this.activeContexts.get(ev.action.id);
+
+      if (stored && isViewSetting(stored.setting)) {
+        void this.updateDisplayFromTelemetry(ev.action.id, telemetry, stored);
+      }
+    });
+  }
+
+  override async onWillDisappear(ev: IDeckWillDisappearEvent<SetupFuelSettings>): Promise<void> {
+    this.sdkController.unsubscribe(ev.action.id);
+    this.activeContexts.delete(ev.action.id);
+    this.lastRenderedValue.delete(ev.action.id);
+    await super.onWillDisappear(ev);
   }
 
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<SetupFuelSettings>): Promise<void> {
     await super.onDidReceiveSettings(ev);
     const settings = this.parseSettings(ev.payload.settings);
-    const activeKey = this.resolveGlobalKey(settings.setting, settings.direction);
-
-    if (activeKey) {
-      this.setActiveBinding(activeKey);
-    }
-
+    this.activeContexts.set(ev.action.id, settings);
+    this.lastRenderedValue.delete(ev.action.id);
+    this.applyActiveBinding(settings);
     await this.updateDisplay(ev, settings);
   }
 
   override async onKeyDown(ev: IDeckKeyDownEvent<SetupFuelSettings>): Promise<void> {
-    this.logger.info("Key down received");
     const settings = this.parseSettings(ev.payload.settings);
+
+    if (isViewSetting(settings.setting)) {
+      this.logger.debug("View sub-mode is read-only, ignoring key press");
+
+      return;
+    }
+
+    this.logger.info("Key down received");
     await this.executeSetting(settings.setting, settings.direction);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<SetupFuelSettings>): Promise<void> {
-    this.logger.info("Dial down received");
     const settings = this.parseSettings(ev.payload.settings);
+
+    if (isViewSetting(settings.setting)) return;
+
+    this.logger.info("Dial down received");
     await this.executeSetting(settings.setting, settings.direction);
   }
 
   override async onDialRotate(ev: IDeckDialRotateEvent<SetupFuelSettings>): Promise<void> {
-    this.logger.info("Dial rotated");
     const settings = this.parseSettings(ev.payload.settings);
 
+    if (isViewSetting(settings.setting)) return;
+
+    this.logger.info("Dial rotated");
+    const adjustSetting = settings.setting as SetupFuelAdjustSetting;
+
     // Non-directional controls have no +/- adjustment — ignore rotation
-    if (!DIRECTIONAL_CONTROLS.has(settings.setting)) {
-      this.logger.debug(`Rotation ignored for ${settings.setting}`);
+    if (!DIRECTIONAL_CONTROLS.has(adjustSetting)) {
+      this.logger.debug(`Rotation ignored for ${adjustSetting}`);
 
       return;
     }
 
     // Clockwise (ticks > 0) = increase, Counter-clockwise (ticks < 0) = decrease
     const direction: DirectionType = ev.payload.ticks > 0 ? "increase" : "decrease";
-    await this.executeSetting(settings.setting, direction);
+    await this.executeSetting(adjustSetting, direction);
   }
 
   private parseSettings(settings: unknown): SetupFuelSettings {
@@ -176,7 +237,21 @@ export class SetupFuel extends ConnectionStateAwareAction<SetupFuelSettings> {
     return parsed.success ? parsed.data : SetupFuelSettings.parse({});
   }
 
-  private async executeSetting(setting: SetupFuelSetting, direction: DirectionType): Promise<void> {
+  private applyActiveBinding(settings: SetupFuelSettings): void {
+    if (isViewSetting(settings.setting)) {
+      this.setActiveBinding(null);
+
+      return;
+    }
+
+    const activeKey = this.resolveGlobalKey(settings.setting, settings.direction);
+
+    if (activeKey) {
+      this.setActiveBinding(activeKey);
+    }
+  }
+
+  private async executeSetting(setting: SetupFuelAdjustSetting, direction: DirectionType): Promise<void> {
     const settingKey = this.resolveGlobalKey(setting, direction);
 
     if (!settingKey) {
@@ -188,7 +263,7 @@ export class SetupFuel extends ConnectionStateAwareAction<SetupFuelSettings> {
     await this.tapBinding(settingKey);
   }
 
-  private resolveGlobalKey(setting: SetupFuelSetting, direction: DirectionType): string | null {
+  private resolveGlobalKey(setting: SetupFuelAdjustSetting, direction: DirectionType): string | null {
     if (DIRECTIONAL_CONTROLS.has(setting)) {
       const key = `${setting}-${direction}`;
 
@@ -202,9 +277,53 @@ export class SetupFuel extends ConnectionStateAwareAction<SetupFuelSettings> {
     ev: IDeckWillAppearEvent<SetupFuelSettings> | IDeckDidReceiveSettingsEvent<SetupFuelSettings>,
     settings: SetupFuelSettings,
   ): Promise<void> {
-    const svgDataUri = generateSetupFuelSvg(settings);
+    const svgDataUri = this.renderIcon(settings);
+
+    if (isViewSetting(settings.setting)) {
+      const telemetry = this.sdkController.getCurrentTelemetry();
+      this.lastRenderedValue.set(ev.action.id, formatViewValue(settings.setting, telemetry));
+    }
+
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateSetupFuelSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () => this.renderIcon(settings));
+  }
+
+  private renderIcon(settings: SetupFuelSettings): string {
+    if (isViewSetting(settings.setting)) {
+      return generateSetupViewSvg({
+        viewId: settings.setting,
+        telemetry: this.sdkController.getCurrentTelemetry(),
+        colorSourceSvg: fuelMixtureIncreaseIconSvg,
+        colorOverrides: settings.colorOverrides,
+        titleOverrides: settings.titleOverrides,
+        borderOverrides: settings.borderOverrides,
+      });
+    }
+
+    return generateSetupFuelSvg(settings);
+  }
+
+  private async updateDisplayFromTelemetry(
+    contextId: string,
+    telemetry: TelemetryData | null,
+    settings: SetupFuelSettings,
+  ): Promise<void> {
+    if (!isViewSetting(settings.setting)) return;
+
+    const value = formatViewValue(settings.setting, telemetry);
+
+    if (this.lastRenderedValue.get(contextId) === value) return;
+
+    this.lastRenderedValue.set(contextId, value);
+    const svgDataUri = generateSetupViewSvg({
+      viewId: settings.setting,
+      telemetry,
+      colorSourceSvg: fuelMixtureIncreaseIconSvg,
+      colorOverrides: settings.colorOverrides,
+      titleOverrides: settings.titleOverrides,
+      borderOverrides: settings.borderOverrides,
+    });
+    await this.updateKeyImage(contextId, svgDataUri);
   }
 }

--- a/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.ejs
+++ b/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.ejs
@@ -8,12 +8,19 @@
 
 		<sdpi-item label="Setting">
 			<sdpi-select id="setting-select" setting="setting" default="mguk-regen-gain">
-				<option value="mguk-regen-gain">MGU-K Re-Gen Gain</option>
-				<option value="mguk-deploy-mode">MGU-K Deploy Mode</option>
-				<option value="mguk-fixed-deploy">MGU-K Fixed Deploy</option>
-				<option value="hys-boost">HYS Boost</option>
-				<option value="hys-regen">HYS Regen</option>
-				<option value="hys-no-boost">HYS No Boost</option>
+				<optgroup label="Adjust">
+					<option value="hys-boost">HYS Boost</option>
+					<option value="hys-no-boost">HYS No Boost</option>
+					<option value="hys-regen">HYS Regen</option>
+					<option value="mguk-deploy-mode">MGU-K Deploy Mode</option>
+					<option value="mguk-fixed-deploy">MGU-K Fixed Deploy</option>
+					<option value="mguk-regen-gain">MGU-K Re-Gen Gain</option>
+				</optgroup>
+				<optgroup label="Display value">
+					<option value="view-mguk-deploy-fixed">View MGU-K Deploy Fixed</option>
+					<option value="view-mguk-deploy-mode">View MGU-K Deploy Mode</option>
+					<option value="view-mguk-regen-gain">View MGU-K Regen Gain</option>
+				</optgroup>
 			</sdpi-select>
 		</sdpi-item>
 
@@ -50,7 +57,8 @@
 			function updateVisibility(setting) {
 				const directionItem = document.getElementById("direction-item");
 				if (!directionItem) return;
-				directionItem.classList.toggle("hidden", NON_DIRECTIONAL.has(setting));
+				const hide = NON_DIRECTIONAL.has(setting) || setting.startsWith("view-");
+				directionItem.classList.toggle("hidden", hide);
 			}
 
 			async function initialize() {

--- a/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.test.ts
+++ b/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.test.ts
@@ -73,6 +73,15 @@ vi.mock("@iracedeck/deck-core", () => ({
     return b.key;
   }),
   generateBorderParts: vi.fn(() => ({ defs: "", rects: "" })),
+  generateTitleText: vi.fn(({ text, fill }: { text: string; fill: string }) => {
+    if (!text) return "";
+
+    return `<text fill="${fill}">${text}</text>`;
+  }),
+  renderIconTemplate: vi.fn((_template: string, data: Record<string, string>) => {
+    return `<svg>${data.value ?? ""} ${data.titleContent ?? ""}</svg>`;
+  }),
+  svgToDataUri: vi.fn((svg: string) => `data:image/svg+xml,${encodeURIComponent(svg)}`),
   getGlobalBorderSettings: vi.fn(() => ({})),
   getGlobalColors: vi.fn(() => ({})),
   getGlobalGraphicSettings: vi.fn(() => ({})),
@@ -513,6 +522,30 @@ describe("SetupHybrid", () => {
       await action.onDialRotate(fakeDialRotateEvent("action-1", { setting: "hys-no-boost" }, 1) as any);
 
       expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("view sub-modes (issue #541)", () => {
+    let action: SetupHybrid;
+
+    beforeEach(() => {
+      action = new SetupHybrid();
+      (action.sdkController.getCurrentTelemetry as any).mockReturnValue({ dcMGUKDeployMode: 2 });
+    });
+
+    it("renders the formatted telemetry value for a View setting", async () => {
+      const ev = fakeEvent("action-1", { setting: "view-mguk-deploy-mode" }) as any;
+      await action.onWillAppear(ev);
+      const calls = (action.setKeyImage as any).mock.calls;
+      const svg = decodeURIComponent(calls[0][1] as string);
+      expect(svg).toContain("2");
+    });
+
+    it("does not fire a binding (tap or hold) when a View setting is pressed", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-mguk-deploy-mode" }) as any);
+
+      expect(mockTapBinding).not.toHaveBeenCalled();
+      expect(mockHoldBinding).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.ts
+++ b/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.ts
@@ -28,9 +28,12 @@ import mgukFixedDeployDecreaseIconSvg from "@iracedeck/icons/setup-hybrid/mguk-f
 import mgukFixedDeployIncreaseIconSvg from "@iracedeck/icons/setup-hybrid/mguk-fixed-deploy-increase.svg";
 import mgukRegenGainDecreaseIconSvg from "@iracedeck/icons/setup-hybrid/mguk-regen-gain-decrease.svg";
 import mgukRegenGainIncreaseIconSvg from "@iracedeck/icons/setup-hybrid/mguk-regen-gain-increase.svg";
+import type { TelemetryData } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
-type SetupHybridSetting =
+import { formatViewValue, generateSetupViewSvg, isViewSetting } from "../../shared/setup-view.js";
+
+type SetupHybridAdjustSetting =
   | "mguk-regen-gain"
   | "mguk-deploy-mode"
   | "mguk-fixed-deploy"
@@ -38,17 +41,23 @@ type SetupHybridSetting =
   | "hys-regen"
   | "hys-no-boost";
 
+/**
+ * The combined `setting` type is the union of `SetupHybridAdjustSetting` and the three
+ * View IDs in `setup-view.ts`. Code paths narrow back to `SetupHybridAdjustSetting`
+ * after `isViewSetting` gates the View branch; nothing needs the full union as a name.
+ */
+
 type DirectionType = "increase" | "decrease";
 
 /** Controls that have +/- direction */
-const DIRECTIONAL_CONTROLS: Set<SetupHybridSetting> = new Set([
+const DIRECTIONAL_CONTROLS: Set<SetupHybridAdjustSetting> = new Set([
   "mguk-regen-gain",
   "mguk-deploy-mode",
   "mguk-fixed-deploy",
 ]);
 
 /** Controls that use long-press hold behavior */
-const HOLD_CONTROLS: Set<SetupHybridSetting> = new Set(["hys-boost", "hys-regen"]);
+const HOLD_CONTROLS: Set<SetupHybridAdjustSetting> = new Set(["hys-boost", "hys-regen"]);
 
 /**
  * Flat icon lookup record mapping setting + direction keys to standalone SVG templates.
@@ -101,6 +110,11 @@ export const SETUP_HYBRID_GLOBAL_KEYS: Record<string, string> = {
 const SetupHybridSettings = CommonSettings.extend({
   setting: z
     .enum([
+      // View sub-modes.
+      "view-mguk-deploy-mode",
+      "view-mguk-regen-gain",
+      "view-mguk-deploy-fixed",
+      // Adjustment sub-modes.
       "mguk-regen-gain",
       "mguk-deploy-mode",
       "mguk-fixed-deploy",
@@ -115,9 +129,10 @@ const SetupHybridSettings = CommonSettings.extend({
 type SetupHybridSettings = z.infer<typeof SetupHybridSettings>;
 
 /**
- * Resolves the flat icon lookup key from setting and direction.
+ * Resolves the flat icon lookup key from adjustment setting and direction.
+ * View sub-modes use a separate render path.
  */
-function resolveIconKey(setting: SetupHybridSetting, direction: DirectionType): string {
+function resolveIconKey(setting: SetupHybridAdjustSetting, direction: DirectionType): string {
   if (DIRECTIONAL_CONTROLS.has(setting)) {
     return `${setting}-${direction}`;
   }
@@ -128,10 +143,23 @@ function resolveIconKey(setting: SetupHybridSetting, direction: DirectionType): 
 /**
  * @internal Exported for testing
  *
- * Generates an SVG data URI icon for the setup hybrid action.
+ * Generates an SVG data URI icon for the setup hybrid action's adjustment sub-modes.
+ * View sub-modes use the shared `generateSetupViewSvg` render path.
  */
 export function generateSetupHybridSvg(settings: SetupHybridSettings): string {
-  const iconKey = resolveIconKey(settings.setting, settings.direction);
+  if (isViewSetting(settings.setting)) {
+    return generateSetupViewSvg({
+      viewId: settings.setting,
+      telemetry: null,
+      colorSourceSvg: mgukRegenGainIncreaseIconSvg,
+      colorOverrides: settings.colorOverrides,
+      titleOverrides: settings.titleOverrides,
+      borderOverrides: settings.borderOverrides,
+    });
+  }
+
+  const setting = settings.setting as SetupHybridAdjustSetting;
+  const iconKey = resolveIconKey(setting, settings.direction);
 
   const iconSvg = SETUP_HYBRID_ICONS[iconKey] || SETUP_HYBRID_ICONS["hys-boost"];
   const defaultTitle = SETUP_HYBRID_TITLES[iconKey] || "SETUP\nHYBRID";
@@ -155,19 +183,32 @@ export function generateSetupHybridSvg(settings: SetupHybridSettings): string {
 export const SETUP_HYBRID_UUID = "com.iracedeck.sd.core.setup-hybrid" as const;
 
 export class SetupHybrid extends ConnectionStateAwareAction<SetupHybridSettings> {
+  /** Current settings per action context, used by the telemetry-tick callback for View sub-modes. */
+  private readonly activeContexts = new Map<string, SetupHybridSettings>();
+
+  /** Last rendered View value per context — memoizes the icon so we only re-emit on actual change. */
+  private readonly lastRenderedValue = new Map<string, string>();
+
   override async onWillAppear(ev: IDeckWillAppearEvent<SetupHybridSettings>): Promise<void> {
     await super.onWillAppear(ev);
     const settings = this.parseSettings(ev.payload.settings);
-    const activeKey = this.resolveGlobalKey(settings.setting, settings.direction);
-
-    if (activeKey) {
-      this.setActiveBinding(activeKey);
-    }
-
+    this.activeContexts.set(ev.action.id, settings);
+    this.applyActiveBinding(settings);
     await this.updateDisplay(ev, settings);
+
+    this.sdkController.subscribe(ev.action.id, (telemetry) => {
+      const stored = this.activeContexts.get(ev.action.id);
+
+      if (stored && isViewSetting(stored.setting)) {
+        void this.updateDisplayFromTelemetry(ev.action.id, telemetry, stored);
+      }
+    });
   }
 
   override async onWillDisappear(ev: IDeckWillDisappearEvent<SetupHybridSettings>): Promise<void> {
+    this.sdkController.unsubscribe(ev.action.id);
+    this.activeContexts.delete(ev.action.id);
+    this.lastRenderedValue.delete(ev.action.id);
     await this.releaseBinding(ev.action.id);
     await super.onWillDisappear(ev);
   }
@@ -175,27 +216,32 @@ export class SetupHybrid extends ConnectionStateAwareAction<SetupHybridSettings>
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<SetupHybridSettings>): Promise<void> {
     await super.onDidReceiveSettings(ev);
     const settings = this.parseSettings(ev.payload.settings);
-    const activeKey = this.resolveGlobalKey(settings.setting, settings.direction);
-
-    if (activeKey) {
-      this.setActiveBinding(activeKey);
-    }
-
+    this.activeContexts.set(ev.action.id, settings);
+    this.lastRenderedValue.delete(ev.action.id);
+    this.applyActiveBinding(settings);
     await this.updateDisplay(ev, settings);
   }
 
   override async onKeyDown(ev: IDeckKeyDownEvent<SetupHybridSettings>): Promise<void> {
-    this.logger.info("Key down received");
     const settings = this.parseSettings(ev.payload.settings);
 
-    if (HOLD_CONTROLS.has(settings.setting)) {
-      const settingKey = this.resolveGlobalKey(settings.setting, "increase");
+    if (isViewSetting(settings.setting)) {
+      this.logger.debug("View sub-mode is read-only, ignoring key press");
+
+      return;
+    }
+
+    this.logger.info("Key down received");
+    const adjustSetting = settings.setting as SetupHybridAdjustSetting;
+
+    if (HOLD_CONTROLS.has(adjustSetting)) {
+      const settingKey = this.resolveGlobalKey(adjustSetting, "increase");
 
       if (settingKey) {
         await this.holdBinding(ev.action.id, settingKey);
       }
     } else {
-      await this.executeTap(settings.setting, settings.direction);
+      await this.executeTap(adjustSetting, settings.direction);
     }
   }
 
@@ -205,17 +251,21 @@ export class SetupHybrid extends ConnectionStateAwareAction<SetupHybridSettings>
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<SetupHybridSettings>): Promise<void> {
-    this.logger.info("Dial down received");
     const settings = this.parseSettings(ev.payload.settings);
 
-    if (HOLD_CONTROLS.has(settings.setting)) {
-      const settingKey = this.resolveGlobalKey(settings.setting, "increase");
+    if (isViewSetting(settings.setting)) return;
+
+    this.logger.info("Dial down received");
+    const adjustSetting = settings.setting as SetupHybridAdjustSetting;
+
+    if (HOLD_CONTROLS.has(adjustSetting)) {
+      const settingKey = this.resolveGlobalKey(adjustSetting, "increase");
 
       if (settingKey) {
         await this.holdBinding(ev.action.id, settingKey);
       }
     } else {
-      await this.executeTap(settings.setting, settings.direction);
+      await this.executeTap(adjustSetting, settings.direction);
     }
   }
 
@@ -225,17 +275,21 @@ export class SetupHybrid extends ConnectionStateAwareAction<SetupHybridSettings>
   }
 
   override async onDialRotate(ev: IDeckDialRotateEvent<SetupHybridSettings>): Promise<void> {
-    this.logger.info("Dial rotated");
     const settings = this.parseSettings(ev.payload.settings);
 
-    if (!DIRECTIONAL_CONTROLS.has(settings.setting)) {
-      this.logger.debug(`Rotation ignored for ${settings.setting}`);
+    if (isViewSetting(settings.setting)) return;
+
+    this.logger.info("Dial rotated");
+    const adjustSetting = settings.setting as SetupHybridAdjustSetting;
+
+    if (!DIRECTIONAL_CONTROLS.has(adjustSetting)) {
+      this.logger.debug(`Rotation ignored for ${adjustSetting}`);
 
       return;
     }
 
     const direction: DirectionType = ev.payload.ticks > 0 ? "increase" : "decrease";
-    await this.executeTap(settings.setting, direction);
+    await this.executeTap(adjustSetting, direction);
   }
 
   private parseSettings(settings: unknown): SetupHybridSettings {
@@ -244,7 +298,21 @@ export class SetupHybrid extends ConnectionStateAwareAction<SetupHybridSettings>
     return parsed.success ? parsed.data : SetupHybridSettings.parse({});
   }
 
-  private resolveGlobalKey(setting: SetupHybridSetting, direction: DirectionType): string | null {
+  private applyActiveBinding(settings: SetupHybridSettings): void {
+    if (isViewSetting(settings.setting)) {
+      this.setActiveBinding(null);
+
+      return;
+    }
+
+    const activeKey = this.resolveGlobalKey(settings.setting, settings.direction);
+
+    if (activeKey) {
+      this.setActiveBinding(activeKey);
+    }
+  }
+
+  private resolveGlobalKey(setting: SetupHybridAdjustSetting, direction: DirectionType): string | null {
     if (DIRECTIONAL_CONTROLS.has(setting)) {
       const key = `${setting}-${direction}`;
 
@@ -254,7 +322,7 @@ export class SetupHybrid extends ConnectionStateAwareAction<SetupHybridSettings>
     return SETUP_HYBRID_GLOBAL_KEYS[setting] ?? null;
   }
 
-  private async executeTap(setting: SetupHybridSetting, direction: DirectionType): Promise<void> {
+  private async executeTap(setting: SetupHybridAdjustSetting, direction: DirectionType): Promise<void> {
     const settingKey = this.resolveGlobalKey(setting, direction);
 
     if (!settingKey) {
@@ -270,9 +338,53 @@ export class SetupHybrid extends ConnectionStateAwareAction<SetupHybridSettings>
     ev: IDeckWillAppearEvent<SetupHybridSettings> | IDeckDidReceiveSettingsEvent<SetupHybridSettings>,
     settings: SetupHybridSettings,
   ): Promise<void> {
-    const svgDataUri = generateSetupHybridSvg(settings);
+    const svgDataUri = this.renderIcon(settings);
+
+    if (isViewSetting(settings.setting)) {
+      const telemetry = this.sdkController.getCurrentTelemetry();
+      this.lastRenderedValue.set(ev.action.id, formatViewValue(settings.setting, telemetry));
+    }
+
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateSetupHybridSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () => this.renderIcon(settings));
+  }
+
+  private renderIcon(settings: SetupHybridSettings): string {
+    if (isViewSetting(settings.setting)) {
+      return generateSetupViewSvg({
+        viewId: settings.setting,
+        telemetry: this.sdkController.getCurrentTelemetry(),
+        colorSourceSvg: mgukRegenGainIncreaseIconSvg,
+        colorOverrides: settings.colorOverrides,
+        titleOverrides: settings.titleOverrides,
+        borderOverrides: settings.borderOverrides,
+      });
+    }
+
+    return generateSetupHybridSvg(settings);
+  }
+
+  private async updateDisplayFromTelemetry(
+    contextId: string,
+    telemetry: TelemetryData | null,
+    settings: SetupHybridSettings,
+  ): Promise<void> {
+    if (!isViewSetting(settings.setting)) return;
+
+    const value = formatViewValue(settings.setting, telemetry);
+
+    if (this.lastRenderedValue.get(contextId) === value) return;
+
+    this.lastRenderedValue.set(contextId, value);
+    const svgDataUri = generateSetupViewSvg({
+      viewId: settings.setting,
+      telemetry,
+      colorSourceSvg: mgukRegenGainIncreaseIconSvg,
+      colorOverrides: settings.colorOverrides,
+      titleOverrides: settings.titleOverrides,
+      borderOverrides: settings.borderOverrides,
+    });
+    await this.updateKeyImage(contextId, svgDataUri);
   }
 }

--- a/packages/iracing-actions/src/actions/setup-traction/setup-traction.ejs
+++ b/packages/iracing-actions/src/actions/setup-traction/setup-traction.ejs
@@ -8,11 +8,19 @@
 
 		<sdpi-item label="Setting">
 			<sdpi-select id="setting-select" setting="setting" default="tc-toggle">
-				<option value="tc-toggle">TC Toggle</option>
-				<option value="tc-slot-1">TC Slot 1</option>
-				<option value="tc-slot-2">TC Slot 2</option>
-				<option value="tc-slot-3">TC Slot 3</option>
-				<option value="tc-slot-4">TC Slot 4</option>
+				<optgroup label="Adjust">
+					<option value="tc-slot-1">TC1</option>
+					<option value="tc-slot-2">TC2</option>
+					<option value="tc-slot-3">TC3</option>
+					<option value="tc-slot-4">TC4</option>
+					<option value="tc-toggle">TC Toggle</option>
+				</optgroup>
+				<optgroup label="Display value">
+					<option value="view-tc-slot-1">View TC1</option>
+					<option value="view-tc-slot-2">View TC2</option>
+					<option value="view-tc-slot-3">View TC3</option>
+					<option value="view-tc-slot-4">View TC4</option>
+				</optgroup>
 			</sdpi-select>
 		</sdpi-item>
 
@@ -44,11 +52,12 @@
 		<%- include('global-common-settings') %>
 
 		<script>
-			// TC Toggle is the only non-directional control
+			// TC Toggle is non-directional; View sub-modes are read-only — both hide Direction.
 			function updateVisibility(setting) {
 				const directionItem = document.getElementById("direction-item");
 				if (!directionItem) return;
-				directionItem.classList.toggle("hidden", setting === "tc-toggle");
+				const hide = setting === "tc-toggle" || setting.startsWith("view-");
+				directionItem.classList.toggle("hidden", hide);
 			}
 
 			async function initialize() {

--- a/packages/iracing-actions/src/actions/setup-traction/setup-traction.test.ts
+++ b/packages/iracing-actions/src/actions/setup-traction/setup-traction.test.ts
@@ -71,6 +71,15 @@ vi.mock("@iracedeck/deck-core", () => ({
     return b.key;
   }),
   generateBorderParts: vi.fn(() => ({ defs: "", rects: "" })),
+  generateTitleText: vi.fn(({ text, fill }: { text: string; fill: string }) => {
+    if (!text) return "";
+
+    return `<text fill="${fill}">${text}</text>`;
+  }),
+  renderIconTemplate: vi.fn((_template: string, data: Record<string, string>) => {
+    return `<svg>${data.value ?? ""} ${data.titleContent ?? ""}</svg>`;
+  }),
+  svgToDataUri: vi.fn((svg: string) => `data:image/svg+xml,${encodeURIComponent(svg)}`),
   getGlobalBorderSettings: vi.fn(() => ({})),
   getGlobalColors: vi.fn(() => ({})),
   getGlobalGraphicSettings: vi.fn(() => ({})),
@@ -238,7 +247,7 @@ describe("SetupTraction", () => {
       const result = generateSetupTractionSvg({ setting: "tc-slot-1", direction: "increase" });
       const decoded = decodeURIComponent(result);
 
-      expect(decoded).toContain("TC SLOT 1");
+      expect(decoded).toContain("TC1");
       expect(decoded).toContain("INCREASE");
     });
 
@@ -246,7 +255,7 @@ describe("SetupTraction", () => {
       const result = generateSetupTractionSvg({ setting: "tc-slot-1", direction: "decrease" });
       const decoded = decodeURIComponent(result);
 
-      expect(decoded).toContain("TC SLOT 1");
+      expect(decoded).toContain("TC1");
       expect(decoded).toContain("DECREASE");
     });
 
@@ -257,20 +266,20 @@ describe("SetupTraction", () => {
           decrease: { mainLabel: "TC", subLabel: "TOGGLE" },
         },
         "tc-slot-1": {
-          increase: { mainLabel: "TC SLOT 1", subLabel: "INCREASE" },
-          decrease: { mainLabel: "TC SLOT 1", subLabel: "DECREASE" },
+          increase: { mainLabel: "TC1", subLabel: "INCREASE" },
+          decrease: { mainLabel: "TC1", subLabel: "DECREASE" },
         },
         "tc-slot-2": {
-          increase: { mainLabel: "TC SLOT 2", subLabel: "INCREASE" },
-          decrease: { mainLabel: "TC SLOT 2", subLabel: "DECREASE" },
+          increase: { mainLabel: "TC2", subLabel: "INCREASE" },
+          decrease: { mainLabel: "TC2", subLabel: "DECREASE" },
         },
         "tc-slot-3": {
-          increase: { mainLabel: "TC SLOT 3", subLabel: "INCREASE" },
-          decrease: { mainLabel: "TC SLOT 3", subLabel: "DECREASE" },
+          increase: { mainLabel: "TC3", subLabel: "INCREASE" },
+          decrease: { mainLabel: "TC3", subLabel: "DECREASE" },
         },
         "tc-slot-4": {
-          increase: { mainLabel: "TC SLOT 4", subLabel: "INCREASE" },
-          decrease: { mainLabel: "TC SLOT 4", subLabel: "DECREASE" },
+          increase: { mainLabel: "TC4", subLabel: "INCREASE" },
+          decrease: { mainLabel: "TC4", subLabel: "DECREASE" },
         },
       };
 
@@ -378,6 +387,41 @@ describe("SetupTraction", () => {
 
     it("should ignore rotation for non-directional controls (tc-toggle)", async () => {
       await action.onDialRotate(fakeDialRotateEvent("action-1", { setting: "tc-toggle" }, 1) as any);
+
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("view sub-modes (issue #541)", () => {
+    let action: SetupTraction;
+
+    beforeEach(() => {
+      action = new SetupTraction();
+      (action.sdkController.getCurrentTelemetry as any).mockReturnValue({
+        dcTractionControl: 3,
+        dcTractionControl2: 5,
+      });
+    });
+
+    it("renders the formatted telemetry value for View TC1", async () => {
+      const ev = fakeEvent("action-1", { setting: "view-tc-slot-1" }) as any;
+      await action.onWillAppear(ev);
+      const calls = (action.setKeyImage as any).mock.calls;
+      const svg = decodeURIComponent(calls[0][1] as string);
+      expect(svg).toContain("3");
+    });
+
+    it("reads the per-slot dc field for View TC2", async () => {
+      const ev = fakeEvent("action-1", { setting: "view-tc-slot-2" }) as any;
+      await action.onWillAppear(ev);
+      const calls = (action.setKeyImage as any).mock.calls;
+      const svg = decodeURIComponent(calls[0][1] as string);
+      expect(svg).toContain("5");
+    });
+
+    it("does not fire a binding when a View setting is pressed", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-tc-slot-1" }) as any);
+      await action.onDialDown(fakeEvent("action-1", { setting: "view-tc-slot-1" }) as any);
 
       expect(mockTapBinding).not.toHaveBeenCalled();
     });

--- a/packages/iracing-actions/src/actions/setup-traction/setup-traction.ts
+++ b/packages/iracing-actions/src/actions/setup-traction/setup-traction.ts
@@ -11,6 +11,7 @@ import {
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
   type IDeckWillAppearEvent,
+  type IDeckWillDisappearEvent,
   resolveBorderSettings,
   resolveGraphicSettings,
   resolveIconColors,
@@ -25,14 +26,23 @@ import tcSlot3IncreaseIconSvg from "@iracedeck/icons/setup-traction/tc-slot-3-in
 import tcSlot4DecreaseIconSvg from "@iracedeck/icons/setup-traction/tc-slot-4-decrease.svg";
 import tcSlot4IncreaseIconSvg from "@iracedeck/icons/setup-traction/tc-slot-4-increase.svg";
 import tcToggleIconSvg from "@iracedeck/icons/setup-traction/tc-toggle.svg";
+import type { TelemetryData } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
-type SetupTractionSetting = "tc-toggle" | "tc-slot-1" | "tc-slot-2" | "tc-slot-3" | "tc-slot-4";
+import { formatViewValue, generateSetupViewSvg, isViewSetting } from "../../shared/setup-view.js";
+
+type SetupTractionAdjustSetting = "tc-toggle" | "tc-slot-1" | "tc-slot-2" | "tc-slot-3" | "tc-slot-4";
+
+/**
+ * The combined `setting` type is the union of `SetupTractionAdjustSetting` and the two
+ * View IDs in `setup-view.ts`. Code paths narrow back to `SetupTractionAdjustSetting`
+ * after `isViewSetting` gates the View branch; nothing needs the full union as a name.
+ */
 
 type DirectionType = "increase" | "decrease";
 
 /** Controls that have +/- direction */
-const DIRECTIONAL_CONTROLS: Set<SetupTractionSetting> = new Set([
+const DIRECTIONAL_CONTROLS: Set<SetupTractionAdjustSetting> = new Set([
   "tc-slot-1",
   "tc-slot-2",
   "tc-slot-3",
@@ -59,14 +69,14 @@ const SETUP_TRACTION_ICONS: Record<string, string> = {
  */
 const SETUP_TRACTION_TITLES: Record<string, string> = {
   "tc-toggle": "TOGGLE\nTC",
-  "tc-slot-1-increase": "INCREASE\nTC SLOT 1",
-  "tc-slot-1-decrease": "DECREASE\nTC SLOT 1",
-  "tc-slot-2-increase": "INCREASE\nTC SLOT 2",
-  "tc-slot-2-decrease": "DECREASE\nTC SLOT 2",
-  "tc-slot-3-increase": "INCREASE\nTC SLOT 3",
-  "tc-slot-3-decrease": "DECREASE\nTC SLOT 3",
-  "tc-slot-4-increase": "INCREASE\nTC SLOT 4",
-  "tc-slot-4-decrease": "DECREASE\nTC SLOT 4",
+  "tc-slot-1-increase": "INCREASE\nTC1",
+  "tc-slot-1-decrease": "DECREASE\nTC1",
+  "tc-slot-2-increase": "INCREASE\nTC2",
+  "tc-slot-2-decrease": "DECREASE\nTC2",
+  "tc-slot-3-increase": "INCREASE\nTC3",
+  "tc-slot-3-decrease": "DECREASE\nTC3",
+  "tc-slot-4-increase": "INCREASE\nTC4",
+  "tc-slot-4-decrease": "DECREASE\nTC4",
 };
 
 /**
@@ -88,7 +98,22 @@ export const SETUP_TRACTION_GLOBAL_KEYS: Record<string, string> = {
 };
 
 const SetupTractionSettings = CommonSettings.extend({
-  setting: z.enum(["tc-toggle", "tc-slot-1", "tc-slot-2", "tc-slot-3", "tc-slot-4"]).default("tc-toggle"),
+  setting: z
+    .enum([
+      // View sub-modes (read-only telemetry display) — one per TC slot, paired with the
+      // matching `tc-slot-N` adjustment entry in the PI dropdown.
+      "view-tc-slot-1",
+      "view-tc-slot-2",
+      "view-tc-slot-3",
+      "view-tc-slot-4",
+      // Adjustment sub-modes.
+      "tc-toggle",
+      "tc-slot-1",
+      "tc-slot-2",
+      "tc-slot-3",
+      "tc-slot-4",
+    ])
+    .default("tc-toggle"),
   direction: z.enum(["increase", "decrease"]).default("increase"),
 });
 
@@ -97,7 +122,7 @@ type SetupTractionSettings = z.infer<typeof SetupTractionSettings>;
 /**
  * Resolves the flat icon lookup key from setting and direction.
  */
-function resolveIconKey(setting: SetupTractionSetting, direction: DirectionType): string {
+function resolveIconKey(setting: SetupTractionAdjustSetting, direction: DirectionType): string {
   if (DIRECTIONAL_CONTROLS.has(setting)) {
     return `${setting}-${direction}`;
   }
@@ -108,10 +133,23 @@ function resolveIconKey(setting: SetupTractionSetting, direction: DirectionType)
 /**
  * @internal Exported for testing
  *
- * Generates an SVG data URI icon for the setup traction action.
+ * Generates an SVG data URI icon for the setup traction action's adjustment sub-modes.
+ * View sub-modes use the shared `generateSetupViewSvg` render path.
  */
 export function generateSetupTractionSvg(settings: SetupTractionSettings): string {
-  const iconKey = resolveIconKey(settings.setting, settings.direction);
+  if (isViewSetting(settings.setting)) {
+    return generateSetupViewSvg({
+      viewId: settings.setting,
+      telemetry: null,
+      colorSourceSvg: tcSlot1IncreaseIconSvg,
+      colorOverrides: settings.colorOverrides,
+      titleOverrides: settings.titleOverrides,
+      borderOverrides: settings.borderOverrides,
+    });
+  }
+
+  const setting = settings.setting as SetupTractionAdjustSetting;
+  const iconKey = resolveIconKey(setting, settings.direction);
 
   const iconSvg = SETUP_TRACTION_ICONS[iconKey] || SETUP_TRACTION_ICONS["tc-toggle"];
   const defaultTitle = SETUP_TRACTION_TITLES[iconKey] || "SETUP\nTC";
@@ -128,62 +166,90 @@ export function generateSetupTractionSvg(settings: SetupTractionSettings): strin
 
 /**
  * Setup Traction Action
- * Provides traction control in-car adjustments (TC Toggle, TC Slots 1-4)
+ * Provides traction control in-car adjustments (TC Toggle, TC1–TC4)
  * via keyboard shortcuts.
  */
 export const SETUP_TRACTION_UUID = "com.iracedeck.sd.core.setup-traction" as const;
 
 export class SetupTraction extends ConnectionStateAwareAction<SetupTractionSettings> {
+  /** Current settings per action context, used by the telemetry-tick callback for View sub-modes. */
+  private readonly activeContexts = new Map<string, SetupTractionSettings>();
+
+  /** Last rendered View value per context — memoizes the icon so we only re-emit on actual change. */
+  private readonly lastRenderedValue = new Map<string, string>();
+
   override async onWillAppear(ev: IDeckWillAppearEvent<SetupTractionSettings>): Promise<void> {
     await super.onWillAppear(ev);
     const settings = this.parseSettings(ev.payload.settings);
-    const activeKey = this.resolveGlobalKey(settings.setting, settings.direction);
-
-    if (activeKey) {
-      this.setActiveBinding(activeKey);
-    }
-
+    this.activeContexts.set(ev.action.id, settings);
+    this.applyActiveBinding(settings);
     await this.updateDisplay(ev, settings);
+
+    this.sdkController.subscribe(ev.action.id, (telemetry) => {
+      const stored = this.activeContexts.get(ev.action.id);
+
+      if (stored && isViewSetting(stored.setting)) {
+        void this.updateDisplayFromTelemetry(ev.action.id, telemetry, stored);
+      }
+    });
+  }
+
+  override async onWillDisappear(ev: IDeckWillDisappearEvent<SetupTractionSettings>): Promise<void> {
+    this.sdkController.unsubscribe(ev.action.id);
+    this.activeContexts.delete(ev.action.id);
+    this.lastRenderedValue.delete(ev.action.id);
+    await super.onWillDisappear(ev);
   }
 
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<SetupTractionSettings>): Promise<void> {
     await super.onDidReceiveSettings(ev);
     const settings = this.parseSettings(ev.payload.settings);
-    const activeKey = this.resolveGlobalKey(settings.setting, settings.direction);
-
-    if (activeKey) {
-      this.setActiveBinding(activeKey);
-    }
-
+    this.activeContexts.set(ev.action.id, settings);
+    this.lastRenderedValue.delete(ev.action.id);
+    this.applyActiveBinding(settings);
     await this.updateDisplay(ev, settings);
   }
 
   override async onKeyDown(ev: IDeckKeyDownEvent<SetupTractionSettings>): Promise<void> {
-    this.logger.info("Key down received");
     const settings = this.parseSettings(ev.payload.settings);
+
+    if (isViewSetting(settings.setting)) {
+      this.logger.debug("View sub-mode is read-only, ignoring key press");
+
+      return;
+    }
+
+    this.logger.info("Key down received");
     await this.executeSetting(settings.setting, settings.direction);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<SetupTractionSettings>): Promise<void> {
-    this.logger.info("Dial down received");
     const settings = this.parseSettings(ev.payload.settings);
+
+    if (isViewSetting(settings.setting)) return;
+
+    this.logger.info("Dial down received");
     await this.executeSetting(settings.setting, settings.direction);
   }
 
   override async onDialRotate(ev: IDeckDialRotateEvent<SetupTractionSettings>): Promise<void> {
-    this.logger.info("Dial rotated");
     const settings = this.parseSettings(ev.payload.settings);
 
+    if (isViewSetting(settings.setting)) return;
+
+    this.logger.info("Dial rotated");
+    const adjustSetting = settings.setting as SetupTractionAdjustSetting;
+
     // Non-directional controls have no +/- adjustment — ignore rotation
-    if (!DIRECTIONAL_CONTROLS.has(settings.setting)) {
-      this.logger.debug(`Rotation ignored for ${settings.setting}`);
+    if (!DIRECTIONAL_CONTROLS.has(adjustSetting)) {
+      this.logger.debug(`Rotation ignored for ${adjustSetting}`);
 
       return;
     }
 
     // Clockwise (ticks > 0) = increase, Counter-clockwise (ticks < 0) = decrease
     const direction: DirectionType = ev.payload.ticks > 0 ? "increase" : "decrease";
-    await this.executeSetting(settings.setting, direction);
+    await this.executeSetting(adjustSetting, direction);
   }
 
   private parseSettings(settings: unknown): SetupTractionSettings {
@@ -192,7 +258,21 @@ export class SetupTraction extends ConnectionStateAwareAction<SetupTractionSetti
     return parsed.success ? parsed.data : SetupTractionSettings.parse({});
   }
 
-  private async executeSetting(setting: SetupTractionSetting, direction: DirectionType): Promise<void> {
+  private applyActiveBinding(settings: SetupTractionSettings): void {
+    if (isViewSetting(settings.setting)) {
+      this.setActiveBinding(null);
+
+      return;
+    }
+
+    const activeKey = this.resolveGlobalKey(settings.setting, settings.direction);
+
+    if (activeKey) {
+      this.setActiveBinding(activeKey);
+    }
+  }
+
+  private async executeSetting(setting: SetupTractionAdjustSetting, direction: DirectionType): Promise<void> {
     const settingKey = this.resolveGlobalKey(setting, direction);
 
     if (!settingKey) {
@@ -204,7 +284,7 @@ export class SetupTraction extends ConnectionStateAwareAction<SetupTractionSetti
     await this.tapBinding(settingKey);
   }
 
-  private resolveGlobalKey(setting: SetupTractionSetting, direction: DirectionType): string | null {
+  private resolveGlobalKey(setting: SetupTractionAdjustSetting, direction: DirectionType): string | null {
     if (DIRECTIONAL_CONTROLS.has(setting)) {
       const key = `${setting}-${direction}`;
 
@@ -218,9 +298,53 @@ export class SetupTraction extends ConnectionStateAwareAction<SetupTractionSetti
     ev: IDeckWillAppearEvent<SetupTractionSettings> | IDeckDidReceiveSettingsEvent<SetupTractionSettings>,
     settings: SetupTractionSettings,
   ): Promise<void> {
-    const svgDataUri = generateSetupTractionSvg(settings);
+    const svgDataUri = this.renderIcon(settings);
+
+    if (isViewSetting(settings.setting)) {
+      const telemetry = this.sdkController.getCurrentTelemetry();
+      this.lastRenderedValue.set(ev.action.id, formatViewValue(settings.setting, telemetry));
+    }
+
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateSetupTractionSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () => this.renderIcon(settings));
+  }
+
+  private renderIcon(settings: SetupTractionSettings): string {
+    if (isViewSetting(settings.setting)) {
+      return generateSetupViewSvg({
+        viewId: settings.setting,
+        telemetry: this.sdkController.getCurrentTelemetry(),
+        colorSourceSvg: tcSlot1IncreaseIconSvg,
+        colorOverrides: settings.colorOverrides,
+        titleOverrides: settings.titleOverrides,
+        borderOverrides: settings.borderOverrides,
+      });
+    }
+
+    return generateSetupTractionSvg(settings);
+  }
+
+  private async updateDisplayFromTelemetry(
+    contextId: string,
+    telemetry: TelemetryData | null,
+    settings: SetupTractionSettings,
+  ): Promise<void> {
+    if (!isViewSetting(settings.setting)) return;
+
+    const value = formatViewValue(settings.setting, telemetry);
+
+    if (this.lastRenderedValue.get(contextId) === value) return;
+
+    this.lastRenderedValue.set(contextId, value);
+    const svgDataUri = generateSetupViewSvg({
+      viewId: settings.setting,
+      telemetry,
+      colorSourceSvg: tcSlot1IncreaseIconSvg,
+      colorOverrides: settings.colorOverrides,
+      titleOverrides: settings.titleOverrides,
+      borderOverrides: settings.borderOverrides,
+    });
+    await this.updateKeyImage(contextId, svgDataUri);
   }
 }

--- a/packages/iracing-actions/src/shared/setup-view.test.ts
+++ b/packages/iracing-actions/src/shared/setup-view.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatInteger,
+  formatPercent,
+  formatPercentRaw,
+  formatSignedPercent,
+  formatViewValue,
+  isViewSetting,
+  VIEW_DEFS,
+  VIEW_NULL_VALUE,
+  type ViewSettingId,
+} from "./setup-view.js";
+
+describe("setup-view formatters", () => {
+  describe("formatPercent", () => {
+    it("renders a 0–1 ratio as an integer percent by default", () => {
+      expect(formatPercent(0.47)).toBe("47%");
+      expect(formatPercent(0.5)).toBe("50%");
+      expect(formatPercent(1)).toBe("100%");
+    });
+
+    it("rounds to the requested decimals", () => {
+      expect(formatPercent(0.563, 1)).toBe("56.3%");
+      expect(formatPercent(0.5625, 2)).toBe("56.25%");
+    });
+
+    it("returns the null placeholder for non-numeric input", () => {
+      expect(formatPercent(undefined)).toBe(VIEW_NULL_VALUE);
+      expect(formatPercent(null)).toBe(VIEW_NULL_VALUE);
+      expect(formatPercent("0.5")).toBe(VIEW_NULL_VALUE);
+      expect(formatPercent(NaN)).toBe(VIEW_NULL_VALUE);
+      expect(formatPercent(Infinity)).toBe(VIEW_NULL_VALUE);
+    });
+
+    it("handles zero as a real value, not a null", () => {
+      expect(formatPercent(0)).toBe("0%");
+    });
+  });
+
+  describe("formatSignedPercent", () => {
+    it("prefixes positive values with +", () => {
+      expect(formatSignedPercent(0.05)).toBe("+5%");
+      expect(formatSignedPercent(0.25, 1)).toBe("+25.0%");
+    });
+
+    it("preserves negative sign without an extra prefix", () => {
+      expect(formatSignedPercent(-0.05)).toBe("-5%");
+    });
+
+    it("does not prefix zero", () => {
+      expect(formatSignedPercent(0)).toBe("0%");
+    });
+
+    it("returns the null placeholder for non-numeric input", () => {
+      expect(formatSignedPercent(undefined)).toBe(VIEW_NULL_VALUE);
+      expect(formatSignedPercent(NaN)).toBe(VIEW_NULL_VALUE);
+    });
+  });
+
+  describe("formatPercentRaw", () => {
+    it("appends % without multiplying the input (default 1 decimal)", () => {
+      expect(formatPercentRaw(54)).toBe("54.0%");
+    });
+
+    it("preserves the exact value iRacing exposes (already in percent units)", () => {
+      expect(formatPercentRaw(54.5, 1)).toBe("54.5%");
+      expect(formatPercentRaw(54, 0)).toBe("54%");
+      expect(formatPercentRaw(54.567, 2)).toBe("54.57%");
+    });
+
+    it("returns the null placeholder for non-numeric input", () => {
+      expect(formatPercentRaw(undefined)).toBe(VIEW_NULL_VALUE);
+      expect(formatPercentRaw(NaN)).toBe(VIEW_NULL_VALUE);
+    });
+  });
+
+  describe("formatInteger", () => {
+    it("returns the integer value as a bare string", () => {
+      expect(formatInteger(0)).toBe("0");
+      expect(formatInteger(3)).toBe("3");
+      expect(formatInteger(10)).toBe("10");
+    });
+
+    it("rounds non-integer values", () => {
+      expect(formatInteger(2.4)).toBe("2");
+      expect(formatInteger(2.5)).toBe("3");
+    });
+
+    it("returns the null placeholder for non-numeric input", () => {
+      expect(formatInteger(undefined)).toBe(VIEW_NULL_VALUE);
+      expect(formatInteger(NaN)).toBe(VIEW_NULL_VALUE);
+      expect(formatInteger("3")).toBe(VIEW_NULL_VALUE);
+    });
+  });
+});
+
+describe("isViewSetting", () => {
+  it("returns true for every registered View id", () => {
+    for (const id of Object.keys(VIEW_DEFS)) {
+      expect(isViewSetting(id)).toBe(true);
+    }
+  });
+
+  it("returns false for non-view setting ids and unrelated strings", () => {
+    expect(isViewSetting("brake-bias")).toBe(false);
+    expect(isViewSetting("abs-toggle")).toBe(false);
+    expect(isViewSetting("")).toBe(false);
+    expect(isViewSetting("view-nonexistent")).toBe(false);
+  });
+});
+
+describe("formatViewValue", () => {
+  it("returns the null placeholder when telemetry is null", () => {
+    expect(formatViewValue("view-brake-bias", null)).toBe(VIEW_NULL_VALUE);
+    expect(formatViewValue("view-brake-bias", undefined)).toBe(VIEW_NULL_VALUE);
+  });
+
+  it("reads the telemetry field named by the View definition", () => {
+    // dcBrakeBias is exposed by iRacing in percent units (54, not 0.54); the formatter
+    // must NOT multiply by 100.
+    expect(formatViewValue("view-brake-bias", { dcBrakeBias: 54 })).toBe("54.0%");
+    expect(formatViewValue("view-tc-slot-1", { dcTractionControl: 3 })).toBe("3");
+    expect(formatViewValue("view-tc-slot-2", { dcTractionControl2: 5 })).toBe("5");
+    expect(formatViewValue("view-weight-jacker-right", { dcWeightJackerRight: 0.04 })).toBe("+4%");
+    expect(formatViewValue("view-weight-jacker-left", { dcWeightJackerLeft: -0.03 })).toBe("-3%");
+  });
+
+  it("returns the null placeholder when the named field is missing", () => {
+    expect(formatViewValue("view-brake-bias", { dcTractionControl: 3 })).toBe(VIEW_NULL_VALUE);
+    expect(formatViewValue("view-mguk-deploy-mode", {})).toBe(VIEW_NULL_VALUE);
+  });
+});
+
+describe("VIEW_DEFS registry", () => {
+  it("has a definition for every ViewSettingId", () => {
+    const ids: ViewSettingId[] = [
+      "view-brake-bias",
+      "view-brake-bias-fine",
+      "view-peak-brake-bias",
+      "view-brake-misc",
+      "view-engine-braking",
+      "view-abs-adjust",
+      "view-tc-slot-1",
+      "view-tc-slot-2",
+      "view-tc-slot-3",
+      "view-tc-slot-4",
+      "view-fuel-mixture",
+      "view-fuel-cut-position",
+      "view-engine-power",
+      "view-throttle-shape",
+      "view-launch-rpm",
+      "view-front-wing",
+      "view-rear-wing",
+      "view-diff-preload",
+      "view-diff-entry",
+      "view-diff-middle",
+      "view-diff-exit",
+      "view-anti-roll-front",
+      "view-anti-roll-rear",
+      "view-power-steering",
+      "view-weight-jacker-left",
+      "view-weight-jacker-right",
+      "view-mguk-deploy-mode",
+      "view-mguk-regen-gain",
+      "view-mguk-deploy-fixed",
+    ];
+
+    for (const id of ids) {
+      expect(VIEW_DEFS[id]).toBeDefined();
+      expect(VIEW_DEFS[id].telemetryField).toMatch(/^dc/);
+      expect(VIEW_DEFS[id].label.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/iracing-actions/src/shared/setup-view.ts
+++ b/packages/iracing-actions/src/shared/setup-view.ts
@@ -1,0 +1,408 @@
+/**
+ * Shared registry, formatters, and render helper for setup-action "View …" sub-modes (issue #541).
+ *
+ * Each setup action exposes a read-only View entry per driver-control telemetry value
+ * (e.g. `view-brake-bias` → `dcBrakeBias`). The action's render path looks up the View
+ * definition here to find the telemetry field, the on-icon label, and the value
+ * formatter. `generateSetupViewSvg` builds the SVG data URI so each setup action's
+ * dispatch is a one-liner; centralising the mapping and the render path keeps the
+ * per-action wiring small and makes it cheap to add new View entries when iRacing
+ * exposes more dc* fields.
+ */
+import {
+  generateBorderParts,
+  generateTitleText,
+  getGlobalBorderSettings,
+  getGlobalColors,
+  getGlobalTitleSettings,
+  renderIconTemplate,
+  resolveBorderSettings,
+  resolveIconColors,
+  resolveTitleSettings,
+  svgToDataUri,
+} from "@iracedeck/deck-core";
+import type { TelemetryData } from "@iracedeck/iracing-sdk";
+
+import setupViewTemplate from "../../icons/setup-view.svg";
+
+/** Identifier shared between the Setting dropdown values, the icon route, and the VIEW_DEFS keys. */
+export type ViewSettingId =
+  // setup-brakes
+  | "view-brake-bias"
+  | "view-brake-bias-fine"
+  | "view-peak-brake-bias"
+  | "view-brake-misc"
+  | "view-engine-braking"
+  | "view-abs-adjust"
+  // setup-traction (per-slot)
+  | "view-tc-slot-1"
+  | "view-tc-slot-2"
+  | "view-tc-slot-3"
+  | "view-tc-slot-4"
+  // setup-fuel
+  | "view-fuel-mixture"
+  | "view-fuel-cut-position"
+  // setup-engine
+  | "view-engine-power"
+  | "view-throttle-shape"
+  | "view-launch-rpm"
+  // setup-aero
+  | "view-front-wing"
+  | "view-rear-wing"
+  // setup-chassis
+  | "view-diff-preload"
+  | "view-diff-entry"
+  | "view-diff-middle"
+  | "view-diff-exit"
+  | "view-anti-roll-front"
+  | "view-anti-roll-rear"
+  | "view-power-steering"
+  | "view-weight-jacker-left"
+  | "view-weight-jacker-right"
+  // setup-hybrid
+  | "view-mguk-deploy-mode"
+  | "view-mguk-regen-gain"
+  | "view-mguk-deploy-fixed";
+
+/** Placeholder used when telemetry is null/undefined or non-numeric. */
+export const VIEW_NULL_VALUE = "---";
+
+/**
+ * Round to a fixed number of decimals without producing trailing zeros that the
+ * caller doesn't want. Returns an integer string when `decimals` is 0.
+ */
+function fixedNoTrailing(value: number, decimals: number): string {
+  return decimals <= 0 ? String(Math.round(value)) : value.toFixed(decimals);
+}
+
+/**
+ * Format a 0.0–1.0 ratio as a percentage (multiplies by 100, appends "%").
+ * Reserved for fields iRacing exposes as a fractional ratio.
+ */
+export function formatPercent(value: unknown, decimals = 0): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return VIEW_NULL_VALUE;
+
+  return `${fixedNoTrailing(value * 100, decimals)}%`;
+}
+
+/**
+ * Append "%" to a value iRacing already exposes in percentage units
+ * (e.g. `dcBrakeBias` is "54", not "0.54"). One decimal by default.
+ */
+export function formatPercentRaw(value: unknown, decimals = 1): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return VIEW_NULL_VALUE;
+
+  return `${fixedNoTrailing(value, decimals)}%`;
+}
+
+/** Same as formatPercent but preserves sign for bidirectional values (e.g. weight jacker). */
+export function formatSignedPercent(value: unknown, decimals = 0): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return VIEW_NULL_VALUE;
+
+  const pct = value * 100;
+  const sign = pct > 0 ? "+" : "";
+
+  return `${sign}${fixedNoTrailing(pct, decimals)}%`;
+}
+
+/** Format a raw integer slot/index (TC slot 0–10, ABS slot, mixture map …). */
+export function formatInteger(value: unknown): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return VIEW_NULL_VALUE;
+
+  return String(Math.round(value));
+}
+
+interface ViewDef {
+  /** TelemetryData field that holds the live value. */
+  readonly telemetryField: keyof TelemetryData;
+  /** Short label rendered at the top of the icon (e.g. "BRAKE BIAS"). */
+  readonly label: string;
+  /** Formats the raw telemetry value into the on-icon display string. */
+  readonly format: (value: unknown) => string;
+  /**
+   * Per-view font size override for the centered value text. Falls back to
+   * `VIEW_VALUE_FONT_SIZE_DEFAULT` (36) when omitted. Bump it up on entries
+   * that always render short single-character strings (e.g. TC slot 0–10)
+   * so the key looks balanced; drop it when the value carries unit text
+   * (e.g. "54.0%") and would otherwise crowd the edges.
+   */
+  readonly valueFontSize?: number;
+}
+
+const VIEW_VALUE_FONT_SIZE_DEFAULT = 36;
+/** Comfortable size for single-/two-character integer readouts (TC slots, ABS, mixture, etc.). */
+const VIEW_VALUE_FONT_SIZE_LARGE = 48;
+/** A step between the default and `LARGE` — used by signed-percent readouts like weight jacker. */
+const VIEW_VALUE_FONT_SIZE_MEDIUM = 40;
+
+/**
+ * Central registry of View sub-modes. Each setup action declares its own View
+ * IDs in its setting enum; the icon render path uses this map to drive the
+ * label + value display.
+ */
+export const VIEW_DEFS: Record<ViewSettingId, ViewDef> = {
+  // setup-brakes — iRacing exposes `dcBrakeBias` / `dcBrakeBiasFine` / `dcPeakBrakeBias`
+  // already in percentage units (e.g. 54.0), so use `formatPercentRaw` rather than the
+  // ratio-multiplying `formatPercent`. The "%-decimal" values stay at the default size to
+  // avoid crowding the key edges; short-integer entries bump up to LARGE.
+  "view-brake-bias": { telemetryField: "dcBrakeBias", label: "BRAKE BIAS", format: (v) => formatPercentRaw(v, 1) },
+  "view-brake-bias-fine": {
+    telemetryField: "dcBrakeBiasFine",
+    label: "BIAS FINE",
+    format: (v) => formatPercentRaw(v, 1),
+  },
+  "view-peak-brake-bias": {
+    telemetryField: "dcPeakBrakeBias",
+    label: "PEAK BIAS",
+    format: (v) => formatPercentRaw(v, 1),
+  },
+  "view-brake-misc": {
+    telemetryField: "dcBrakeMisc",
+    label: "BRAKE MISC",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  "view-engine-braking": {
+    telemetryField: "dcEngineBraking",
+    label: "ENG BRAKE",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  "view-abs-adjust": {
+    telemetryField: "dcABS",
+    label: "ABS",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  // setup-traction — slot 1 is the canonical `dcTractionControl`; cars with multiple TC
+  // presets expose the others as `dcTractionControl2`/`3`/`4`.
+  "view-tc-slot-1": {
+    telemetryField: "dcTractionControl",
+    label: "TC1",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  "view-tc-slot-2": {
+    telemetryField: "dcTractionControl2",
+    label: "TC2",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  "view-tc-slot-3": {
+    telemetryField: "dcTractionControl3",
+    label: "TC3",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  "view-tc-slot-4": {
+    telemetryField: "dcTractionControl4",
+    label: "TC4",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  // setup-fuel
+  "view-fuel-mixture": {
+    telemetryField: "dcFuelMixture",
+    label: "FUEL MIX",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  "view-fuel-cut-position": {
+    telemetryField: "dcFuelCutPosition",
+    label: "FUEL CUT",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  // setup-engine — Launch RPM keeps the default since it can render 4–5 digits (e.g. 12000).
+  "view-engine-power": {
+    telemetryField: "dcEnginePower",
+    label: "ENG POWER",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  "view-throttle-shape": {
+    telemetryField: "dcThrottleShape",
+    label: "THROTTLE",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  "view-launch-rpm": { telemetryField: "dcLaunchRPM", label: "LAUNCH RPM", format: formatInteger },
+  // setup-aero
+  "view-front-wing": {
+    telemetryField: "dcFrontWing",
+    label: "FRONT WING",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  "view-rear-wing": {
+    telemetryField: "dcRearWing",
+    label: "REAR WING",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  // setup-chassis
+  "view-diff-preload": {
+    telemetryField: "dcDiffPreload",
+    label: "DIFF PRELOAD",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  "view-diff-entry": {
+    telemetryField: "dcDiffEntry",
+    label: "DIFF ENTRY",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  "view-diff-middle": {
+    telemetryField: "dcDiffMiddle",
+    label: "DIFF MIDDLE",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  "view-diff-exit": {
+    telemetryField: "dcDiffExit",
+    label: "DIFF EXIT",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  "view-anti-roll-front": {
+    telemetryField: "dcAntiRollFront",
+    label: "ARB FRONT",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  "view-anti-roll-rear": {
+    telemetryField: "dcAntiRollRear",
+    label: "ARB REAR",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  "view-power-steering": {
+    telemetryField: "dcPowerSteering",
+    label: "PWR STEER",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  "view-weight-jacker-left": {
+    telemetryField: "dcWeightJackerLeft",
+    label: "WJKR LEFT",
+    format: (v) => formatSignedPercent(v, 0),
+    valueFontSize: VIEW_VALUE_FONT_SIZE_MEDIUM,
+  },
+  "view-weight-jacker-right": {
+    telemetryField: "dcWeightJackerRight",
+    label: "WJKR RIGHT",
+    format: (v) => formatSignedPercent(v, 0),
+    valueFontSize: VIEW_VALUE_FONT_SIZE_MEDIUM,
+  },
+  // setup-hybrid
+  "view-mguk-deploy-mode": {
+    telemetryField: "dcMGUKDeployMode",
+    label: "DEPLOY MODE",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  "view-mguk-regen-gain": {
+    telemetryField: "dcMGUKRegenGain",
+    label: "REGEN GAIN",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+  "view-mguk-deploy-fixed": {
+    telemetryField: "dcMGUKDeployFixed",
+    label: "FIXED DEPLOY",
+    format: formatInteger,
+    valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+  },
+};
+
+const VIEW_IDS: ReadonlySet<string> = new Set(Object.keys(VIEW_DEFS));
+
+/** Type guard: is `id` a known View setting? Used to gate rendering and press handlers. */
+export function isViewSetting(id: string): id is ViewSettingId {
+  return VIEW_IDS.has(id);
+}
+
+/**
+ * Format the current telemetry snapshot for the given View setting. Returns the
+ * null-value placeholder when telemetry is unavailable or the field is missing.
+ */
+export function formatViewValue(viewId: ViewSettingId, telemetry: TelemetryData | null | undefined): string {
+  if (!telemetry) return VIEW_NULL_VALUE;
+
+  const def = VIEW_DEFS[viewId];
+
+  return def.format(telemetry[def.telemetryField]);
+}
+
+/**
+ * Inputs the setup-action passes to the shared View renderer. The fields are
+ * a subset of CommonSettings — typing them as `unknown` lets each per-action
+ * settings shape pass through without coupling this module to the action's
+ * Zod-inferred type.
+ */
+export interface SetupViewRenderInputs {
+  readonly viewId: ViewSettingId;
+  readonly telemetry: TelemetryData | null | undefined;
+  /**
+   * Optional representative static icon from the parent setup action. Its `<desc>`
+   * metadata supplies the default `backgroundColor` / `textColor` / etc. so a View
+   * key inherits the action's category color scheme (e.g. setup-engine's green
+   * background instead of the shared template's blue). Falls back to the shared
+   * View template's own defaults when omitted.
+   */
+  readonly colorSourceSvg?: string;
+  readonly colorOverrides?: unknown;
+  readonly titleOverrides?: unknown;
+  readonly borderOverrides?: unknown;
+}
+
+/**
+ * Render the SVG data URI for a View sub-mode. Uses the shared dynamic icon
+ * template (`icons/setup-view.svg`) for the layout but reads default colors /
+ * title / border from `colorSourceSvg` (the action's representative static icon)
+ * so the View key stays visually consistent with the action's adjust icons.
+ */
+export function generateSetupViewSvg(inputs: SetupViewRenderInputs): string {
+  const { viewId, telemetry } = inputs;
+  const def = VIEW_DEFS[viewId];
+  const value = formatViewValue(viewId, telemetry);
+
+  const styleSource = inputs.colorSourceSvg ?? setupViewTemplate;
+  const colors = resolveIconColors(styleSource, getGlobalColors(), inputs.colorOverrides);
+  const resolvedTitle = resolveTitleSettings(styleSource, getGlobalTitleSettings(), inputs.titleOverrides, def.label);
+
+  const titleContent = resolvedTitle.showTitle
+    ? generateTitleText({
+        text: resolvedTitle.titleText,
+        fontSize: resolvedTitle.fontSize,
+        bold: resolvedTitle.bold,
+        position: resolvedTitle.position,
+        customPosition: resolvedTitle.customPosition,
+        fill: colors.textColor,
+      })
+    : "";
+
+  const border = resolveBorderSettings(styleSource, getGlobalBorderSettings(), inputs.borderOverrides);
+  const borderSvg = generateBorderParts(border);
+
+  // Per-view override (set in VIEW_DEFS) wins; fall back to the default size that fits
+  // longer values like "54.0%" without crowding the key's left/right edges.
+  const valueFontSize = String(def.valueFontSize ?? VIEW_VALUE_FONT_SIZE_DEFAULT);
+  // Default title sits at the bottom (per TITLE_DEFAULTS); the value sits a bit
+  // below center so it's well-separated from the title without hugging the top.
+  const valueY = "79";
+
+  const svg = renderIconTemplate(setupViewTemplate, {
+    backgroundColor: colors.backgroundColor,
+    textColor: colors.textColor,
+    titleContent,
+    borderDefs: borderSvg.defs,
+    borderContent: borderSvg.rects,
+    value,
+    valueFontSize,
+    valueY,
+  });
+
+  return svgToDataUri(svg);
+}

--- a/packages/iracing-native/src/defines.ts
+++ b/packages/iracing-native/src/defines.ts
@@ -697,6 +697,40 @@ export interface TelemetryData {
   DRS_Status?: number;
   dcPushToPass?: boolean;
   dcDRSToggle?: boolean;
+  // In-car setup adjustments — surfaced by setup-* actions' "View …" sub-modes (issue #541).
+  // All optional and scalar; iRacing exposes them by name in the shared-memory snapshot so the
+  // parser picks them up automatically without any translator changes.
+  dcBrakeBias?: number;
+  dcBrakeBiasFine?: number;
+  dcPeakBrakeBias?: number;
+  dcBrakeMisc?: number;
+  dcEngineBraking?: number;
+  dcABS?: number;
+  // TC slots 1–4: slot 1 is the canonical `dcTractionControl`; iRacing exposes per-slot
+  // values as `dcTractionControl<N>` on cars that have multiple TC presets.
+  dcTractionControl?: number;
+  dcTractionControl2?: number;
+  dcTractionControl3?: number;
+  dcTractionControl4?: number;
+  dcFuelMixture?: number;
+  dcFuelCutPosition?: number;
+  dcEnginePower?: number;
+  dcThrottleShape?: number;
+  dcLaunchRPM?: number;
+  dcFrontWing?: number;
+  dcRearWing?: number;
+  dcAntiRollFront?: number;
+  dcAntiRollRear?: number;
+  dcDiffPreload?: number;
+  dcDiffEntry?: number;
+  dcDiffMiddle?: number;
+  dcDiffExit?: number;
+  dcPowerSteering?: number;
+  dcWeightJackerLeft?: number;
+  dcWeightJackerRight?: number;
+  dcMGUKDeployMode?: number;
+  dcMGUKRegenGain?: number;
+  dcMGUKDeployFixed?: number;
 }
 
 /**

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-aero.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-aero.md
@@ -3,11 +3,22 @@ title: Setup Aero
 description: Adjust aerodynamic settings like front wing, rear wing, and qualifying tape during a session.
 sidebar:
   badge:
-    text: "4 modes"
+    text: "6 modes"
     variant: tip
 ---
 
 Adjust aerodynamic setup options from the cockpit — front and rear wing angles, qualifying tape, and the right-front brake attachment.
+
+## View sub-modes
+
+The **View …** entries are read-only live readouts. No Direction, no key fires on press.
+
+| View setting | Telemetry source | Format | Typical range |
+|---|---|---|---|
+| View Front Wing | `dcFrontWing` | integer | car-dependent slot or angle |
+| View Rear Wing | `dcRearWing` | integer | car-dependent slot or angle |
+
+Cars without a driver-adjustable wing render "---". Qualifying tape and the RF brake attachment toggle have no `dc*` telemetry on common cars, so they don't have View entries.
 
 ## Modes
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-brakes.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-brakes.md
@@ -3,11 +3,24 @@ title: Setup Brakes
 description: Adjust brake settings including ABS, brake bias, peak brake bias, engine braking, and more.
 sidebar:
   badge:
-    text: "7 modes"
+    text: "13 modes"
     variant: tip
 ---
 
 Adjust brake-related setup options from the cockpit — ABS level, brake bias (coarse and fine), peak brake bias, miscellaneous brake settings, and engine braking.
+
+## View sub-modes
+
+The **View …** entries at the top of the Setting dropdown are read-only live readouts of the current value in the car. Pick "View Brake Bias" to turn the key into a continuously updating display of the current brake bias percentage — no Direction setting, no key fires on press.
+
+| View setting | Telemetry source | Format | Typical range |
+|---|---|---|---|
+| View Brake Bias | `dcBrakeBias` | percent, 1 decimal | ~50–60% |
+| View Brake Bias Fine | `dcBrakeBiasFine` | percent, 1 decimal | ~50–60% |
+| View Peak Brake Bias | `dcPeakBrakeBias` | percent, 1 decimal | ~50–80% |
+| View Brake Misc | `dcBrakeMisc` | integer | car-dependent |
+| View Engine Braking | `dcEngineBraking` | integer | car-dependent slot |
+| View ABS Adjust | `dcABS` | integer | car-dependent slot |
 
 ## Modes
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-chassis.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-chassis.md
@@ -3,11 +3,27 @@ title: Setup Chassis
 description: Adjust chassis setup options — differential, anti-roll bars, springs, shocks, and power steering — during a session.
 sidebar:
   badge:
-    text: "13 modes"
+    text: "22 modes"
     variant: tip
 ---
 
 Adjust chassis setup options from the cockpit: differential curves, anti-roll bars, spring preloads, shock absorbers, and power steering.
+
+## View sub-modes
+
+The **View …** entries are read-only live readouts. No Direction, no key fires on press.
+
+| View setting | Telemetry source | Format | Typical range |
+|---|---|---|---|
+| View Diff Preload | `dcDiffPreload` | integer | car-dependent slot |
+| View Diff Entry | `dcDiffEntry` | integer | car-dependent slot |
+| View Diff Middle | `dcDiffMiddle` | integer | car-dependent slot |
+| View Diff Exit | `dcDiffExit` | integer | car-dependent slot |
+| View Anti-Roll Front | `dcAntiRollFront` | integer | car-dependent slot |
+| View Anti-Roll Rear | `dcAntiRollRear` | integer | car-dependent slot |
+| View Power Steering | `dcPowerSteering` | integer | car-dependent slot |
+| View Weight Jacker Left | `dcWeightJackerLeft` | signed percent | ±a few % |
+| View Weight Jacker Right | `dcWeightJackerRight` | signed percent | ±a few % |
 
 ## Modes
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-chassis.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-chassis.md
@@ -27,7 +27,7 @@ The **View …** entries are read-only live readouts. No Direction, no key fires
 
 ## Modes
 
-Select the mode from the **Setting** dropdown in the Property Inspector. Every chassis mode is directional — pick **Increase** or **Decrease** in the **Direction** setting to control what a button press does.
+Select the mode from the **Setting** dropdown in the Property Inspector. **Adjust** modes are directional — pick **Increase** or **Decrease** in the **Direction** setting to control what a button press does. **View** modes are read-only and do not use Direction.
 
 ### Differential Preload
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-engine.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-engine.md
@@ -3,11 +3,21 @@ title: Setup Engine
 description: Adjust engine settings including power, throttle shaping, boost level, and launch RPM during a session.
 sidebar:
   badge:
-    text: "4 modes"
+    text: "7 modes"
     variant: tip
 ---
 
 Adjust engine-related setup options from the cockpit: engine power, throttle shaping, boost level, and launch RPM.
+
+## View sub-modes
+
+The **View …** entries are read-only live readouts. No Direction, no key fires on press.
+
+| View setting | Telemetry source | Format | Typical range |
+|---|---|---|---|
+| View Engine Power | `dcEnginePower` | integer | car-dependent slot |
+| View Throttle Shape | `dcThrottleShape` | integer | car-dependent slot |
+| View Launch RPM | `dcLaunchRPM` | integer | RPM |
 
 ## Modes
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-engine.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-engine.md
@@ -21,7 +21,7 @@ The **View …** entries are read-only live readouts. No Direction, no key fires
 
 ## Modes
 
-Select the mode from the **Setting** dropdown in the Property Inspector. Every engine mode is directional — pick **Increase** or **Decrease** in the **Direction** setting to control what a button press does.
+Select the mode from the **Setting** dropdown in the Property Inspector. **Adjust** modes are directional — pick **Increase** or **Decrease** in the **Direction** setting to control what a button press does. **View** modes are read-only and do not use Direction.
 
 ### Engine Power
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-fuel.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-fuel.md
@@ -3,11 +3,20 @@ title: Setup Fuel
 description: Adjust in-car fuel settings including mixture, fuel cut position, and FCY mode during a session.
 sidebar:
   badge:
-    text: "5 modes"
+    text: "7 modes"
     variant: tip
 ---
 
 Adjust in-car fuel settings from the cockpit: fuel mixture, fuel cut position, disable fuel cut, low fuel accept, and full-course yellow mode. These are live car adjustments, not pit service fuel requests.
+
+## View sub-modes
+
+The **View …** entries are read-only live readouts. No Direction, no key fires on press.
+
+| View setting | Telemetry source | Format | Typical range |
+|---|---|---|---|
+| View Fuel Mixture | `dcFuelMixture` | integer | car-dependent slot |
+| View Fuel Cut Position | `dcFuelCutPosition` | integer | car-dependent slot |
 
 ## Modes
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-hybrid.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-hybrid.md
@@ -3,11 +3,21 @@ title: Setup Hybrid
 description: Control hybrid system settings including MGU-K regen, deploy modes, and HYS boost/regen during a session.
 sidebar:
   badge:
-    text: "6 modes"
+    text: "9 modes"
     variant: tip
 ---
 
 Control hybrid energy recovery and deployment settings from the cockpit: MGU-K regeneration gain, deploy mode, fixed deploy level, HYS (Hybrid System) boost, HYS regen, and the HYS no-boost toggle.
+
+## View sub-modes
+
+The **View …** entries are read-only live readouts. No Direction, no key fires on press.
+
+| View setting | Telemetry source | Format | Typical range |
+|---|---|---|---|
+| View MGU-K Deploy Mode | `dcMGUKDeployMode` | integer | 0–4 |
+| View MGU-K Regen Gain | `dcMGUKRegenGain` | integer | car-dependent slot |
+| View MGU-K Deploy Fixed | `dcMGUKDeployFixed` | integer | car-dependent slot |
 
 ## Modes
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-traction.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-traction.md
@@ -3,15 +3,28 @@ title: Setup Traction
 description: Adjust traction control settings across multiple TC slots during a session.
 sidebar:
   badge:
-    text: "5 modes"
+    text: "9 modes"
     variant: tip
 ---
 
 Adjust traction control from the cockpit: toggle TC on or off, and step the four independent TC slot levels.
 
+## View sub-modes
+
+The **View TC1 / TC2 / TC3 / TC4** entries are read-only live readouts. Each pairs with the corresponding adjustment entry in the dropdown — handy for placing a value readout next to the same slot's +/- keys. No Direction, no key fires on press.
+
+| View setting | Telemetry source | Format | Typical range |
+|---|---|---|---|
+| View TC1 | `dcTractionControl` | integer | 0–10 slot |
+| View TC2 | `dcTractionControl2` | integer | 0–10 slot |
+| View TC3 | `dcTractionControl3` | integer | 0–10 slot |
+| View TC4 | `dcTractionControl4` | integer | 0–10 slot |
+
+Slot 1 is the canonical `dcTractionControl` field iRacing exposes for every TC-equipped car. Slots 2–4 are populated on cars that have multiple TC presets; cars that only have a single TC value render "---" for the higher slots.
+
 ## Modes
 
-Select the mode from the **Setting** dropdown in the Property Inspector. TC Slot modes expose a **Direction** setting for Increase / Decrease; TC Toggle does not.
+Select the mode from the **Setting** dropdown in the Property Inspector. TC1–TC4 modes expose a **Direction** setting for Increase / Decrease; TC Toggle does not.
 
 ### TC Toggle
 
@@ -29,14 +42,14 @@ Toggle traction control on or off.
 
 ---
 
-### TC Slot 1
+### TC1
 
 Adjust TC slot 1.
 
 #### Details
 
 - **Dial:** Rotation adjusts TC slot 1 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
-- **Default binding:** No default key binding — both TC Slot 1 + and TC Slot 1 - must be configured in iRacing and in the Property Inspector
+- **Default binding:** No default key binding — both TC1 + and TC1 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
 #### Setting: Direction
@@ -46,14 +59,14 @@ Adjust TC slot 1.
 
 ---
 
-### TC Slot 2
+### TC2
 
 Adjust TC slot 2.
 
 #### Details
 
 - **Dial:** Rotation adjusts TC slot 2 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
-- **Default binding:** No default key binding — both TC Slot 2 + and TC Slot 2 - must be configured in iRacing and in the Property Inspector
+- **Default binding:** No default key binding — both TC2 + and TC2 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
 #### Setting: Direction
@@ -63,14 +76,14 @@ Adjust TC slot 2.
 
 ---
 
-### TC Slot 3
+### TC3
 
 Adjust TC slot 3.
 
 #### Details
 
 - **Dial:** Rotation adjusts TC slot 3 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
-- **Default binding:** No default key binding — both TC Slot 3 + and TC Slot 3 - must be configured in iRacing and in the Property Inspector
+- **Default binding:** No default key binding — both TC3 + and TC3 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
 #### Setting: Direction
@@ -80,14 +93,14 @@ Adjust TC slot 3.
 
 ---
 
-### TC Slot 4
+### TC4
 
 Adjust TC slot 4.
 
 #### Details
 
 - **Dial:** Rotation adjusts TC slot 4 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
-- **Default binding:** No default key binding — both TC Slot 4 + and TC Slot 4 - must be configured in iRacing and in the Property Inspector
+- **Default binding:** No default key binding — both TC4 + and TC4 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
 #### Setting: Direction

--- a/packages/website/src/content/docs/docs/reference/keyboard-shortcuts.md
+++ b/packages/website/src/content/docs/docs/reference/keyboard-shortcuts.md
@@ -204,10 +204,10 @@ Actions marked "Available via SDK" use SDK commands directly and don't require k
 | Action | Default Shortcut | Available via SDK | iRacing Setting |
 |--------|-----------------|-------------------|-----------------|
 | TC Toggle | - | No | Traction Control Toggle |
-| Adjust TC Slot 1 | - | No | Traction Control Set |
-| Adjust TC Slot 2 | - | No | Traction Control 2 Set |
-| Adjust TC Slot 3 | - | No | Traction Control 3 Set |
-| Adjust TC Slot 4 | - | No | Traction Control 4 Set |
+| Adjust TC1 | - | No | Traction Control Set |
+| Adjust TC2 | - | No | Traction Control 2 Set |
+| Adjust TC3 | - | No | Traction Control 3 Set |
+| Adjust TC4 | - | No | Traction Control 4 Set |
 
 ### Aerodynamics
 

--- a/packages/website/src/content/docs/index.mdx
+++ b/packages/website/src/content/docs/index.mdx
@@ -82,7 +82,7 @@ hero:
   </a>
   <a class="category-card" href="/docs/actions/car-setup/setup-aero/">
     <span class="category-title">Car Setup</span>
-    <span class="category-desc">Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control — all adjustable live.</span>
+    <span class="category-desc">Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control — all adjustable live, plus read-only View readouts of the current values.</span>
   </a>
   <a class="category-card" href="/docs/actions/communication/chat/">
     <span class="category-title">Communication</span>


### PR DESCRIPTION
## Related Issue

Fixes #541

## What changed?

Each setup action now exposes a read-only **View …** entry per driver-control telemetry value. View entries render the live `dc*` value on the key via a shared dynamic icon template; key presses are no-ops. Pairs with the existing Increase/Decrease adjust modes — a typical layout is "View + adjust +/-" next to each other.

- **28 new View entries** across setup-aero (2), setup-brakes (6), setup-chassis (9), setup-engine (3), setup-fuel (2), setup-hybrid (3), setup-traction (4 = TC1–TC4).
- **Shared `setup-view` module** owns the View definitions: `ViewSettingId` union, `VIEW_DEFS` registry mapping each ID to a telemetry field, on-icon label, value formatter, and per-view font size override.
- **Dynamic icon template** (`icons/setup-view.svg`) inherits the action's category color scheme by reading defaults from a representative static icon passed in by each action — so a View key looks like the matching adjust keys (green for engine, blue for chassis, etc.) rather than a neutral blue.
- **Property Inspector dropdowns** restructured into `Adjust` / `Display value` optgroups, both alphabetised internally. Display items are prefixed "View".
- **TC slot naming:** the four TC slot entries (adjust + view) are now labelled `TC1`–`TC4` (was `TC Slot N`).
- **24 new `dc*` fields** added to `TelemetryData` (`dcBrakeBias`, `dcTractionControl[2-4]`, `dcMGUKDeployMode`, …). The iRacing-sdk parser auto-picks them up from shared memory, no translator wiring required.
- **Brake-bias formatter fix:** iRacing exposes `dcBrakeBias` already in percent units (e.g. `54`, not `0.54`). New `formatPercentRaw` helper appends `%` without multiplying.

## How to test

1. Configure a key as e.g. `View Brake Bias` on the Brake Setup action. Connect iRacing. Confirm the live brake bias value renders within the next telemetry tick.
2. Adjust brake bias in-car (via wheel rotary or the matching `Brake Bias +/-` key). Confirm the View key updates.
3. Press the View key. Confirm no SDK command / keypress fires.
4. Repeat one sample View per setup action (setup-aero View Front Wing, setup-engine View Engine Power, setup-traction View TC1, etc.).
5. Open the PI for any setup action: confirm the Setting dropdown shows `Adjust` and `Display value` optgroups with alphabetised entries.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests (`setup-view.test.ts` + per-action view sub-mode blocks)
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — both plugins rebuild without code edits
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only "View" sub-modes for car setup actions to show live telemetry on Stream Deck keys (brakes, chassis, aero, engine, fuel, hybrid, traction).

* **Improvements**
  * Reorganized setup menus into "Adjust" and "Display value" groups.
  * Direction control now hides automatically for view (read-only) modes.
  * Shortened traction labels from "TC Slot 1/2/3/4" to "TC1/TC2/TC3/TC4".
  * Total modes increased to 289 across setup actions.

* **Documentation**
  * Updated docs to list new view sub-modes and mode counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->