### PR TITLE
fix(sim-events-iracing): re-fire session-start callout on session change (#564)

### DIFF
--- a/packages/sim-events-iracing/src/translator.test.ts
+++ b/packages/sim-events-iracing/src/translator.test.ts
@@ -1177,13 +1177,108 @@ describe("sim-events-iracing translator", () => {
       bus.subscribe("driver.firstOnTrack", handler);
       initializeSimEventsIracing(bus, controller, createMockLogger());
 
-      controller.__tick(telemetry({ IsReplayPlaying: true, IsOnTrack: false }));
-      controller.__tick(telemetry({ IsReplayPlaying: false, IsOnTrack: true })); // drive out — fires
-      controller.__tick(telemetry({ IsReplayPlaying: true, IsOnTrack: false })); // back to garage
-      controller.__tick(telemetry({ IsReplayPlaying: false, IsOnTrack: true })); // drive out again
+      controller.__tick(telemetry({ SessionNum: 0, IsReplayPlaying: true, IsOnTrack: false }));
+      controller.__tick(telemetry({ SessionNum: 0, IsReplayPlaying: false, IsOnTrack: true })); // drive out — fires
+      controller.__tick(telemetry({ SessionNum: 0, IsReplayPlaying: true, IsOnTrack: false })); // back to garage
+      controller.__tick(telemetry({ SessionNum: 0, IsReplayPlaying: false, IsOnTrack: true })); // drive out again
 
-      // The lifetime milestone survives the replay guard's resets — no re-fire.
+      // Same session throughout — no re-fire across garage cycles.
       expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    // Issue #564: session-start callout must re-fire when SessionNum changes
+    // (practice → qualifying → race), even though it stays single-fire within
+    // a session. Three scenarios cover the bug end-to-end.
+
+    it("re-fires driver.firstOnTrack when SessionNum changes mid-drive", () => {
+      const controller = createMockController();
+      const bus = getEventBus();
+      const handler = vi.fn();
+      bus.subscribe("driver.firstOnTrack", handler);
+      initializeSimEventsIracing(bus, controller, createMockLogger());
+
+      // Practice: on track, callout fires.
+      controller.__tick(telemetry({ SessionNum: 0, IsOnTrack: false }));
+      controller.__tick(telemetry({ SessionNum: 0, IsOnTrack: true }));
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      // Qualifying starts while still on track — must re-fire.
+      controller.__tick(telemetry({ SessionNum: 1, IsOnTrack: true }));
+      expect(handler).toHaveBeenCalledTimes(2);
+
+      // Race starts — must re-fire again.
+      controller.__tick(telemetry({ SessionNum: 2, IsOnTrack: true }));
+      expect(handler).toHaveBeenCalledTimes(3);
+    });
+
+    it("re-fires driver.firstOnTrack on the replay → live-on-track transition that follows a session change", () => {
+      const controller = createMockController();
+      const bus = getEventBus();
+      const handler = vi.fn();
+      bus.subscribe("driver.firstOnTrack", handler);
+      initializeSimEventsIracing(bus, controller, createMockLogger());
+
+      // Practice: drive out, callout fires.
+      controller.__tick(telemetry({ SessionNum: 0, IsReplayPlaying: true, IsOnTrack: false }));
+      controller.__tick(telemetry({ SessionNum: 0, IsReplayPlaying: false, IsOnTrack: true }));
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      // Practice ends → iRacing returns to replay/menu, then qualifying starts.
+      // The SessionNum delta arrives on a replay-mode tick (the realistic path:
+      // user is in the session-load screen when the number flips).
+      controller.__tick(telemetry({ SessionNum: 0, IsReplayPlaying: true, IsOnTrack: false }));
+      controller.__tick(telemetry({ SessionNum: 1, IsReplayPlaying: true, IsOnTrack: false }));
+      expect(handler).toHaveBeenCalledTimes(1); // still in replay — no fire yet
+
+      // Driver clicks Drive in qualifying — fires on the live-on-track edge.
+      controller.__tick(telemetry({ SessionNum: 1, IsReplayPlaying: false, IsOnTrack: true }));
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+
+    it("still publishes session.changed on the tick that triggers the session reset", () => {
+      // The instance-level session-num tracker drives the state wipe, but the
+      // bus event must keep firing through `diffLifecycle` so external
+      // subscribers (scenario harness, future consumers) keep working. The
+      // reset preserves `state.lastSessionNum` exactly for this reason.
+      const controller = createMockController();
+      const bus = getEventBus();
+      const handler = vi.fn();
+      bus.subscribe("session.changed", handler);
+      initializeSimEventsIracing(bus, controller, createMockLogger());
+
+      controller.__tick(telemetry({ SessionNum: 0 }));
+      controller.__tick(telemetry({ SessionNum: 1 }));
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      const ev = handler.mock.calls[0]![0] as SimEventOf<"session.changed">;
+      expect(ev.data).toEqual({ from: 0, to: 1 });
+    });
+
+    it("wipes per-session diff state on SessionNum change so the next tick re-seeds", () => {
+      // Sanity check that the reset isn't limited to `firstOnTrackFired` —
+      // representative per-session state must clear too. We use the toggles
+      // diff: it tracks `lastP2PActive` and emits `carControl.p2pToggled` only
+      // on a rising edge. If practice ended with P2P active, the reset must
+      // let qualifying re-emit on a fresh rising edge instead of suppressing
+      // it as "unchanged".
+      const controller = createMockController();
+      const bus = getEventBus();
+      const handler = vi.fn();
+      bus.subscribe("carControl.p2pToggled", handler);
+      initializeSimEventsIracing(bus, controller, createMockLogger());
+
+      // Practice: P2P off → on (rising edge fires once).
+      controller.__tick(telemetry({ SessionNum: 0, P2P_Status: false }));
+      controller.__tick(telemetry({ SessionNum: 0, P2P_Status: true }));
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      // Session changes to qualifying. The toggles diff's `lastP2PActive` was
+      // `true` at the moment of the change; the reset wipes it back to `false`
+      // (toggleStateInitialized: false), so the first qual tick re-seeds and
+      // the next rising edge fires fresh.
+      controller.__tick(telemetry({ SessionNum: 1, P2P_Status: false })); // re-seed in qual
+      controller.__tick(telemetry({ SessionNum: 1, P2P_Status: true })); // rising edge in qual
+      expect(handler).toHaveBeenCalledTimes(2);
     });
 
     it("does not synthesize lap.started when Lap resets to a lower number (session flip)", () => {

--- a/packages/sim-events-iracing/src/translator.test.ts
+++ b/packages/sim-events-iracing/src/translator.test.ts
@@ -1254,6 +1254,35 @@ describe("sim-events-iracing translator", () => {
       expect(ev.data).toEqual({ from: 0, to: 1 });
     });
 
+    it("publishes radar.changed → clear when SessionNum changes with radar active", () => {
+      // Mirrors the `handleDisconnect` teardown contract: a downstream radar
+      // audio engine latched on the prior session's "left"/"right" beep
+      // would stay latched if the reset wiped `radarState` without emitting
+      // the clear edge first. Covers the replay-mode session-transition path
+      // explicitly because that's where the bug bites — the replay guard's
+      // own teardown check would see the already-cleared state and skip.
+      const controller = createMockController();
+      const bus = getEventBus();
+      const handler = vi.fn();
+      bus.subscribe("radar.changed", handler);
+      initializeSimEventsIracing(bus, controller, createMockLogger());
+
+      // Practice: car appears on the left, radar emits left.
+      controller.__tick(telemetry({ SessionNum: 0, CarLeftRight: CarLeftRight.Off }));
+      controller.__tick(telemetry({ SessionNum: 0, CarLeftRight: CarLeftRight.CarLeft }));
+      expect(handler).toHaveBeenCalledTimes(1);
+      const activate = handler.mock.calls[0]![0] as SimEventOf<"radar.changed">;
+      expect(activate.data).toEqual({ from: "clear", to: "left" });
+
+      // Session flips to qualifying on a replay-mode tick (the path that
+      // would otherwise swallow the teardown). The reset must fire the clear
+      // edge before wiping state so the audio engine stops the beep.
+      controller.__tick(telemetry({ SessionNum: 1, IsReplayPlaying: true, CarLeftRight: CarLeftRight.CarLeft }));
+      expect(handler).toHaveBeenCalledTimes(2);
+      const teardown = handler.mock.calls[1]![0] as SimEventOf<"radar.changed">;
+      expect(teardown.data).toEqual({ from: "left", to: "clear" });
+    });
+
     it("wipes per-session diff state on SessionNum change so the next tick re-seeds", () => {
       // Sanity check that the reset isn't limited to `firstOnTrackFired` —
       // representative per-session state must clear too. We use the toggles

--- a/packages/sim-events-iracing/src/translator.ts
+++ b/packages/sim-events-iracing/src/translator.ts
@@ -288,6 +288,14 @@ function handleDisconnect(self: TranslatorInstance): void {
  * and race each get a fresh slate for callouts that should fire once per
  * session (session-start, fuel thresholds, incident counters, …).
  *
+ * Publishes a `radar.changed → clear` teardown before wiping state — mirrors
+ * `handleDisconnect`. Without it, a downstream radar audio engine latched on
+ * the prior session's "left" / "right" beep would stay latched: the post-
+ * wipe `state.radarState` is already `"clear"`, so the replay guard's
+ * teardown check would see no edge and skip the emit, leaving the engine
+ * mid-loop indefinitely. Any future active-state subsystem with a similar
+ * latch contract plugs in here the same way.
+ *
  * The lifecycle diff's baselines (`lifecycleInitialized`, `lastSessionNum`,
  * `lastEngineRunning`, `lastLap`) are preserved across the wipe. Without
  * that, the reset would put `lifecycleInitialized = false`, the very next
@@ -307,7 +315,16 @@ function handleDisconnect(self: TranslatorInstance): void {
  * invalidate via `resolvePitSpeedLimit`'s `${TrackID}|${SessionNum}` cache key
  * and need no reset here.
  */
-function resetPerSessionState(self: TranslatorInstance): void {
+function resetPerSessionState(self: TranslatorInstance, telemetry: TelemetryData): void {
+  if (self.state.radarState !== "clear") {
+    publish(
+      self,
+      { event: "radar.changed", data: { from: self.state.radarState, to: "clear" } },
+      telemetry,
+      Date.now(),
+    );
+  }
+
   const preservedLifecycle = {
     lifecycleInitialized: self.state.lifecycleInitialized,
     lastSessionNum: self.state.lastSessionNum,
@@ -371,7 +388,7 @@ function handleTick(self: TranslatorInstance, telemetry: TelemetryData): void {
     self.lastObservedSessionNum !== null &&
     currentSessionNum !== self.lastObservedSessionNum
   ) {
-    resetPerSessionState(self);
+    resetPerSessionState(self, telemetry);
   }
 
   if (currentSessionNum !== null) {

--- a/packages/sim-events-iracing/src/translator.ts
+++ b/packages/sim-events-iracing/src/translator.ts
@@ -59,11 +59,24 @@ type TranslatorInstance = {
   /** Tracks the `IsReplayPlaying` edge so we can reset state on transition. */
   lastTickInReplay: boolean;
   /**
-   * `driver.firstOnTrack` tracking. Connection-lifetime milestone — kept on
-   * the instance, not `TranslatorState`, so it survives the per-tick state
-   * resets the replay guard performs (seed-and-bail would otherwise re-run
-   * on every replay exit and swallow the genuine first-on-track moment).
-   * Both reset only on `handleDisconnect`. See `diffFirstOnTrack`.
+   * `telemetry.SessionNum` tracker for session-change detection (issue #564).
+   * Kept on the instance — not in `TranslatorState` — so it survives the
+   * replay guard's per-tick state wipes. iRacing's between-session transition
+   * commonly passes through `IsReplayPlaying: true` ticks, and if the tracker
+   * lived in state the wipe would null it out before the SessionNum delta
+   * could be detected. `null` until the first tick observes a value; reset
+   * only by `handleDisconnect`.
+   */
+  lastObservedSessionNum: number | null;
+  /**
+   * `driver.firstOnTrack` tracking — session-scoped (issue #564), not
+   * connection-scoped. Kept on the instance (not `TranslatorState`) so it
+   * survives the replay guard's per-tick state wipes; reset by
+   * `resetPerSessionState` on a `SessionNum` change and by `handleDisconnect`
+   * on a fresh connection. Seeding stays `true` across session resets — if
+   * the driver is already on track at the moment of the transition,
+   * re-seeding would silently mark fired and swallow the very fire we want.
+   * See `diffFirstOnTrack`.
    */
   firstOnTrackSeeded: boolean;
   firstOnTrackFired: boolean;
@@ -94,6 +107,7 @@ export function initializeSimEventsIracing(
     pitSpeedLimitMps: 0,
     pitSpeedLimitKey: "",
     lastTickInReplay: false,
+    lastObservedSessionNum: null,
     firstOnTrackSeeded: false,
     firstOnTrackFired: false,
   };
@@ -259,10 +273,51 @@ function handleDisconnect(self: TranslatorInstance): void {
   self.latestTelemetry = null;
   self.pitSpeedLimitMps = 0;
   self.pitSpeedLimitKey = "";
-  // `driver.firstOnTrack` is a connection-lifetime milestone — cleared only
-  // here so a genuine reconnect re-seeds (and a mid-drive reconnect stays
-  // silent), while replay scrubbing within one connection does not.
+  self.lastObservedSessionNum = null;
+  // `driver.firstOnTrack` seeding is reset only here (not on session change)
+  // so a mid-drive reconnect seeds silently and doesn't synthesize a welcome.
+  // Session-change resets clear only `firstOnTrackFired` — see
+  // `resetPerSessionState`.
   self.firstOnTrackSeeded = false;
+  self.firstOnTrackFired = false;
+}
+
+/**
+ * Wipe per-session state on a `SessionNum` change (issue #564). The Race
+ * Engineer's "everything is in session context" model: practice, qualifying,
+ * and race each get a fresh slate for callouts that should fire once per
+ * session (session-start, fuel thresholds, incident counters, …).
+ *
+ * The lifecycle diff's baselines (`lifecycleInitialized`, `lastSessionNum`,
+ * `lastEngineRunning`, `lastLap`) are preserved across the wipe. Without
+ * that, the reset would put `lifecycleInitialized = false`, the very next
+ * `diffLifecycle` call this same tick would silently re-seed `lastSessionNum`
+ * to the new value (skipping the emit), and `session.changed` would never
+ * reach subscribers. Preserving the baselines also avoids synthesizing a
+ * spurious `engine.startup` (`lastEngineRunning` would be the sentinel
+ * `false` against a still-running engine) on every session transition. The
+ * lifecycle state IS the diff-baseline channel — not the session state — so
+ * preserving it through a session boundary is the correct semantic.
+ *
+ * `firstOnTrackSeeded` stays `true`; only `firstOnTrackFired` clears. Re-
+ * seeding would silently mark fired = true if the driver is already on track
+ * at the transition and swallow the very fire we want.
+ *
+ * Track-level instance fields (`pitSpeedLimitMps` / `pitSpeedLimitKey`) self-
+ * invalidate via `resolvePitSpeedLimit`'s `${TrackID}|${SessionNum}` cache key
+ * and need no reset here.
+ */
+function resetPerSessionState(self: TranslatorInstance): void {
+  const preservedLifecycle = {
+    lifecycleInitialized: self.state.lifecycleInitialized,
+    lastSessionNum: self.state.lastSessionNum,
+    lastEngineRunning: self.state.lastEngineRunning,
+    lastLap: self.state.lastLap,
+  };
+
+  self.state = createInitialState();
+  Object.assign(self.state, preservedLifecycle);
+
   self.firstOnTrackFired = false;
 }
 
@@ -299,6 +354,30 @@ function diffFirstOnTrack(self: TranslatorInstance, telemetry: TelemetryData): v
 }
 
 function handleTick(self: TranslatorInstance, telemetry: TelemetryData): void {
+  // Session-change reset (issue #564). Runs on every tick — including replay
+  // ticks — because iRacing's between-session transition commonly passes
+  // through replay-mode ticks (waiting for the next session to load). Using
+  // the instance-level `lastObservedSessionNum` (not `state.lastSessionNum`)
+  // means the tracker survives the replay guard's per-tick state wipes that
+  // would otherwise null out the comparison baseline and let the transition
+  // slip past. The reset wipes `state` (preserving `lastSessionNum` so
+  // `diffLifecycle` can still emit `session.changed`) and clears
+  // `firstOnTrackFired` so the session-start callout re-fires on the next
+  // live-on-track tick.
+  const currentSessionNum = telemetry.SessionNum ?? null;
+
+  if (
+    currentSessionNum !== null &&
+    self.lastObservedSessionNum !== null &&
+    currentSessionNum !== self.lastObservedSessionNum
+  ) {
+    resetPerSessionState(self);
+  }
+
+  if (currentSessionNum !== null) {
+    self.lastObservedSessionNum = currentSessionNum;
+  }
+
   // `driver.firstOnTrack` is detected on every tick — including replay ticks
   // — so the genuine garage/replay → live-on-track transition is never
   // missed. Must run before the replay guard's early return below.


### PR DESCRIPTION
## Related Issue

Fixes #564

## What changed?

`firstOnTrackFired` was placed on the translator instance with connection-lifetime semantics, so the Race Engineer session-start callout (added in #551 for #542) fired once per iRacing process — not once per session. Practice's fire silenced qualifying and the race.

Adds an instance-level `lastObservedSessionNum` tracker (outside the replay guard's state-wipe zone, so session transitions arriving on `IsReplayPlaying: true` ticks can't slip past) and a `resetPerSessionState` helper that runs at the top of `handleTick`. On a `SessionNum` delta the helper re-creates `state` from `createInitialState()` and clears `firstOnTrackFired`, while preserving the lifecycle diff's baselines (`lifecycleInitialized`, `lastSessionNum`, `lastEngineRunning`, `lastLap`) so `session.changed` still publishes for external subscribers and the reset doesn't synthesize spurious `engine.startup` / `lap.started`. `firstOnTrackSeeded` stays `true` — re-seeding would silently mark fired when the driver is already on track at the transition and swallow the very fire we want.

No other packages need changes. `audio-scenarios`, `event-bus`, `deck-core`, and both plugins continue to work unchanged because they subscribe to the bus event, not the instance state.

## How to test

1. `pnpm install && pnpm build && pnpm test && pnpm lint && pnpm format` — all green.
2. **iRacing:** join a practice + qualifying + race event. Go on track in each session. The Race Engineer session-start brief plays three separate times (greeting, session type, pit speed, temps, wetness) — once per session.
3. **Regression guard:** within a single session, garage → track → garage → track does NOT re-fire (still once-per-session).
4. **Tests cover:**
   - mid-drive `SessionNum` increment re-fires `driver.firstOnTrack`
   - `SessionNum` transition that arrives during an `IsReplayPlaying: true` tick still produces the fire on the next live-on-track tick
   - `session.changed` still publishes on the reset tick
   - representative per-session diff state (`carControl.p2pToggled` baseline) wipes so the next session's rising edge fires fresh

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — translator is shared by both; no per-plugin changes needed
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * driver.firstOnTrack now reliably re-fires when SessionNum changes (practice→qualifying→race) and across replay→live transitions
  * session.changed is published on the same tick that triggers the session reset
  * radar.changed emits the proper teardown (left→clear) before per-session wipe
  * Per-session state is reset so events can re-trigger correctly in new sessions

* **Tests**
  * Added regression tests for session transitions, replay/live edge cases, radar teardown, and per-session state wiping (p2p toggle re-fire)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niklam/iracedeck/pull/565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->