### PR TITLE
fix(audio-assets): hoist ffmpeg processing into its own turbo task (#562)

### DIFF
--- a/packages/audio-assets/package.json
+++ b/packages/audio-assets/package.json
@@ -12,6 +12,7 @@
     "./presets": "./src/presets.mjs"
   },
   "scripts": {
+    "build": "node src/build/prebuild.mjs",
     "generate": "tsx src/generate/generate.ts",
     "generate:dry-run": "tsx src/generate/generate.ts --dry-run",
     "generate:manifest": "node scripts/generate-audio-manifest.mjs"

--- a/packages/audio-assets/src/build/index.d.ts
+++ b/packages/audio-assets/src/build/index.d.ts
@@ -14,4 +14,10 @@ export function processAndCopyAudioAssetsPlugin(options: { sdPlugin: string }): 
   generateBundle: () => Promise<void>;
 };
 
+export type PrebuildAudioAssetCacheOptions = {
+  logger?: (message: string) => void;
+};
+
+export function prebuildAudioAssetCache(options?: PrebuildAudioAssetCacheOptions): Promise<void>;
+
 export function wipeProcessedCache(): Promise<void>;

--- a/packages/audio-assets/src/build/index.mjs
+++ b/packages/audio-assets/src/build/index.mjs
@@ -22,13 +22,18 @@ const CACHE_ROOT = path.join(packageRoot, ".cache");
 const SKIP_FOLDERS = new Set([".cache", "node_modules", "scripts", "src"]);
 
 // Serializes operations that mutate the shared `.cache/` tree
-// (`processAndCopyAudioAssets`, `wipeProcessedCache`). The harness exposes
-// both as separate "Reload audio" / "Wipe ffmpeg cache" buttons, and a
-// rapid Wipe-then-Reload (or vice versa) would otherwise race: an rmSync
-// can drop a file the other call just stat'd or is mid-write into, with
-// ENOENT or partial-output as fallout. The Rollup build path only invokes
-// `processAndCopyAudioAssets` once per build so it's not affected, but
-// the lock costs nothing in the single-call case.
+// (`processAndCopyAudioAssets`, `prebuildAudioAssetCache`, `wipeProcessedCache`).
+// The harness exposes Reload and Wipe as separate buttons, and a rapid
+// Wipe-then-Reload (or vice versa) would otherwise race: an rmSync can drop
+// a file the other call just stat'd or is mid-write into, with ENOENT or
+// partial-output as fallout.
+//
+// Cross-process contention on the shared cache is handled architecturally
+// rather than here — `@iracedeck/audio-assets#build` warms the cache via
+// `prebuildAudioAssetCache` before the parallel plugin builds run, so each
+// plugin's Rollup `processAndCopyAudioAssets` call only reads cache files.
+// This in-process lock is the residual guard for the harness UI and for
+// single-process watcher rebuilds.
 let cacheLock = Promise.resolve();
 function withCacheLock(operation) {
   // `.then(fn, fn)` makes the queue continue even if a prior operation
@@ -121,6 +126,96 @@ export function wipeProcessedCache() {
   });
 }
 
+// Recursively walk a voice subtree, queuing every .mp3 for radio-filter
+// processing or cache-hit copying. The caller picks behaviour via callbacks
+// so the same walk drives both the prebuild cache-warm pass (which only
+// writes to `cacheDir`) and the per-plugin copy pass (which also writes
+// to `destDir`).
+//
+// `onFresh(cachedPath, destDir, fileName)` is invoked when the cache file
+// is newer than the source. `onMiss(srcPath, cachedPath, destDir, fileName)`
+// is invoked when the cache is stale or missing — the ffmpeg call has not
+// been made yet, the callback decides whether to run it and whether to
+// follow it with a copy.
+function buildVoiceTreeTasks(srcDir, cacheDir, destDir, { onFresh, onMiss }) {
+  const tasks = [];
+
+  const walk = (currentSrc, currentCache, currentDest) => {
+    mkdirSync(currentCache, { recursive: true });
+    if (currentDest) mkdirSync(currentDest, { recursive: true });
+
+    for (const entry of readdirSync(currentSrc, { withFileTypes: true })) {
+      const srcPath = path.join(currentSrc, entry.name);
+
+      if (entry.isDirectory()) {
+        walk(srcPath, path.join(currentCache, entry.name), currentDest ? path.join(currentDest, entry.name) : null);
+        continue;
+      }
+
+      if (!entry.isFile() || !entry.name.toLowerCase().endsWith(".mp3")) continue;
+
+      const cachedPath = path.join(currentCache, entry.name);
+
+      if (cacheIsFresh(srcPath, cachedPath)) {
+        tasks.push(() => onFresh(cachedPath, currentDest, entry.name));
+      } else {
+        tasks.push(() => onMiss(srcPath, cachedPath, currentDest, entry.name));
+      }
+    }
+  };
+
+  walk(srcDir, cacheDir, destDir);
+  return tasks;
+}
+
+/**
+ * Warm `.cache/<pipeline-hash>/voice/...` by running every source voice clip
+ * through ffmpeg, without copying anywhere. Intended to run as its own turbo
+ * task (`@iracedeck/audio-assets#build`) before the plugin builds, so the
+ * parallel per-plugin `processAndCopyAudioAssets` calls find a fully-warm
+ * cache and only ever read from it — no two processes contend over the same
+ * `.cache/.../68.mp3` write.
+ *
+ * Per-file mtime check (`cacheIsFresh`) makes a warm cache a no-op, so this
+ * is cheap to run on every build.
+ *
+ * `logger` is an optional `(msg: string) => void` for build-summary output.
+ */
+export async function prebuildAudioAssetCache({ logger } = {}) {
+  if (!existsSync(audioAssetsPath)) return;
+  return withCacheLock(() => runPrebuildCache({ logger }));
+}
+
+async function runPrebuildCache({ logger }) {
+  const ffmpegPath = require("ffmpeg-static");
+  const hash = pipelineHash(RADIO_ENGINEER_FILTER, ENCODE_ARGS);
+  const cacheRoot = path.join(CACHE_ROOT, hash);
+  const concurrency = Math.min(4, Math.max(1, os.availableParallelism?.() ?? os.cpus().length));
+
+  const voiceSrc = path.join(audioAssetsPath, VOICE_ROOT);
+  if (!existsSync(voiceSrc)) {
+    logger?.(`Audio assets prebuild: no voice/ tree under ${audioAssetsPath} (pipeline hash ${hash})`);
+    return;
+  }
+
+  let processed = 0;
+  let cached = 0;
+
+  const tasks = buildVoiceTreeTasks(voiceSrc, path.join(cacheRoot, VOICE_ROOT), null, {
+    onFresh: () => {
+      cached++;
+    },
+    onMiss: async (srcPath, cachedPath) => {
+      await runFfmpeg(ffmpegPath, srcPath, cachedPath, RADIO_ENGINEER_FILTER);
+      processed++;
+    },
+  });
+
+  await runWithConcurrency(tasks, concurrency);
+
+  logger?.(`Audio assets prebuild: ${processed} processed, ${cached} cache-hit (pipeline hash ${hash})`);
+}
+
 /**
  * Copies `packages/audio-assets/` into `destRoot`. Every .mp3 under voice/
  * (at any depth) passes through ffmpeg with RADIO_ENGINEER_FILTER applied;
@@ -170,40 +265,6 @@ async function runProcessAndCopy({ destRoot, logger, wipe }) {
   let cached = 0;
   let copiedAsIs = 0;
 
-  // Recursively walk a voice subtree, queuing every .mp3 for radio-filter
-  // processing. Preserves directory structure under destRoot/cacheRoot.
-  const queueVoiceTree = (srcDir, destDir, cacheDir) => {
-    mkdirSync(destDir, { recursive: true });
-    mkdirSync(cacheDir, { recursive: true });
-
-    for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
-      const srcPath = path.join(srcDir, entry.name);
-
-      if (entry.isDirectory()) {
-        queueVoiceTree(srcPath, path.join(destDir, entry.name), path.join(cacheDir, entry.name));
-        continue;
-      }
-
-      if (!entry.isFile() || !entry.name.toLowerCase().endsWith(".mp3")) continue;
-
-      const cachedPath = path.join(cacheDir, entry.name);
-      const destPath = path.join(destDir, entry.name);
-
-      if (cacheIsFresh(srcPath, cachedPath)) {
-        tasks.push(async () => {
-          copyFileSync(cachedPath, destPath);
-          cached++;
-        });
-      } else {
-        tasks.push(async () => {
-          await runFfmpeg(ffmpegPath, srcPath, cachedPath, RADIO_ENGINEER_FILTER);
-          copyFileSync(cachedPath, destPath);
-          processed++;
-        });
-      }
-    }
-  };
-
   const copyTreeAsIs = (srcDir, destDir) => {
     cpSync(srcDir, destDir, { recursive: true });
     // cpSync copies recursively, so the counter has to walk recursively
@@ -226,7 +287,19 @@ async function runProcessAndCopy({ destRoot, logger, wipe }) {
     const destDir = path.join(destRoot, entry.name);
 
     if (entry.name === VOICE_ROOT) {
-      queueVoiceTree(srcDir, destDir, path.join(cacheRoot, VOICE_ROOT));
+      tasks.push(
+        ...buildVoiceTreeTasks(srcDir, path.join(cacheRoot, VOICE_ROOT), destDir, {
+          onFresh: async (cachedPath, currentDest, fileName) => {
+            copyFileSync(cachedPath, path.join(currentDest, fileName));
+            cached++;
+          },
+          onMiss: async (srcPath, cachedPath, currentDest, fileName) => {
+            await runFfmpeg(ffmpegPath, srcPath, cachedPath, RADIO_ENGINEER_FILTER);
+            copyFileSync(cachedPath, path.join(currentDest, fileName));
+            processed++;
+          },
+        }),
+      );
     } else {
       mkdirSync(destDir, { recursive: true });
       copyTreeAsIs(srcDir, destDir);

--- a/packages/audio-assets/src/build/prebuild.mjs
+++ b/packages/audio-assets/src/build/prebuild.mjs
@@ -1,0 +1,8 @@
+// Turbo entry for `@iracedeck/audio-assets#build`. Warms
+// `.cache/<pipeline-hash>/voice/...` so the parallel plugin builds that
+// depend on this task (`^build`) find a fully-warm cache and only read
+// from it. See `prebuildAudioAssetCache` for the contention rationale.
+
+import { prebuildAudioAssetCache } from "./index.mjs";
+
+await prebuildAudioAssetCache({ logger: (msg) => console.log(msg) });

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,10 @@
         "com.iracedeck.sd.*.sdPlugin/**"
       ]
     },
+    "@iracedeck/audio-assets#build": {
+      "inputs": ["voice/**", "src/build/**", "src/presets.mjs"],
+      "outputs": [".cache/**"]
+    },
     "dev": {
       "dependsOn": ["^build"],
       "cache": false,


### PR DESCRIPTION
## Related Issue

Fixes #562

## What changed?

The two plugin Rollup builds ran in parallel as separate Node processes and both called `processAndCopyAudioAssets`, contending over writes to the shared `.cache/<pipeline-hash>/voice/...` tree. The module-scope `cacheLock` only serializes within one Node process, so on a cold cache two ffmpeg children could open the same output path concurrently and fail with `EACCES` on Windows (`ffmpeg exit 4294967283`). Failing CI run: https://github.com/niklam/iracedeck/actions/runs/25920075949/job/76186511052.

This PR hoists the ffmpeg processing step out of the per-plugin Rollup build into a dedicated `@iracedeck/audio-assets#build` turbo task that runs once before both plugin builds. Both plugins already declare `@iracedeck/audio-assets` as a workspace dependency, so turbo's `dependsOn: ["^build"]` automatically schedules the prebuild first. The parallel plugin Rollup steps now only ever *read* the cache — the contended write path is gone.

Touched:

- **`packages/audio-assets/src/build/index.mjs`** — new exported `prebuildAudioAssetCache()` that walks `voice/` and writes ffmpeg outputs to `.cache/<pipeline-hash>/voice/...` without copying anywhere. Factored the recursive voice-tree walk into a shared `buildVoiceTreeTasks()` with `onFresh` / `onMiss` callbacks so the new prebuild path and the existing `processAndCopyAudioAssets` share traversal logic (cache freshness check, ffmpeg invocation, mtime-based skip — all unchanged). Updated the now-stale `cacheLock` rationale comment.
- **`packages/audio-assets/src/build/index.d.ts`** — declared the new export.
- **`packages/audio-assets/src/build/prebuild.mjs`** — new three-line entry script that turbo invokes.
- **`packages/audio-assets/package.json`** — added `"build": "node src/build/prebuild.mjs"`.
- **`turbo.json`** — added a per-task override for `@iracedeck/audio-assets#build` with `inputs: ["voice/**", "src/build/**", "src/presets.mjs"]` and `outputs: [".cache/**"]` so turbo can cache the prebuild across runs.

No changes to plugin `rollup.config.mjs`, plugin `package.json`, or the harness — `processAndCopyAudioAssets` keeps the same signature and behaviour, and on a warm cache it falls through to pure `copyFileSync` per file. The in-process `cacheLock` stays as a residual guard for the harness UI and single-process watcher rebuilds.

## How to test

1. `pnpm install && pnpm build` — 18/18 tasks succeed; on a fresh checkout you should see:

    ```text
    @iracedeck/audio-assets:build:                Audio assets prebuild: 541 processed, 0 cache-hit
    @iracedeck/iracing-plugin-mirabox:build:      Audio assets: 0 processed, 541 cache-hit, 8 copied as-is
    @iracedeck/iracing-plugin-stream-deck:build:  Audio assets: 0 processed, 541 cache-hit, 8 copied as-is
    ```

2. Re-run `pnpm build` — turbo caches the prebuild (`13 cached, 18 total`).
3. Wipe the cache (`rm -rf packages/audio-assets/.cache`) and `pnpm build --force` to confirm the cold path still works.
4. `pnpm test` — 4106/4106 pass.
5. `pnpm lint:fix && pnpm format:fix` — clean.
6. Optional watcher path: `pnpm watch:stream-deck` still works on a cold cache (it bypasses turbo, processes via the same `processAndCopyAudioAssets` in-process, single Node so the existing `cacheLock` covers it).

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests — no new pure logic; the shared `buildVoiceTreeTasks()` is exercised by both call sites and verified end-to-end by the existing build path (cold and warm).
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — both consume `@iracedeck/audio-assets` already; the new turbo task wires in via the existing `^build` edge with no per-plugin changes.
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio asset cache prewarming to accelerate build performance and enable better parallel build handling.

* **Chores**
  * Updated build system configuration to optimize audio asset build task scheduling and caching outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niklam/iracedeck/pull/563)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->