### PR TITLE
feat(replay-control): jump to fastest lap (My Car / Viewed Car) (#577)

### DIFF
--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -9,7 +9,7 @@ description: Use when looking up Stream Deck actions, sub-actions, modes, catego
 
 Complete action definitions: `docs/reference/actions.json`
 
-The website currently documents **31 actions with 289 modes** (the totals used in this file and in user-facing docs). `docs/reference/actions.json` has not yet been re-synced to the new per-mode counting convention; use this skill file or the website as the source of truth for action and mode counts, and treat `actions.json` as a detailed inventory of individual mode values that is occasionally out of date.
+The website currently documents **31 actions with 290 modes** (the totals used in this file and in user-facing docs). `docs/reference/actions.json` has not yet been re-synced to the new per-mode counting convention; use this skill file or the website as the source of truth for action and mode counts, and treat `actions.json` as a detailed inventory of individual mode values that is occasionally out of date.
 
 Each action entry:
 ```json
@@ -45,7 +45,7 @@ When asked about actions or controls:
 | Pit Service | 3 | 15 | Fuel, tires, compounds, tearoff, fast repair |
 | Car Setup | 7 | 73 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control — adjustment modes plus live-display "View …" sub-modes; each View sub-mode also supports dual-press (tap = configured direction, long-press = opposite) so one key both shows the value and adjusts it (#540) |
 | Communication | 2 | 34 | Chat, macros (15), whisper, toggle, reply, race admin commands |
-| **Total** | **31** | **289** | |
+| **Total** | **31** | **290** | |
 
 Mode counts reflect the PI Mode/Setting dropdown choices documented in each action page. Directional variants (Increase/Decrease) are treated as a single mode with a Direction sub-setting, matching the per-mode website format. Legacy replay actions (Replay Transport, Replay Speed, Replay Navigation) and Camera Cycle (Legacy) still exist in the plugin manifest for backward compatibility but are not counted as documented actions.
 
@@ -84,7 +84,7 @@ Mode counts reflect the PI Mode/Setting dropdown choices documented in each acti
 | Action | Modes | Mode values |
 |--------|-------|-------------|
 | View Adjustment | 5 | fov (+/-), horizon (+/-), driver-height (+/-), recenter-vr, ui-size (+/-) |
-| Replay Control | 26 | play/pause, play-backward, stop, FF, rewind, slow-mo, slow-mo-rewind (FF/RW + slow-mo modes share a configurable Step Rate that walks the speed ladder per press), frame +/-, speed +/-, set-speed, speed-display, session next/prev, lap next/prev, incident next/prev, jump to beginning/live/my car, next/prev car, next/prev car number |
+| Replay Control | 27 | play/pause, play-backward, stop, FF, rewind, slow-mo, slow-mo-rewind (FF/RW + slow-mo modes share a configurable Step Rate that walks the speed ladder per press), frame +/-, speed +/-, set-speed, speed-display, session next/prev, lap next/prev, incident next/prev, jump to beginning/live/my car, jump-to-fastest-lap (target: Viewed Car / Always my car; session-scoped; no clean-lap filter; no encoder support), next/prev car, next/prev car number |
 | Camera Controls | 12 | change-camera, cycle (camera / sub-camera / car / driving), focus (your car / leader / incident / most exciting), switch (by position / car number), set-camera-state |
 | Camera Editor Adjustments | 15 | latitude, longitude, altitude, yaw, pitch, fov-zoom, key-step, vanish-x, vanish-y, blimp-radius, blimp-velocity, mic-gain (all +/-), auto-set-mic-gain, f-number (+/-), focus-depth (+/-) |
 | Camera Editor Controls | 30 | Open Camera Tool, 14 toggles (key accel/10x, parabolic mic, temp edits, dampening, zoom, beyond fence, in cockpit, mouse nav, pitch/roll gyro, limit shot range, show camera, shot selection, manual focus), cycle position/aim type, acquire start/end, camera CRUD (insert/remove/copy/paste), group CRUD (copy/paste), track/car save/load |

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@
 
 ## Features
 
-**31 actions** with **258+ modes** across 8 categories, with Stream Deck+ dial rotation support on most modes:
+**31 actions** with **259+ modes** across 8 categories, with Stream Deck+ dial rotation support on most modes:
 
 | Category                | Actions | Modes | Examples                                                              |
 | ----------------------- | ------- | ----- | --------------------------------------------------------------------- |
 | **Display & Session**   | 2       | 7     | Incidents, laps, position, fuel, flags                                |
 | **Driving Controls**    | 6       | 30    | AI spotter, audio, black box cycling, look direction, car control, pit crew |
 | **Cockpit & Interface** | 5       | 33    | Wipers, FFB, splits & reference, telemetry, UI toggles                |
-| **View & Camera**       | 5       | 88    | FOV, replay, camera controls, broadcast tools                         |
+| **View & Camera**       | 5       | 89    | FOV, replay, camera controls, broadcast tools                         |
 | **Media**               | 1       | 7     | Video recording, screenshots                                          |
 | **Pit Service**         | 3       | 15    | Fuel, tires, compounds, tearoff, fast repair                          |
 | **Car Setup**           | 7       | 44    | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control |

--- a/docs/reference/actions.json
+++ b/docs/reference/actions.json
@@ -328,6 +328,12 @@
             { "value": "jump-to-beginning", "label": "Jump to Beginning" },
             { "value": "jump-to-live", "label": "Jump to Live" },
             { "value": "jump-to-my-car", "label": "Jump to My Car" },
+            {
+              "value": "jump-to-fastest-lap",
+              "label": "Jump to Fastest Lap",
+              "additionalSettings": ["fastestLapTarget"],
+              "description": "Jump the replay cursor to the fastest lap of either the viewed car or always your own car (session-scoped; no encoder support)"
+            },
             { "value": "next-car", "label": "Next Car" },
             { "value": "prev-car", "label": "Previous Car" },
             {

--- a/packages/deck-core/src/global-settings.test.ts
+++ b/packages/deck-core/src/global-settings.test.ts
@@ -486,3 +486,33 @@ describe("dualPressDirections (issue #540)", () => {
     expect(() => GlobalSettingsSchema.parse({ dualPressDirections: "tap-toggles" })).toThrow();
   });
 });
+
+describe("fastestLapSearchDelayMs (issue #577)", () => {
+  it("defaults to 400 when not specified", () => {
+    const parsed = GlobalSettingsSchema.parse({}) as Record<string, unknown>;
+    expect(parsed.fastestLapSearchDelayMs).toBe(400);
+  });
+
+  it("accepts the lower bound (50 ms)", () => {
+    const parsed = GlobalSettingsSchema.parse({ fastestLapSearchDelayMs: 50 }) as Record<string, unknown>;
+    expect(parsed.fastestLapSearchDelayMs).toBe(50);
+  });
+
+  it("accepts the upper bound (1000 ms)", () => {
+    const parsed = GlobalSettingsSchema.parse({ fastestLapSearchDelayMs: 1000 }) as Record<string, unknown>;
+    expect(parsed.fastestLapSearchDelayMs).toBe(1000);
+  });
+
+  it("coerces a numeric string from the Property Inspector slider", () => {
+    const parsed = GlobalSettingsSchema.parse({ fastestLapSearchDelayMs: "650" }) as Record<string, unknown>;
+    expect(parsed.fastestLapSearchDelayMs).toBe(650);
+  });
+
+  it("rejects values below 50", () => {
+    expect(() => GlobalSettingsSchema.parse({ fastestLapSearchDelayMs: 49 })).toThrow();
+  });
+
+  it("rejects values above 1000", () => {
+    expect(() => GlobalSettingsSchema.parse({ fastestLapSearchDelayMs: 1001 })).toThrow();
+  });
+});

--- a/packages/deck-core/src/global-settings.ts
+++ b/packages/deck-core/src/global-settings.ts
@@ -540,6 +540,17 @@ export const GlobalSettingsSchema = z
      * - `"tap-decreases"` — tap fires Decrease, long-press fires Increase
      */
     dualPressDirections: z.enum(["tap-increases", "tap-decreases"]).default("tap-increases"),
+    /**
+     * Delay in milliseconds between consecutive replay lap-search broadcasts
+     * the Replay Control "Jump to Fastest Lap" mode emits while walking the
+     * cursor to the target lap (issue #577). Even when the replay is paused,
+     * iRacing resolves the exact lap-boundary position asynchronously after
+     * each `ReplaySearch`, and a follow-up broadcast that arrives before
+     * that work finishes leaves the cursor parked mid-lap. 400 ms is the
+     * empirical default that works reliably; slower machines and longer
+     * tracks may need higher values. Range 50–1000 ms, step 50.
+     */
+    fastestLapSearchDelayMs: z.coerce.number().min(50).max(1000).default(400),
   })
   .passthrough();
 

--- a/packages/deck-core/src/simhub-service.test.ts
+++ b/packages/deck-core/src/simhub-service.test.ts
@@ -92,6 +92,7 @@ describe("SimHub Service", () => {
       flagFlashDurationSeconds: 15,
       dualPressThresholdMs: 500,
       dualPressDirections: "tap-increases",
+      fastestLapSearchDelayMs: 400,
     });
   });
 
@@ -233,6 +234,7 @@ describe("SimHub Service", () => {
         flagFlashDurationSeconds: 15,
         dualPressThresholdMs: 500,
         dualPressDirections: "tap-increases",
+        fastestLapSearchDelayMs: 400,
       });
 
       initializeSimHub(mockLogger);

--- a/packages/icons/preview/replay-control/jump-to-fastest-lap.svg
+++ b/packages/icons/preview/replay-control/jump-to-fastest-lap.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 56 56" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a4a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"FASTEST\nLAP"},"border":{"color":"#5a6a7a"}}</desc>
+
+
+    <rect x="23" y="2" width="10" height="8" rx="2" fill="#ffffff" stroke="none"/>
+    <circle cx="28" cy="32" r="22" fill="none" stroke="#ffffff" stroke-width="4"/>
+    <polygon points="28,20 30.9,28 39.4,28.3 32.8,33.5 35.1,41.7 28,37 20.9,41.7 23.2,33.5 16.6,28.3 25.1,28" fill="#ffffff" stroke="none"/>
+
+</svg>

--- a/packages/icons/replay-control/jump-to-fastest-lap.svg
+++ b/packages/icons/replay-control/jump-to-fastest-lap.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 56 56" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a4a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"FASTEST\nLAP"},"border":{"color":"#5a6a7a"}}</desc>
+
+
+    <rect x="23" y="2" width="10" height="8" rx="2" fill="{{graphic1Color}}" stroke="none"/>
+    <circle cx="28" cy="32" r="22" fill="none" stroke="{{graphic1Color}}" stroke-width="4"/>
+    <polygon points="28,20 30.9,28 39.4,28.3 32.8,33.5 35.1,41.7 28,37 20.9,41.7 23.2,33.5 16.6,28.3 25.1,28" fill="{{graphic1Color}}" stroke="none"/>
+
+</svg>

--- a/packages/iracing-actions/src/actions/data/icon-defaults.json
+++ b/packages/iracing-actions/src/actions/data/icon-defaults.json
@@ -229,6 +229,10 @@
     "backgroundColor": "#2a3444",
     "textColor": "#ffffff"
   },
+  "setup-view": {
+    "backgroundColor": "#2a3444",
+    "textColor": "#ffffff"
+  },
   "telemetry-display": {
     "backgroundColor": "#2a3444",
     "textColor": "#ffffff"

--- a/packages/iracing-actions/src/actions/replay-control/replay-control.ejs
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.ejs
@@ -34,6 +34,7 @@
 					<option value="prev-incident">Previous Incident</option>
 					<option value="jump-to-beginning">Jump to Beginning</option>
 					<option value="jump-to-live">Jump to Live</option>
+					<option value="jump-to-fastest-lap">Jump to Fastest Lap</option>
 				</optgroup>
 				<optgroup label="Camera">
 					<option value="jump-to-my-car">Jump to My Car</option>
@@ -47,6 +48,13 @@
 
 		<sdpi-item id="step-rate-setting" label="Step Rate" class="hidden">
 			<ird-range-input setting="stepRate" min="1" max="15" step="1" default="1" showlabels></ird-range-input>
+		</sdpi-item>
+
+		<sdpi-item id="fastest-lap-target-setting" label="Target" class="hidden">
+			<sdpi-radio setting="fastestLapTarget" default="viewed-car" columns="1">
+				<option value="viewed-car">Viewed Car</option>
+				<option value="always-my-car">Always my car</option>
+			</sdpi-radio>
 		</sdpi-item>
 
 		<sdpi-item id="speed-setting" label="Speed" class="hidden">
@@ -147,6 +155,13 @@
 					stepRateSetting?.classList.remove("hidden");
 				} else {
 					stepRateSetting?.classList.add("hidden");
+				}
+
+				const fastestLapTargetSetting = document.getElementById("fastest-lap-target-setting");
+				if (mode === "jump-to-fastest-lap") {
+					fastestLapTargetSetting?.classList.remove("hidden");
+				} else {
+					fastestLapTargetSetting?.classList.add("hidden");
 				}
 			}
 

--- a/packages/iracing-actions/src/actions/replay-control/replay-control.test.ts
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.test.ts
@@ -1,10 +1,16 @@
-import { getAllCarNumbers, getCarNumberFromSessionInfo, TrkLoc } from "@iracedeck/iracing-sdk";
+import {
+  getAllCarNumbers,
+  getCarNumberFromSessionInfo,
+  getCarNumberRawFromSessionInfo,
+  TrkLoc,
+} from "@iracedeck/iracing-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   calculateNeedleAngle,
   findAdjacentCarByNumber,
   findAdjacentCarOnTrack,
+  findFastestLapForCar,
   formatSetSpeedLabel,
   formatSpeedDisplay,
   generateReplayControlSvg,
@@ -82,6 +88,9 @@ vi.mock("@iracedeck/icons/replay-control/jump-to-live.svg", () => ({
 vi.mock("@iracedeck/icons/replay-control/jump-to-my-car.svg", () => ({
   default: '<svg xmlns="http://www.w3.org/2000/svg">jump-to-my-car {{mainLabel}} {{subLabel}}</svg>',
 }));
+vi.mock("@iracedeck/icons/replay-control/jump-to-fastest-lap.svg", () => ({
+  default: '<svg xmlns="http://www.w3.org/2000/svg">jump-to-fastest-lap {{mainLabel}} {{subLabel}}</svg>',
+}));
 vi.mock("@iracedeck/icons/replay-control/next-car.svg", () => ({
   default: '<svg xmlns="http://www.w3.org/2000/svg">next-car {{mainLabel}} {{subLabel}}</svg>',
 }));
@@ -121,7 +130,12 @@ vi.mock("@iracedeck/deck-core", () => ({
   },
   ConnectionStateAwareAction: class MockConnectionStateAwareAction {
     logger = { trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
-    sdkController = { subscribe: vi.fn(), unsubscribe: vi.fn(), getCurrentTelemetry: vi.fn(() => null) };
+    sdkController = {
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+      getCurrentTelemetry: vi.fn(() => null),
+      getSessionInfo: vi.fn(() => null),
+    };
     updateConnectionState = vi.fn();
     setKeyImage = vi.fn();
     setRegenerateCallback = vi.fn();
@@ -160,6 +174,7 @@ vi.mock("@iracedeck/deck-core", () => ({
   generateBorderParts: vi.fn(() => ({ defs: "", rects: "" })),
   getGlobalBorderSettings: vi.fn(() => ({})),
   getGlobalColors: vi.fn(() => ({})),
+  getGlobalSettings: vi.fn(() => ({ fastestLapSearchDelayMs: 400 })),
   getGlobalGraphicSettings: vi.fn(() => ({})),
   LogLevel: { Info: 2 },
   parseSvgViewBox: vi.fn(() => undefined),
@@ -335,6 +350,7 @@ describe("ReplayControl", () => {
       "jump-to-beginning",
       "jump-to-live",
       "jump-to-my-car",
+      "jump-to-fastest-lap",
       "next-car",
       "prev-car",
       "next-car-number",
@@ -544,6 +560,13 @@ describe("ReplayControl", () => {
 
       expect(decoded).toContain("MY CAR");
       expect(decoded).toContain("JUMP TO");
+    });
+
+    it("should include FASTEST and LAP labels for jump-to-fastest-lap mode", () => {
+      const decoded = decodeURIComponent(generateReplayControlSvg({ mode: "jump-to-fastest-lap" }));
+
+      expect(decoded).toContain("FASTEST");
+      expect(decoded).toContain("LAP");
     });
 
     it("should include NEXT and CAR labels for next-car mode", () => {
@@ -919,6 +942,91 @@ describe("ReplayControl", () => {
       vi.mocked(getCarNumberFromSessionInfo).mockReturnValue("7");
 
       expect(findAdjacentCarByNumber({}, 0, "next")).toBe(3042);
+    });
+  });
+
+  describe("findFastestLapForCar", () => {
+    function sessionInfoWith(
+      sessions: Array<{ SessionNum: number; ResultsPositions?: Array<{ CarIdx: number; FastestLap: number }> }>,
+    ) {
+      return { SessionInfo: { Sessions: sessions } };
+    }
+
+    it("prefers ResultsPositions over telemetry CarIdxBestLapNum", () => {
+      const sessionInfo = sessionInfoWith([
+        {
+          SessionNum: 2,
+          ResultsPositions: [
+            { CarIdx: 5, FastestLap: 12 },
+            { CarIdx: 7, FastestLap: 9 },
+          ],
+        },
+      ]);
+      const telemetry = { SessionNum: 2, CarIdxBestLapNum: [0, 0, 0, 0, 0, 99, 0, 99] } as any;
+
+      expect(findFastestLapForCar(sessionInfo, telemetry, 5)).toBe(12);
+      expect(findFastestLapForCar(sessionInfo, telemetry, 7)).toBe(9);
+    });
+
+    it("matches the right session by SessionNum field, not array index", () => {
+      // Sessions are sometimes listed out of order — never trust the index.
+      const sessionInfo = sessionInfoWith([
+        { SessionNum: 0, ResultsPositions: [{ CarIdx: 3, FastestLap: 7 }] },
+        { SessionNum: 2, ResultsPositions: [{ CarIdx: 3, FastestLap: 15 }] },
+        { SessionNum: 1, ResultsPositions: [{ CarIdx: 3, FastestLap: 11 }] },
+      ]);
+      const telemetry = { SessionNum: 1, CarIdxBestLapNum: [] } as any;
+
+      expect(findFastestLapForCar(sessionInfo, telemetry, 3)).toBe(11);
+    });
+
+    it("returns null when ResultsPositions has no entry for the target car", () => {
+      const sessionInfo = sessionInfoWith([{ SessionNum: 0, ResultsPositions: [{ CarIdx: 1, FastestLap: 5 }] }]);
+      const telemetry = { SessionNum: 0 } as any;
+
+      expect(findFastestLapForCar(sessionInfo, telemetry, 99)).toBeNull();
+    });
+
+    it("falls back to telemetry when ResultsPositions is empty (live session)", () => {
+      const sessionInfo = sessionInfoWith([{ SessionNum: 0, ResultsPositions: [] }]);
+      const telemetry = { SessionNum: 0, CarIdxBestLapNum: [0, 0, 8] } as any;
+
+      expect(findFastestLapForCar(sessionInfo, telemetry, 2)).toBe(8);
+    });
+
+    it("falls back to telemetry when ResultsPositions has the car but FastestLap is 0", () => {
+      // Practice session, driver completed an out-lap but no flying lap yet —
+      // ResultsPositions exists with FastestLap=0; only live telemetry has the recorded lap.
+      const sessionInfo = sessionInfoWith([{ SessionNum: 0, ResultsPositions: [{ CarIdx: 2, FastestLap: 0 }] }]);
+      const telemetry = { SessionNum: 0, CarIdxBestLapNum: [0, 0, 6] } as any;
+
+      expect(findFastestLapForCar(sessionInfo, telemetry, 2)).toBe(6);
+    });
+
+    it("falls back to telemetry when sessionInfo lacks the current session", () => {
+      const sessionInfo = sessionInfoWith([{ SessionNum: 1, ResultsPositions: [{ CarIdx: 2, FastestLap: 5 }] }]);
+      const telemetry = { SessionNum: 0, CarIdxBestLapNum: [0, 0, 4] } as any;
+
+      expect(findFastestLapForCar(sessionInfo, telemetry, 2)).toBe(4);
+    });
+
+    it("returns null when neither source has data", () => {
+      const sessionInfo = sessionInfoWith([{ SessionNum: 0, ResultsPositions: [] }]);
+      const telemetry = { SessionNum: 0, CarIdxBestLapNum: [] } as any;
+
+      expect(findFastestLapForCar(sessionInfo, telemetry, 2)).toBeNull();
+    });
+
+    it("returns null when telemetry is null and sessionInfo is empty", () => {
+      expect(findFastestLapForCar(null, null, 0)).toBeNull();
+    });
+
+    it("handles missing SessionNum on telemetry by falling back to telemetry-only path", () => {
+      const sessionInfo = sessionInfoWith([{ SessionNum: 0, ResultsPositions: [{ CarIdx: 2, FastestLap: 5 }] }]);
+      const telemetry = { CarIdxBestLapNum: [0, 0, 3] } as any;
+
+      // No SessionNum → skips ResultsPositions matching → falls back to telemetry.
+      expect(findFastestLapForCar(sessionInfo, telemetry, 2)).toBe(3);
     });
   });
 
@@ -1352,6 +1460,580 @@ describe("ReplayControl", () => {
       await action.onDidReceiveSettings(fakeEvent("ctx-1", { mode: "next-session" }) as any);
 
       expect(action.setActiveBinding).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe("jump-to-fastest-lap", () => {
+    function fakeEvent(actionId: string, settings: Record<string, unknown> = {}) {
+      return {
+        action: { id: actionId, setTitle: vi.fn(), setImage: vi.fn() },
+        payload: { settings },
+      };
+    }
+
+    const mockReplay = {
+      play: vi.fn(() => true),
+      pause: vi.fn(() => true),
+      setPlaySpeed: vi.fn(() => true),
+      nextLap: vi.fn(() => true),
+      prevLap: vi.fn(() => true),
+    };
+
+    const mockCamera = {
+      switchNum: vi.fn(() => true),
+    };
+
+    let action: ReplayControl;
+
+    beforeEach(async () => {
+      vi.clearAllMocks();
+      const { getCommands } = await import("@iracedeck/deck-core");
+      // getCarNumberRawFromSessionInfo is mocked in the shared @iracedeck/iracing-sdk block;
+      // default it to returning the carIdx as the raw number so individual tests don't have
+      // to wire fake session info.
+      vi.mocked(getCarNumberRawFromSessionInfo).mockImplementation((_si: unknown, idx: number) => idx);
+      vi.mocked(getCommands).mockReturnValue({ replay: mockReplay, camera: mockCamera } as any);
+      action = new ReplayControl();
+    });
+
+    describe("resolveFastestLapCarIdx", () => {
+      it("returns CamCarIdx when target is viewed-car", () => {
+        const carIdx = action.resolveFastestLapCarIdx("viewed-car", { CamCarIdx: 7 } as any);
+
+        expect(carIdx).toBe(7);
+      });
+
+      it("returns -1 when target is viewed-car and telemetry is null", () => {
+        expect(action.resolveFastestLapCarIdx("viewed-car", null)).toBe(-1);
+      });
+
+      it("returns DriverCarIdx from session info when target is always-my-car", () => {
+        action.sdkController.getSessionInfo = vi.fn(() => ({ DriverInfo: { DriverCarIdx: 3 } }) as any);
+
+        expect(action.resolveFastestLapCarIdx("always-my-car", { CamCarIdx: 99 } as any)).toBe(3);
+      });
+
+      it("returns -1 when target is always-my-car and session info is missing", () => {
+        action.sdkController.getSessionInfo = vi.fn(() => null);
+
+        expect(action.resolveFastestLapCarIdx("always-my-car", { CamCarIdx: 99 } as any)).toBe(-1);
+      });
+    });
+
+    describe("dispatch", () => {
+      function telemetryWithBest(carIdx: number, bestLapNum: number, currentLap: number) {
+        const bestLapNums: number[] = [];
+        const currentLaps: number[] = [];
+
+        bestLapNums[carIdx] = bestLapNum;
+        currentLaps[carIdx] = currentLap;
+
+        return {
+          CamCarIdx: carIdx,
+          CarIdxBestLapNum: bestLapNums,
+          CarIdxLap: currentLaps,
+        };
+      }
+
+      it("logs a warning and does nothing when no target car is available (viewed-car)", async () => {
+        action.sdkController.getCurrentTelemetry = vi.fn(() => ({ CamCarIdx: -1 }) as any);
+
+        await action.onWillAppear(
+          fakeEvent("ctx-1", { mode: "jump-to-fastest-lap", fastestLapTarget: "viewed-car" }) as any,
+        );
+        await action.onKeyDown(
+          fakeEvent("ctx-1", { mode: "jump-to-fastest-lap", fastestLapTarget: "viewed-car" }) as any,
+        );
+
+        expect(mockReplay.nextLap).not.toHaveBeenCalled();
+        expect(mockReplay.prevLap).not.toHaveBeenCalled();
+        expect(mockCamera.switchNum).not.toHaveBeenCalled();
+        expect(action.logger.warn).toHaveBeenCalledWith(expect.stringContaining("No target car"));
+      });
+
+      it("logs info and skips when the target car has no best lap yet", async () => {
+        action.sdkController.getCurrentTelemetry = vi.fn(() => telemetryWithBest(2, 0, 0) as any);
+
+        await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+        await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+
+        expect(mockReplay.nextLap).not.toHaveBeenCalled();
+        expect(mockReplay.prevLap).not.toHaveBeenCalled();
+        expect(mockCamera.switchNum).not.toHaveBeenCalled();
+        expect(action.logger.info).toHaveBeenCalledWith(expect.stringContaining("no best lap"));
+      });
+
+      /**
+       * Build a telemetry source that returns the live `currentLap` ref on
+       * each call (the walker reads it between steps). `nextLap` / `prevLap`
+       * mutate the ref so the cursor "advances" each tick.
+       */
+      function liveCursor(
+        carIdx: number,
+        targetLap: number,
+        opts: { startLap: number; advanceOnNext?: boolean; advanceOnPrev?: boolean } = { startLap: 0 },
+      ) {
+        const state = { currentLap: opts.startLap };
+        const bestLapNums: number[] = [];
+
+        bestLapNums[carIdx] = targetLap;
+
+        action.sdkController.getCurrentTelemetry = vi.fn(() => {
+          const currentLaps: number[] = [];
+
+          currentLaps[carIdx] = state.currentLap;
+
+          return {
+            CamCarIdx: carIdx,
+            CarIdxBestLapNum: bestLapNums,
+            CarIdxLap: currentLaps,
+          } as any;
+        });
+
+        if (opts.advanceOnNext !== false) {
+          mockReplay.nextLap.mockImplementation(() => {
+            state.currentLap++;
+
+            return true;
+          });
+        }
+
+        if (opts.advanceOnPrev !== false) {
+          mockReplay.prevLap.mockImplementation(() => {
+            state.currentLap--;
+
+            return true;
+          });
+        }
+
+        return state;
+      }
+
+      it("walks the cursor up to one lap before the fastest lap (forward)", async () => {
+        vi.useFakeTimers();
+
+        try {
+          // FastestLap = 10 means iRacing's nextLap would land on the end of
+          // lap 10; subtract 1 so the cursor ends at the start of lap 10.
+          const state = liveCursor(4, 10, { startLap: 5 });
+
+          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+
+          expect(mockCamera.switchNum).toHaveBeenCalledWith(4, 0, 0);
+          await vi.runAllTimersAsync();
+
+          // Walker target = 10 - 1 = 9. From lap 5 → lap 9 = 4 steps.
+          expect(state.currentLap).toBe(9);
+          expect(mockReplay.nextLap).toHaveBeenCalledTimes(4);
+          expect(mockReplay.prevLap).not.toHaveBeenCalled();
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it("walks the cursor down to one lap before the fastest lap (backward)", async () => {
+        vi.useFakeTimers();
+
+        try {
+          const state = liveCursor(2, 3, { startLap: 8 });
+
+          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+
+          expect(mockCamera.switchNum).toHaveBeenCalledWith(2, 0, 0);
+          await vi.runAllTimersAsync();
+
+          // Walker target = 3 - 1 = 2. From lap 8 → lap 2 = 6 steps.
+          expect(state.currentLap).toBe(2);
+          expect(mockReplay.prevLap).toHaveBeenCalledTimes(6);
+          expect(mockReplay.nextLap).not.toHaveBeenCalled();
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it("retries on dropped messages — re-sends nextLap when the cursor didn't advance", async () => {
+        vi.useFakeTimers();
+
+        try {
+          // Simulate iRacing dropping every other ReplaySearch broadcast: only
+          // every second call actually advances the cursor.
+          const state = { currentLap: 0 };
+          let callIdx = 0;
+
+          mockReplay.nextLap.mockImplementation(() => {
+            if (callIdx++ % 2 === 0) state.currentLap++;
+
+            return true;
+          });
+
+          const bestLapNums: number[] = [];
+
+          // FastestLap = 5 → walker target = 4.
+          bestLapNums[3] = 5;
+
+          action.sdkController.getCurrentTelemetry = vi.fn(() => {
+            const currentLaps: number[] = [];
+
+            currentLaps[3] = state.currentLap;
+
+            return { CamCarIdx: 3, CarIdxBestLapNum: bestLapNums, CarIdxLap: currentLaps } as any;
+          });
+
+          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+          await vi.runAllTimersAsync();
+
+          // Cursor should still reach the walker target (4) — the walker just
+          // calls nextLap more times to compensate for the dropped messages.
+          expect(state.currentLap).toBe(4);
+          // 7 calls = 4 that landed (callIdx 0,2,4,6) + 3 dropped retries
+          // (callIdx 1,3,5). The walker detects target reached on iteration 8
+          // before sending another step.
+          expect(mockReplay.nextLap).toHaveBeenCalledTimes(7);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it("does no lap steps when the cursor is already at the start of the fastest lap", async () => {
+        // FastestLap=7 → walker target=6. Cursor at lap 6 already means the
+        // cursor is sitting at the end of lap 6 = start of lap 7.
+        liveCursor(1, 7, { startLap: 6, advanceOnNext: false, advanceOnPrev: false });
+
+        await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+        await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+
+        expect(mockCamera.switchNum).toHaveBeenCalledWith(1, 0, 0);
+        expect(mockReplay.nextLap).not.toHaveBeenCalled();
+        expect(mockReplay.prevLap).not.toHaveBeenCalled();
+      });
+
+      it("uses DriverCarIdx (not CamCarIdx) when target is always-my-car", async () => {
+        vi.useFakeTimers();
+
+        try {
+          const state = { currentLap: 2 };
+          const bestLapNums: number[] = [];
+
+          // FastestLap = 4 → walker target = 3. From cursor=2, 1 step needed.
+          bestLapNums[3] = 4;
+
+          action.sdkController.getCurrentTelemetry = vi.fn(() => {
+            const currentLaps: number[] = [];
+
+            currentLaps[3] = state.currentLap;
+
+            return {
+              CamCarIdx: 99, // viewer is watching some other car
+              CarIdxBestLapNum: bestLapNums,
+              CarIdxLap: currentLaps,
+            } as any;
+          });
+          action.sdkController.getSessionInfo = vi.fn(() => ({ DriverInfo: { DriverCarIdx: 3 } }) as any);
+          mockReplay.nextLap.mockImplementation(() => {
+            state.currentLap++;
+
+            return true;
+          });
+
+          await action.onWillAppear(
+            fakeEvent("ctx-1", { mode: "jump-to-fastest-lap", fastestLapTarget: "always-my-car" }) as any,
+          );
+          await action.onKeyDown(
+            fakeEvent("ctx-1", { mode: "jump-to-fastest-lap", fastestLapTarget: "always-my-car" }) as any,
+          );
+          await vi.runAllTimersAsync();
+
+          expect(mockCamera.switchNum).toHaveBeenCalledWith(3, 0, 0);
+          expect(state.currentLap).toBe(3);
+          expect(mockReplay.nextLap).toHaveBeenCalledTimes(1);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it("warns when the target car has no resolvable car number", async () => {
+        vi.mocked(getCarNumberRawFromSessionInfo).mockReturnValue(null);
+        liveCursor(2, 5, { startLap: 3, advanceOnNext: false });
+
+        await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+        await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+
+        expect(mockCamera.switchNum).not.toHaveBeenCalled();
+        expect(mockReplay.nextLap).not.toHaveBeenCalled();
+        expect(action.logger.warn).toHaveBeenCalledWith(expect.stringContaining("car number"));
+      });
+
+      it("bails when the cursor is stuck (target unreachable)", async () => {
+        vi.useFakeTimers();
+
+        try {
+          // Cursor never advances — simulates the replay buffer not reaching
+          // the target lap.
+          liveCursor(2, 50, { startLap: 0, advanceOnNext: false });
+
+          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+          await vi.runAllTimersAsync();
+
+          // LAP_WALK_STUCK_LIMIT (5) consecutive no-progress iterations before
+          // bail; nextLap is called on iterations 1..5 (iter 6 detects stuck
+          // and returns without sending).
+          expect(mockReplay.nextLap).toHaveBeenCalledTimes(5);
+          expect(action.logger.warn).toHaveBeenCalledWith(expect.stringContaining("stuck"));
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it("hits the MAX_LAP_SEARCH_STEPS safety cap on a wildly large delta", async () => {
+        vi.useFakeTimers();
+
+        try {
+          // Target far beyond what the iteration cap permits; cursor keeps
+          // advancing on every call (no stuck bail).
+          liveCursor(0, 10_000, { startLap: 0 });
+
+          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+          await vi.runAllTimersAsync();
+
+          // Walker exits after MAX_LAP_SEARCH_STEPS body iterations.
+          expect(mockReplay.nextLap).toHaveBeenCalledTimes(150);
+          expect(action.logger.warn).toHaveBeenCalledWith(expect.stringContaining("safety cap"));
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it("ignores a second press while a walk is already in flight on the same context", async () => {
+        vi.useFakeTimers();
+
+        try {
+          // FastestLap = 10 → walker target = 9. From cursor=0, 9 steps.
+          liveCursor(2, 10, { startLap: 0 });
+
+          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+
+          // First press kicks off the walker; before the timers drain, a second
+          // press arrives. The second press should not double-fire steps.
+          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+
+          await vi.runAllTimersAsync();
+
+          // Only the first walk drove the cursor; second press was no-op
+          // (verified by count = exactly the delta).
+          expect(mockReplay.nextLap).toHaveBeenCalledTimes(9);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it("uses ResultsPositions when telemetry CarIdxBestLapNum is empty (freshly-loaded replay)", async () => {
+        vi.useFakeTimers();
+
+        try {
+          // Replay load case: SessionInfo has authoritative ResultsPositions but
+          // CarIdxBestLapNum hasn't been populated yet because the cursor hasn't
+          // walked the laps. Without the ResultsPositions path this would no-op.
+          const state = { currentLap: 0 };
+
+          action.sdkController.getCurrentTelemetry = vi.fn(() => {
+            const currentLaps: number[] = [];
+
+            currentLaps[4] = state.currentLap;
+
+            return {
+              CamCarIdx: 4,
+              SessionNum: 2,
+              // CarIdxBestLapNum intentionally omitted (or empty)
+              CarIdxLap: currentLaps,
+            } as any;
+          });
+          action.sdkController.getSessionInfo = vi.fn(
+            () =>
+              ({
+                SessionInfo: {
+                  Sessions: [
+                    { SessionNum: 0, ResultsPositions: [{ CarIdx: 4, FastestLap: 99 }] },
+                    { SessionNum: 2, ResultsPositions: [{ CarIdx: 4, FastestLap: 8 }] },
+                  ],
+                },
+              }) as any,
+          );
+          mockReplay.nextLap.mockImplementation(() => {
+            state.currentLap++;
+
+            return true;
+          });
+
+          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+          await vi.runAllTimersAsync();
+
+          expect(mockCamera.switchNum).toHaveBeenCalledWith(4, 0, 0);
+          // FastestLap = 8 (Session 2's value, not Session 0's 99) → walker
+          // target = 7. From cursor=0, 7 steps to reach lap 7 (= start of lap 8).
+          expect(state.currentLap).toBe(7);
+          expect(mockReplay.nextLap).toHaveBeenCalledTimes(7);
+          expect(mockReplay.prevLap).not.toHaveBeenCalled();
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it("bails immediately when CarIdxLap for the target car is unavailable", async () => {
+        vi.useFakeTimers();
+
+        try {
+          // CarIdxBestLapNum populated (so targetLap resolves) but CarIdxLap
+          // for that car isn't — walker can't compute delta, returns silently.
+          const bestLapNums: number[] = [];
+
+          bestLapNums[5] = 8;
+          action.sdkController.getCurrentTelemetry = vi.fn(
+            () =>
+              ({
+                CamCarIdx: 5,
+                CarIdxBestLapNum: bestLapNums,
+                // CarIdxLap intentionally omitted
+              }) as any,
+          );
+
+          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+          await vi.runAllTimersAsync();
+
+          expect(mockCamera.switchNum).toHaveBeenCalledWith(5, 0, 0);
+          expect(mockReplay.nextLap).not.toHaveBeenCalled();
+          expect(mockReplay.prevLap).not.toHaveBeenCalled();
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it("reads fastestLapSearchDelayMs live on every iteration", async () => {
+        vi.useFakeTimers();
+
+        try {
+          const { getGlobalSettings } = await import("@iracedeck/deck-core");
+          // Start with a fast delay.
+          vi.mocked(getGlobalSettings).mockReturnValue({ fastestLapSearchDelayMs: 100 } as any);
+
+          // FastestLap = 5 → walker target = 4. From cursor=0: 4 steps.
+          liveCursor(2, 5, { startLap: 0 });
+
+          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+
+          // iter 1: step fires immediately; walker is now sleeping on gap=100ms
+          // (read at the end of iter 1, before the change below).
+          expect(mockReplay.nextLap).toHaveBeenCalledTimes(1);
+
+          // Change the mock — iter 2's gap read (still 100ms below) won't see
+          // this, but iter 3 onward will.
+          vi.mocked(getGlobalSettings).mockReturnValue({ fastestLapSearchDelayMs: 500 } as any);
+
+          // 100ms elapses → iter 2 fires (gap from iter 1 was 100), reads
+          // currentLap=1, sends step, then reads the new gap=500.
+          await vi.advanceTimersByTimeAsync(100);
+          expect(mockReplay.nextLap).toHaveBeenCalledTimes(2);
+
+          // 400ms isn't enough — iter 3's sleep is 500ms.
+          await vi.advanceTimersByTimeAsync(400);
+          expect(mockReplay.nextLap).toHaveBeenCalledTimes(2);
+
+          // 100ms more → 500ms total since iter 2 ended; iter 3 fires.
+          await vi.advanceTimersByTimeAsync(100);
+          expect(mockReplay.nextLap).toHaveBeenCalledTimes(3);
+
+          // Drain remaining iterations (iter 4 finishes at cursor=4 = target).
+          await vi.runAllTimersAsync();
+          expect(mockReplay.nextLap).toHaveBeenCalledTimes(4);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it("clamps an out-of-range fastestLapSearchDelayMs setting", async () => {
+        vi.useFakeTimers();
+
+        try {
+          const { getGlobalSettings } = await import("@iracedeck/deck-core");
+          // 5000 ms is above the 1000 ms cap — should clamp to 1000.
+          vi.mocked(getGlobalSettings).mockReturnValue({ fastestLapSearchDelayMs: 5000 } as any);
+
+          // FastestLap = 3 → walker target = 2. From cursor=0: 2 steps total
+          // (gives us one inter-step delay to verify the clamp).
+          liveCursor(2, 3, { startLap: 0 });
+
+          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+
+          expect(mockReplay.nextLap).toHaveBeenCalledTimes(1);
+          // 999 ms — below the clamped cap, no additional fires yet.
+          await vi.advanceTimersByTimeAsync(999);
+          expect(mockReplay.nextLap).toHaveBeenCalledTimes(1);
+          // 1 more ms = 1000 total → next step fires.
+          await vi.advanceTimersByTimeAsync(1);
+          expect(mockReplay.nextLap).toHaveBeenCalledTimes(2);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+    });
+
+    describe("encoder is a no-op for this mode", () => {
+      function telemetryWithBest(carIdx: number, bestLapNum: number, currentLap: number) {
+        const bestLapNums: number[] = [];
+        const currentLaps: number[] = [];
+
+        bestLapNums[carIdx] = bestLapNum;
+        currentLaps[carIdx] = currentLap;
+
+        return {
+          CamCarIdx: carIdx,
+          CarIdxBestLapNum: bestLapNums,
+          CarIdxLap: currentLaps,
+        };
+      }
+
+      it("onDialDown does nothing", async () => {
+        action.sdkController.getCurrentTelemetry = vi.fn(() => telemetryWithBest(2, 10, 5) as any);
+
+        await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+        await action.onDialDown({
+          action: { id: "ctx-1", setTitle: vi.fn(), setImage: vi.fn() },
+          payload: { settings: { mode: "jump-to-fastest-lap", fastestLapTarget: "viewed-car" } },
+        } as any);
+
+        expect(mockReplay.nextLap).not.toHaveBeenCalled();
+        expect(mockReplay.prevLap).not.toHaveBeenCalled();
+        expect(mockReplay.play).not.toHaveBeenCalled();
+        expect(mockCamera.switchNum).not.toHaveBeenCalled();
+      });
+
+      it("onDialRotate does nothing in either direction", async () => {
+        action.sdkController.getCurrentTelemetry = vi.fn(() => telemetryWithBest(2, 10, 5) as any);
+
+        await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+        await action.onDialRotate({
+          action: { id: "ctx-1", setTitle: vi.fn(), setImage: vi.fn() },
+          payload: { settings: { mode: "jump-to-fastest-lap", fastestLapTarget: "viewed-car" }, ticks: 1 },
+        } as any);
+        await action.onDialRotate({
+          action: { id: "ctx-1", setTitle: vi.fn(), setImage: vi.fn() },
+          payload: { settings: { mode: "jump-to-fastest-lap", fastestLapTarget: "viewed-car" }, ticks: -1 },
+        } as any);
+
+        expect(mockReplay.nextLap).not.toHaveBeenCalled();
+        expect(mockReplay.prevLap).not.toHaveBeenCalled();
+        expect(mockReplay.play).not.toHaveBeenCalled();
+        expect(mockCamera.switchNum).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/packages/iracing-actions/src/actions/replay-control/replay-control.test.ts
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.test.ts
@@ -1483,6 +1483,21 @@ describe("ReplayControl", () => {
       switchNum: vi.fn(() => true),
     };
 
+    /** Shared helper — used by the dispatch + encoder describes below. */
+    function telemetryWithBest(carIdx: number, bestLapNum: number, currentLap: number) {
+      const bestLapNums: number[] = [];
+      const currentLaps: number[] = [];
+
+      bestLapNums[carIdx] = bestLapNum;
+      currentLaps[carIdx] = currentLap;
+
+      return {
+        CamCarIdx: carIdx,
+        CarIdxBestLapNum: bestLapNums,
+        CarIdxLap: currentLaps,
+      };
+    }
+
     let action: ReplayControl;
 
     beforeEach(async () => {
@@ -1521,20 +1536,6 @@ describe("ReplayControl", () => {
     });
 
     describe("dispatch", () => {
-      function telemetryWithBest(carIdx: number, bestLapNum: number, currentLap: number) {
-        const bestLapNums: number[] = [];
-        const currentLaps: number[] = [];
-
-        bestLapNums[carIdx] = bestLapNum;
-        currentLaps[carIdx] = currentLap;
-
-        return {
-          CamCarIdx: carIdx,
-          CarIdxBestLapNum: bestLapNums,
-          CarIdxLap: currentLaps,
-        };
-      }
-
       it("logs a warning and does nothing when no target car is available (viewed-car)", async () => {
         action.sdkController.getCurrentTelemetry = vi.fn(() => ({ CamCarIdx: -1 }) as any);
 
@@ -1549,6 +1550,45 @@ describe("ReplayControl", () => {
         expect(mockReplay.prevLap).not.toHaveBeenCalled();
         expect(mockCamera.switchNum).not.toHaveBeenCalled();
         expect(action.logger.warn).toHaveBeenCalledWith(expect.stringContaining("No target car"));
+      });
+
+      it("rejects CarIdx 255 (no-driver/pace-car placeholder) before resolving the fastest lap", async () => {
+        // CamCarIdx=255 happens mid-camera-transition and on the pace car —
+        // never a real target. Should short-circuit before any walk starts.
+        action.sdkController.getCurrentTelemetry = vi.fn(() => ({ CamCarIdx: 255 }) as any);
+
+        await action.onWillAppear(
+          fakeEvent("ctx-1", { mode: "jump-to-fastest-lap", fastestLapTarget: "viewed-car" }) as any,
+        );
+        await action.onKeyDown(
+          fakeEvent("ctx-1", { mode: "jump-to-fastest-lap", fastestLapTarget: "viewed-car" }) as any,
+        );
+
+        expect(mockReplay.nextLap).not.toHaveBeenCalled();
+        expect(mockReplay.prevLap).not.toHaveBeenCalled();
+        expect(mockCamera.switchNum).not.toHaveBeenCalled();
+        expect(action.logger.warn).toHaveBeenCalledWith(expect.stringContaining("No target car"));
+      });
+
+      it("aborts the walk and warns when camera.switchNum fails", async () => {
+        vi.useFakeTimers();
+
+        try {
+          // Camera switch returns false (SDK refused) — walker must not start.
+          mockCamera.switchNum.mockReturnValueOnce(false);
+          liveCursor(2, 5, { startLap: 0 });
+
+          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+          await vi.runAllTimersAsync();
+
+          expect(mockCamera.switchNum).toHaveBeenCalledWith(2, 0, 0);
+          expect(mockReplay.nextLap).not.toHaveBeenCalled();
+          expect(mockReplay.prevLap).not.toHaveBeenCalled();
+          expect(action.logger.warn).toHaveBeenCalledWith(expect.stringContaining("camera switch failed"));
+        } finally {
+          vi.useRealTimers();
+        }
       });
 
       it("logs info and skips when the target car has no best lap yet", async () => {
@@ -1987,20 +2027,6 @@ describe("ReplayControl", () => {
     });
 
     describe("encoder is a no-op for this mode", () => {
-      function telemetryWithBest(carIdx: number, bestLapNum: number, currentLap: number) {
-        const bestLapNums: number[] = [];
-        const currentLaps: number[] = [];
-
-        bestLapNums[carIdx] = bestLapNum;
-        currentLaps[carIdx] = currentLap;
-
-        return {
-          CamCarIdx: carIdx,
-          CarIdxBestLapNum: bestLapNums,
-          CarIdxLap: currentLaps,
-        };
-      }
-
       it("onDialDown does nothing", async () => {
         action.sdkController.getCurrentTelemetry = vi.fn(() => telemetryWithBest(2, 10, 5) as any);
 

--- a/packages/iracing-actions/src/actions/replay-control/replay-control.ts
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.ts
@@ -11,6 +11,7 @@ import {
   getGlobalBorderSettings,
   getGlobalColors,
   getGlobalGraphicSettings,
+  getGlobalSettings,
   getGlobalTitleSettings,
   ICON_BASE_TEMPLATE,
   type IDeckDialDownEvent,
@@ -32,6 +33,7 @@ import fastForwardIconSvg from "@iracedeck/icons/replay-control/fast-forward.svg
 import frameBackwardIconSvg from "@iracedeck/icons/replay-control/frame-backward.svg";
 import frameForwardIconSvg from "@iracedeck/icons/replay-control/frame-forward.svg";
 import jumpToBeginningIconSvg from "@iracedeck/icons/replay-control/jump-to-beginning.svg";
+import jumpToFastestLapIconSvg from "@iracedeck/icons/replay-control/jump-to-fastest-lap.svg";
 import jumpToLiveIconSvg from "@iracedeck/icons/replay-control/jump-to-live.svg";
 import jumpToMyCarIconSvg from "@iracedeck/icons/replay-control/jump-to-my-car.svg";
 import nextCarNumberIconSvg from "@iracedeck/icons/replay-control/next-car-number.svg";
@@ -89,6 +91,7 @@ const REPLAY_CONTROL_MODES = [
   "jump-to-beginning",
   "jump-to-live",
   "jump-to-my-car",
+  "jump-to-fastest-lap",
   "next-car",
   "prev-car",
   "next-car-number",
@@ -120,6 +123,7 @@ const REPLAY_CONTROL_ICONS: Record<ReplayControlMode, string> = {
   "jump-to-beginning": jumpToBeginningIconSvg,
   "jump-to-live": jumpToLiveIconSvg,
   "jump-to-my-car": jumpToMyCarIconSvg,
+  "jump-to-fastest-lap": jumpToFastestLapIconSvg,
   "next-car": nextCarIconSvg,
   "prev-car": prevCarIconSvg,
   "next-car-number": nextCarNumberIconSvg,
@@ -149,6 +153,7 @@ const REPLAY_CONTROL_TITLES: Record<ReplayControlMode, string> = {
   "jump-to-beginning": "JUMP TO\nBEGINNING",
   "jump-to-live": "JUMP TO\nLIVE",
   "jump-to-my-car": "JUMP TO\nMY CAR",
+  "jump-to-fastest-lap": "FASTEST\nLAP",
   "next-car": "CAR\nNEXT",
   "prev-car": "CAR\nPREVIOUS",
   "next-car-number": "CAR #\nNEXT",
@@ -217,6 +222,54 @@ const LONG_PRESS_INITIAL_DELAY = 500;
 const LONG_PRESS_REPEAT_GAP_MS = 250;
 /** Maximum duration for long-press repeat before auto-stop (safety net for missed keyUp) */
 const LONG_PRESS_MAX_DURATION_MS = 15_000;
+
+/**
+ * Safety cap on iterations the adaptive lap walker performs in a single
+ * press. Combined with `REPLAY_LAP_SEARCH_GAP_MS`, this bounds the worst-case
+ * wall-clock time at MAX × GAP. Each iteration reads telemetry first, so a
+ * normal delta finishes in `delta + a-few-retries` iterations; the cap only
+ * trips on a pathological scenario.
+ */
+const MAX_LAP_SEARCH_STEPS = 150;
+
+/**
+ * Default gap between consecutive replay lap-search broadcasts when the
+ * `fastestLapSearchDelayMs` global setting isn't set. Even when the replay
+ * is paused, the manual Next Lap / Previous Lap actions exhibit the same
+ * drift when pressed in rapid succession: iRacing appears to be resolving
+ * the exact lap-boundary position asynchronously after each `ReplaySearch`
+ * and a follow-up broadcast that arrives before that work finishes leaves
+ * the cursor parked mid-lap. 400 ms is the empirical default that works
+ * reliably; slower machines and longer tracks can raise it via Common
+ * Settings → Replay → Fastest Lap Search Delay.
+ */
+const REPLAY_LAP_SEARCH_GAP_DEFAULT_MS = 400;
+
+const REPLAY_LAP_SEARCH_GAP_MIN_MS = 50;
+const REPLAY_LAP_SEARCH_GAP_MAX_MS = 1000;
+
+/**
+ * Reads the live `fastestLapSearchDelayMs` global setting, clamped to the
+ * accepted range. Falls back to {@link REPLAY_LAP_SEARCH_GAP_DEFAULT_MS} on
+ * any non-numeric value so a corrupted persisted value can't break the
+ * walker.
+ */
+function readFastestLapSearchDelayMs(): number {
+  const raw = (getGlobalSettings() as Record<string, unknown>).fastestLapSearchDelayMs;
+  const value = typeof raw === "number" ? raw : Number(raw);
+
+  if (!Number.isFinite(value)) return REPLAY_LAP_SEARCH_GAP_DEFAULT_MS;
+
+  return Math.min(Math.max(value, REPLAY_LAP_SEARCH_GAP_MIN_MS), REPLAY_LAP_SEARCH_GAP_MAX_MS);
+}
+
+/**
+ * Consecutive iterations the adaptive walker tolerates without the cursor
+ * advancing before giving up. Covers the case where the cursor is at a
+ * session boundary or the target lap is unreachable in the current replay
+ * buffer.
+ */
+const LAP_WALK_STUCK_LIMIT = 5;
 
 /**
  * @internal Exported for testing
@@ -430,6 +483,55 @@ export function findAdjacentCarOnTrack(telemetry: TelemetryData | null, directio
 /**
  * @internal Exported for testing
  *
+ * Resolves a car's fastest lap number for the **current replay session**,
+ * preferring `SessionInfo.Sessions[].ResultsPositions[].FastestLap` over
+ * live telemetry. `ResultsPositions` is the authoritative post-session
+ * record iRacing populates as soon as a replay is loaded — `CarIdxBestLapNum`
+ * only fills in for laps the replay cursor has actually visited, which is
+ * empty on a freshly-loaded replay.
+ *
+ * Session matching is by `SessionNum` field equality (not by array index),
+ * because the array order is not contractually tied to the session number.
+ *
+ * Returns `null` when neither source yields a positive lap number.
+ */
+export function findFastestLapForCar(
+  sessionInfo: unknown,
+  telemetry: TelemetryData | null,
+  carIdx: number,
+): number | null {
+  const sessionNum = telemetry?.SessionNum as number | undefined;
+  const sessionInfoRoot = (sessionInfo as Record<string, unknown> | undefined)?.SessionInfo as
+    | Record<string, unknown>
+    | undefined;
+  const sessions = sessionInfoRoot?.Sessions as Array<Record<string, unknown>> | undefined;
+
+  if (sessions && typeof sessionNum === "number") {
+    const session = sessions.find((s) => (s?.SessionNum as number | undefined) === sessionNum);
+    const positions = session?.ResultsPositions as Array<Record<string, unknown>> | undefined;
+    const entry = positions?.find((p) => (p?.CarIdx as number | undefined) === carIdx);
+    const fastestLap = entry?.FastestLap as number | undefined;
+
+    if (typeof fastestLap === "number" && fastestLap > 0) {
+      return fastestLap;
+    }
+  }
+
+  // Fallback for live sessions where ResultsPositions hasn't been written yet
+  // (race in progress, practice without finalised positions, etc.).
+  const bestLapNums = telemetry?.CarIdxBestLapNum as number[] | undefined;
+  const telemetryLap = bestLapNums?.[carIdx];
+
+  if (typeof telemetryLap === "number" && telemetryLap > 0) {
+    return telemetryLap;
+  }
+
+  return null;
+}
+
+/**
+ * @internal Exported for testing
+ *
  * Find the next or previous car by car number order.
  * Includes all cars (even in pits), skips the pace car.
  * Returns the CarNumberRaw value for camera API use, or null if not found.
@@ -471,6 +573,7 @@ const ReplayControlSettings = CommonSettings.extend({
   mode: z.enum(REPLAY_CONTROL_MODES).default("play-pause"),
   speed: z.string().default("1"),
   stepRate: z.coerce.number().int().min(1).max(15).default(1),
+  fastestLapTarget: z.enum(["viewed-car", "always-my-car"]).default("viewed-car"),
 });
 
 type ReplayControlSettings = z.infer<typeof ReplayControlSettings>;
@@ -504,6 +607,13 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
 
   /** Cached settings per context for telemetry-driven display updates */
   private activeContexts = new Map<string, ReplayControlSettings>();
+
+  /**
+   * Context IDs with an in-flight jump-to-fastest-lap walk. A second press
+   * while one is running is dropped (the in-flight walk is converging on the
+   * same target, so re-kicking would just race itself).
+   */
+  private fastestLapWalkInFlight = new Set<string>();
 
   /** Last rendered state key per context (prevents redundant re-renders) */
   private lastState = new Map<string, string>();
@@ -706,6 +816,107 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
     const telemetry = this.sdkController.getCurrentTelemetry();
 
     return findAdjacentCarOnTrack(telemetry, direction);
+  }
+
+  /**
+   * @internal Exposed for testing.
+   *
+   * Resolves the carIdx whose fastest lap we should jump to. For
+   * `always-my-car` the lookup is the driver's own car (the same path
+   * `jump-to-my-car` uses). For `viewed-car` it's whichever car the replay
+   * camera is currently framing (`telemetry.CamCarIdx`). Returns `-1` when
+   * the resolution fails — caller is responsible for the warn.
+   */
+  resolveFastestLapCarIdx(target: "viewed-car" | "always-my-car", telemetry: TelemetryData | null): number {
+    if (target === "always-my-car") {
+      const sessionInfo = this.sdkController.getSessionInfo();
+      const driverInfo = (sessionInfo as Record<string, unknown>)?.DriverInfo as Record<string, unknown> | undefined;
+
+      return (driverInfo?.DriverCarIdx as number) ?? -1;
+    }
+
+    return (telemetry?.CamCarIdx as number) ?? -1;
+  }
+
+  /**
+   * @internal Exposed for testing.
+   *
+   * Adaptive walker that drives the replay cursor to a target lap for a
+   * specific car. Reads `CarIdxLap[carIdx]` between each step and re-sends
+   * `nextLap`/`prevLap` when the cursor didn't advance — that recovers from
+   * iRacing dropping individual `ReplaySearch` broadcasts (the failure mode
+   * fixed-spacing bursts had at every tested gap, including 100 ms). Bails
+   * when the cursor sits still for {@link LAP_WALK_STUCK_LIMIT} consecutive
+   * iterations (e.g. target lap is outside the replay buffer) or when
+   * iterations reach {@link MAX_LAP_SEARCH_STEPS}. Only one walk per context
+   * runs at a time; second presses while one is in flight are ignored.
+   */
+  async walkToFastestLap(contextId: string, carIdx: number, targetLap: number): Promise<void> {
+    if (this.fastestLapWalkInFlight.has(contextId)) {
+      this.logger.debug(`Jump to fastest lap: walk already in flight for ${contextId}; ignoring`);
+
+      return;
+    }
+
+    this.fastestLapWalkInFlight.add(contextId);
+
+    try {
+      const replay = getCommands().replay;
+      let attempts = 0;
+      let lastObservedLap: number | null = null;
+      let stuckCount = 0;
+
+      while (attempts++ < MAX_LAP_SEARCH_STEPS) {
+        const telemetry = this.sdkController.getCurrentTelemetry();
+        const currentLaps = telemetry?.CarIdxLap as number[] | undefined;
+        const currentLap = currentLaps?.[carIdx];
+
+        if (typeof currentLap !== "number" || currentLap < 0) {
+          this.logger.debug(`Jump to fastest lap: bail, CarIdxLap[${carIdx}] is unavailable`);
+
+          return;
+        }
+
+        if (currentLap === targetLap) {
+          this.logger.debug(`Jump to fastest lap: reached lap ${targetLap} after ${attempts} iterations`);
+
+          return;
+        }
+
+        // Detect the cursor not advancing — either a session-edge condition
+        // or the replay buffer doesn't reach the target lap.
+        if (lastObservedLap !== null && currentLap === lastObservedLap) {
+          stuckCount++;
+
+          if (stuckCount >= LAP_WALK_STUCK_LIMIT) {
+            this.logger.warn(`Jump to fastest lap: cursor stuck at lap ${currentLap} (target ${targetLap}); giving up`);
+
+            return;
+          }
+        } else {
+          stuckCount = 0;
+        }
+
+        lastObservedLap = currentLap;
+
+        if (currentLap < targetLap) {
+          replay.nextLap();
+        } else {
+          replay.prevLap();
+        }
+
+        // Read the gap live on every iteration so a user can drag the slider
+        // mid-walk and have the next step pick up the new value.
+        const gapMs = readFastestLapSearchDelayMs();
+        await new Promise<void>((resolve) => setTimeout(resolve, gapMs));
+      }
+
+      this.logger.warn(
+        `Jump to fastest lap: safety cap hit (${MAX_LAP_SEARCH_STEPS} iterations) at lap ${lastObservedLap}, target ${targetLap}`,
+      );
+    } finally {
+      this.fastestLapWalkInFlight.delete(contextId);
+    }
   }
 
   private executeMode(contextId: string, settings: ReplayControlSettings): void {
@@ -989,6 +1200,54 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
         this.logger.debug(`Result: ${success}, carNum: ${carNum}`);
         break;
       }
+      case "jump-to-fastest-lap": {
+        const telemetry = this.sdkController.getCurrentTelemetry();
+        const sessionInfo = this.sdkController.getSessionInfo();
+        const targetCarIdx = this.resolveFastestLapCarIdx(settings.fastestLapTarget, telemetry);
+
+        if (targetCarIdx < 0) {
+          this.logger.warn("No target car available for jump to fastest lap");
+          this.logger.debug(`Target setting: ${settings.fastestLapTarget}`);
+          break;
+        }
+
+        const targetLap = findFastestLapForCar(sessionInfo, telemetry, targetCarIdx);
+
+        if (targetLap === null) {
+          this.logger.info("Jump to fastest lap: no best lap recorded yet for target car");
+          this.logger.debug(`Target carIdx: ${targetCarIdx}`);
+          break;
+        }
+
+        // Switch the replay camera onto the target car so iRacing's lap-search
+        // operates against the right driver. For viewed-car this is usually a
+        // no-op (camera is already there); for always-my-car it actively
+        // re-frames before the lap walk.
+        const carNum = this.getCarNumberRawByIdx(targetCarIdx);
+
+        if (carNum === null) {
+          this.logger.warn("Could not find car number for jump-to-fastest-lap target");
+          break;
+        }
+
+        getCommands().camera.switchNum(carNum, 0, 0);
+
+        // iRacing's nextLap jumps to the *end* of the targeted lap (=start of
+        // the lap after it). Subtract one so the cursor lands at the start of
+        // the fastest lap, not at its end.
+        const walkTargetLap = targetLap - 1;
+
+        // Adaptive lap walk: read CarIdxLap between steps and re-send when the
+        // cursor didn't advance. iRacing's broadcast queue drops fixed-spacing
+        // bursts (observed at 50 / 100 ms in live testing), so polling between
+        // steps is the only reliable way to converge on the target lap.
+        // Fire-and-forget — the press handler returns immediately.
+        void this.walkToFastestLap(contextId, targetCarIdx, walkTargetLap);
+
+        this.logger.info("Jump to fastest lap executed");
+        this.logger.debug(`Target carIdx: ${targetCarIdx}, fastest lap: ${targetLap}, walker target: ${walkTargetLap}`);
+        break;
+      }
       case "next-car": {
         // Send the configured keystroke (default: V) so iRacing's own car-ordering
         // drives the cycle. Telemetry-driven selection picks the wrong driver during
@@ -1057,6 +1316,8 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
       this.executeMode(contextId, settings);
     } else if (mode === "jump-to-my-car") {
       this.executeMode(contextId, settings);
+    } else if (mode === "jump-to-fastest-lap") {
+      // Single-shot jump — no meaningful encoder push semantic.
     } else {
       // Transport modes: encoder push plays
       const success = replay.play();
@@ -1070,6 +1331,11 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
   private executeDialRotate(contextId: string, mode: ReplayControlMode, ticks: number): void {
     const replay = getCommands().replay;
 
+    if (mode === "jump-to-fastest-lap") {
+      // Single-shot jump — rotation has no meaningful semantic.
+      return;
+    }
+
     if (mode === "speed-increase" || mode === "speed-decrease") {
       // Speed modes: rotate adjusts speed progressively
       const adjustedMode: ReplayControlMode = ticks > 0 ? "speed-increase" : "speed-decrease";
@@ -1077,6 +1343,7 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
         mode: adjustedMode,
         speed: "1",
         stepRate: 1,
+        fastestLapTarget: "viewed-car",
         flagsOverlay: false,
         addedWithVersion: "0.0.0",
       });
@@ -1087,6 +1354,7 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
         mode: nav,
         speed: "1",
         stepRate: 1,
+        fastestLapTarget: "viewed-car",
         flagsOverlay: false,
         addedWithVersion: "0.0.0",
       });

--- a/packages/iracing-actions/src/actions/replay-control/replay-control.ts
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.ts
@@ -1205,9 +1205,14 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
         const sessionInfo = this.sdkController.getSessionInfo();
         const targetCarIdx = this.resolveFastestLapCarIdx(settings.fastestLapTarget, telemetry);
 
-        if (targetCarIdx < 0) {
+        // CarIdx 255 is iRacing's "no driver" placeholder — appears when the
+        // camera is mid-transition or focused on the pace car. The downstream
+        // `findFastestLapForCar` would just return null and we'd log
+        // "no best lap" anyway, but a direct guard is clearer and avoids
+        // burning a SessionInfo/telemetry read.
+        if (targetCarIdx < 0 || targetCarIdx === 255) {
           this.logger.warn("No target car available for jump to fastest lap");
-          this.logger.debug(`Target setting: ${settings.fastestLapTarget}`);
+          this.logger.debug(`Target setting: ${settings.fastestLapTarget}, carIdx: ${targetCarIdx}`);
           break;
         }
 
@@ -1230,7 +1235,16 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
           break;
         }
 
-        getCommands().camera.switchNum(carNum, 0, 0);
+        const cameraSwitched = getCommands().camera.switchNum(carNum, 0, 0);
+
+        if (!cameraSwitched) {
+          // The walker depends on the camera being on the right car (iRacing's
+          // lap-search is camera-focus-relative). If the SDK refused, abort
+          // rather than burn the retry budget walking the wrong driver.
+          this.logger.warn("Jump to fastest lap: camera switch failed, aborting walk");
+          this.logger.debug(`Failed switchNum: carNum=${carNum}, carIdx=${targetCarIdx}`);
+          break;
+        }
 
         // iRacing's nextLap jumps to the *end* of the targeted lap (=start of
         // the lap after it). Subtract one so the cursor lands at the start of

--- a/packages/pi-components/partials/global-common-settings.ejs
+++ b/packages/pi-components/partials/global-common-settings.ejs
@@ -52,5 +52,16 @@
       Which direction a short press fires on a setup View sub-mode; the long-press
       always fires the opposite. Applies plugin-wide to every dual-press View.
     </div>
+    <div class="ird-section-subtitle">Replay</div>
+    <sdpi-item label="Fastest Lap Search Delay (ms)">
+      <ird-range-input setting="fastestLapSearchDelayMs" min="50" max="1000" step="50" default="400" global showlabels></ird-range-input>
+    </sdpi-item>
+    <div class="ird-supporting-text">
+      Time the Replay Control "Jump to Fastest Lap" mode waits between each lap-search
+      broadcast while walking the cursor. iRacing resolves the exact lap-boundary
+      position asynchronously after each step, so a too-short delay can leave the
+      cursor parked mid-lap. Default 400 ms. Slower computers and longer tracks may
+      need to increase the value.
+    </div>
   `
 }) %>

--- a/packages/website/src/content/docs/docs/actions/view-camera/replay-control.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/replay-control.md
@@ -3,7 +3,7 @@ title: Replay Control
 description: Full replay transport, speed, and navigation in a single configurable action.
 sidebar:
   badge:
-    text: "26 modes"
+    text: "27 modes"
     variant: tip
 ---
 
@@ -368,6 +368,31 @@ Jump the replay camera to your own car.
 #### Settings
 
 - No additional settings
+
+---
+
+### Jump to Fastest Lap
+
+Jump the replay cursor to a driver's fastest lap in the current replay session. The default target is **Viewed Car** so the same button can be reused — focus the camera on a competitor and press, focus on yourself and press, etc. Switch the target to **Always my car** to make the button always navigate to your own fastest lap regardless of which car the camera is currently watching.
+
+"Fastest" means the best lap time iRacing reports for that car. The lookup prefers the session's authoritative `ResultsPositions` table (available immediately when a replay is loaded, so the button works without first scrubbing through the replay) and falls back to live `CarIdxBestLapNum` for an in-progress session that hasn't published positions yet. There is no clean-lap filter — iRacing telemetry doesn't expose per-lap incident status, so a lap with a slide or off counts the same as a clean one. The search is also session-scoped: it jumps within whichever practice / qualifying / race session the replay cursor is currently in (matched by `SessionNum`) and does not cross session boundaries.
+
+If the target car hasn't completed a lap yet, the press is a no-op (nothing moves, no error). If the camera target can't be resolved (e.g., transitioning between cars), the press is also a no-op.
+
+The walker spaces each lap-search broadcast by **Common Settings → Replay → Fastest Lap Search Delay** (default 400 ms). iRacing resolves the exact lap-boundary position asynchronously after each step, so a too-short delay can leave the cursor parked mid-lap. Slower computers and longer tracks may need to increase the value; the slider accepts 50–1000 ms in 50 ms steps.
+
+#### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+#### Setting: Target
+
+Which driver's fastest lap the button jumps to. Defaults to **Viewed Car**.
+
+- **Viewed Car** — the car the replay camera is currently focused on
+- **Always my car** — your own car, regardless of where the camera is pointed (the camera also moves onto your car so the lap you jump to is what you actually see)
 
 ---
 


### PR DESCRIPTION
## Related Issue

Fixes #577

## What changed?

Adds a **Jump to Fastest Lap** sub-action to the Replay Control action. Walks the replay cursor to the start of a driver's fastest lap in the current session — either the car the camera is currently watching (default, matches the Race Admin "viewed car" pattern) or always the user's own car.

Key implementation details:

- **Lap-number source** — prefers `SessionInfo.Sessions[].ResultsPositions[].FastestLap` (matched by `SessionNum`, authoritative on replay load) and falls back to live `CarIdxBestLapNum` for in-progress sessions.
- **Adaptive walker** — reads `CarIdxLap` between each `nextLap`/`prevLap`, re-sends when the cursor didn't advance, bails after 5 consecutive no-progress iterations or 150 total iterations. Concurrency-guarded per Stream Deck context so rapid double-presses don't double-fire.
- **Walks to `fastestLap - 1`** — iRacing's `nextLap` lands at the *end* of the targeted lap, so subtracting one puts the cursor at the start of the fastest lap.
- **Configurable inter-step delay** — new global setting `fastestLapSearchDelayMs` (Common Settings → Replay → Fastest Lap Search Delay, 50–1000 ms in 50 ms steps, default 400 ms). iRacing resolves the exact lap-boundary position asynchronously after each broadcast and shorter delays leave the cursor parked mid-lap; slower machines and longer tracks can raise the value.
- **No keyboard binding, no encoder support** — single-shot jump.

## How to test

1. Load a saved replay (or be live in a session with a fastest lap recorded for someone).
2. Configure a button: Replay Control → **Jump to Fastest Lap**, Target = **Viewed Car**. Focus the camera on yourself, press → cursor jumps to the start of your fastest lap. Focus the camera on a competitor and press again → cursor jumps to the start of their fastest lap.
3. Switch the radio to **Always my car**, focus the camera on a competitor, press → camera switches to your car and cursor jumps to the start of your fastest lap.
4. Press the button before the target car has completed a lap → no-op, info log only.
5. Open the Property Inspector → Global Settings → Common Settings → Replay → drag **Fastest Lap Search Delay** to a different value. The next press uses the new delay (slider is live-read on every iteration).
6. Schema test fixtures + simhub mock include the new key — `pnpm build && pnpm test` is clean.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Jump to Fastest Lap" replay mode with selectable target (viewed car or always your car).
  * Dial-down triggers single-shot jump; dial rotation is a no-op for this mode.

* **Settings**
  * New configurable replay search delay (50–1000 ms, default 400 ms) with UI control.

* **Documentation**
  * Updated mode counts and Replay Control docs to reflect the new mode.

* **Tests**
  * Expanded tests covering fastest-lap resolution, cursor walking, retries, and delay handling.

* **UI**
  * Added icon/default coloring for a related view entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niklam/iracedeck/pull/578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->