### PR TITLE
feat(actions): add dual-press control to setup View sub-modes (#540)

### DIFF
--- a/.claude/rules/pi-templates.md
+++ b/.claude/rules/pi-templates.md
@@ -119,6 +119,24 @@ Located in `packages/pi-components/partials/`:
 - **docs-link.ejs** - Documentation link to the action's page on iracedeck.com (conditional, hidden when no URL mapped)
 - **version.ejs** - Version footer with downloads link
 
+## Shared CSS Classes
+
+Common style classes are defined in `head-common.ejs` (loaded by every PI page). Use these classes — never inline `style="..."` attributes — so styling stays consistent and changes apply everywhere at once.
+
+- **`ird-section-subtitle`** — uppercase group label inside an accordion (e.g. "Window Focus", "SimHub Server").
+- **`ird-supporting-text`** — help/explanatory text shown directly beneath an `sdpi-item`. The class includes a 95px left padding so the text aligns under the control column (not the label), matching the `sdpi-item` layout. Always use this class for help blurbs:
+
+  ```html
+  <sdpi-item label="Directions">
+    <sdpi-select setting="dualPressDirections" default="tap-increases" global>...</sdpi-select>
+  </sdpi-item>
+  <div class="ird-supporting-text">
+    Which direction a short press fires; the long-press always fires the opposite.
+  </div>
+  ```
+
+When a new shared style is needed, add the class to `head-common.ejs` and document it here — do not introduce inline styles in partials or per-action templates.
+
 ## Title Overrides Partial
 
 Adds per-action title customization controls. Settings are stored under the `titleOverrides` key in action settings.

--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -43,7 +43,7 @@ When asked about actions or controls:
 | View & Camera | 5 | 88 | FOV, replay, camera controls, broadcast tools |
 | Media | 1 | 7 | Video recording, screenshots, texture management |
 | Pit Service | 3 | 15 | Fuel, tires, compounds, tearoff, fast repair |
-| Car Setup | 7 | 73 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control — adjustment modes plus read-only "View …" sub-modes that display live dc* telemetry on the key |
+| Car Setup | 7 | 73 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control — adjustment modes plus live-display "View …" sub-modes; each View sub-mode also supports dual-press (tap = configured direction, long-press = opposite) so one key both shows the value and adjusts it (#540) |
 | Communication | 2 | 34 | Chat, macros (15), whisper, toggle, reply, race admin commands |
 | **Total** | **31** | **289** | |
 

--- a/packages/deck-core/src/dual-press.test.ts
+++ b/packages/deck-core/src/dual-press.test.ts
@@ -1,0 +1,192 @@
+import type { ILogger } from "@iracedeck/logger";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DUAL_PRESS_DIRECTIONS_FALLBACK,
+  DUAL_PRESS_THRESHOLD_FALLBACK_MS,
+  DualPressTracker,
+  getDualPressDirections,
+  getDualPressThresholdMs,
+} from "./dual-press.js";
+import { _resetGlobalSettings, initGlobalSettings, updateGlobalSettings } from "./global-settings.js";
+import type { IDeckPlatformAdapter } from "./types.js";
+
+type EchoCallback = (settings: unknown) => void;
+
+function createMockLogger(): ILogger {
+  return {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  } as unknown as ILogger;
+}
+
+function createMockAdapter(): IDeckPlatformAdapter {
+  let echo: EchoCallback | null = null;
+
+  return {
+    onDidReceiveGlobalSettings: (cb: EchoCallback) => {
+      echo = cb;
+    },
+    setGlobalSettings: vi.fn<(settings: Record<string, unknown>) => void>(),
+    getGlobalSettings: vi.fn<() => void>(() => {
+      echo?.({});
+    }),
+  } as unknown as IDeckPlatformAdapter;
+}
+
+describe("DualPressTracker", () => {
+  let nowValue: number;
+  const now = () => nowValue;
+
+  beforeEach(() => {
+    _resetGlobalSettings();
+    initGlobalSettings(createMockAdapter(), createMockLogger());
+    nowValue = 0;
+  });
+
+  afterEach(() => {
+    _resetGlobalSettings();
+  });
+
+  it("returns undefined when key-down has not been recorded (stray key-up)", () => {
+    const tracker = new DualPressTracker(now);
+    expect(tracker.computeOutcome("ctx", "tap", "long")).toBeUndefined();
+  });
+
+  it("returns tap outcome for presses below the threshold", () => {
+    updateGlobalSettings({ dualPressThresholdMs: 500 });
+    const tracker = new DualPressTracker(now);
+    nowValue = 1000;
+    tracker.recordKeyDown("ctx");
+    nowValue = 1100;
+    expect(tracker.computeOutcome("ctx", "tap", "long")).toBe("tap");
+  });
+
+  it("returns long-press outcome at the threshold boundary", () => {
+    updateGlobalSettings({ dualPressThresholdMs: 500 });
+    const tracker = new DualPressTracker(now);
+    nowValue = 1000;
+    tracker.recordKeyDown("ctx");
+    nowValue = 1500;
+    expect(tracker.computeOutcome("ctx", "tap", "long")).toBe("long");
+  });
+
+  it("returns long-press outcome above the threshold", () => {
+    updateGlobalSettings({ dualPressThresholdMs: 500 });
+    const tracker = new DualPressTracker(now);
+    nowValue = 1000;
+    tracker.recordKeyDown("ctx");
+    nowValue = 1800;
+    expect(tracker.computeOutcome("ctx", "tap", "long")).toBe("long");
+  });
+
+  it("uses the live threshold from settings — slider change takes effect on the next press", () => {
+    updateGlobalSettings({ dualPressThresholdMs: 500 });
+    const tracker = new DualPressTracker(now);
+
+    nowValue = 1000;
+    tracker.recordKeyDown("ctx");
+    nowValue = 1400;
+    expect(tracker.computeOutcome("ctx", "tap", "long")).toBe("tap");
+
+    updateGlobalSettings({ dualPressThresholdMs: 300 });
+    nowValue = 2000;
+    tracker.recordKeyDown("ctx");
+    nowValue = 2400;
+    expect(tracker.computeOutcome("ctx", "tap", "long")).toBe("long");
+  });
+
+  it("consumes the pending timestamp on resolve (second resolve returns undefined)", () => {
+    updateGlobalSettings({ dualPressThresholdMs: 500 });
+    const tracker = new DualPressTracker(now);
+    nowValue = 1000;
+    tracker.recordKeyDown("ctx");
+    nowValue = 1800;
+    tracker.computeOutcome("ctx", "tap", "long");
+
+    nowValue = 5000;
+    expect(tracker.computeOutcome("ctx", "tap", "long")).toBeUndefined();
+  });
+
+  it("tracks contexts independently", () => {
+    updateGlobalSettings({ dualPressThresholdMs: 500 });
+    const tracker = new DualPressTracker(now);
+
+    nowValue = 1000;
+    tracker.recordKeyDown("a");
+    nowValue = 1200;
+    tracker.recordKeyDown("b");
+
+    nowValue = 2100; // a held 1100 ms
+    expect(tracker.computeOutcome("a", "tap", "long")).toBe("long");
+
+    nowValue = 1300; // b held 100 ms relative to its 1200 ms keydown
+    expect(tracker.computeOutcome("b", "tap", "long")).toBe("tap");
+  });
+
+  it("clear() drops the pending timestamp without firing", () => {
+    updateGlobalSettings({ dualPressThresholdMs: 500 });
+    const tracker = new DualPressTracker(now);
+    nowValue = 1000;
+    tracker.recordKeyDown("ctx");
+    expect(tracker.hasPending("ctx")).toBe(true);
+
+    tracker.clear("ctx");
+    expect(tracker.hasPending("ctx")).toBe(false);
+
+    nowValue = 5000;
+    expect(tracker.computeOutcome("ctx", "tap", "long")).toBeUndefined();
+  });
+});
+
+describe("getDualPressThresholdMs", () => {
+  beforeEach(() => {
+    _resetGlobalSettings();
+  });
+
+  afterEach(() => {
+    _resetGlobalSettings();
+  });
+
+  it("falls back to 500 ms before initGlobalSettings runs", () => {
+    expect(getDualPressThresholdMs()).toBe(DUAL_PRESS_THRESHOLD_FALLBACK_MS);
+    expect(getDualPressThresholdMs()).toBe(500);
+  });
+
+  it("reflects the live value after updateGlobalSettings", () => {
+    initGlobalSettings(createMockAdapter(), createMockLogger());
+    updateGlobalSettings({ dualPressThresholdMs: 1200 });
+    expect(getDualPressThresholdMs()).toBe(1200);
+  });
+});
+
+describe("getDualPressDirections", () => {
+  beforeEach(() => {
+    _resetGlobalSettings();
+  });
+
+  afterEach(() => {
+    _resetGlobalSettings();
+  });
+
+  it("falls back to tap-increases before initGlobalSettings runs", () => {
+    expect(getDualPressDirections()).toBe(DUAL_PRESS_DIRECTIONS_FALLBACK);
+    expect(getDualPressDirections()).toBe("tap-increases");
+  });
+
+  it("reflects the live value after updateGlobalSettings", () => {
+    initGlobalSettings(createMockAdapter(), createMockLogger());
+    updateGlobalSettings({ dualPressDirections: "tap-decreases" });
+    expect(getDualPressDirections()).toBe("tap-decreases");
+  });
+
+  it("falls back when the stored value is unrecognised", () => {
+    initGlobalSettings(createMockAdapter(), createMockLogger());
+    // Bypass the schema by writing through the passthrough cache directly.
+    updateGlobalSettings({ dualPressDirections: "tap-increases" });
+    expect(getDualPressDirections()).toBe("tap-increases");
+  });
+});

--- a/packages/deck-core/src/dual-press.test.ts
+++ b/packages/deck-core/src/dual-press.test.ts
@@ -8,8 +8,12 @@ import {
   getDualPressDirections,
   getDualPressThresholdMs,
 } from "./dual-press.js";
-import { _resetGlobalSettings, initGlobalSettings, updateGlobalSettings } from "./global-settings.js";
+// Namespace import so the unrecognised-value test can spy on getGlobalSettings;
+// the named bindings below keep the rest of the file unchanged.
+import * as globalSettings from "./global-settings.js";
 import type { IDeckPlatformAdapter } from "./types.js";
+
+const { _resetGlobalSettings, initGlobalSettings, updateGlobalSettings } = globalSettings;
 
 type EchoCallback = (settings: unknown) => void;
 
@@ -184,9 +188,21 @@ describe("getDualPressDirections", () => {
   });
 
   it("falls back when the stored value is unrecognised", () => {
-    initGlobalSettings(createMockAdapter(), createMockLogger());
-    // Bypass the schema by writing through the passthrough cache directly.
-    updateGlobalSettings({ dualPressDirections: "tap-increases" });
-    expect(getDualPressDirections()).toBe("tap-increases");
+    // The GlobalSettingsSchema enum rejects invalid values, so an unrecognised
+    // dualPressDirections can only reach the reader if the settings cache is
+    // bypassed. Stub getGlobalSettings directly to exercise the defensive branch.
+    type Settings = ReturnType<typeof globalSettings.getGlobalSettings>;
+    const spy = vi.spyOn(globalSettings, "getGlobalSettings");
+
+    // Sanity check the spy is intercepting: "tap-decreases" is not the cache
+    // default, so getting it back proves the reader read through the stub.
+    spy.mockReturnValue({ dualPressDirections: "tap-decreases" } as unknown as Settings);
+    expect(getDualPressDirections()).toBe("tap-decreases");
+
+    // An unrecognised value resolves to the defensive fallback.
+    spy.mockReturnValue({ dualPressDirections: "sideways" } as unknown as Settings);
+    expect(getDualPressDirections()).toBe(DUAL_PRESS_DIRECTIONS_FALLBACK);
+
+    spy.mockRestore();
   });
 });

--- a/packages/deck-core/src/dual-press.ts
+++ b/packages/deck-core/src/dual-press.ts
@@ -1,0 +1,110 @@
+/**
+ * Dual-press tracker
+ *
+ * One physical key, two outcomes: a short press fires one outcome and a long
+ * press (held ≥ `dualPressThresholdMs` from global settings) fires the other.
+ * Used by setup actions in `view-*` sub-modes (issue #540) so a single key can
+ * both display the live value and adjust it in either direction.
+ *
+ * Mechanism is plugin-agnostic — actions instantiate a tracker, call
+ * `recordKeyDown(contextId)` in `onKeyDown`, and resolve the outcome in
+ * `onKeyUp` via `computeOutcome(contextId, tapOutcome, longPressOutcome)`.
+ * The tracker reads the live threshold from global settings on every resolve,
+ * so a slider change in the PI takes effect on the next press without
+ * re-registering anything.
+ */
+import { getGlobalSettings } from "./global-settings.js";
+
+/**
+ * Fallback threshold used when the global setting is missing or out of range.
+ * Mirrors the schema default in `global-settings.ts`.
+ */
+export const DUAL_PRESS_THRESHOLD_FALLBACK_MS = 500;
+
+/**
+ * Resolve the live dual-press threshold from global settings, with a safe
+ * fallback when the cache is empty (early startup) or the persisted value
+ * isn't a finite number.
+ */
+export function getDualPressThresholdMs(): number {
+  const settings = getGlobalSettings() as Record<string, unknown>;
+  const raw = settings.dualPressThresholdMs;
+
+  if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+
+  if (typeof raw === "string" && raw.length > 0) {
+    const parsed = Number(raw);
+
+    if (Number.isFinite(parsed)) return parsed;
+  }
+
+  return DUAL_PRESS_THRESHOLD_FALLBACK_MS;
+}
+
+/** Which direction a tap fires; the long-press fires the opposite. */
+export type DualPressDirections = "tap-increases" | "tap-decreases";
+
+/** Fallback used by `getDualPressDirections()` when the setting is missing. */
+export const DUAL_PRESS_DIRECTIONS_FALLBACK: DualPressDirections = "tap-increases";
+
+/**
+ * Resolve the live dual-press tap direction from global settings. Falls back
+ * to `"tap-increases"` when the value is missing or not one of the two known
+ * enum values.
+ */
+export function getDualPressDirections(): DualPressDirections {
+  const settings = getGlobalSettings() as Record<string, unknown>;
+  const raw = settings.dualPressDirections;
+
+  if (raw === "tap-increases" || raw === "tap-decreases") return raw;
+
+  return DUAL_PRESS_DIRECTIONS_FALLBACK;
+}
+
+/**
+ * Per-action tap-vs-long-press timing helper. State is keyed by an opaque
+ * context id (typically the deck action context id) so a single tracker
+ * instance can serve every visible key for an action class.
+ */
+export class DualPressTracker {
+  private readonly keyDownTimestamps = new Map<string, number>();
+  private readonly now: () => number;
+
+  constructor(now: () => number = Date.now) {
+    this.now = now;
+  }
+
+  /** Stamp the moment a context's key went down. Overwrites any previous stamp. */
+  recordKeyDown(contextId: string): void {
+    this.keyDownTimestamps.set(contextId, this.now());
+  }
+
+  /**
+   * Resolve which outcome to fire on key-up. Consumes the recorded key-down
+   * timestamp; returns `undefined` when no key-down was ever recorded so a
+   * stray key-up (or a second key-up after the first was consumed) is a
+   * no-op for the caller. This matters when dual-press is enabled mid-press:
+   * the key-down never landed under the new rule, and silently firing the
+   * tap outcome on the key-up would surprise the driver.
+   */
+  computeOutcome<T>(contextId: string, tapOutcome: T, longPressOutcome: T): T | undefined {
+    const start = this.keyDownTimestamps.get(contextId);
+    this.keyDownTimestamps.delete(contextId);
+
+    if (start === undefined) return undefined;
+
+    const duration = this.now() - start;
+
+    return duration >= getDualPressThresholdMs() ? longPressOutcome : tapOutcome;
+  }
+
+  /** Drop any pending key-down for a context (call from `onWillDisappear`). */
+  clear(contextId: string): void {
+    this.keyDownTimestamps.delete(contextId);
+  }
+
+  /** @internal */
+  hasPending(contextId: string): boolean {
+    return this.keyDownTimestamps.has(contextId);
+  }
+}

--- a/packages/deck-core/src/global-settings.test.ts
+++ b/packages/deck-core/src/global-settings.test.ts
@@ -440,3 +440,49 @@ describe("flagFlashDurationSeconds (issue #490)", () => {
     expect(() => GlobalSettingsSchema.parse({ flagFlashDurationSeconds: 31 })).toThrow();
   });
 });
+
+describe("dualPressThresholdMs (issue #540)", () => {
+  it("defaults to 500 when not specified", () => {
+    const parsed = GlobalSettingsSchema.parse({}) as Record<string, unknown>;
+    expect(parsed.dualPressThresholdMs).toBe(500);
+  });
+
+  it("accepts the lower bound (200 ms)", () => {
+    const parsed = GlobalSettingsSchema.parse({ dualPressThresholdMs: 200 }) as Record<string, unknown>;
+    expect(parsed.dualPressThresholdMs).toBe(200);
+  });
+
+  it("accepts the upper bound (2000 ms)", () => {
+    const parsed = GlobalSettingsSchema.parse({ dualPressThresholdMs: 2000 }) as Record<string, unknown>;
+    expect(parsed.dualPressThresholdMs).toBe(2000);
+  });
+
+  it("coerces a numeric string from the Property Inspector slider", () => {
+    const parsed = GlobalSettingsSchema.parse({ dualPressThresholdMs: "750" }) as Record<string, unknown>;
+    expect(parsed.dualPressThresholdMs).toBe(750);
+  });
+
+  it("rejects values below 200", () => {
+    expect(() => GlobalSettingsSchema.parse({ dualPressThresholdMs: 199 })).toThrow();
+  });
+
+  it("rejects values above 2000", () => {
+    expect(() => GlobalSettingsSchema.parse({ dualPressThresholdMs: 2001 })).toThrow();
+  });
+});
+
+describe("dualPressDirections (issue #540)", () => {
+  it("defaults to tap-increases when not specified", () => {
+    const parsed = GlobalSettingsSchema.parse({}) as Record<string, unknown>;
+    expect(parsed.dualPressDirections).toBe("tap-increases");
+  });
+
+  it("accepts tap-decreases", () => {
+    const parsed = GlobalSettingsSchema.parse({ dualPressDirections: "tap-decreases" }) as Record<string, unknown>;
+    expect(parsed.dualPressDirections).toBe("tap-decreases");
+  });
+
+  it("rejects unknown enum values", () => {
+    expect(() => GlobalSettingsSchema.parse({ dualPressDirections: "tap-toggles" })).toThrow();
+  });
+});

--- a/packages/deck-core/src/global-settings.ts
+++ b/packages/deck-core/src/global-settings.ts
@@ -402,6 +402,25 @@ export const GlobalSettingsSchema = z
      * concept and stays a constant.
      */
     flagFlashDurationSeconds: z.coerce.number().min(0).max(30).default(15),
+    /**
+     * Threshold in milliseconds separating a short tap from a long press for
+     * dual-press controls (issue #540). On a View sub-mode of a setup action,
+     * a press shorter than this fires the configured tap direction and a
+     * press at or above it fires the opposite direction. Range 200–2000 ms,
+     * default 500 ms. The fallback used by `getDualPressThresholdMs()` when
+     * settings are unavailable matches this default.
+     */
+    dualPressThresholdMs: z.coerce.number().min(200).max(2000).default(500),
+    /**
+     * Which direction a short press fires on a dual-press setup View sub-mode
+     * (issue #540). The long-press always fires the opposite. Plugin-wide
+     * because drivers want a consistent muscle-memory rule across every setup
+     * action, not a per-key choice.
+     *
+     * - `"tap-increases"` — tap fires Increase, long-press fires Decrease (default)
+     * - `"tap-decreases"` — tap fires Decrease, long-press fires Increase
+     */
+    dualPressDirections: z.enum(["tap-increases", "tap-decreases"]).default("tap-increases"),
   })
   .passthrough();
 

--- a/packages/deck-core/src/index.ts
+++ b/packages/deck-core/src/index.ts
@@ -211,6 +211,16 @@ export {
 // Key binding utilities
 export { formatKeyBinding, parseKeyBinding, parseBinding } from "./key-binding-utils.js";
 
+// Dual-press tracker (issue #540)
+export {
+  DualPressTracker,
+  DUAL_PRESS_THRESHOLD_FALLBACK_MS,
+  DUAL_PRESS_DIRECTIONS_FALLBACK,
+  type DualPressDirections,
+  getDualPressThresholdMs,
+  getDualPressDirections,
+} from "./dual-press.js";
+
 // Plugin config singleton
 export {
   initPluginConfig,

--- a/packages/deck-core/src/simhub-service.test.ts
+++ b/packages/deck-core/src/simhub-service.test.ts
@@ -82,6 +82,8 @@ describe("SimHub Service", () => {
       calloutEnabledIncidentCollisionCar: true,
       calloutEnabledTrackWetness: true,
       flagFlashDurationSeconds: 15,
+      dualPressThresholdMs: 500,
+      dualPressDirections: "tap-increases",
     });
   });
 
@@ -213,6 +215,8 @@ describe("SimHub Service", () => {
         calloutEnabledIncidentCollisionCar: true,
         calloutEnabledTrackWetness: true,
         flagFlashDurationSeconds: 15,
+        dualPressThresholdMs: 500,
+        dualPressDirections: "tap-increases",
       });
 
       initializeSimHub(mockLogger);

--- a/packages/iracing-actions/src/actions/data/key-bindings.json
+++ b/packages/iracing-actions/src/actions/data/key-bindings.json
@@ -504,6 +504,30 @@
       "label": "Power Steering -",
       "default": "",
       "setting": "setupChassisPowerSteeringDecrease"
+    },
+    {
+      "id": "weightJackerLeftIncrease",
+      "label": "Weight Jacker Left +",
+      "default": "",
+      "setting": "setupChassisWeightJackerLeftIncrease"
+    },
+    {
+      "id": "weightJackerLeftDecrease",
+      "label": "Weight Jacker Left -",
+      "default": "",
+      "setting": "setupChassisWeightJackerLeftDecrease"
+    },
+    {
+      "id": "weightJackerRightIncrease",
+      "label": "Weight Jacker Right +",
+      "default": "",
+      "setting": "setupChassisWeightJackerRightIncrease"
+    },
+    {
+      "id": "weightJackerRightDecrease",
+      "label": "Weight Jacker Right -",
+      "default": "",
+      "setting": "setupChassisWeightJackerRightDecrease"
     }
   ],
   "setupAero": [

--- a/packages/iracing-actions/src/actions/setup-aero/setup-aero.ejs
+++ b/packages/iracing-actions/src/actions/setup-aero/setup-aero.ejs
@@ -28,6 +28,8 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<%- include('dual-press-overrides') %>
+
 		<%- include('title-overrides') %>
 
 		<%- include('color-overrides', { slots: ['backgroundColor', 'textColor', 'graphic1Color'], defaults: require('./data/icon-defaults.json')['setup-aero'] }) %>
@@ -49,12 +51,20 @@
 		<%- include('global-common-settings') %>
 
 		<script>
-			// RF Brake Attached is non-directional; View sub-modes are read-only — both hide Direction.
+			// RF Brake Attached is non-directional; View sub-modes are read-only displays —
+			// both hide Direction. View sub-modes additionally show the dual-press opt-in.
+			function isViewSetting(setting) {
+				return typeof setting === "string" && setting.startsWith("view-");
+			}
+
 			function updateVisibility(setting) {
 				const directionItem = document.getElementById("direction-item");
-				if (!directionItem) return;
-				const hide = setting === "rf-brake-attached" || setting.startsWith("view-");
-				directionItem.classList.toggle("hidden", hide);
+				const dualEnabledItem = document.getElementById("dual-press-enabled-item");
+
+				const view = isViewSetting(setting);
+				const hideDirection = setting === "rf-brake-attached" || view;
+				directionItem?.classList.toggle("hidden", hideDirection);
+				dualEnabledItem?.classList.toggle("hidden", !view);
 			}
 
 			async function initialize() {
@@ -66,14 +76,10 @@
 					const initialValue = settingSelect.value || "front-wing";
 					updateVisibility(initialValue);
 
-					settingSelect.addEventListener("change", (ev) => {
-						updateVisibility(ev.target.value || "front-wing");
-					});
-					settingSelect.addEventListener("input", (ev) => {
-						updateVisibility(ev.target.value || "front-wing");
-					});
+					const onChange = (ev) => updateVisibility(ev.target.value || "front-wing");
+					settingSelect.addEventListener("change", onChange);
+					settingSelect.addEventListener("input", onChange);
 
-					// Polling fallback for reliable detection
 					let lastValue = settingSelect.value || "front-wing";
 					setInterval(() => {
 						const currentValue = settingSelect.value;

--- a/packages/iracing-actions/src/actions/setup-aero/setup-aero.test.ts
+++ b/packages/iracing-actions/src/actions/setup-aero/setup-aero.test.ts
@@ -57,6 +57,14 @@ vi.mock("@iracedeck/deck-core", () => ({
     async onDidReceiveSettings() {}
     async onWillDisappear() {}
   },
+  DualPressTracker: class MockDualPressTracker {
+    recordKeyDown = vi.fn();
+    computeOutcome = vi.fn(() => undefined);
+    clear = vi.fn();
+    hasPending = vi.fn(() => false);
+  },
+  getDualPressThresholdMs: vi.fn(() => 500),
+  getDualPressDirections: vi.fn(() => "tap-increases"),
   formatKeyBinding: vi.fn((b: { key: string; modifiers: string[] }) => {
     if (b.modifiers?.length) {
       return `${b.modifiers.join("+")}+${b.key}`;

--- a/packages/iracing-actions/src/actions/setup-aero/setup-aero.test.ts
+++ b/packages/iracing-actions/src/actions/setup-aero/setup-aero.test.ts
@@ -1,6 +1,11 @@
+import { getDualPressDirections } from "@iracedeck/deck-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { generateSetupAeroSvg, SETUP_AERO_GLOBAL_KEYS, SetupAero } from "./setup-aero.js";
+
+// Convenience handle so dual-press tests can switch the live tap direction the same
+// way the runtime does (via the @iracedeck/deck-core getDualPressDirections reader).
+const mockGetDualPressDirections = getDualPressDirections as unknown as ReturnType<typeof vi.fn>;
 
 const { mockTapBinding } = vi.hoisted(() => ({
   mockTapBinding: vi.fn().mockResolvedValue(undefined),
@@ -402,6 +407,104 @@ describe("SetupAero", () => {
       await action.onKeyDown(fakeEvent("action-1", { setting: "view-rear-wing" }) as any);
 
       expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("dual-press dispatch (issue #540)", () => {
+    let action: SetupAero;
+
+    beforeEach(() => {
+      action = new SetupAero();
+    });
+
+    it("records keyDown on View + dual-press enabled and does not fire on its own", async () => {
+      const tracker = (action as any).dualPress as { recordKeyDown: ReturnType<typeof vi.fn> };
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-front-wing", dualPressEnabled: true }) as any);
+
+      expect(tracker.recordKeyDown).toHaveBeenCalledWith("action-1");
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("does not record keyDown when dual-press is disabled", async () => {
+      const tracker = (action as any).dualPress as { recordKeyDown: ReturnType<typeof vi.fn> };
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-front-wing", dualPressEnabled: false }) as any);
+
+      expect(tracker.recordKeyDown).not.toHaveBeenCalled();
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("fires the increase binding on a short press with tap-increases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue("increase");
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-front-wing", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupAeroFrontWingIncrease");
+    });
+
+    it("fires the decrease binding on a long press with tap-increases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue("decrease");
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-front-wing", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupAeroFrontWingDecrease");
+    });
+
+    it("inverts directions when the global dualPressDirections is tap-decreases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-decreases");
+      // The mock passes the chosen outcome through computeOutcome unchanged, so
+      // we set the return based on what the tap direction should be.
+      tracker.computeOutcome.mockImplementation((_id: string, tap: string, _long: string) => tap);
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-front-wing", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupAeroFrontWingDecrease");
+    });
+
+    it("does not fire when the tracker returns undefined (stray key-up)", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue(undefined);
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-front-wing", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("does not fire when dual-press is disabled on key-up", async () => {
+      const tracker = (action as any).dualPress as {
+        computeOutcome: ReturnType<typeof vi.fn>;
+        clear: ReturnType<typeof vi.fn>;
+      };
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-front-wing", dualPressEnabled: false }) as any);
+
+      expect(tracker.computeOutcome).not.toHaveBeenCalled();
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("clears tracker on key-up for non-View settings (so future View presses start clean)", async () => {
+      const tracker = (action as any).dualPress as { clear: ReturnType<typeof vi.fn> };
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "front-wing", direction: "increase" }) as any);
+
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
+    });
+
+    it("clears tracker on willDisappear", async () => {
+      const tracker = (action as any).dualPress as { clear: ReturnType<typeof vi.fn> };
+
+      await action.onWillDisappear({
+        action: { id: "action-1" },
+        payload: { settings: { setting: "view-front-wing" } },
+      } as any);
+
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
     });
   });
 });

--- a/packages/iracing-actions/src/actions/setup-aero/setup-aero.ts
+++ b/packages/iracing-actions/src/actions/setup-aero/setup-aero.ts
@@ -2,6 +2,8 @@ import {
   assembleIcon,
   CommonSettings,
   ConnectionStateAwareAction,
+  DualPressTracker,
+  getDualPressDirections,
   getGlobalBorderSettings,
   getGlobalColors,
   getGlobalGraphicSettings,
@@ -10,6 +12,7 @@ import {
   type IDeckDialRotateEvent,
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
+  type IDeckKeyUpEvent,
   type IDeckWillAppearEvent,
   type IDeckWillDisappearEvent,
   resolveBorderSettings,
@@ -27,7 +30,12 @@ import rfBrakeAttachedIconSvg from "@iracedeck/icons/setup-aero/rf-brake-attache
 import type { TelemetryData } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
-import { formatViewValue, generateSetupViewSvg, isViewSetting } from "../../shared/setup-view.js";
+import {
+  formatViewValue,
+  generateSetupViewSvg,
+  getAdjustmentModeForView,
+  isViewSetting,
+} from "../../shared/setup-view.js";
 
 type SetupAeroAdjustSetting = "front-wing" | "rear-wing" | "qualifying-tape" | "rf-brake-attached";
 
@@ -98,6 +106,18 @@ const SetupAeroSettings = CommonSettings.extend({
     ])
     .default("front-wing"),
   direction: z.enum(["increase", "decrease"]).default("increase"),
+  /**
+   * Dual-press opt-in for View sub-modes (issue #540). When `true` (default),
+   * a View key fires the global tap direction on a short press and the
+   * opposite on a long press (held ≥ `dualPressThresholdMs`). When `false`,
+   * the View stays purely read-only. Ignored for adjustment / toggle
+   * sub-modes. The tap direction itself is the plugin-wide
+   * `dualPressDirections` global setting.
+   */
+  dualPressEnabled: z
+    .union([z.boolean(), z.string()])
+    .transform((v) => v === true || v === "true")
+    .default(true),
 });
 
 type SetupAeroSettings = z.infer<typeof SetupAeroSettings>;
@@ -151,6 +171,9 @@ export class SetupAero extends ConnectionStateAwareAction<SetupAeroSettings> {
   /** Last rendered View value per context — memoizes the icon so we only re-emit on actual change. */
   private readonly lastRenderedValue = new Map<string, string>();
 
+  /** Per-context key-down timestamps for dual-press dispatch on View sub-modes (#540). */
+  private readonly dualPress = new DualPressTracker();
+
   override async onWillAppear(ev: IDeckWillAppearEvent<SetupAeroSettings>): Promise<void> {
     await super.onWillAppear(ev);
     const settings = this.parseSettings(ev.payload.settings);
@@ -171,6 +194,7 @@ export class SetupAero extends ConnectionStateAwareAction<SetupAeroSettings> {
     this.sdkController.unsubscribe(ev.action.id);
     this.activeContexts.delete(ev.action.id);
     this.lastRenderedValue.delete(ev.action.id);
+    this.dualPress.clear(ev.action.id);
     await super.onWillDisappear(ev);
   }
 
@@ -187,13 +211,53 @@ export class SetupAero extends ConnectionStateAwareAction<SetupAeroSettings> {
     const settings = this.parseSettings(ev.payload.settings);
 
     if (isViewSetting(settings.setting)) {
-      this.logger.debug("View sub-mode is read-only, ignoring key press");
+      if (settings.dualPressEnabled) {
+        this.dualPress.recordKeyDown(ev.action.id);
+      } else {
+        this.logger.debug("View sub-mode is read-only (dual-press off), ignoring key press");
+      }
 
       return;
     }
 
     this.logger.info("Key down received");
     await this.executeSetting(settings.setting, settings.direction);
+  }
+
+  override async onKeyUp(ev: IDeckKeyUpEvent<SetupAeroSettings>): Promise<void> {
+    const settings = this.parseSettings(ev.payload.settings);
+
+    if (!isViewSetting(settings.setting) || !settings.dualPressEnabled) {
+      this.dualPress.clear(ev.action.id);
+
+      return;
+    }
+
+    const adjustMode = getAdjustmentModeForView(settings.setting);
+
+    if (!adjustMode) {
+      this.dualPress.clear(ev.action.id);
+
+      return;
+    }
+
+    const tapDir: DirectionType = getDualPressDirections() === "tap-increases" ? "increase" : "decrease";
+    const longDir: DirectionType = tapDir === "increase" ? "decrease" : "increase";
+    const direction = this.dualPress.computeOutcome(ev.action.id, tapDir, longDir);
+
+    if (direction === undefined) return;
+
+    this.logger.info("Dual-press dispatch");
+    this.logger.debug(`Dual-press: ${adjustMode} ${direction}`);
+    const settingKey = SETUP_AERO_GLOBAL_KEYS[`${adjustMode}-${direction}`];
+
+    if (!settingKey) {
+      this.logger.warn(`No global key mapping for dual-press ${adjustMode} ${direction}`);
+
+      return;
+    }
+
+    await this.tapBinding(settingKey);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<SetupAeroSettings>): Promise<void> {
@@ -233,7 +297,16 @@ export class SetupAero extends ConnectionStateAwareAction<SetupAeroSettings> {
 
   private applyActiveBinding(settings: SetupAeroSettings): void {
     if (isViewSetting(settings.setting)) {
-      this.setActiveBinding(null);
+      if (!settings.dualPressEnabled) {
+        this.setActiveBinding(null);
+
+        return;
+      }
+
+      const adjustMode = getAdjustmentModeForView(settings.setting);
+      const tapDir: DirectionType = getDualPressDirections() === "tap-increases" ? "increase" : "decrease";
+      const activeKey = adjustMode ? (SETUP_AERO_GLOBAL_KEYS[`${adjustMode}-${tapDir}`] ?? null) : null;
+      this.setActiveBinding(activeKey);
 
       return;
     }

--- a/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.ejs
+++ b/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.ejs
@@ -35,6 +35,8 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<%- include('dual-press-overrides') %>
+
 		<%- include('title-overrides') %>
 
 		<%- include('color-overrides', { slots: ['backgroundColor', 'textColor', 'graphic1Color'], defaults: require('./data/icon-defaults.json')['setup-brakes'] }) %>
@@ -56,12 +58,20 @@
 		<%- include('global-common-settings') %>
 
 		<script>
-			// ABS Toggle is non-directional; View sub-modes are read-only — both hide Direction.
+			// ABS Toggle is non-directional; View sub-modes are read-only displays — both hide Direction.
+			// View sub-modes show the dual-press opt-in; non-View sub-modes hide it.
+			function isViewSetting(setting) {
+				return typeof setting === "string" && setting.startsWith("view-");
+			}
+
 			function updateVisibility(setting) {
 				const directionItem = document.getElementById("direction-item");
-				if (!directionItem) return;
-				const hide = setting === "abs-toggle" || setting.startsWith("view-");
-				directionItem.classList.toggle("hidden", hide);
+				const dualEnabledItem = document.getElementById("dual-press-enabled-item");
+
+				const view = isViewSetting(setting);
+				const hideDirection = setting === "abs-toggle" || view;
+				directionItem?.classList.toggle("hidden", hideDirection);
+				dualEnabledItem?.classList.toggle("hidden", !view);
 			}
 
 			async function initialize() {
@@ -73,14 +83,11 @@
 					const initialValue = settingSelect.value || "brake-bias";
 					updateVisibility(initialValue);
 
-					settingSelect.addEventListener("change", (ev) => {
-						updateVisibility(ev.target.value || "brake-bias");
-					});
-					settingSelect.addEventListener("input", (ev) => {
-						updateVisibility(ev.target.value || "brake-bias");
-					});
+					const onChange = (ev) => updateVisibility(ev.target.value || "brake-bias");
+					settingSelect.addEventListener("change", onChange);
+					settingSelect.addEventListener("input", onChange);
 
-					// Polling fallback for reliable detection
+					// Polling fallback — sdpi-select events can be unreliable.
 					let lastValue = settingSelect.value || "brake-bias";
 					setInterval(() => {
 						const currentValue = settingSelect.value;

--- a/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.test.ts
+++ b/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.test.ts
@@ -1,7 +1,12 @@
+// Convenience handle so dual-press tests can switch the live tap direction the same
+// way the runtime does (via the @iracedeck/deck-core getDualPressDirections reader).
+import { getDualPressDirections } from "@iracedeck/deck-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { generateSetupBrakesSvg, SETUP_BRAKES_GLOBAL_KEYS } from "./setup-brakes.js";
 import { SetupBrakes } from "./setup-brakes.js";
+
+const mockGetDualPressDirections = getDualPressDirections as unknown as ReturnType<typeof vi.fn>;
 
 const { mockTapBinding } = vi.hoisted(() => ({
   mockTapBinding: vi.fn().mockResolvedValue(undefined),
@@ -76,6 +81,14 @@ vi.mock("@iracedeck/deck-core", () => ({
     async onDidReceiveSettings() {}
     async onWillDisappear() {}
   },
+  DualPressTracker: class MockDualPressTracker {
+    recordKeyDown = vi.fn();
+    computeOutcome = vi.fn(() => undefined);
+    clear = vi.fn();
+    hasPending = vi.fn(() => false);
+  },
+  getDualPressThresholdMs: vi.fn(() => 500),
+  getDualPressDirections: vi.fn(() => "tap-increases"),
   formatKeyBinding: vi.fn((b: { key: string; modifiers: string[] }) => {
     if (b.modifiers?.length) {
       return `${b.modifiers.join("+")}+${b.key}`;
@@ -510,12 +523,109 @@ describe("SetupBrakes", () => {
       expect(unsubscribe).toHaveBeenCalledWith("action-1");
     });
 
-    it("clears active binding when switching to a View setting", async () => {
+    it("clears active binding when switching to a View setting with dual-press off", async () => {
       const setActive = action.setActiveBinding as any;
-      await action.onWillAppear(fakeEvent("action-1", { setting: "view-brake-bias" }) as any);
+      await action.onWillAppear(fakeEvent("action-1", { setting: "view-brake-bias", dualPressEnabled: false }) as any);
 
-      // setActiveBinding is called with null for view sub-modes.
       expect(setActive).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe("dual-press dispatch (issue #540)", () => {
+    let action: SetupBrakes;
+
+    beforeEach(() => {
+      action = new SetupBrakes();
+    });
+
+    it("records keyDown on View + dual-press enabled and does not fire on its own", async () => {
+      const tracker = (action as any).dualPress as { recordKeyDown: ReturnType<typeof vi.fn> };
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-brake-bias", dualPressEnabled: true }) as any);
+
+      expect(tracker.recordKeyDown).toHaveBeenCalledWith("action-1");
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("does not record keyDown when dual-press is disabled", async () => {
+      const tracker = (action as any).dualPress as { recordKeyDown: ReturnType<typeof vi.fn> };
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-brake-bias", dualPressEnabled: false }) as any);
+
+      expect(tracker.recordKeyDown).not.toHaveBeenCalled();
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("fires the increase binding on a short press with tap-increases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue("increase");
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-brake-bias", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupBrakesBrakeBiasIncrease");
+    });
+
+    it("fires the decrease binding on a long press with tap-increases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue("decrease");
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-brake-bias", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupBrakesBrakeBiasDecrease");
+    });
+
+    it("inverts directions when the global dualPressDirections is tap-decreases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-decreases");
+      // The mock passes the chosen outcome through computeOutcome unchanged, so
+      // we set the return based on what the tap direction should be.
+      tracker.computeOutcome.mockImplementation((_id: string, tap: string, _long: string) => tap);
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-brake-bias", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupBrakesBrakeBiasDecrease");
+    });
+
+    it("does not fire when the tracker returns undefined (stray key-up)", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue(undefined);
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-brake-bias", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("does not fire when dual-press is disabled on key-up", async () => {
+      const tracker = (action as any).dualPress as {
+        computeOutcome: ReturnType<typeof vi.fn>;
+        clear: ReturnType<typeof vi.fn>;
+      };
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-brake-bias", dualPressEnabled: false }) as any);
+
+      expect(tracker.computeOutcome).not.toHaveBeenCalled();
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("clears tracker on key-up for non-View settings (so future View presses start clean)", async () => {
+      const tracker = (action as any).dualPress as { clear: ReturnType<typeof vi.fn> };
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "brake-bias", direction: "increase" }) as any);
+
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
+    });
+
+    it("clears tracker on willDisappear", async () => {
+      const tracker = (action as any).dualPress as { clear: ReturnType<typeof vi.fn> };
+
+      await action.onWillDisappear({
+        action: { id: "action-1" },
+        payload: { settings: { setting: "view-brake-bias" } },
+      } as any);
+
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
     });
   });
 });

--- a/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.ts
+++ b/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.ts
@@ -2,6 +2,8 @@ import {
   assembleIcon,
   CommonSettings,
   ConnectionStateAwareAction,
+  DualPressTracker,
+  getDualPressDirections,
   getGlobalBorderSettings,
   getGlobalColors,
   getGlobalGraphicSettings,
@@ -10,6 +12,7 @@ import {
   type IDeckDialRotateEvent,
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
+  type IDeckKeyUpEvent,
   type IDeckWillAppearEvent,
   type IDeckWillDisappearEvent,
   resolveBorderSettings,
@@ -33,7 +36,12 @@ import peakBrakeBiasIncreaseIconSvg from "@iracedeck/icons/setup-brakes/peak-bra
 import type { TelemetryData } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
-import { formatViewValue, generateSetupViewSvg, isViewSetting } from "../../shared/setup-view.js";
+import {
+  formatViewValue,
+  generateSetupViewSvg,
+  getAdjustmentModeForView,
+  isViewSetting,
+} from "../../shared/setup-view.js";
 
 type SetupBrakesAdjustSetting =
   | "abs-toggle"
@@ -143,6 +151,18 @@ const SetupBrakesSettings = CommonSettings.extend({
     ])
     .default("brake-bias"),
   direction: z.enum(["increase", "decrease"]).default("increase"),
+  /**
+   * Dual-press opt-in for View sub-modes (issue #540). When `true` (default),
+   * a View key fires the global tap direction on a short press and the
+   * opposite on a long press (held ≥ `dualPressThresholdMs`). When `false`,
+   * the View stays purely read-only. Ignored for adjustment / toggle
+   * sub-modes. The tap direction itself is the plugin-wide
+   * `dualPressDirections` global setting.
+   */
+  dualPressEnabled: z
+    .union([z.boolean(), z.string()])
+    .transform((v) => v === true || v === "true")
+    .default(true),
 });
 
 type SetupBrakesSettings = z.infer<typeof SetupBrakesSettings>;
@@ -210,6 +230,9 @@ export class SetupBrakes extends ConnectionStateAwareAction<SetupBrakesSettings>
   /** Last rendered View value per context — memoizes the icon so we only re-emit on actual change. */
   private readonly lastRenderedValue = new Map<string, string>();
 
+  /** Per-context key-down timestamps for dual-press dispatch on View sub-modes (#540). */
+  private readonly dualPress = new DualPressTracker();
+
   override async onWillAppear(ev: IDeckWillAppearEvent<SetupBrakesSettings>): Promise<void> {
     await super.onWillAppear(ev);
     const settings = this.parseSettings(ev.payload.settings);
@@ -232,6 +255,7 @@ export class SetupBrakes extends ConnectionStateAwareAction<SetupBrakesSettings>
     this.sdkController.unsubscribe(ev.action.id);
     this.activeContexts.delete(ev.action.id);
     this.lastRenderedValue.delete(ev.action.id);
+    this.dualPress.clear(ev.action.id);
     await super.onWillDisappear(ev);
   }
 
@@ -250,13 +274,57 @@ export class SetupBrakes extends ConnectionStateAwareAction<SetupBrakesSettings>
     const settings = this.parseSettings(ev.payload.settings);
 
     if (isViewSetting(settings.setting)) {
-      this.logger.debug("View sub-mode is read-only, ignoring key press");
+      if (settings.dualPressEnabled) {
+        this.dualPress.recordKeyDown(ev.action.id);
+      } else {
+        this.logger.debug("View sub-mode is read-only (dual-press off), ignoring key press");
+      }
 
       return;
     }
 
     this.logger.info("Key down received");
     await this.executeSetting(settings.setting, settings.direction);
+  }
+
+  override async onKeyUp(ev: IDeckKeyUpEvent<SetupBrakesSettings>): Promise<void> {
+    const settings = this.parseSettings(ev.payload.settings);
+
+    if (!isViewSetting(settings.setting) || !settings.dualPressEnabled) {
+      // Non-View modes already fired on key-down; dual-press disabled means read-only.
+      this.dualPress.clear(ev.action.id);
+
+      return;
+    }
+
+    const adjustMode = getAdjustmentModeForView(settings.setting);
+
+    if (!adjustMode) {
+      this.dualPress.clear(ev.action.id);
+
+      return;
+    }
+
+    const tapDir: DirectionType = getDualPressDirections() === "tap-increases" ? "increase" : "decrease";
+    const longDir: DirectionType = tapDir === "increase" ? "decrease" : "increase";
+    const direction = this.dualPress.computeOutcome(ev.action.id, tapDir, longDir);
+
+    if (direction === undefined) {
+      // Stray key-up with no matching key-down (e.g. dual-press just enabled mid-press).
+      return;
+    }
+
+    this.logger.info("Dual-press dispatch");
+    this.logger.debug(`Dual-press: ${adjustMode} ${direction}`);
+    const settingKey = SETUP_BRAKES_GLOBAL_KEYS[`${adjustMode}-${direction}`];
+
+    if (!settingKey) {
+      this.logger.warn(`No global key mapping for dual-press ${adjustMode} ${direction}`);
+
+      return;
+    }
+
+    await this.tapBinding(settingKey);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<SetupBrakesSettings>): Promise<void> {
@@ -296,9 +364,20 @@ export class SetupBrakes extends ConnectionStateAwareAction<SetupBrakesSettings>
 
   private applyActiveBinding(settings: SetupBrakesSettings): void {
     if (isViewSetting(settings.setting)) {
-      // View sub-modes don't fire any binding — clear the active binding so the
-      // readiness overlay reflects "no binding" instead of carrying a stale key.
-      this.setActiveBinding(null);
+      if (!settings.dualPressEnabled) {
+        // Read-only View — no binding drives the key, so clear the readiness overlay.
+        this.setActiveBinding(null);
+
+        return;
+      }
+
+      // Dual-press is active: the tap direction is the primary action, so the
+      // readiness overlay tracks that binding. (Long-press fires the opposite,
+      // but a single chip can only show one — pick the tap.)
+      const adjustMode = getAdjustmentModeForView(settings.setting);
+      const tapDir: DirectionType = getDualPressDirections() === "tap-increases" ? "increase" : "decrease";
+      const activeKey = adjustMode ? (SETUP_BRAKES_GLOBAL_KEYS[`${adjustMode}-${tapDir}`] ?? null) : null;
+      this.setActiveBinding(activeKey);
 
       return;
     }

--- a/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.ejs
+++ b/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.ejs
@@ -44,6 +44,8 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<%- include('dual-press-overrides') %>
+
 		<%- include('title-overrides') %>
 
 		<%- include('color-overrides', { slots: ['backgroundColor', 'textColor', 'graphic1Color'], defaults: require('./data/icon-defaults.json')['setup-chassis'] }) %>
@@ -65,11 +67,18 @@
 		<%- include('global-common-settings') %>
 
 		<script>
-			// View sub-modes are read-only — hide Direction when one is selected.
+			// View sub-modes are read-only displays — hide Direction and show the dual-press opt-in.
+			function isViewSetting(setting) {
+				return typeof setting === "string" && setting.startsWith("view-");
+			}
+
 			function updateVisibility(setting) {
 				const directionItem = document.getElementById("direction-item");
-				if (!directionItem) return;
-				directionItem.classList.toggle("hidden", setting.startsWith("view-"));
+				const dualEnabledItem = document.getElementById("dual-press-enabled-item");
+
+				const view = isViewSetting(setting);
+				directionItem?.classList.toggle("hidden", view);
+				dualEnabledItem?.classList.toggle("hidden", !view);
 			}
 
 			async function initialize() {
@@ -81,14 +90,10 @@
 					const initialValue = settingSelect.value || "differential-preload";
 					updateVisibility(initialValue);
 
-					settingSelect.addEventListener("change", (ev) => {
-						updateVisibility(ev.target.value || "differential-preload");
-					});
-					settingSelect.addEventListener("input", (ev) => {
-						updateVisibility(ev.target.value || "differential-preload");
-					});
+					const onChange = (ev) => updateVisibility(ev.target.value || "differential-preload");
+					settingSelect.addEventListener("change", onChange);
+					settingSelect.addEventListener("input", onChange);
 
-					// Polling fallback for reliable detection
 					let lastValue = settingSelect.value || "differential-preload";
 					setInterval(() => {
 						const currentValue = settingSelect.value;

--- a/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.test.ts
+++ b/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.test.ts
@@ -114,6 +114,14 @@ vi.mock("@iracedeck/deck-core", () => ({
     async onDidReceiveSettings() {}
     async onWillDisappear() {}
   },
+  DualPressTracker: class MockDualPressTracker {
+    recordKeyDown = vi.fn();
+    computeOutcome = vi.fn(() => undefined);
+    clear = vi.fn();
+    hasPending = vi.fn(() => false);
+  },
+  getDualPressThresholdMs: vi.fn(() => 500),
+  getDualPressDirections: vi.fn(() => "tap-increases"),
   formatKeyBinding: vi.fn((b: { key: string; modifiers: string[] }) => {
     if (b.modifiers?.length) {
       return `${b.modifiers.join("+")}+${b.key}`;
@@ -307,8 +315,15 @@ describe("SetupChassis", () => {
       expect(SETUP_CHASSIS_GLOBAL_KEYS["power-steering-decrease"]).toBe("setupChassisPowerSteeringDecrease");
     });
 
-    it("should have exactly 26 entries", () => {
-      expect(Object.keys(SETUP_CHASSIS_GLOBAL_KEYS)).toHaveLength(26);
+    it("should have correct mappings for weight-jacker dual-press targets (issue #540)", () => {
+      expect(SETUP_CHASSIS_GLOBAL_KEYS["weight-jacker-left-increase"]).toBe("setupChassisWeightJackerLeftIncrease");
+      expect(SETUP_CHASSIS_GLOBAL_KEYS["weight-jacker-left-decrease"]).toBe("setupChassisWeightJackerLeftDecrease");
+      expect(SETUP_CHASSIS_GLOBAL_KEYS["weight-jacker-right-increase"]).toBe("setupChassisWeightJackerRightIncrease");
+      expect(SETUP_CHASSIS_GLOBAL_KEYS["weight-jacker-right-decrease"]).toBe("setupChassisWeightJackerRightDecrease");
+    });
+
+    it("should have exactly 30 entries (26 chassis adjust + 4 weight-jacker dual-press targets)", () => {
+      expect(Object.keys(SETUP_CHASSIS_GLOBAL_KEYS)).toHaveLength(30);
     });
   });
 

--- a/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.test.ts
+++ b/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.test.ts
@@ -1,6 +1,11 @@
+import { getDualPressDirections } from "@iracedeck/deck-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { generateSetupChassisSvg, SETUP_CHASSIS_GLOBAL_KEYS, SetupChassis } from "./setup-chassis.js";
+
+// Convenience handle so dual-press tests can switch the live tap direction the same
+// way the runtime does (via the @iracedeck/deck-core getDualPressDirections reader).
+const mockGetDualPressDirections = getDualPressDirections as unknown as ReturnType<typeof vi.fn>;
 
 const { mockTapBinding } = vi.hoisted(() => ({
   mockTapBinding: vi.fn().mockResolvedValue(undefined),
@@ -616,6 +621,104 @@ describe("SetupChassis", () => {
       await action.onKeyDown(fakeEvent("action-1", { setting: "view-power-steering" }) as any);
 
       expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("dual-press dispatch (issue #540)", () => {
+    let action: SetupChassis;
+
+    beforeEach(() => {
+      action = new SetupChassis();
+    });
+
+    it("records keyDown on View + dual-press enabled and does not fire on its own", async () => {
+      const tracker = (action as any).dualPress as { recordKeyDown: ReturnType<typeof vi.fn> };
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-diff-preload", dualPressEnabled: true }) as any);
+
+      expect(tracker.recordKeyDown).toHaveBeenCalledWith("action-1");
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("does not record keyDown when dual-press is disabled", async () => {
+      const tracker = (action as any).dualPress as { recordKeyDown: ReturnType<typeof vi.fn> };
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-diff-preload", dualPressEnabled: false }) as any);
+
+      expect(tracker.recordKeyDown).not.toHaveBeenCalled();
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("fires the increase binding on a short press with tap-increases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue("increase");
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-diff-preload", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupChassisDifferentialPreloadIncrease");
+    });
+
+    it("fires the decrease binding on a long press with tap-increases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue("decrease");
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-diff-preload", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupChassisDifferentialPreloadDecrease");
+    });
+
+    it("inverts directions when the global dualPressDirections is tap-decreases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-decreases");
+      // The mock passes the chosen outcome through computeOutcome unchanged, so
+      // we set the return based on what the tap direction should be.
+      tracker.computeOutcome.mockImplementation((_id: string, tap: string, _long: string) => tap);
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-diff-preload", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupChassisDifferentialPreloadDecrease");
+    });
+
+    it("does not fire when the tracker returns undefined (stray key-up)", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue(undefined);
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-diff-preload", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("does not fire when dual-press is disabled on key-up", async () => {
+      const tracker = (action as any).dualPress as {
+        computeOutcome: ReturnType<typeof vi.fn>;
+        clear: ReturnType<typeof vi.fn>;
+      };
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-diff-preload", dualPressEnabled: false }) as any);
+
+      expect(tracker.computeOutcome).not.toHaveBeenCalled();
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("clears tracker on key-up for non-View settings (so future View presses start clean)", async () => {
+      const tracker = (action as any).dualPress as { clear: ReturnType<typeof vi.fn> };
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "differential-preload", direction: "increase" }) as any);
+
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
+    });
+
+    it("clears tracker on willDisappear", async () => {
+      const tracker = (action as any).dualPress as { clear: ReturnType<typeof vi.fn> };
+
+      await action.onWillDisappear({
+        action: { id: "action-1" },
+        payload: { settings: { setting: "view-diff-preload" } },
+      } as any);
+
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
     });
   });
 });

--- a/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.ts
+++ b/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.ts
@@ -2,6 +2,8 @@ import {
   assembleIcon,
   CommonSettings,
   ConnectionStateAwareAction,
+  DualPressTracker,
+  getDualPressDirections,
   getGlobalBorderSettings,
   getGlobalColors,
   getGlobalGraphicSettings,
@@ -10,6 +12,7 @@ import {
   type IDeckDialRotateEvent,
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
+  type IDeckKeyUpEvent,
   type IDeckWillAppearEvent,
   type IDeckWillDisappearEvent,
   resolveBorderSettings,
@@ -46,7 +49,12 @@ import rrShockIncreaseIconSvg from "@iracedeck/icons/setup-chassis/rr-shock-incr
 import type { TelemetryData } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
-import { formatViewValue, generateSetupViewSvg, isViewSetting } from "../../shared/setup-view.js";
+import {
+  formatViewValue,
+  generateSetupViewSvg,
+  getAdjustmentModeForView,
+  isViewSetting,
+} from "../../shared/setup-view.js";
 
 type DirectionType = "increase" | "decrease";
 
@@ -147,6 +155,14 @@ export const SETUP_CHASSIS_GLOBAL_KEYS: Record<string, string> = {
   "rr-shock-decrease": "setupChassisRrShockDecrease",
   "power-steering-increase": "setupChassisPowerSteeringIncrease",
   "power-steering-decrease": "setupChassisPowerSteeringDecrease",
+  // Weight jacker entries are dual-press dispatch targets only — they don't
+  // appear as user-selectable adjustment modes (issue #540). Drivers can
+  // configure these keys in the PI and trigger them via the corresponding
+  // view-weight-jacker-{left,right} View sub-mode.
+  "weight-jacker-left-increase": "setupChassisWeightJackerLeftIncrease",
+  "weight-jacker-left-decrease": "setupChassisWeightJackerLeftDecrease",
+  "weight-jacker-right-increase": "setupChassisWeightJackerRightIncrease",
+  "weight-jacker-right-decrease": "setupChassisWeightJackerRightDecrease",
 };
 
 const SetupChassisSettings = CommonSettings.extend({
@@ -179,6 +195,18 @@ const SetupChassisSettings = CommonSettings.extend({
     ])
     .default("differential-preload"),
   direction: z.enum(["increase", "decrease"]).default("increase"),
+  /**
+   * Dual-press opt-in for View sub-modes (issue #540). When `true` (default),
+   * a View key fires the global tap direction on a short press and the
+   * opposite on a long press (held ≥ `dualPressThresholdMs`). When `false`,
+   * the View stays purely read-only. Ignored for adjustment / toggle
+   * sub-modes. The tap direction itself is the plugin-wide
+   * `dualPressDirections` global setting.
+   */
+  dualPressEnabled: z
+    .union([z.boolean(), z.string()])
+    .transform((v) => v === true || v === "true")
+    .default(true),
 });
 
 type SetupChassisSettings = z.infer<typeof SetupChassisSettings>;
@@ -231,6 +259,9 @@ export class SetupChassis extends ConnectionStateAwareAction<SetupChassisSetting
   /** Last rendered View value per context — memoizes the icon so we only re-emit on actual change. */
   private readonly lastRenderedValue = new Map<string, string>();
 
+  /** Per-context key-down timestamps for dual-press dispatch on View sub-modes (#540). */
+  private readonly dualPress = new DualPressTracker();
+
   override async onWillAppear(ev: IDeckWillAppearEvent<SetupChassisSettings>): Promise<void> {
     await super.onWillAppear(ev);
     const settings = this.parseSettings(ev.payload.settings);
@@ -251,6 +282,7 @@ export class SetupChassis extends ConnectionStateAwareAction<SetupChassisSetting
     this.sdkController.unsubscribe(ev.action.id);
     this.activeContexts.delete(ev.action.id);
     this.lastRenderedValue.delete(ev.action.id);
+    this.dualPress.clear(ev.action.id);
     await super.onWillDisappear(ev);
   }
 
@@ -267,13 +299,53 @@ export class SetupChassis extends ConnectionStateAwareAction<SetupChassisSetting
     const settings = this.parseSettings(ev.payload.settings);
 
     if (isViewSetting(settings.setting)) {
-      this.logger.debug("View sub-mode is read-only, ignoring key press");
+      if (settings.dualPressEnabled) {
+        this.dualPress.recordKeyDown(ev.action.id);
+      } else {
+        this.logger.debug("View sub-mode is read-only (dual-press off), ignoring key press");
+      }
 
       return;
     }
 
     this.logger.info("Key down received");
     await this.executeSetting(settings.setting, settings.direction);
+  }
+
+  override async onKeyUp(ev: IDeckKeyUpEvent<SetupChassisSettings>): Promise<void> {
+    const settings = this.parseSettings(ev.payload.settings);
+
+    if (!isViewSetting(settings.setting) || !settings.dualPressEnabled) {
+      this.dualPress.clear(ev.action.id);
+
+      return;
+    }
+
+    const adjustMode = getAdjustmentModeForView(settings.setting);
+
+    if (!adjustMode) {
+      this.dualPress.clear(ev.action.id);
+
+      return;
+    }
+
+    const tapDir: DirectionType = getDualPressDirections() === "tap-increases" ? "increase" : "decrease";
+    const longDir: DirectionType = tapDir === "increase" ? "decrease" : "increase";
+    const direction = this.dualPress.computeOutcome(ev.action.id, tapDir, longDir);
+
+    if (direction === undefined) return;
+
+    this.logger.info("Dual-press dispatch");
+    this.logger.debug(`Dual-press: ${adjustMode} ${direction}`);
+    const settingKey = SETUP_CHASSIS_GLOBAL_KEYS[`${adjustMode}-${direction}`];
+
+    if (!settingKey) {
+      this.logger.warn(`No global key mapping for dual-press ${adjustMode} ${direction}`);
+
+      return;
+    }
+
+    await this.tapBinding(settingKey);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<SetupChassisSettings>): Promise<void> {
@@ -304,7 +376,16 @@ export class SetupChassis extends ConnectionStateAwareAction<SetupChassisSetting
 
   private applyActiveBinding(settings: SetupChassisSettings): void {
     if (isViewSetting(settings.setting)) {
-      this.setActiveBinding(null);
+      if (!settings.dualPressEnabled) {
+        this.setActiveBinding(null);
+
+        return;
+      }
+
+      const adjustMode = getAdjustmentModeForView(settings.setting);
+      const tapDir: DirectionType = getDualPressDirections() === "tap-increases" ? "increase" : "decrease";
+      const activeKey = adjustMode ? (SETUP_CHASSIS_GLOBAL_KEYS[`${adjustMode}-${tapDir}`] ?? null) : null;
+      this.setActiveBinding(activeKey);
 
       return;
     }

--- a/packages/iracing-actions/src/actions/setup-engine/setup-engine.ejs
+++ b/packages/iracing-actions/src/actions/setup-engine/setup-engine.ejs
@@ -29,6 +29,8 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<%- include('dual-press-overrides') %>
+
 		<%- include('title-overrides') %>
 
 		<%- include('color-overrides', { slots: ['backgroundColor', 'textColor', 'graphic1Color'], defaults: require('./data/icon-defaults.json')['setup-engine'] }) %>
@@ -50,11 +52,18 @@
 		<%- include('global-common-settings') %>
 
 		<script>
-			// View sub-modes are read-only — hide Direction when one is selected.
+			// View sub-modes are read-only displays — hide Direction and show the dual-press opt-in.
+			function isViewSetting(setting) {
+				return typeof setting === "string" && setting.startsWith("view-");
+			}
+
 			function updateVisibility(setting) {
 				const directionItem = document.getElementById("direction-item");
-				if (!directionItem) return;
-				directionItem.classList.toggle("hidden", setting.startsWith("view-"));
+				const dualEnabledItem = document.getElementById("dual-press-enabled-item");
+
+				const view = isViewSetting(setting);
+				directionItem?.classList.toggle("hidden", view);
+				dualEnabledItem?.classList.toggle("hidden", !view);
 			}
 
 			async function initialize() {
@@ -66,14 +75,10 @@
 					const initialValue = settingSelect.value || "engine-power";
 					updateVisibility(initialValue);
 
-					settingSelect.addEventListener("change", (ev) => {
-						updateVisibility(ev.target.value || "engine-power");
-					});
-					settingSelect.addEventListener("input", (ev) => {
-						updateVisibility(ev.target.value || "engine-power");
-					});
+					const onChange = (ev) => updateVisibility(ev.target.value || "engine-power");
+					settingSelect.addEventListener("change", onChange);
+					settingSelect.addEventListener("input", onChange);
 
-					// Polling fallback for reliable detection
 					let lastValue = settingSelect.value || "engine-power";
 					setInterval(() => {
 						const currentValue = settingSelect.value;

--- a/packages/iracing-actions/src/actions/setup-engine/setup-engine.test.ts
+++ b/packages/iracing-actions/src/actions/setup-engine/setup-engine.test.ts
@@ -61,6 +61,14 @@ vi.mock("@iracedeck/deck-core", () => ({
     async onDidReceiveSettings() {}
     async onWillDisappear() {}
   },
+  DualPressTracker: class MockDualPressTracker {
+    recordKeyDown = vi.fn();
+    computeOutcome = vi.fn(() => undefined);
+    clear = vi.fn();
+    hasPending = vi.fn(() => false);
+  },
+  getDualPressThresholdMs: vi.fn(() => 500),
+  getDualPressDirections: vi.fn(() => "tap-increases"),
   formatKeyBinding: vi.fn((b: { key: string; modifiers: string[] }) => {
     if (b.modifiers?.length) {
       return `${b.modifiers.join("+")}+${b.key}`;

--- a/packages/iracing-actions/src/actions/setup-engine/setup-engine.test.ts
+++ b/packages/iracing-actions/src/actions/setup-engine/setup-engine.test.ts
@@ -1,7 +1,12 @@
+import { getDualPressDirections } from "@iracedeck/deck-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { generateSetupEngineSvg, SETUP_ENGINE_GLOBAL_KEYS } from "./setup-engine.js";
 import { SetupEngine } from "./setup-engine.js";
+
+// Convenience handle so dual-press tests can switch the live tap direction the same
+// way the runtime does (via the @iracedeck/deck-core getDualPressDirections reader).
+const mockGetDualPressDirections = getDualPressDirections as unknown as ReturnType<typeof vi.fn>;
 
 const { mockTapBinding } = vi.hoisted(() => ({
   mockTapBinding: vi.fn().mockResolvedValue(undefined),
@@ -405,6 +410,104 @@ describe("SetupEngine", () => {
       await action.onKeyDown(fakeEvent("action-1", { setting: "view-throttle-shape" }) as any);
 
       expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("dual-press dispatch (issue #540)", () => {
+    let action: SetupEngine;
+
+    beforeEach(() => {
+      action = new SetupEngine();
+    });
+
+    it("records keyDown on View + dual-press enabled and does not fire on its own", async () => {
+      const tracker = (action as any).dualPress as { recordKeyDown: ReturnType<typeof vi.fn> };
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-engine-power", dualPressEnabled: true }) as any);
+
+      expect(tracker.recordKeyDown).toHaveBeenCalledWith("action-1");
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("does not record keyDown when dual-press is disabled", async () => {
+      const tracker = (action as any).dualPress as { recordKeyDown: ReturnType<typeof vi.fn> };
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-engine-power", dualPressEnabled: false }) as any);
+
+      expect(tracker.recordKeyDown).not.toHaveBeenCalled();
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("fires the increase binding on a short press with tap-increases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue("increase");
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-engine-power", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupEngineEnginePowerIncrease");
+    });
+
+    it("fires the decrease binding on a long press with tap-increases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue("decrease");
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-engine-power", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupEngineEnginePowerDecrease");
+    });
+
+    it("inverts directions when the global dualPressDirections is tap-decreases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-decreases");
+      // The mock passes the chosen outcome through computeOutcome unchanged, so
+      // we set the return based on what the tap direction should be.
+      tracker.computeOutcome.mockImplementation((_id: string, tap: string, _long: string) => tap);
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-engine-power", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupEngineEnginePowerDecrease");
+    });
+
+    it("does not fire when the tracker returns undefined (stray key-up)", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue(undefined);
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-engine-power", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("does not fire when dual-press is disabled on key-up", async () => {
+      const tracker = (action as any).dualPress as {
+        computeOutcome: ReturnType<typeof vi.fn>;
+        clear: ReturnType<typeof vi.fn>;
+      };
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-engine-power", dualPressEnabled: false }) as any);
+
+      expect(tracker.computeOutcome).not.toHaveBeenCalled();
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("clears tracker on key-up for non-View settings (so future View presses start clean)", async () => {
+      const tracker = (action as any).dualPress as { clear: ReturnType<typeof vi.fn> };
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "engine-power", direction: "increase" }) as any);
+
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
+    });
+
+    it("clears tracker on willDisappear", async () => {
+      const tracker = (action as any).dualPress as { clear: ReturnType<typeof vi.fn> };
+
+      await action.onWillDisappear({
+        action: { id: "action-1" },
+        payload: { settings: { setting: "view-engine-power" } },
+      } as any);
+
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
     });
   });
 });

--- a/packages/iracing-actions/src/actions/setup-engine/setup-engine.ts
+++ b/packages/iracing-actions/src/actions/setup-engine/setup-engine.ts
@@ -2,6 +2,8 @@ import {
   assembleIcon,
   CommonSettings,
   ConnectionStateAwareAction,
+  DualPressTracker,
+  getDualPressDirections,
   getGlobalBorderSettings,
   getGlobalColors,
   getGlobalGraphicSettings,
@@ -10,6 +12,7 @@ import {
   type IDeckDialRotateEvent,
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
+  type IDeckKeyUpEvent,
   type IDeckWillAppearEvent,
   type IDeckWillDisappearEvent,
   resolveBorderSettings,
@@ -28,7 +31,12 @@ import throttleShapingIncreaseIconSvg from "@iracedeck/icons/setup-engine/thrott
 import type { TelemetryData } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
-import { formatViewValue, generateSetupViewSvg, isViewSetting } from "../../shared/setup-view.js";
+import {
+  formatViewValue,
+  generateSetupViewSvg,
+  getAdjustmentModeForView,
+  isViewSetting,
+} from "../../shared/setup-view.js";
 
 type SetupEngineAdjustSetting = "engine-power" | "throttle-shaping" | "boost-level" | "launch-rpm";
 
@@ -100,6 +108,18 @@ const SetupEngineSettings = CommonSettings.extend({
     ])
     .default("engine-power"),
   direction: z.enum(["increase", "decrease"]).default("increase"),
+  /**
+   * Dual-press opt-in for View sub-modes (issue #540). When `true` (default),
+   * a View key fires the global tap direction on a short press and the
+   * opposite on a long press (held ≥ `dualPressThresholdMs`). When `false`,
+   * the View stays purely read-only. Ignored for adjustment / toggle
+   * sub-modes. The tap direction itself is the plugin-wide
+   * `dualPressDirections` global setting.
+   */
+  dualPressEnabled: z
+    .union([z.boolean(), z.string()])
+    .transform((v) => v === true || v === "true")
+    .default(true),
 });
 
 type SetupEngineSettings = z.infer<typeof SetupEngineSettings>;
@@ -153,6 +173,9 @@ export class SetupEngine extends ConnectionStateAwareAction<SetupEngineSettings>
   /** Last rendered View value per context — memoizes the icon so we only re-emit on actual change. */
   private readonly lastRenderedValue = new Map<string, string>();
 
+  /** Per-context key-down timestamps for dual-press dispatch on View sub-modes (#540). */
+  private readonly dualPress = new DualPressTracker();
+
   override async onWillAppear(ev: IDeckWillAppearEvent<SetupEngineSettings>): Promise<void> {
     await super.onWillAppear(ev);
     const settings = this.parseSettings(ev.payload.settings);
@@ -173,6 +196,7 @@ export class SetupEngine extends ConnectionStateAwareAction<SetupEngineSettings>
     this.sdkController.unsubscribe(ev.action.id);
     this.activeContexts.delete(ev.action.id);
     this.lastRenderedValue.delete(ev.action.id);
+    this.dualPress.clear(ev.action.id);
     await super.onWillDisappear(ev);
   }
 
@@ -189,13 +213,53 @@ export class SetupEngine extends ConnectionStateAwareAction<SetupEngineSettings>
     const settings = this.parseSettings(ev.payload.settings);
 
     if (isViewSetting(settings.setting)) {
-      this.logger.debug("View sub-mode is read-only, ignoring key press");
+      if (settings.dualPressEnabled) {
+        this.dualPress.recordKeyDown(ev.action.id);
+      } else {
+        this.logger.debug("View sub-mode is read-only (dual-press off), ignoring key press");
+      }
 
       return;
     }
 
     this.logger.info("Key down received");
     await this.executeSetting(settings.setting, settings.direction);
+  }
+
+  override async onKeyUp(ev: IDeckKeyUpEvent<SetupEngineSettings>): Promise<void> {
+    const settings = this.parseSettings(ev.payload.settings);
+
+    if (!isViewSetting(settings.setting) || !settings.dualPressEnabled) {
+      this.dualPress.clear(ev.action.id);
+
+      return;
+    }
+
+    const adjustMode = getAdjustmentModeForView(settings.setting);
+
+    if (!adjustMode) {
+      this.dualPress.clear(ev.action.id);
+
+      return;
+    }
+
+    const tapDir: DirectionType = getDualPressDirections() === "tap-increases" ? "increase" : "decrease";
+    const longDir: DirectionType = tapDir === "increase" ? "decrease" : "increase";
+    const direction = this.dualPress.computeOutcome(ev.action.id, tapDir, longDir);
+
+    if (direction === undefined) return;
+
+    this.logger.info("Dual-press dispatch");
+    this.logger.debug(`Dual-press: ${adjustMode} ${direction}`);
+    const settingKey = SETUP_ENGINE_GLOBAL_KEYS[`${adjustMode}-${direction}`];
+
+    if (!settingKey) {
+      this.logger.warn(`No global key mapping for dual-press ${adjustMode} ${direction}`);
+
+      return;
+    }
+
+    await this.tapBinding(settingKey);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<SetupEngineSettings>): Promise<void> {
@@ -226,7 +290,16 @@ export class SetupEngine extends ConnectionStateAwareAction<SetupEngineSettings>
 
   private applyActiveBinding(settings: SetupEngineSettings): void {
     if (isViewSetting(settings.setting)) {
-      this.setActiveBinding(null);
+      if (!settings.dualPressEnabled) {
+        this.setActiveBinding(null);
+
+        return;
+      }
+
+      const adjustMode = getAdjustmentModeForView(settings.setting);
+      const tapDir: DirectionType = getDualPressDirections() === "tap-increases" ? "increase" : "decrease";
+      const activeKey = adjustMode ? (SETUP_ENGINE_GLOBAL_KEYS[`${adjustMode}-${tapDir}`] ?? null) : null;
+      this.setActiveBinding(activeKey);
 
       return;
     }

--- a/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.ejs
+++ b/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.ejs
@@ -29,6 +29,8 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<%- include('dual-press-overrides') %>
+
 		<%- include('title-overrides') %>
 
 		<%- include('color-overrides', { slots: ['backgroundColor', 'textColor', 'graphic1Color'], defaults: require('./data/icon-defaults.json')['setup-fuel'] }) %>
@@ -50,14 +52,22 @@
 		<%- include('global-common-settings') %>
 
 		<script>
-			// Non-directional controls: hide direction dropdown. View sub-modes also hide it (read-only).
+			// Non-directional controls hide Direction; View sub-modes are read-only displays — they
+			// also hide Direction but show the dual-press opt-in instead.
 			const NON_DIRECTIONAL = new Set(["disable-fuel-cut", "low-fuel-accept", "fcy-mode-toggle"]);
+
+			function isViewSetting(setting) {
+				return typeof setting === "string" && setting.startsWith("view-");
+			}
 
 			function updateVisibility(setting) {
 				const directionItem = document.getElementById("direction-item");
-				if (!directionItem) return;
-				const hide = NON_DIRECTIONAL.has(setting) || setting.startsWith("view-");
-				directionItem.classList.toggle("hidden", hide);
+				const dualEnabledItem = document.getElementById("dual-press-enabled-item");
+
+				const view = isViewSetting(setting);
+				const hideDirection = NON_DIRECTIONAL.has(setting) || view;
+				directionItem?.classList.toggle("hidden", hideDirection);
+				dualEnabledItem?.classList.toggle("hidden", !view);
 			}
 
 			async function initialize() {
@@ -69,14 +79,10 @@
 					const initialValue = settingSelect.value || "fuel-mixture";
 					updateVisibility(initialValue);
 
-					settingSelect.addEventListener("change", (ev) => {
-						updateVisibility(ev.target.value || "fuel-mixture");
-					});
-					settingSelect.addEventListener("input", (ev) => {
-						updateVisibility(ev.target.value || "fuel-mixture");
-					});
+					const onChange = (ev) => updateVisibility(ev.target.value || "fuel-mixture");
+					settingSelect.addEventListener("change", onChange);
+					settingSelect.addEventListener("input", onChange);
 
-					// Polling fallback for reliable detection
 					let lastValue = settingSelect.value || "fuel-mixture";
 					setInterval(() => {
 						const currentValue = settingSelect.value;

--- a/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.test.ts
+++ b/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.test.ts
@@ -1,6 +1,11 @@
+import { getDualPressDirections } from "@iracedeck/deck-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { generateSetupFuelSvg, SETUP_FUEL_GLOBAL_KEYS, SetupFuel } from "./setup-fuel.js";
+
+// Convenience handle so dual-press tests can switch the live tap direction the same
+// way the runtime does (via the @iracedeck/deck-core getDualPressDirections reader).
+const mockGetDualPressDirections = getDualPressDirections as unknown as ReturnType<typeof vi.fn>;
 
 const { mockTapBinding } = vi.hoisted(() => ({
   mockTapBinding: vi.fn().mockResolvedValue(undefined),
@@ -492,6 +497,104 @@ describe("SetupFuel", () => {
       await action.onKeyDown(fakeEvent("action-1", { setting: "view-fuel-cut-position" }) as any);
 
       expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("dual-press dispatch (issue #540)", () => {
+    let action: SetupFuel;
+
+    beforeEach(() => {
+      action = new SetupFuel();
+    });
+
+    it("records keyDown on View + dual-press enabled and does not fire on its own", async () => {
+      const tracker = (action as any).dualPress as { recordKeyDown: ReturnType<typeof vi.fn> };
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-fuel-mixture", dualPressEnabled: true }) as any);
+
+      expect(tracker.recordKeyDown).toHaveBeenCalledWith("action-1");
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("does not record keyDown when dual-press is disabled", async () => {
+      const tracker = (action as any).dualPress as { recordKeyDown: ReturnType<typeof vi.fn> };
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-fuel-mixture", dualPressEnabled: false }) as any);
+
+      expect(tracker.recordKeyDown).not.toHaveBeenCalled();
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("fires the increase binding on a short press with tap-increases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue("increase");
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-fuel-mixture", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupFuelFuelMixtureIncrease");
+    });
+
+    it("fires the decrease binding on a long press with tap-increases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue("decrease");
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-fuel-mixture", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupFuelFuelMixtureDecrease");
+    });
+
+    it("inverts directions when the global dualPressDirections is tap-decreases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-decreases");
+      // The mock passes the chosen outcome through computeOutcome unchanged, so
+      // we set the return based on what the tap direction should be.
+      tracker.computeOutcome.mockImplementation((_id: string, tap: string, _long: string) => tap);
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-fuel-mixture", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupFuelFuelMixtureDecrease");
+    });
+
+    it("does not fire when the tracker returns undefined (stray key-up)", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue(undefined);
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-fuel-mixture", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("does not fire when dual-press is disabled on key-up", async () => {
+      const tracker = (action as any).dualPress as {
+        computeOutcome: ReturnType<typeof vi.fn>;
+        clear: ReturnType<typeof vi.fn>;
+      };
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-fuel-mixture", dualPressEnabled: false }) as any);
+
+      expect(tracker.computeOutcome).not.toHaveBeenCalled();
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("clears tracker on key-up for non-View settings (so future View presses start clean)", async () => {
+      const tracker = (action as any).dualPress as { clear: ReturnType<typeof vi.fn> };
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "fuel-mixture", direction: "increase" }) as any);
+
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
+    });
+
+    it("clears tracker on willDisappear", async () => {
+      const tracker = (action as any).dualPress as { clear: ReturnType<typeof vi.fn> };
+
+      await action.onWillDisappear({
+        action: { id: "action-1" },
+        payload: { settings: { setting: "view-fuel-mixture" } },
+      } as any);
+
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
     });
   });
 });

--- a/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.test.ts
+++ b/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.test.ts
@@ -57,6 +57,14 @@ vi.mock("@iracedeck/deck-core", () => ({
     async onDidReceiveSettings() {}
     async onWillDisappear() {}
   },
+  DualPressTracker: class MockDualPressTracker {
+    recordKeyDown = vi.fn();
+    computeOutcome = vi.fn(() => undefined);
+    clear = vi.fn();
+    hasPending = vi.fn(() => false);
+  },
+  getDualPressThresholdMs: vi.fn(() => 500),
+  getDualPressDirections: vi.fn(() => "tap-increases"),
   formatKeyBinding: vi.fn((b: { key: string; modifiers: string[] }) => {
     if (b.modifiers?.length) {
       return `${b.modifiers.join("+")}+${b.key}`;

--- a/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.ts
+++ b/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.ts
@@ -2,6 +2,8 @@ import {
   assembleIcon,
   CommonSettings,
   ConnectionStateAwareAction,
+  DualPressTracker,
+  getDualPressDirections,
   getGlobalBorderSettings,
   getGlobalColors,
   getGlobalGraphicSettings,
@@ -10,6 +12,7 @@ import {
   type IDeckDialRotateEvent,
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
+  type IDeckKeyUpEvent,
   type IDeckWillAppearEvent,
   type IDeckWillDisappearEvent,
   resolveBorderSettings,
@@ -27,7 +30,12 @@ import lowFuelAcceptIconSvg from "@iracedeck/icons/setup-fuel/low-fuel-accept.sv
 import type { TelemetryData } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
-import { formatViewValue, generateSetupViewSvg, isViewSetting } from "../../shared/setup-view.js";
+import {
+  formatViewValue,
+  generateSetupViewSvg,
+  getAdjustmentModeForView,
+  isViewSetting,
+} from "../../shared/setup-view.js";
 
 type SetupFuelAdjustSetting =
   | "fuel-mixture"
@@ -104,6 +112,18 @@ const SetupFuelSettings = CommonSettings.extend({
     ])
     .default("fuel-mixture"),
   direction: z.enum(["increase", "decrease"]).default("increase"),
+  /**
+   * Dual-press opt-in for View sub-modes (issue #540). When `true` (default),
+   * a View key fires the global tap direction on a short press and the
+   * opposite on a long press (held ≥ `dualPressThresholdMs`). When `false`,
+   * the View stays purely read-only. Ignored for adjustment / toggle
+   * sub-modes. The tap direction itself is the plugin-wide
+   * `dualPressDirections` global setting.
+   */
+  dualPressEnabled: z
+    .union([z.boolean(), z.string()])
+    .transform((v) => v === true || v === "true")
+    .default(true),
 });
 
 type SetupFuelSettings = z.infer<typeof SetupFuelSettings>;
@@ -157,6 +177,9 @@ export class SetupFuel extends ConnectionStateAwareAction<SetupFuelSettings> {
   /** Last rendered View value per context — memoizes the icon so we only re-emit on actual change. */
   private readonly lastRenderedValue = new Map<string, string>();
 
+  /** Per-context key-down timestamps for dual-press dispatch on View sub-modes (#540). */
+  private readonly dualPress = new DualPressTracker();
+
   override async onWillAppear(ev: IDeckWillAppearEvent<SetupFuelSettings>): Promise<void> {
     await super.onWillAppear(ev);
     const settings = this.parseSettings(ev.payload.settings);
@@ -177,6 +200,7 @@ export class SetupFuel extends ConnectionStateAwareAction<SetupFuelSettings> {
     this.sdkController.unsubscribe(ev.action.id);
     this.activeContexts.delete(ev.action.id);
     this.lastRenderedValue.delete(ev.action.id);
+    this.dualPress.clear(ev.action.id);
     await super.onWillDisappear(ev);
   }
 
@@ -193,13 +217,53 @@ export class SetupFuel extends ConnectionStateAwareAction<SetupFuelSettings> {
     const settings = this.parseSettings(ev.payload.settings);
 
     if (isViewSetting(settings.setting)) {
-      this.logger.debug("View sub-mode is read-only, ignoring key press");
+      if (settings.dualPressEnabled) {
+        this.dualPress.recordKeyDown(ev.action.id);
+      } else {
+        this.logger.debug("View sub-mode is read-only (dual-press off), ignoring key press");
+      }
 
       return;
     }
 
     this.logger.info("Key down received");
     await this.executeSetting(settings.setting, settings.direction);
+  }
+
+  override async onKeyUp(ev: IDeckKeyUpEvent<SetupFuelSettings>): Promise<void> {
+    const settings = this.parseSettings(ev.payload.settings);
+
+    if (!isViewSetting(settings.setting) || !settings.dualPressEnabled) {
+      this.dualPress.clear(ev.action.id);
+
+      return;
+    }
+
+    const adjustMode = getAdjustmentModeForView(settings.setting);
+
+    if (!adjustMode) {
+      this.dualPress.clear(ev.action.id);
+
+      return;
+    }
+
+    const tapDir: DirectionType = getDualPressDirections() === "tap-increases" ? "increase" : "decrease";
+    const longDir: DirectionType = tapDir === "increase" ? "decrease" : "increase";
+    const direction = this.dualPress.computeOutcome(ev.action.id, tapDir, longDir);
+
+    if (direction === undefined) return;
+
+    this.logger.info("Dual-press dispatch");
+    this.logger.debug(`Dual-press: ${adjustMode} ${direction}`);
+    const settingKey = SETUP_FUEL_GLOBAL_KEYS[`${adjustMode}-${direction}`];
+
+    if (!settingKey) {
+      this.logger.warn(`No global key mapping for dual-press ${adjustMode} ${direction}`);
+
+      return;
+    }
+
+    await this.tapBinding(settingKey);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<SetupFuelSettings>): Promise<void> {
@@ -239,7 +303,16 @@ export class SetupFuel extends ConnectionStateAwareAction<SetupFuelSettings> {
 
   private applyActiveBinding(settings: SetupFuelSettings): void {
     if (isViewSetting(settings.setting)) {
-      this.setActiveBinding(null);
+      if (!settings.dualPressEnabled) {
+        this.setActiveBinding(null);
+
+        return;
+      }
+
+      const adjustMode = getAdjustmentModeForView(settings.setting);
+      const tapDir: DirectionType = getDualPressDirections() === "tap-increases" ? "increase" : "decrease";
+      const activeKey = adjustMode ? (SETUP_FUEL_GLOBAL_KEYS[`${adjustMode}-${tapDir}`] ?? null) : null;
+      this.setActiveBinding(activeKey);
 
       return;
     }

--- a/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.ejs
+++ b/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.ejs
@@ -31,6 +31,8 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<%- include('dual-press-overrides') %>
+
 		<%- include('title-overrides') %>
 
 		<%- include('color-overrides', { slots: ['backgroundColor', 'textColor', 'graphic1Color'], defaults: require('./data/icon-defaults.json')['setup-hybrid'] }) %>
@@ -52,13 +54,22 @@
 		<%- include('global-common-settings') %>
 
 		<script>
+			// HYS hold-style controls are non-directional; View sub-modes are read-only displays —
+			// both hide Direction. View sub-modes additionally show the dual-press opt-in.
 			const NON_DIRECTIONAL = new Set(["hys-boost", "hys-regen", "hys-no-boost"]);
+
+			function isViewSetting(setting) {
+				return typeof setting === "string" && setting.startsWith("view-");
+			}
 
 			function updateVisibility(setting) {
 				const directionItem = document.getElementById("direction-item");
-				if (!directionItem) return;
-				const hide = NON_DIRECTIONAL.has(setting) || setting.startsWith("view-");
-				directionItem.classList.toggle("hidden", hide);
+				const dualEnabledItem = document.getElementById("dual-press-enabled-item");
+
+				const view = isViewSetting(setting);
+				const hideDirection = NON_DIRECTIONAL.has(setting) || view;
+				directionItem?.classList.toggle("hidden", hideDirection);
+				dualEnabledItem?.classList.toggle("hidden", !view);
 			}
 
 			async function initialize() {
@@ -70,14 +81,10 @@
 					const initialValue = settingSelect.value || "mguk-regen-gain";
 					updateVisibility(initialValue);
 
-					settingSelect.addEventListener("change", (ev) => {
-						updateVisibility(ev.target.value || "mguk-regen-gain");
-					});
-					settingSelect.addEventListener("input", (ev) => {
-						updateVisibility(ev.target.value || "mguk-regen-gain");
-					});
+					const onChange = (ev) => updateVisibility(ev.target.value || "mguk-regen-gain");
+					settingSelect.addEventListener("change", onChange);
+					settingSelect.addEventListener("input", onChange);
 
-					// Polling fallback for reliable detection
 					let lastValue = settingSelect.value || "mguk-regen-gain";
 					setInterval(() => {
 						const currentValue = settingSelect.value;

--- a/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.test.ts
+++ b/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.test.ts
@@ -1,6 +1,11 @@
+import { getDualPressDirections } from "@iracedeck/deck-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { generateSetupHybridSvg, SETUP_HYBRID_GLOBAL_KEYS, SetupHybrid } from "./setup-hybrid.js";
+
+// Convenience handle so dual-press tests can switch the live tap direction the same
+// way the runtime does (via the @iracedeck/deck-core getDualPressDirections reader).
+const mockGetDualPressDirections = getDualPressDirections as unknown as ReturnType<typeof vi.fn>;
 
 const { mockTapBinding, mockHoldBinding, mockReleaseBinding } = vi.hoisted(() => ({
   mockTapBinding: vi.fn().mockResolvedValue(undefined),
@@ -554,6 +559,108 @@ describe("SetupHybrid", () => {
 
       expect(mockTapBinding).not.toHaveBeenCalled();
       expect(mockHoldBinding).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("dual-press dispatch (issue #540)", () => {
+    let action: SetupHybrid;
+
+    beforeEach(() => {
+      action = new SetupHybrid();
+    });
+
+    it("records keyDown on View + dual-press enabled and does not fire on its own", async () => {
+      const tracker = (action as any).dualPress as { recordKeyDown: ReturnType<typeof vi.fn> };
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-mguk-regen-gain", dualPressEnabled: true }) as any);
+
+      expect(tracker.recordKeyDown).toHaveBeenCalledWith("action-1");
+      expect(mockTapBinding).not.toHaveBeenCalled();
+      expect(mockHoldBinding).not.toHaveBeenCalled();
+    });
+
+    it("does not record keyDown when dual-press is disabled", async () => {
+      const tracker = (action as any).dualPress as { recordKeyDown: ReturnType<typeof vi.fn> };
+      await action.onKeyDown(
+        fakeEvent("action-1", { setting: "view-mguk-regen-gain", dualPressEnabled: false }) as any,
+      );
+
+      expect(tracker.recordKeyDown).not.toHaveBeenCalled();
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("fires the increase binding on a short press with tap-increases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue("increase");
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-mguk-regen-gain", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupHybridMgukRegenGainIncrease");
+    });
+
+    it("fires the decrease binding on a long press with tap-increases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue("decrease");
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-mguk-regen-gain", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupHybridMgukRegenGainDecrease");
+    });
+
+    it("inverts directions when the global dualPressDirections is tap-decreases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-decreases");
+      // The mock passes the chosen outcome through computeOutcome unchanged, so
+      // we set the return based on what the tap direction should be.
+      tracker.computeOutcome.mockImplementation((_id: string, tap: string, _long: string) => tap);
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-mguk-regen-gain", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupHybridMgukRegenGainDecrease");
+    });
+
+    it("does not fire when the tracker returns undefined (stray key-up)", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue(undefined);
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-mguk-regen-gain", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("does not fire when dual-press is disabled on key-up", async () => {
+      const tracker = (action as any).dualPress as {
+        computeOutcome: ReturnType<typeof vi.fn>;
+        clear: ReturnType<typeof vi.fn>;
+      };
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-mguk-regen-gain", dualPressEnabled: false }) as any);
+
+      expect(tracker.computeOutcome).not.toHaveBeenCalled();
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("releases the held binding on key-up for non-View settings (hold path is unaffected)", async () => {
+      // setup-hybrid merges the dual-press View path and the existing hold/release
+      // path in a single onKeyUp — a non-View key-up still routes to releaseBinding.
+      await action.onKeyUp(fakeEvent("action-1", { setting: "mguk-regen-gain", direction: "increase" }) as any);
+
+      expect(mockReleaseBinding).toHaveBeenCalledWith("action-1");
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("clears tracker on willDisappear", async () => {
+      const tracker = (action as any).dualPress as { clear: ReturnType<typeof vi.fn> };
+
+      await action.onWillDisappear({
+        action: { id: "action-1" },
+        payload: { settings: { setting: "view-mguk-regen-gain" } },
+      } as any);
+
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
     });
   });
 });

--- a/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.test.ts
+++ b/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.test.ts
@@ -65,6 +65,14 @@ vi.mock("@iracedeck/deck-core", () => ({
     async onDidReceiveSettings() {}
     async onWillDisappear() {}
   },
+  DualPressTracker: class MockDualPressTracker {
+    recordKeyDown = vi.fn();
+    computeOutcome = vi.fn(() => undefined);
+    clear = vi.fn();
+    hasPending = vi.fn(() => false);
+  },
+  getDualPressThresholdMs: vi.fn(() => 500),
+  getDualPressDirections: vi.fn(() => "tap-increases"),
   formatKeyBinding: vi.fn((b: { key: string; modifiers: string[] }) => {
     if (b.modifiers?.length) {
       return `${b.modifiers.join("+")}+${b.key}`;

--- a/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.ts
+++ b/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.ts
@@ -2,6 +2,8 @@ import {
   assembleIcon,
   CommonSettings,
   ConnectionStateAwareAction,
+  DualPressTracker,
+  getDualPressDirections,
   getGlobalBorderSettings,
   getGlobalColors,
   getGlobalGraphicSettings,
@@ -31,7 +33,12 @@ import mgukRegenGainIncreaseIconSvg from "@iracedeck/icons/setup-hybrid/mguk-reg
 import type { TelemetryData } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
-import { formatViewValue, generateSetupViewSvg, isViewSetting } from "../../shared/setup-view.js";
+import {
+  formatViewValue,
+  generateSetupViewSvg,
+  getAdjustmentModeForView,
+  isViewSetting,
+} from "../../shared/setup-view.js";
 
 type SetupHybridAdjustSetting =
   | "mguk-regen-gain"
@@ -124,6 +131,18 @@ const SetupHybridSettings = CommonSettings.extend({
     ])
     .default("mguk-regen-gain"),
   direction: z.enum(["increase", "decrease"]).default("increase"),
+  /**
+   * Dual-press opt-in for View sub-modes (issue #540). When `true` (default),
+   * a View key fires the global tap direction on a short press and the
+   * opposite on a long press (held ≥ `dualPressThresholdMs`). When `false`,
+   * the View stays purely read-only. Ignored for adjustment / toggle / hold
+   * sub-modes. The tap direction itself is the plugin-wide
+   * `dualPressDirections` global setting.
+   */
+  dualPressEnabled: z
+    .union([z.boolean(), z.string()])
+    .transform((v) => v === true || v === "true")
+    .default(true),
 });
 
 type SetupHybridSettings = z.infer<typeof SetupHybridSettings>;
@@ -189,6 +208,9 @@ export class SetupHybrid extends ConnectionStateAwareAction<SetupHybridSettings>
   /** Last rendered View value per context — memoizes the icon so we only re-emit on actual change. */
   private readonly lastRenderedValue = new Map<string, string>();
 
+  /** Per-context key-down timestamps for dual-press dispatch on View sub-modes (#540). */
+  private readonly dualPress = new DualPressTracker();
+
   override async onWillAppear(ev: IDeckWillAppearEvent<SetupHybridSettings>): Promise<void> {
     await super.onWillAppear(ev);
     const settings = this.parseSettings(ev.payload.settings);
@@ -209,6 +231,7 @@ export class SetupHybrid extends ConnectionStateAwareAction<SetupHybridSettings>
     this.sdkController.unsubscribe(ev.action.id);
     this.activeContexts.delete(ev.action.id);
     this.lastRenderedValue.delete(ev.action.id);
+    this.dualPress.clear(ev.action.id);
     await this.releaseBinding(ev.action.id);
     await super.onWillDisappear(ev);
   }
@@ -226,7 +249,11 @@ export class SetupHybrid extends ConnectionStateAwareAction<SetupHybridSettings>
     const settings = this.parseSettings(ev.payload.settings);
 
     if (isViewSetting(settings.setting)) {
-      this.logger.debug("View sub-mode is read-only, ignoring key press");
+      if (settings.dualPressEnabled) {
+        this.dualPress.recordKeyDown(ev.action.id);
+      } else {
+        this.logger.debug("View sub-mode is read-only (dual-press off), ignoring key press");
+      }
 
       return;
     }
@@ -246,6 +273,44 @@ export class SetupHybrid extends ConnectionStateAwareAction<SetupHybridSettings>
   }
 
   override async onKeyUp(ev: IDeckKeyUpEvent<SetupHybridSettings>): Promise<void> {
+    const settings = this.parseSettings(ev.payload.settings);
+
+    if (isViewSetting(settings.setting)) {
+      if (!settings.dualPressEnabled) {
+        this.dualPress.clear(ev.action.id);
+
+        return;
+      }
+
+      const adjustMode = getAdjustmentModeForView(settings.setting);
+
+      if (!adjustMode) {
+        this.dualPress.clear(ev.action.id);
+
+        return;
+      }
+
+      const tapDir: DirectionType = getDualPressDirections() === "tap-increases" ? "increase" : "decrease";
+      const longDir: DirectionType = tapDir === "increase" ? "decrease" : "increase";
+      const direction = this.dualPress.computeOutcome(ev.action.id, tapDir, longDir);
+
+      if (direction === undefined) return;
+
+      this.logger.info("Dual-press dispatch");
+      this.logger.debug(`Dual-press: ${adjustMode} ${direction}`);
+      const settingKey = SETUP_HYBRID_GLOBAL_KEYS[`${adjustMode}-${direction}`];
+
+      if (!settingKey) {
+        this.logger.warn(`No global key mapping for dual-press ${adjustMode} ${direction}`);
+
+        return;
+      }
+
+      await this.tapBinding(settingKey);
+
+      return;
+    }
+
     this.logger.info("Key up received");
     await this.releaseBinding(ev.action.id);
   }
@@ -300,7 +365,16 @@ export class SetupHybrid extends ConnectionStateAwareAction<SetupHybridSettings>
 
   private applyActiveBinding(settings: SetupHybridSettings): void {
     if (isViewSetting(settings.setting)) {
-      this.setActiveBinding(null);
+      if (!settings.dualPressEnabled) {
+        this.setActiveBinding(null);
+
+        return;
+      }
+
+      const adjustMode = getAdjustmentModeForView(settings.setting);
+      const tapDir: DirectionType = getDualPressDirections() === "tap-increases" ? "increase" : "decrease";
+      const activeKey = adjustMode ? (SETUP_HYBRID_GLOBAL_KEYS[`${adjustMode}-${tapDir}`] ?? null) : null;
+      this.setActiveBinding(activeKey);
 
       return;
     }

--- a/packages/iracing-actions/src/actions/setup-traction/setup-traction.ejs
+++ b/packages/iracing-actions/src/actions/setup-traction/setup-traction.ejs
@@ -31,6 +31,8 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<%- include('dual-press-overrides') %>
+
 		<%- include('title-overrides') %>
 
 		<%- include('color-overrides', { slots: ['backgroundColor', 'textColor', 'graphic1Color'], defaults: require('./data/icon-defaults.json')['setup-traction'] }) %>
@@ -52,12 +54,20 @@
 		<%- include('global-common-settings') %>
 
 		<script>
-			// TC Toggle is non-directional; View sub-modes are read-only — both hide Direction.
+			// TC Toggle is non-directional; View sub-modes are read-only displays — both hide Direction.
+			// View sub-modes show the dual-press opt-in; non-View sub-modes hide it.
+			function isViewSetting(setting) {
+				return typeof setting === "string" && setting.startsWith("view-");
+			}
+
 			function updateVisibility(setting) {
 				const directionItem = document.getElementById("direction-item");
-				if (!directionItem) return;
-				const hide = setting === "tc-toggle" || setting.startsWith("view-");
-				directionItem.classList.toggle("hidden", hide);
+				const dualEnabledItem = document.getElementById("dual-press-enabled-item");
+
+				const view = isViewSetting(setting);
+				const hideDirection = setting === "tc-toggle" || view;
+				directionItem?.classList.toggle("hidden", hideDirection);
+				dualEnabledItem?.classList.toggle("hidden", !view);
 			}
 
 			async function initialize() {
@@ -69,14 +79,10 @@
 					const initialValue = settingSelect.value || "tc-toggle";
 					updateVisibility(initialValue);
 
-					settingSelect.addEventListener("change", (ev) => {
-						updateVisibility(ev.target.value || "tc-toggle");
-					});
-					settingSelect.addEventListener("input", (ev) => {
-						updateVisibility(ev.target.value || "tc-toggle");
-					});
+					const onChange = (ev) => updateVisibility(ev.target.value || "tc-toggle");
+					settingSelect.addEventListener("change", onChange);
+					settingSelect.addEventListener("input", onChange);
 
-					// Polling fallback for reliable detection
 					let lastValue = settingSelect.value || "tc-toggle";
 					setInterval(() => {
 						const currentValue = settingSelect.value;

--- a/packages/iracing-actions/src/actions/setup-traction/setup-traction.test.ts
+++ b/packages/iracing-actions/src/actions/setup-traction/setup-traction.test.ts
@@ -1,6 +1,11 @@
+import { getDualPressDirections } from "@iracedeck/deck-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { generateSetupTractionSvg, SETUP_TRACTION_GLOBAL_KEYS, SetupTraction } from "./setup-traction.js";
+
+// Convenience handle so dual-press tests can switch the live tap direction the same
+// way the runtime does (via the @iracedeck/deck-core getDualPressDirections reader).
+const mockGetDualPressDirections = getDualPressDirections as unknown as ReturnType<typeof vi.fn>;
 
 const { mockTapBinding } = vi.hoisted(() => ({
   mockTapBinding: vi.fn().mockResolvedValue(undefined),
@@ -432,6 +437,104 @@ describe("SetupTraction", () => {
       await action.onDialDown(fakeEvent("action-1", { setting: "view-tc-slot-1" }) as any);
 
       expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("dual-press dispatch (issue #540)", () => {
+    let action: SetupTraction;
+
+    beforeEach(() => {
+      action = new SetupTraction();
+    });
+
+    it("records keyDown on View + dual-press enabled and does not fire on its own", async () => {
+      const tracker = (action as any).dualPress as { recordKeyDown: ReturnType<typeof vi.fn> };
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-tc-slot-1", dualPressEnabled: true }) as any);
+
+      expect(tracker.recordKeyDown).toHaveBeenCalledWith("action-1");
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("does not record keyDown when dual-press is disabled", async () => {
+      const tracker = (action as any).dualPress as { recordKeyDown: ReturnType<typeof vi.fn> };
+      await action.onKeyDown(fakeEvent("action-1", { setting: "view-tc-slot-1", dualPressEnabled: false }) as any);
+
+      expect(tracker.recordKeyDown).not.toHaveBeenCalled();
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("fires the increase binding on a short press with tap-increases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue("increase");
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-tc-slot-1", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupTractionTcSlot1Increase");
+    });
+
+    it("fires the decrease binding on a long press with tap-increases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue("decrease");
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-tc-slot-1", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupTractionTcSlot1Decrease");
+    });
+
+    it("inverts directions when the global dualPressDirections is tap-decreases", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-decreases");
+      // The mock passes the chosen outcome through computeOutcome unchanged, so
+      // we set the return based on what the tap direction should be.
+      tracker.computeOutcome.mockImplementation((_id: string, tap: string, _long: string) => tap);
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-tc-slot-1", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("setupTractionTcSlot1Decrease");
+    });
+
+    it("does not fire when the tracker returns undefined (stray key-up)", async () => {
+      const tracker = (action as any).dualPress as { computeOutcome: ReturnType<typeof vi.fn> };
+      mockGetDualPressDirections.mockReturnValue("tap-increases");
+      tracker.computeOutcome.mockReturnValue(undefined);
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-tc-slot-1", dualPressEnabled: true }) as any);
+
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("does not fire when dual-press is disabled on key-up", async () => {
+      const tracker = (action as any).dualPress as {
+        computeOutcome: ReturnType<typeof vi.fn>;
+        clear: ReturnType<typeof vi.fn>;
+      };
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "view-tc-slot-1", dualPressEnabled: false }) as any);
+
+      expect(tracker.computeOutcome).not.toHaveBeenCalled();
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
+      expect(mockTapBinding).not.toHaveBeenCalled();
+    });
+
+    it("clears tracker on key-up for non-View settings (so future View presses start clean)", async () => {
+      const tracker = (action as any).dualPress as { clear: ReturnType<typeof vi.fn> };
+
+      await action.onKeyUp(fakeEvent("action-1", { setting: "tc-slot-1", direction: "increase" }) as any);
+
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
+    });
+
+    it("clears tracker on willDisappear", async () => {
+      const tracker = (action as any).dualPress as { clear: ReturnType<typeof vi.fn> };
+
+      await action.onWillDisappear({
+        action: { id: "action-1" },
+        payload: { settings: { setting: "view-tc-slot-1" } },
+      } as any);
+
+      expect(tracker.clear).toHaveBeenCalledWith("action-1");
     });
   });
 });

--- a/packages/iracing-actions/src/actions/setup-traction/setup-traction.test.ts
+++ b/packages/iracing-actions/src/actions/setup-traction/setup-traction.test.ts
@@ -63,6 +63,14 @@ vi.mock("@iracedeck/deck-core", () => ({
     async onDidReceiveSettings() {}
     async onWillDisappear() {}
   },
+  DualPressTracker: class MockDualPressTracker {
+    recordKeyDown = vi.fn();
+    computeOutcome = vi.fn(() => undefined);
+    clear = vi.fn();
+    hasPending = vi.fn(() => false);
+  },
+  getDualPressThresholdMs: vi.fn(() => 500),
+  getDualPressDirections: vi.fn(() => "tap-increases"),
   formatKeyBinding: vi.fn((b: { key: string; modifiers: string[] }) => {
     if (b.modifiers?.length) {
       return `${b.modifiers.join("+")}+${b.key}`;

--- a/packages/iracing-actions/src/actions/setup-traction/setup-traction.ts
+++ b/packages/iracing-actions/src/actions/setup-traction/setup-traction.ts
@@ -2,6 +2,8 @@ import {
   assembleIcon,
   CommonSettings,
   ConnectionStateAwareAction,
+  DualPressTracker,
+  getDualPressDirections,
   getGlobalBorderSettings,
   getGlobalColors,
   getGlobalGraphicSettings,
@@ -10,6 +12,7 @@ import {
   type IDeckDialRotateEvent,
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
+  type IDeckKeyUpEvent,
   type IDeckWillAppearEvent,
   type IDeckWillDisappearEvent,
   resolveBorderSettings,
@@ -29,7 +32,12 @@ import tcToggleIconSvg from "@iracedeck/icons/setup-traction/tc-toggle.svg";
 import type { TelemetryData } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
-import { formatViewValue, generateSetupViewSvg, isViewSetting } from "../../shared/setup-view.js";
+import {
+  formatViewValue,
+  generateSetupViewSvg,
+  getAdjustmentModeForView,
+  isViewSetting,
+} from "../../shared/setup-view.js";
 
 type SetupTractionAdjustSetting = "tc-toggle" | "tc-slot-1" | "tc-slot-2" | "tc-slot-3" | "tc-slot-4";
 
@@ -115,6 +123,18 @@ const SetupTractionSettings = CommonSettings.extend({
     ])
     .default("tc-toggle"),
   direction: z.enum(["increase", "decrease"]).default("increase"),
+  /**
+   * Dual-press opt-in for View sub-modes (issue #540). When `true` (default),
+   * a View key fires the global tap direction on a short press and the
+   * opposite on a long press (held ≥ `dualPressThresholdMs`). When `false`,
+   * the View stays purely read-only. Ignored for adjustment / toggle
+   * sub-modes. The tap direction itself is the plugin-wide
+   * `dualPressDirections` global setting.
+   */
+  dualPressEnabled: z
+    .union([z.boolean(), z.string()])
+    .transform((v) => v === true || v === "true")
+    .default(true),
 });
 
 type SetupTractionSettings = z.infer<typeof SetupTractionSettings>;
@@ -178,6 +198,9 @@ export class SetupTraction extends ConnectionStateAwareAction<SetupTractionSetti
   /** Last rendered View value per context — memoizes the icon so we only re-emit on actual change. */
   private readonly lastRenderedValue = new Map<string, string>();
 
+  /** Per-context key-down timestamps for dual-press dispatch on View sub-modes (#540). */
+  private readonly dualPress = new DualPressTracker();
+
   override async onWillAppear(ev: IDeckWillAppearEvent<SetupTractionSettings>): Promise<void> {
     await super.onWillAppear(ev);
     const settings = this.parseSettings(ev.payload.settings);
@@ -198,6 +221,7 @@ export class SetupTraction extends ConnectionStateAwareAction<SetupTractionSetti
     this.sdkController.unsubscribe(ev.action.id);
     this.activeContexts.delete(ev.action.id);
     this.lastRenderedValue.delete(ev.action.id);
+    this.dualPress.clear(ev.action.id);
     await super.onWillDisappear(ev);
   }
 
@@ -214,13 +238,53 @@ export class SetupTraction extends ConnectionStateAwareAction<SetupTractionSetti
     const settings = this.parseSettings(ev.payload.settings);
 
     if (isViewSetting(settings.setting)) {
-      this.logger.debug("View sub-mode is read-only, ignoring key press");
+      if (settings.dualPressEnabled) {
+        this.dualPress.recordKeyDown(ev.action.id);
+      } else {
+        this.logger.debug("View sub-mode is read-only (dual-press off), ignoring key press");
+      }
 
       return;
     }
 
     this.logger.info("Key down received");
     await this.executeSetting(settings.setting, settings.direction);
+  }
+
+  override async onKeyUp(ev: IDeckKeyUpEvent<SetupTractionSettings>): Promise<void> {
+    const settings = this.parseSettings(ev.payload.settings);
+
+    if (!isViewSetting(settings.setting) || !settings.dualPressEnabled) {
+      this.dualPress.clear(ev.action.id);
+
+      return;
+    }
+
+    const adjustMode = getAdjustmentModeForView(settings.setting);
+
+    if (!adjustMode) {
+      this.dualPress.clear(ev.action.id);
+
+      return;
+    }
+
+    const tapDir: DirectionType = getDualPressDirections() === "tap-increases" ? "increase" : "decrease";
+    const longDir: DirectionType = tapDir === "increase" ? "decrease" : "increase";
+    const direction = this.dualPress.computeOutcome(ev.action.id, tapDir, longDir);
+
+    if (direction === undefined) return;
+
+    this.logger.info("Dual-press dispatch");
+    this.logger.debug(`Dual-press: ${adjustMode} ${direction}`);
+    const settingKey = SETUP_TRACTION_GLOBAL_KEYS[`${adjustMode}-${direction}`];
+
+    if (!settingKey) {
+      this.logger.warn(`No global key mapping for dual-press ${adjustMode} ${direction}`);
+
+      return;
+    }
+
+    await this.tapBinding(settingKey);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<SetupTractionSettings>): Promise<void> {
@@ -260,7 +324,16 @@ export class SetupTraction extends ConnectionStateAwareAction<SetupTractionSetti
 
   private applyActiveBinding(settings: SetupTractionSettings): void {
     if (isViewSetting(settings.setting)) {
-      this.setActiveBinding(null);
+      if (!settings.dualPressEnabled) {
+        this.setActiveBinding(null);
+
+        return;
+      }
+
+      const adjustMode = getAdjustmentModeForView(settings.setting);
+      const tapDir: DirectionType = getDualPressDirections() === "tap-increases" ? "increase" : "decrease";
+      const activeKey = adjustMode ? (SETUP_TRACTION_GLOBAL_KEYS[`${adjustMode}-${tapDir}`] ?? null) : null;
+      this.setActiveBinding(activeKey);
 
       return;
     }

--- a/packages/iracing-actions/src/shared/setup-view.ts
+++ b/packages/iracing-actions/src/shared/setup-view.ts
@@ -10,6 +10,8 @@
  * exposes more dc* fields.
  */
 import {
+  type BorderOverrides,
+  type ColorSlots,
   generateBorderParts,
   generateTitleText,
   getGlobalBorderSettings,
@@ -20,6 +22,7 @@ import {
   resolveIconColors,
   resolveTitleSettings,
   svgToDataUri,
+  type TitleOverrides,
 } from "@iracedeck/deck-core";
 import type { TelemetryData } from "@iracedeck/iracing-sdk";
 
@@ -127,6 +130,15 @@ interface ViewDef {
    * (e.g. "54.0%") and would otherwise crowd the edges.
    */
   readonly valueFontSize?: number;
+  /**
+   * Adjustment-mode id this View maps to for dual-press dispatch (issue #540).
+   * The per-action `SETUP_*_GLOBAL_KEYS` map uses this id (plus `-increase` /
+   * `-decrease`) to look up the global key binding to tap on key-up. The id
+   * is *not* always the View id with `view-` stripped — setup-engine has
+   * `view-throttle-shape` mapping to `throttle-shaping`, setup-chassis has
+   * `view-diff-*` mapping to `differential-*`, etc.
+   */
+  readonly adjustmentMode: string;
 }
 
 const VIEW_VALUE_FONT_SIZE_DEFAULT = 36;
@@ -145,34 +157,44 @@ export const VIEW_DEFS: Record<ViewSettingId, ViewDef> = {
   // already in percentage units (e.g. 54.0), so use `formatPercentRaw` rather than the
   // ratio-multiplying `formatPercent`. The "%-decimal" values stay at the default size to
   // avoid crowding the key edges; short-integer entries bump up to LARGE.
-  "view-brake-bias": { telemetryField: "dcBrakeBias", label: "BRAKE BIAS", format: (v) => formatPercentRaw(v, 1) },
+  "view-brake-bias": {
+    telemetryField: "dcBrakeBias",
+    label: "BRAKE BIAS",
+    format: (v) => formatPercentRaw(v, 1),
+    adjustmentMode: "brake-bias",
+  },
   "view-brake-bias-fine": {
     telemetryField: "dcBrakeBiasFine",
     label: "BIAS FINE",
     format: (v) => formatPercentRaw(v, 1),
+    adjustmentMode: "brake-bias-fine",
   },
   "view-peak-brake-bias": {
     telemetryField: "dcPeakBrakeBias",
     label: "PEAK BIAS",
     format: (v) => formatPercentRaw(v, 1),
+    adjustmentMode: "peak-brake-bias",
   },
   "view-brake-misc": {
     telemetryField: "dcBrakeMisc",
     label: "BRAKE MISC",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "brake-misc",
   },
   "view-engine-braking": {
     telemetryField: "dcEngineBraking",
     label: "ENG BRAKE",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "engine-braking",
   },
   "view-abs-adjust": {
     telemetryField: "dcABS",
     label: "ABS",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "abs-adjust",
   },
   // setup-traction — slot 1 is the canonical `dcTractionControl`; cars with multiple TC
   // presets expose the others as `dcTractionControl2`/`3`/`4`.
@@ -181,24 +203,28 @@ export const VIEW_DEFS: Record<ViewSettingId, ViewDef> = {
     label: "TC1",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "tc-slot-1",
   },
   "view-tc-slot-2": {
     telemetryField: "dcTractionControl2",
     label: "TC2",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "tc-slot-2",
   },
   "view-tc-slot-3": {
     telemetryField: "dcTractionControl3",
     label: "TC3",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "tc-slot-3",
   },
   "view-tc-slot-4": {
     telemetryField: "dcTractionControl4",
     label: "TC4",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "tc-slot-4",
   },
   // setup-fuel
   "view-fuel-mixture": {
@@ -206,12 +232,14 @@ export const VIEW_DEFS: Record<ViewSettingId, ViewDef> = {
     label: "FUEL MIX",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "fuel-mixture",
   },
   "view-fuel-cut-position": {
     telemetryField: "dcFuelCutPosition",
     label: "FUEL CUT",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "fuel-cut-position",
   },
   // setup-engine — Launch RPM keeps the default since it can render 4–5 digits (e.g. 12000).
   "view-engine-power": {
@@ -219,102 +247,136 @@ export const VIEW_DEFS: Record<ViewSettingId, ViewDef> = {
     label: "ENG POWER",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "engine-power",
   },
   "view-throttle-shape": {
     telemetryField: "dcThrottleShape",
     label: "THROTTLE",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "throttle-shaping",
   },
-  "view-launch-rpm": { telemetryField: "dcLaunchRPM", label: "LAUNCH RPM", format: formatInteger },
+  "view-launch-rpm": {
+    telemetryField: "dcLaunchRPM",
+    label: "LAUNCH RPM",
+    format: formatInteger,
+    adjustmentMode: "launch-rpm",
+  },
   // setup-aero
   "view-front-wing": {
     telemetryField: "dcFrontWing",
     label: "FRONT WING",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "front-wing",
   },
   "view-rear-wing": {
     telemetryField: "dcRearWing",
     label: "REAR WING",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "rear-wing",
   },
-  // setup-chassis
+  // setup-chassis — `view-diff-*` and `view-anti-roll-*` map to differently-named
+  // adjustment modes (`differential-*` / `*-arb`); weight-jacker ids are new
+  // dispatch-only keys added in #540 so the View can drive them via dual-press.
   "view-diff-preload": {
     telemetryField: "dcDiffPreload",
     label: "DIFF PRELOAD",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "differential-preload",
   },
   "view-diff-entry": {
     telemetryField: "dcDiffEntry",
     label: "DIFF ENTRY",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "differential-entry",
   },
   "view-diff-middle": {
     telemetryField: "dcDiffMiddle",
     label: "DIFF MIDDLE",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "differential-middle",
   },
   "view-diff-exit": {
     telemetryField: "dcDiffExit",
     label: "DIFF EXIT",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "differential-exit",
   },
   "view-anti-roll-front": {
     telemetryField: "dcAntiRollFront",
     label: "ARB FRONT",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "front-arb",
   },
   "view-anti-roll-rear": {
     telemetryField: "dcAntiRollRear",
     label: "ARB REAR",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "rear-arb",
   },
   "view-power-steering": {
     telemetryField: "dcPowerSteering",
     label: "PWR STEER",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "power-steering",
   },
   "view-weight-jacker-left": {
     telemetryField: "dcWeightJackerLeft",
     label: "WJKR LEFT",
     format: (v) => formatSignedPercent(v, 0),
     valueFontSize: VIEW_VALUE_FONT_SIZE_MEDIUM,
+    adjustmentMode: "weight-jacker-left",
   },
   "view-weight-jacker-right": {
     telemetryField: "dcWeightJackerRight",
     label: "WJKR RIGHT",
     format: (v) => formatSignedPercent(v, 0),
     valueFontSize: VIEW_VALUE_FONT_SIZE_MEDIUM,
+    adjustmentMode: "weight-jacker-right",
   },
-  // setup-hybrid
+  // setup-hybrid — `view-mguk-deploy-fixed` maps to the existing `mguk-fixed-deploy`
+  // adjustment mode (the View id was named in the noun-verb order to read more
+  // naturally on the icon, the adjustment id keeps the original verb-noun order).
   "view-mguk-deploy-mode": {
     telemetryField: "dcMGUKDeployMode",
     label: "DEPLOY MODE",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "mguk-deploy-mode",
   },
   "view-mguk-regen-gain": {
     telemetryField: "dcMGUKRegenGain",
     label: "REGEN GAIN",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "mguk-regen-gain",
   },
   "view-mguk-deploy-fixed": {
     telemetryField: "dcMGUKDeployFixed",
     label: "FIXED DEPLOY",
     format: formatInteger,
     valueFontSize: VIEW_VALUE_FONT_SIZE_LARGE,
+    adjustmentMode: "mguk-fixed-deploy",
   },
 };
+
+/**
+ * Look up the adjustment-mode id used to dispatch dual-press for a View (#540).
+ * Returns `undefined` if `id` isn't a known View — callers should pre-filter
+ * with `isViewSetting`.
+ */
+export function getAdjustmentModeForView(id: string): string | undefined {
+  return isViewSetting(id) ? VIEW_DEFS[id].adjustmentMode : undefined;
+}
 
 const VIEW_IDS: ReadonlySet<string> = new Set(Object.keys(VIEW_DEFS));
 
@@ -336,10 +398,11 @@ export function formatViewValue(viewId: ViewSettingId, telemetry: TelemetryData 
 }
 
 /**
- * Inputs the setup-action passes to the shared View renderer. The fields are
- * a subset of CommonSettings — typing them as `unknown` lets each per-action
- * settings shape pass through without coupling this module to the action's
- * Zod-inferred type.
+ * Inputs the setup-action passes to the shared View renderer. The override
+ * fields mirror the matching `CommonSettings` fields verbatim; importing the
+ * types here keeps the renderer type-checked end-to-end while still letting
+ * each per-action settings shape pass through (CommonSettings is the shared
+ * base, so every setup-action's Zod-inferred type is assignable).
  */
 export interface SetupViewRenderInputs {
   readonly viewId: ViewSettingId;
@@ -352,9 +415,9 @@ export interface SetupViewRenderInputs {
    * View template's own defaults when omitted.
    */
   readonly colorSourceSvg?: string;
-  readonly colorOverrides?: unknown;
-  readonly titleOverrides?: unknown;
-  readonly borderOverrides?: unknown;
+  readonly colorOverrides?: ColorSlots;
+  readonly titleOverrides?: TitleOverrides;
+  readonly borderOverrides?: BorderOverrides;
 }
 
 /**

--- a/packages/pi-components/partials/dual-press-overrides.ejs
+++ b/packages/pi-components/partials/dual-press-overrides.ejs
@@ -1,0 +1,16 @@
+<!--
+  Dual-Press Overrides (issue #540)
+
+  Per-action opt-in for a setup View sub-mode's dual-press control. When checked,
+  a short press fires the global tap direction (see Global Common Settings →
+  Dual-Press → Directions) and a long press fires the opposite. When unchecked,
+  the View stays purely read-only.
+
+  Hidden by `updateVisibility(setting)` when the selected `setting` is not a
+  View sub-mode. The global threshold (`dualPressThresholdMs`) and direction
+  (`dualPressDirections`) live in Global Common Settings since they apply to
+  every action that uses dual-press.
+-->
+<sdpi-item label="Dual-Press" id="dual-press-enabled-item">
+  <sdpi-checkbox setting="dualPressEnabled" label="Enable dual-press" default="true"></sdpi-checkbox>
+</sdpi-item>

--- a/packages/pi-components/partials/global-common-settings.ejs
+++ b/packages/pi-components/partials/global-common-settings.ejs
@@ -18,7 +18,7 @@
         global
       ></sdpi-checkbox>
     </sdpi-item>
-    <div style="padding: 0 16px 8px; font-size: 11px; color: #999;">
+    <div class="ird-supporting-text">
       Automatically focuses the iRacing window before sending key inputs.
       Enable if actions aren't working when iRacing is in the background.
     </div>
@@ -29,9 +29,28 @@
     <sdpi-item label="Port">
       <sdpi-textfield setting="simHubPort" default="8888" global pattern="[0-9]{1,5}" inputmode="numeric"></sdpi-textfield>
     </sdpi-item>
-    <div style="padding: 0 16px 8px; font-size: 11px; color: #999;">
+    <div class="ird-supporting-text">
       Connection settings for SimHub Control Mapper integration.
       Default: 127.0.0.1:8888
+    </div>
+    <div class="ird-section-subtitle">Dual-Press</div>
+    <sdpi-item label="Long-press threshold (ms)">
+      <ird-range-input setting="dualPressThresholdMs" min="200" max="2000" step="50" default="500" global showlabels></ird-range-input>
+    </sdpi-item>
+    <div class="ird-supporting-text">
+      How long a key must be held before a setup View sub-mode treats it as a long-press
+      (firing the opposite direction). Shorter values feel snappier; longer values are
+      more forgiving against accidental long-presses.
+    </div>
+    <sdpi-item label="Directions">
+      <sdpi-select setting="dualPressDirections" default="tap-increases" global>
+        <option value="tap-increases">Tap increases, long-press decreases</option>
+        <option value="tap-decreases">Tap decreases, long-press increases</option>
+      </sdpi-select>
+    </sdpi-item>
+    <div class="ird-supporting-text">
+      Which direction a short press fires on a setup View sub-mode; the long-press
+      always fires the opposite. Applies plugin-wide to every dual-press View.
     </div>
   `
 }) %>

--- a/packages/pi-components/partials/global-flag-flash.ejs
+++ b/packages/pi-components/partials/global-flag-flash.ejs
@@ -13,7 +13,7 @@
     <sdpi-item label="Duration (s)">
       <ird-range-input setting="flagFlashDurationSeconds" min="0" max="30" step="1" default="15" global showlabels></ird-range-input>
     </sdpi-item>
-    <div style="padding: 0 16px 8px; font-family: 'Segoe UI', Arial, Roboto, Helvetica, sans-serif; font-size: 9pt; color: #888;">
+    <div class="ird-supporting-text">
       How long the flag overlay flashes after a new flag transition.
       Set to 0 to flash continuously while the flag is raised.
     </div>

--- a/packages/pi-components/partials/head-common.ejs
+++ b/packages/pi-components/partials/head-common.ejs
@@ -78,6 +78,16 @@
     letter-spacing: 0.3px;
   }
 
+  /* Supporting/help text shown beneath an sdpi-item. The 95px left padding aligns
+     the text under the control column (not the label), matching the sdpi-item
+     layout. Use this class for every help blurb instead of inline styles. */
+  .ird-supporting-text {
+    padding: 0 20px 8px 95px;
+    font-family: "Segoe UI", Arial, Roboto, Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 9pt;
+    color: #888;
+  }
+
   /* Documentation link */
   .ird-docs-link {
     text-align: center;

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-aero.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-aero.md
@@ -11,7 +11,7 @@ Adjust aerodynamic setup options from the cockpit — front and rear wing angles
 
 ## View sub-modes
 
-The **View …** entries are read-only live readouts. No Direction, no key fires on press.
+The **View …** entries turn the key into a continuously updating display of the current value in the car. With **dual-press** enabled (default) the same key also adjusts the value: a short press fires one direction and a long press fires the opposite — so one key replaces the separate Increase / Decrease keys you'd otherwise need.
 
 | View setting | Telemetry source | Format | Typical range |
 |---|---|---|---|
@@ -19,6 +19,14 @@ The **View …** entries are read-only live readouts. No Direction, no key fires
 | View Rear Wing | `dcRearWing` | integer | car-dependent slot or angle |
 
 Cars without a driver-adjustable wing render "---". Qualifying tape and the RF brake attachment toggle have no `dc*` telemetry on common cars, so they don't have View entries.
+
+### Dual-press control
+
+Each View sub-mode exposes a single extra setting in the Property Inspector:
+
+- **Enable dual-press** (default *on*) — when off, the key stays a pure read-only display and presses do nothing. When on, presses dispatch to the matching adjustment binding (e.g. View Front Wing dispatches to *Front Wing +* / *Front Wing −*), so configure those bindings in the **Global Settings → Setup Aero** section.
+
+The tap direction is a single plugin-wide setting under **Global Common Settings → Dual-Press → Directions** (default *Tap increases, long-press decreases*; the long-press always fires the opposite of the tap). The threshold separating "short" from "long" is a sibling setting **Long-press threshold (ms)** (200–2000 ms, default 500 ms). Both take effect on the next press without needing a restart.
 
 ## Modes
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-brakes.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-brakes.md
@@ -11,7 +11,7 @@ Adjust brake-related setup options from the cockpit — ABS level, brake bias (c
 
 ## View sub-modes
 
-The **View …** entries at the top of the Setting dropdown are read-only live readouts of the current value in the car. Pick "View Brake Bias" to turn the key into a continuously updating display of the current brake bias percentage — no Direction setting, no key fires on press.
+The **View …** entries at the top of the Setting dropdown turn the key into a continuously updating display of the current value in the car. With **dual-press** enabled (default) the same key also adjusts the value: a short press fires one direction and a long press fires the opposite — so one key replaces the separate Increase / Decrease keys you'd otherwise need.
 
 | View setting | Telemetry source | Format | Typical range |
 |---|---|---|---|
@@ -21,6 +21,14 @@ The **View …** entries at the top of the Setting dropdown are read-only live r
 | View Brake Misc | `dcBrakeMisc` | integer | car-dependent |
 | View Engine Braking | `dcEngineBraking` | integer | car-dependent slot |
 | View ABS Adjust | `dcABS` | integer | car-dependent slot |
+
+### Dual-press control
+
+Each View sub-mode exposes a single extra setting in the Property Inspector:
+
+- **Enable dual-press** (default *on*) — when off, the key stays a pure read-only display and presses do nothing. When on, presses dispatch to the matching adjustment binding (e.g. View Brake Bias dispatches to *Brake Bias +* / *Brake Bias −*), so configure those bindings in the **Global Settings → Setup Brakes** section.
+
+The tap direction is a single plugin-wide setting under **Global Common Settings → Dual-Press → Directions** (default *Tap increases, long-press decreases*; the long-press always fires the opposite of the tap). The threshold separating "short" from "long" is a sibling setting **Long-press threshold (ms)** (200–2000 ms, default 500 ms). Both take effect on the next press without needing a restart.
 
 ## Modes
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-chassis.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-chassis.md
@@ -11,7 +11,7 @@ Adjust chassis setup options from the cockpit: differential curves, anti-roll ba
 
 ## View sub-modes
 
-The **View …** entries are read-only live readouts. No Direction, no key fires on press.
+The **View …** entries turn the key into a continuously updating display of the current value in the car. With **dual-press** enabled (default) the same key also adjusts the value: a short press fires one direction and a long press fires the opposite — so one key replaces the separate Increase / Decrease keys you'd otherwise need.
 
 | View setting | Telemetry source | Format | Typical range |
 |---|---|---|---|
@@ -24,6 +24,14 @@ The **View …** entries are read-only live readouts. No Direction, no key fires
 | View Power Steering | `dcPowerSteering` | integer | car-dependent slot |
 | View Weight Jacker Left | `dcWeightJackerLeft` | signed percent | ±a few % |
 | View Weight Jacker Right | `dcWeightJackerRight` | signed percent | ±a few % |
+
+### Dual-press control
+
+Each View sub-mode exposes a single extra setting in the Property Inspector:
+
+- **Enable dual-press** (default *on*) — when off, the key stays a pure read-only display and presses do nothing. When on, presses dispatch to the matching adjustment binding (e.g. View Diff Preload dispatches to *Diff Preload +* / *Diff Preload −*), so configure those bindings in the **Global Settings → Setup Chassis** section. Weight Jacker Left / Right do not appear as adjustment modes in the Setting dropdown; their +/- bindings still live in **Global Settings → Setup Chassis** so the View can drive them via dual-press.
+
+The tap direction is a single plugin-wide setting under **Global Common Settings → Dual-Press → Directions** (default *Tap increases, long-press decreases*; the long-press always fires the opposite of the tap). The threshold separating "short" from "long" is a sibling setting **Long-press threshold (ms)** (200–2000 ms, default 500 ms). Both take effect on the next press without needing a restart.
 
 ## Modes
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-chassis.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-chassis.md
@@ -35,7 +35,7 @@ The tap direction is a single plugin-wide setting under **Global Common Settings
 
 ## Modes
 
-Select the mode from the **Setting** dropdown in the Property Inspector. **Adjust** modes are directional — pick **Increase** or **Decrease** in the **Direction** setting to control what a button press does. **View** modes are read-only and do not use Direction.
+Select the mode from the **Setting** dropdown in the Property Inspector. **Adjust** modes are directional — pick **Increase** or **Decrease** in the **Direction** setting to control what a button press does. **View** modes show a live readout and, with **Enable dual-press** on (default), also accept short / long presses — see [View sub-modes](#view-sub-modes) above. They don't use the per-action **Direction** setting; the tap direction is the plugin-wide **Global Common Settings → Dual-Press → Directions**.
 
 ### Differential Preload
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-engine.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-engine.md
@@ -29,7 +29,7 @@ The tap direction is a single plugin-wide setting under **Global Common Settings
 
 ## Modes
 
-Select the mode from the **Setting** dropdown in the Property Inspector. **Adjust** modes are directional — pick **Increase** or **Decrease** in the **Direction** setting to control what a button press does. **View** modes are read-only and do not use Direction.
+Select the mode from the **Setting** dropdown in the Property Inspector. **Adjust** modes are directional — pick **Increase** or **Decrease** in the **Direction** setting to control what a button press does. **View** modes show a live readout and, with **Enable dual-press** on (default), also accept short / long presses — see [View sub-modes](#view-sub-modes) above. They don't use the per-action **Direction** setting; the tap direction is the plugin-wide **Global Common Settings → Dual-Press → Directions**.
 
 ### Engine Power
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-engine.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-engine.md
@@ -11,13 +11,21 @@ Adjust engine-related setup options from the cockpit: engine power, throttle sha
 
 ## View sub-modes
 
-The **View …** entries are read-only live readouts. No Direction, no key fires on press.
+The **View …** entries turn the key into a continuously updating display of the current value in the car. With **dual-press** enabled (default) the same key also adjusts the value: a short press fires one direction and a long press fires the opposite — so one key replaces the separate Increase / Decrease keys you'd otherwise need. (Boost Level has no View counterpart — iRacing doesn't expose a matching `dc*` field, so Boost Level remains a directional-only adjustment mode.)
 
 | View setting | Telemetry source | Format | Typical range |
 |---|---|---|---|
 | View Engine Power | `dcEnginePower` | integer | car-dependent slot |
 | View Throttle Shape | `dcThrottleShape` | integer | car-dependent slot |
 | View Launch RPM | `dcLaunchRPM` | integer | RPM |
+
+### Dual-press control
+
+Each View sub-mode exposes a single extra setting in the Property Inspector:
+
+- **Enable dual-press** (default *on*) — when off, the key stays a pure read-only display and presses do nothing. When on, presses dispatch to the matching adjustment binding (e.g. View Engine Power dispatches to *Engine Power +* / *Engine Power −*), so configure those bindings in the **Global Settings → Setup Engine** section.
+
+The tap direction is a single plugin-wide setting under **Global Common Settings → Dual-Press → Directions** (default *Tap increases, long-press decreases*; the long-press always fires the opposite of the tap). The threshold separating "short" from "long" is a sibling setting **Long-press threshold (ms)** (200–2000 ms, default 500 ms). Both take effect on the next press without needing a restart.
 
 ## Modes
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-fuel.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-fuel.md
@@ -11,12 +11,20 @@ Adjust in-car fuel settings from the cockpit: fuel mixture, fuel cut position, d
 
 ## View sub-modes
 
-The **View …** entries are read-only live readouts. No Direction, no key fires on press.
+The **View …** entries turn the key into a continuously updating display of the current value in the car. With **dual-press** enabled (default) the same key also adjusts the value: a short press fires one direction and a long press fires the opposite — so one key replaces the separate Increase / Decrease keys you'd otherwise need.
 
 | View setting | Telemetry source | Format | Typical range |
 |---|---|---|---|
 | View Fuel Mixture | `dcFuelMixture` | integer | car-dependent slot |
 | View Fuel Cut Position | `dcFuelCutPosition` | integer | car-dependent slot |
+
+### Dual-press control
+
+Each View sub-mode exposes a single extra setting in the Property Inspector:
+
+- **Enable dual-press** (default *on*) — when off, the key stays a pure read-only display and presses do nothing. When on, presses dispatch to the matching adjustment binding (e.g. View Fuel Mixture dispatches to *Fuel Mixture +* / *Fuel Mixture −*), so configure those bindings in the **Global Settings → Setup Fuel** section.
+
+The tap direction is a single plugin-wide setting under **Global Common Settings → Dual-Press → Directions** (default *Tap increases, long-press decreases*; the long-press always fires the opposite of the tap). The threshold separating "short" from "long" is a sibling setting **Long-press threshold (ms)** (200–2000 ms, default 500 ms). Both take effect on the next press without needing a restart.
 
 ## Modes
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-hybrid.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-hybrid.md
@@ -11,13 +11,21 @@ Control hybrid energy recovery and deployment settings from the cockpit: MGU-K r
 
 ## View sub-modes
 
-The **View …** entries are read-only live readouts. No Direction, no key fires on press.
+The **View …** entries turn the key into a continuously updating display of the current value in the car. With **dual-press** enabled (default) the same key also adjusts the value: a short press fires one direction and a long press fires the opposite — so one key replaces the separate Increase / Decrease keys you'd otherwise need.
 
 | View setting | Telemetry source | Format | Typical range |
 |---|---|---|---|
 | View MGU-K Deploy Mode | `dcMGUKDeployMode` | integer | 0–4 |
 | View MGU-K Regen Gain | `dcMGUKRegenGain` | integer | car-dependent slot |
 | View MGU-K Deploy Fixed | `dcMGUKDeployFixed` | integer | car-dependent slot |
+
+### Dual-press control
+
+Each View sub-mode exposes a single extra setting in the Property Inspector:
+
+- **Enable dual-press** (default *on*) — when off, the key stays a pure read-only display and presses do nothing. When on, presses dispatch to the matching adjustment binding (e.g. View MGU-K Regen Gain dispatches to *MGU-K Regen Gain +* / *MGU-K Regen Gain −*), so configure those bindings in the **Global Settings → Setup Hybrid** section.
+
+The tap direction is a single plugin-wide setting under **Global Common Settings → Dual-Press → Directions** (default *Tap increases, long-press decreases*; the long-press always fires the opposite of the tap). The threshold separating "short" from "long" is a sibling setting **Long-press threshold (ms)** (200–2000 ms, default 500 ms). Both take effect on the next press without needing a restart.
 
 ## Modes
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-traction.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-traction.md
@@ -11,7 +11,7 @@ Adjust traction control from the cockpit: toggle TC on or off, and step the four
 
 ## View sub-modes
 
-The **View TC1 / TC2 / TC3 / TC4** entries are read-only live readouts. Each pairs with the corresponding adjustment entry in the dropdown — handy for placing a value readout next to the same slot's +/- keys. No Direction, no key fires on press.
+The **View TC1 / TC2 / TC3 / TC4** entries turn the key into a continuously updating display of the slot's current value. With **dual-press** enabled (default) the same key also adjusts that slot: a short press fires one direction and a long press fires the opposite — so one key replaces the separate Increase / Decrease keys you'd otherwise need.
 
 | View setting | Telemetry source | Format | Typical range |
 |---|---|---|---|
@@ -21,6 +21,14 @@ The **View TC1 / TC2 / TC3 / TC4** entries are read-only live readouts. Each pai
 | View TC4 | `dcTractionControl4` | integer | 0–10 slot |
 
 Slot 1 is the canonical `dcTractionControl` field iRacing exposes for every TC-equipped car. Slots 2–4 are populated on cars that have multiple TC presets; cars that only have a single TC value render "---" for the higher slots.
+
+### Dual-press control
+
+Each View sub-mode exposes a single extra setting in the Property Inspector:
+
+- **Enable dual-press** (default *on*) — when off, the key stays a pure read-only display and presses do nothing. When on, presses dispatch to the matching adjustment binding (e.g. View TC1 dispatches to *TC Slot 1 +* / *TC Slot 1 −*), so configure those bindings in the **Global Settings → Setup Traction** section.
+
+The tap direction is a single plugin-wide setting under **Global Common Settings → Dual-Press → Directions** (default *Tap increases, long-press decreases*; the long-press always fires the opposite of the tap). The threshold separating "short" from "long" is a sibling setting **Long-press threshold (ms)** (200–2000 ms, default 500 ms). Both take effect on the next press without needing a restart.
 
 ## Modes
 


### PR DESCRIPTION
## Related Issue

Fixes #540

## What changed?

PR #541 added read-only "View …" sub-modes to the seven directional setup actions. This PR turns those View sub-modes into one-key **dual-press** controls: while the key shows the live telemetry value, a short press fires one direction and a long press fires the opposite — replacing two physical keys (separate Increase + Decrease) with one that also displays the value.

- **`@iracedeck/deck-core`** — new `DualPressTracker` (per-context tap/long-press timing keyed by action context id). Two new global settings: `dualPressThresholdMs` (200–2000 ms, default 500) and `dualPressDirections` (`tap-increases` | `tap-decreases`, default `tap-increases`), with `getDualPressThresholdMs()` / `getDualPressDirections()` readers. Both are plugin-wide so the tap-vs-long-press rule stays consistent across every setup action.
- **`@iracedeck/iracing-actions`** — each of the 7 setup actions gains a per-action `dualPressEnabled` opt-in (default on). When enabled, a View sub-mode records key-down in `onKeyDown` and dispatches the resolved direction in `onKeyUp` via the existing global key bindings. `setup-view.ts` maps each View id to its underlying adjustment mode (`getAdjustmentModeForView`); `setup-chassis` adds dispatch-only weight-jacker key bindings (no matching adjustment mode existed). Directional adjustment, toggle, and encoder behaviour are untouched.
- **`@iracedeck/pi-components`** — new `dual-press-overrides` partial (the per-action enable checkbox), global threshold + directions rows in the Common Settings accordion, and a shared `ird-supporting-text` CSS class for help text (replaces inline styles across `global-common-settings.ejs` and `global-flag-flash.ejs`).
- **Docs / website / skill** — all 7 website setup action pages document the dual-press control; tap direction and threshold are documented as plugin-wide Global Common Settings. `.claude/rules/pi-templates.md` documents the `ird-supporting-text` class.

## How to test

- `pnpm install && pnpm build && pnpm test && pnpm lint:fix && pnpm format:fix` — all green (3944 tests).
- In iRacing on a Stream Deck:
  - Configure brake-bias `+` / `-` global key bindings, drop a "Setup Brakes" key, pick `view-brake-bias`. Verify the live value renders.
  - Tap → bias moves one way; hold ~1 s → bias moves the other way.
  - Global Common Settings → Dual-Press → Directions: switch to "Tap decreases" → directions invert on the next press.
  - Toggle the per-action **Enable dual-press** off → the key goes back to a read-only display; the value still updates from telemetry.
  - Global Common Settings → Long-press threshold: 250 ms / 1500 ms → the tap/long-press boundary moves accordingly.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dual-press support for View sub-modes (short vs long press perform opposite adjustments).
  * Global dual-press settings: long-press threshold and tap-direction.
  * New Weight Jacker controls in chassis setup.
  * Per-action “Enable dual-press” toggle and UI updates to expose it.

* **Documentation**
  * Shared CSS Classes doc and updated setup action guides describing dual-press.

* **Tests**
  * Added/expanded test coverage for dual-press behavior and global settings validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niklam/iracedeck/pull/548)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->