### PR TITLE
feat(chat): configurable Send Message timing delays and Enter key hold (#581)

### DIFF
--- a/packages/deck-core/src/global-settings.ts
+++ b/packages/deck-core/src/global-settings.ts
@@ -587,6 +587,24 @@ export const GlobalSettingsSchema = z
      * tracks may need higher values. Range 50–1000 ms, step 50.
      */
     fastestLapSearchDelayMs: z.coerce.number().min(50).max(1000).default(400),
+    /**
+     * Delay in milliseconds the Chat > Send Message pipeline waits after
+     * opening the chat window (BeginChat) before pasting the message
+     * (issue #581). Also used by Race Admin "Type in Chat" for its
+     * open→paste wait. Too short and the paste lands before iRacing has
+     * focused the chat input, dropping the text — slower machines, heavy
+     * load, or a clipboard-manager app stealing focus all push this out.
+     * Range 0–2000 ms, step 100, default 200.
+     */
+    chatOpenToPasteDelayMs: z.coerce.number().min(0).max(2000).default(200),
+    /**
+     * Delay in milliseconds the Chat > Send Message pipeline waits after
+     * pasting before pressing Enter (issue #581). Too short and Enter fires
+     * before the paste has registered, sending an empty or partial message.
+     * Race Admin doesn't press Enter, so this delay doesn't apply there.
+     * Range 0–2000 ms, step 100, default 200.
+     */
+    chatPasteToEnterDelayMs: z.coerce.number().min(0).max(2000).default(200),
   })
   .passthrough();
 

--- a/packages/deck-core/src/simhub-service.test.ts
+++ b/packages/deck-core/src/simhub-service.test.ts
@@ -96,6 +96,8 @@ describe("SimHub Service", () => {
       dualPressThresholdMs: 500,
       dualPressDirections: "tap-increases",
       fastestLapSearchDelayMs: 400,
+      chatOpenToPasteDelayMs: 200,
+      chatPasteToEnterDelayMs: 200,
     });
   });
 
@@ -241,6 +243,8 @@ describe("SimHub Service", () => {
         dualPressThresholdMs: 500,
         dualPressDirections: "tap-increases",
         fastestLapSearchDelayMs: 400,
+        chatOpenToPasteDelayMs: 200,
+        chatPasteToEnterDelayMs: 200,
       });
 
       initializeSimHub(mockLogger);

--- a/packages/iracing-actions/src/actions/chat/chat.test.ts
+++ b/packages/iracing-actions/src/actions/chat/chat.test.ts
@@ -526,7 +526,24 @@ describe("Chat", () => {
     it("should call chat.sendMessage() on keyDown for send-message", async () => {
       await action.onKeyDown(fakeEvent("action-1", { mode: "send-message", message: "Hello!" }) as any);
 
-      expect(mockSendMessage).toHaveBeenCalledWith("Hello!");
+      expect(mockSendMessage).toHaveBeenCalledWith("Hello!", {
+        openToPasteDelayMs: undefined,
+        pasteToEnterDelayMs: undefined,
+      });
+    });
+
+    it("should forward configured chat timing delays to chat.sendMessage()", async () => {
+      mockGetGlobalSettings.mockReturnValueOnce({
+        chatOpenToPasteDelayMs: 350,
+        chatPasteToEnterDelayMs: 500,
+      });
+
+      await action.onKeyDown(fakeEvent("action-1", { mode: "send-message", message: "Hello!" }) as any);
+
+      expect(mockSendMessage).toHaveBeenCalledWith("Hello!", {
+        openToPasteDelayMs: 350,
+        pasteToEnterDelayMs: 500,
+      });
     });
 
     it("should not call chat.sendMessage() when message is empty", async () => {

--- a/packages/iracing-actions/src/actions/chat/chat.ts
+++ b/packages/iracing-actions/src/actions/chat/chat.ts
@@ -7,6 +7,7 @@ import {
   getGlobalBorderSettings,
   getGlobalColors,
   getGlobalGraphicSettings,
+  getGlobalSettings,
   getGlobalTitleSettings,
   type IDeckDialDownEvent,
   type IDeckDialRotateEvent,
@@ -439,8 +440,12 @@ export class Chat extends ConnectionStateAwareAction<ChatSettings> {
       this.logger.debug(`Resolved template: "${resolvedMessage}"`);
     }
 
+    const globalSettings = getGlobalSettings();
     const chat = getCommands().chat;
-    const success = await chat.sendMessage(resolvedMessage);
+    const success = await chat.sendMessage(resolvedMessage, {
+      openToPasteDelayMs: globalSettings.chatOpenToPasteDelayMs,
+      pasteToEnterDelayMs: globalSettings.chatPasteToEnterDelayMs,
+    });
 
     if (success) {
       this.logger.info("Send message executed");

--- a/packages/iracing-actions/src/actions/race-admin/race-admin.test.ts
+++ b/packages/iracing-actions/src/actions/race-admin/race-admin.test.ts
@@ -103,6 +103,12 @@ const mockSendMessage = vi.fn(async () => true);
 const mockBeginChat = vi.fn(() => true);
 const mockSetClipboardText = vi.fn(() => true);
 const mockSendKeyCombination = vi.fn(async () => true);
+// Small default open→paste delay so the real-timer tests below resolve quickly.
+// vi.hoisted so the object-returning factory is initialized before the hoisted
+// vi.mock("@iracedeck/deck-core") factory references it.
+const { mockGetGlobalSettings } = vi.hoisted(() => ({
+  mockGetGlobalSettings: vi.fn(() => ({ chatOpenToPasteDelayMs: 10 })),
+}));
 
 vi.mock("@iracedeck/deck-core", () => ({
   CommonSettings: {
@@ -135,6 +141,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     camera: { switchNum: vi.fn(() => true) },
   })),
   getClipboard: vi.fn(() => ({ setClipboardText: mockSetClipboardText })),
+  getGlobalSettings: mockGetGlobalSettings,
   getKeyboard: vi.fn(() => ({ sendKeyCombination: mockSendKeyCombination })),
   generateBorderParts: vi.fn(() => ({ defs: "", rects: "" })),
   getGlobalBorderSettings: vi.fn(() => ({})),
@@ -538,7 +545,8 @@ describe("RaceAdmin", () => {
       const ev = makeKeyDownEvent(baseSettings);
 
       await action.onKeyDown(ev);
-      // Wait past the 100ms internal delay so the keyboard call has fired.
+      // Wait past the configurable open→paste delay (mocked to 10ms) so the
+      // keyboard call has fired.
       await new Promise((r) => setTimeout(r, 150));
 
       expect(mockSetClipboardText).toHaveBeenCalledTimes(1);
@@ -557,6 +565,33 @@ describe("RaceAdmin", () => {
       });
       expect(enterCalls).toHaveLength(0);
       expect(mockSendMessage).not.toHaveBeenCalled();
+    });
+
+    it("type-in-chat: open→paste wait honors the chatOpenToPasteDelayMs setting", async () => {
+      mockGetGlobalSettings.mockReturnValueOnce({ chatOpenToPasteDelayMs: 800 });
+      vi.useFakeTimers();
+
+      try {
+        const action = new RaceAdmin();
+        const promise = action.onKeyDown(makeKeyDownEvent(baseSettings));
+
+        // Flush the synchronous pipeline (clipboard write + beginChat) up to the delay.
+        await vi.advanceTimersByTimeAsync(0);
+        expect(mockSetClipboardText).toHaveBeenCalledTimes(1);
+        expect(mockBeginChat).toHaveBeenCalledTimes(1);
+        expect(mockSendKeyCombination).not.toHaveBeenCalled();
+
+        // Just before the configured delay elapses, the paste must not have fired.
+        await vi.advanceTimersByTimeAsync(799);
+        expect(mockSendKeyCombination).not.toHaveBeenCalled();
+
+        // Crossing the 800ms boundary fires the paste.
+        await vi.advanceTimersByTimeAsync(1);
+        await promise;
+        expect(mockSendKeyCombination).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("type-in-chat: clipboard write failure aborts before opening chat", async () => {

--- a/packages/iracing-actions/src/actions/race-admin/race-admin.ts
+++ b/packages/iracing-actions/src/actions/race-admin/race-admin.ts
@@ -14,6 +14,7 @@ import {
   getGlobalBorderSettings,
   getGlobalColors,
   getGlobalGraphicSettings,
+  getGlobalSettings,
   getGlobalTitleSettings,
   getKeyboard,
   type IDeckDialDownEvent,
@@ -303,10 +304,13 @@ export class RaceAdmin extends ConnectionStateAwareAction<RaceAdminSettings> {
         return;
       }
 
-      // Match the chat-send pipeline's kChatStepDelayMs (addon.cc:352): give
-      // iRacing a couple frames to actually focus the chat input box before
-      // pasting. Without this, Ctrl+V lands on an empty viewport.
-      await new Promise<void>((resolve) => setTimeout(resolve, 100));
+      // Give iRacing a couple frames to actually focus the chat input box
+      // before pasting. Without this, Ctrl+V lands on an empty viewport. The
+      // wait is the shared `chatOpenToPasteDelayMs` global setting (issue
+      // #581) so every paste-into-chat flow tunes from one place; Race Admin
+      // doesn't press Enter, so the paste→enter delay doesn't apply here.
+      const openToPasteDelayMs = getGlobalSettings().chatOpenToPasteDelayMs ?? 200;
+      await new Promise<void>((resolve) => setTimeout(resolve, openToPasteDelayMs));
 
       await getKeyboard().sendKeyCombination({ key: "v", code: "KeyV", modifiers: ["ctrl"] });
 

--- a/packages/iracing-native/CLAUDE.md
+++ b/packages/iracing-native/CLAUDE.md
@@ -75,6 +75,19 @@ Writes a UTF-16 string to the Windows clipboard as `CF_UNICODETEXT`. Returns `tr
 
 Pasting is the caller's responsibility — `setClipboardText` only writes. Send `Ctrl+V` via `getKeyboard().sendKeyCombination(...)` from `@iracedeck/deck-core` to paste. Used by race-admin's "Type in Chat" driver-target mode and any future flows that need to put text on the clipboard without going through the full chat-send sequence.
 
+## Chat Functions
+
+### `sendChatMessage(message: string, openToPasteDelayMs?: number, pasteToEnterDelayMs?: number): Promise<boolean>`
+
+Runs the full chat-send pipeline (copy → `Cancel` → `BeginChat` → paste → `Enter` → `Cancel`) on a libuv worker thread and resolves `true` on success, `false` on failure. Concurrent sends are serialized natively via `g_chatSendMutex`.
+
+The two waits flanking the paste are caller-supplied (issue #581) and each default to `200` ms when omitted:
+
+- `openToPasteDelayMs` — wait after `BeginChat` before pasting. Sourced from the `chatOpenToPasteDelayMs` global setting by the action layer.
+- `pasteToEnterDelayMs` — wait after pasting before pressing `Enter`. Sourced from `chatPasteToEnterDelayMs`.
+
+The cancel→begin and enter→close waits stay on the fixed `kChatStepDelayMs` (100 ms). The `Enter` keypress is split into key-down → `Sleep(kChatEnterHoldMs)` (40 ms) → key-up so a zero-duration press isn't dropped under load; `kChatEnterHoldMs` is a fixed native constant, not user-configurable.
+
 ## Cross-Package Sync
 
 The TypeScript wrapper in `src/index.ts` must mirror every function exported from `addon.cc`. When adding or modifying native keyboard functions:

--- a/packages/iracing-native/CLAUDE.md
+++ b/packages/iracing-native/CLAUDE.md
@@ -86,6 +86,8 @@ The two waits flanking the paste are caller-supplied (issue #581) and each defau
 - `openToPasteDelayMs` — wait after `BeginChat` before pasting. Sourced from the `chatOpenToPasteDelayMs` global setting by the action layer.
 - `pasteToEnterDelayMs` — wait after pasting before pressing `Enter`. Sourced from `chatPasteToEnterDelayMs`.
 
+Each delay is read defensively and clamped into `[0, kMaxChatDelayMs]` (10000 ms). Reading as a double (not `Uint32Value()`) avoids ECMAScript `ToUint32` wrapping a negative value into a huge `DWORD` and turning `Sleep()` into a multi-day stall while `g_chatSendMutex` is held.
+
 The cancel→begin and enter→close waits stay on the fixed `kChatStepDelayMs` (100 ms). The `Enter` keypress is split into key-down → `Sleep(kChatEnterHoldMs)` (40 ms) → key-up so a zero-duration press isn't dropped under load; `kChatEnterHoldMs` is a fixed native constant, not user-configurable.
 
 ## Cross-Package Sync

--- a/packages/iracing-native/src/addon.cc
+++ b/packages/iracing-native/src/addon.cc
@@ -349,7 +349,15 @@ static void sendPaste()
     SendInput(4, inputs, sizeof(INPUT));
 }
 
+// Fixed delay for the two pipeline sleeps that stay non-configurable
+// (cancel→begin and enter→close). The open→paste and paste→enter waits are
+// caller-supplied (issue #581).
 static constexpr DWORD kChatStepDelayMs = 100;
+
+// Fixed hold for the Enter keypress (issue #581). A zero-duration down+up can
+// be dropped by iRacing under load; ~40ms gives the key event time to register
+// without feeling sluggish. Intentionally not user-configurable.
+static constexpr DWORD kChatEnterHoldMs = 40;
 
 /**
  * Async worker that runs the full chat-send pipeline on a libuv worker
@@ -361,6 +369,10 @@ static constexpr DWORD kChatStepDelayMs = 100;
  * ~400ms native pipeline. setTimeout callbacks and Stream Deck events
  * continue to flow while a chat message is being typed.
  *
+ * The open→paste and paste→enter waits are caller-supplied (issue #581) so
+ * users on slower machines can dial in reliable sends; the cancel→begin and
+ * enter→close waits stay on kChatStepDelayMs. Enter is held kChatEnterHoldMs.
+ *
  * Serialized via g_chatSendMutex so concurrent sends queue up instead of
  * clobbering each other: iRacing only has one chat window, and two
  * overlapping sends would fight over the clipboard.
@@ -368,9 +380,11 @@ static constexpr DWORD kChatStepDelayMs = 100;
 class ChatSendWorker : public Napi::AsyncWorker
 {
 public:
-    ChatSendWorker(Napi::Env env, std::u16string message)
+    ChatSendWorker(Napi::Env env, std::u16string message, DWORD openToPasteDelayMs, DWORD pasteToEnterDelayMs)
         : Napi::AsyncWorker(env),
           message_(std::move(message)),
+          openToPasteDelayMs_(openToPasteDelayMs),
+          pasteToEnterDelayMs_(pasteToEnterDelayMs),
           deferred_(Napi::Promise::Deferred::New(env)),
           result_(false)
     {
@@ -407,18 +421,26 @@ public:
         Sleep(kChatStepDelayMs);
 
         irsdk_broadcastMsg(irsdk_BroadcastChatComand, irsdk_ChatCommand_BeginChat, 0);
-        Sleep(kChatStepDelayMs);
+        Sleep(openToPasteDelayMs_);
 
         sendPaste();
-        Sleep(kChatStepDelayMs);
+        Sleep(pasteToEnterDelayMs_);
 
-        INPUT enterInputs[2] = {};
-        enterInputs[0].type = INPUT_KEYBOARD;
-        enterInputs[0].ki.wVk = VK_RETURN;
-        enterInputs[1].type = INPUT_KEYBOARD;
-        enterInputs[1].ki.wVk = VK_RETURN;
-        enterInputs[1].ki.dwFlags = KEYEVENTF_KEYUP;
-        SendInput(2, enterInputs, sizeof(INPUT));
+        // Hold Enter for kChatEnterHoldMs rather than sending a zero-duration
+        // down+up batch — the instantaneous press can be dropped by iRacing
+        // under load, leaving the message typed but unsent (issue #581).
+        INPUT enterDown = {};
+        enterDown.type = INPUT_KEYBOARD;
+        enterDown.ki.wVk = VK_RETURN;
+        SendInput(1, &enterDown, sizeof(INPUT));
+
+        Sleep(kChatEnterHoldMs);
+
+        INPUT enterUp = {};
+        enterUp.type = INPUT_KEYBOARD;
+        enterUp.ki.wVk = VK_RETURN;
+        enterUp.ki.dwFlags = KEYEVENTF_KEYUP;
+        SendInput(1, &enterUp, sizeof(INPUT));
 
         Sleep(kChatStepDelayMs);
 
@@ -441,9 +463,15 @@ public:
 
 private:
     std::u16string message_;
+    DWORD openToPasteDelayMs_;
+    DWORD pasteToEnterDelayMs_;
     Napi::Promise::Deferred deferred_;
     bool result_;
 };
+
+// Fallback delay (ms) used when the caller omits a timing argument. Matches
+// the chatOpenToPasteDelayMs / chatPasteToEnterDelayMs global-settings default.
+static constexpr DWORD kChatDefaultDelayMs = 200;
 
 /**
  * Send a complete chat message to iRacing using clipboard paste.
@@ -452,9 +480,13 @@ private:
  * The full pipeline runs on a libuv worker thread (see ChatSendWorker),
  * so the JS event loop remains responsive during the ~400ms native work.
  *
- * Each step waits kChatStepDelayMs to give iRacing time to process.
+ * The open→paste and paste→enter waits are caller-supplied (issue #581),
+ * each defaulting to kChatDefaultDelayMs when omitted. The cancel→begin and
+ * enter→close waits stay on kChatStepDelayMs; Enter is held kChatEnterHoldMs.
  *
  * @param message - The message to send
+ * @param openToPasteDelayMs - (optional) ms to wait after opening chat before pasting
+ * @param pasteToEnterDelayMs - (optional) ms to wait after pasting before pressing Enter
  * @returns Promise<boolean>
  */
 Napi::Value SendChatMessage(const Napi::CallbackInfo &info)
@@ -463,13 +495,21 @@ Napi::Value SendChatMessage(const Napi::CallbackInfo &info)
 
     if (info.Length() < 1 || !info[0].IsString())
     {
-        Napi::TypeError::New(env, "Expected (message: string)").ThrowAsJavaScriptException();
+        Napi::TypeError::New(env, "Expected (message: string, openToPasteDelayMs?: number, pasteToEnterDelayMs?: number)")
+            .ThrowAsJavaScriptException();
         return env.Undefined();
     }
 
     std::u16string message = info[0].As<Napi::String>().Utf16Value();
 
-    ChatSendWorker *worker = new ChatSendWorker(env, std::move(message));
+    DWORD openToPasteDelayMs = (info.Length() > 1 && info[1].IsNumber())
+                                   ? static_cast<DWORD>(info[1].As<Napi::Number>().Uint32Value())
+                                   : kChatDefaultDelayMs;
+    DWORD pasteToEnterDelayMs = (info.Length() > 2 && info[2].IsNumber())
+                                    ? static_cast<DWORD>(info[2].As<Napi::Number>().Uint32Value())
+                                    : kChatDefaultDelayMs;
+
+    ChatSendWorker *worker = new ChatSendWorker(env, std::move(message), openToPasteDelayMs, pasteToEnterDelayMs);
     Napi::Promise promise = worker->GetPromise();
     worker->Queue();
 

--- a/packages/iracing-native/src/addon.cc
+++ b/packages/iracing-native/src/addon.cc
@@ -473,6 +473,48 @@ private:
 // the chatOpenToPasteDelayMs / chatPasteToEnterDelayMs global-settings default.
 static constexpr DWORD kChatDefaultDelayMs = 200;
 
+// Safety ceiling (ms) for a caller-supplied chat delay. The Property Inspector
+// caps the settings at 2000 ms; this generous upper bound exists only so a
+// bad/out-of-range native caller can't turn Sleep() into a multi-day stall
+// while ChatSendWorker holds g_chatSendMutex (which would block every other
+// chat send).
+static constexpr DWORD kMaxChatDelayMs = 10000;
+
+/**
+ * Read an optional chat-delay argument and clamp it into [0, kMaxChatDelayMs].
+ *
+ * Falls back to kChatDefaultDelayMs when the argument is absent, non-numeric,
+ * or NaN. We read the value as a double rather than via Uint32Value() because
+ * Uint32Value() applies ECMAScript ToUint32, which would wrap a negative input
+ * (e.g. -1) into a huge DWORD (~4.29e9 ms ≈ 49 days) — exactly the runaway
+ * Sleep() this guards against.
+ */
+static DWORD readChatDelayArg(const Napi::CallbackInfo &info, size_t index)
+{
+    if (index >= info.Length() || !info[index].IsNumber())
+    {
+        return kChatDefaultDelayMs;
+    }
+
+    double value = info[index].As<Napi::Number>().DoubleValue();
+
+    // NaN is the only value not equal to itself; avoids needing <cmath>.
+    if (value != value)
+    {
+        return kChatDefaultDelayMs;
+    }
+    if (value < 0.0)
+    {
+        return 0;
+    }
+    if (value > static_cast<double>(kMaxChatDelayMs))
+    {
+        return kMaxChatDelayMs;
+    }
+
+    return static_cast<DWORD>(value);
+}
+
 /**
  * Send a complete chat message to iRacing using clipboard paste.
  * Returns a Promise that resolves to true on success, false on failure.
@@ -502,12 +544,8 @@ Napi::Value SendChatMessage(const Napi::CallbackInfo &info)
 
     std::u16string message = info[0].As<Napi::String>().Utf16Value();
 
-    DWORD openToPasteDelayMs = (info.Length() > 1 && info[1].IsNumber())
-                                   ? static_cast<DWORD>(info[1].As<Napi::Number>().Uint32Value())
-                                   : kChatDefaultDelayMs;
-    DWORD pasteToEnterDelayMs = (info.Length() > 2 && info[2].IsNumber())
-                                    ? static_cast<DWORD>(info[2].As<Napi::Number>().Uint32Value())
-                                    : kChatDefaultDelayMs;
+    DWORD openToPasteDelayMs = readChatDelayArg(info, 1);
+    DWORD pasteToEnterDelayMs = readChatDelayArg(info, 2);
 
     ChatSendWorker *worker = new ChatSendWorker(env, std::move(message), openToPasteDelayMs, pasteToEnterDelayMs);
     Napi::Promise promise = worker->GetPromise();

--- a/packages/iracing-native/src/index.ts
+++ b/packages/iracing-native/src/index.ts
@@ -185,11 +185,19 @@ export class IRacingNative {
    * thread and returns a Promise, so the JS event loop remains responsive
    * during the ~400ms native work. Concurrent sends are serialized natively.
    *
+   * The open→paste and paste→enter waits are caller-supplied (issue #581);
+   * each defaults to 200 ms when omitted. The Enter keypress is held a fixed
+   * ~40 ms natively (not configurable).
+   *
    * @param message - The message to send
+   * @param openToPasteDelayMs - (optional) ms to wait after opening chat before pasting
+   * @param pasteToEnterDelayMs - (optional) ms to wait after pasting before pressing Enter
    * @returns Promise resolving to true on success, false on failure
    */
-  sendChatMessage(message: string): Promise<boolean> {
-    return addon ? addon.sendChatMessage(message) : this.getMock().sendChatMessage(message);
+  sendChatMessage(message: string, openToPasteDelayMs?: number, pasteToEnterDelayMs?: number): Promise<boolean> {
+    return addon
+      ? addon.sendChatMessage(message, openToPasteDelayMs ?? 200, pasteToEnterDelayMs ?? 200)
+      : this.getMock().sendChatMessage(message, openToPasteDelayMs, pasteToEnterDelayMs);
   }
 
   // ============================================================================

--- a/packages/iracing-native/src/mock-impl.test.ts
+++ b/packages/iracing-native/src/mock-impl.test.ts
@@ -130,6 +130,11 @@ describe("IRacingNativeMock", () => {
       expect(console.debug).toHaveBeenCalled();
     });
 
+    it("sendChatMessage should accept timing delays and resolve to true", async () => {
+      await expect(mock.sendChatMessage("test", 300, 450)).resolves.toBe(true);
+      expect(console.debug).toHaveBeenCalled();
+    });
+
     it("sendScanKeys should not throw", () => {
       expect(() => mock.sendScanKeys([0x1e])).not.toThrow();
       expect(console.debug).toHaveBeenCalled();

--- a/packages/iracing-native/src/mock-impl.ts
+++ b/packages/iracing-native/src/mock-impl.ts
@@ -90,8 +90,10 @@ export class IRacingNativeMock {
     console.debug(`[IRacingNativeMock] broadcastMsg(${msg}, ${var1}, ${var2 ?? 0}, ${var3 ?? 0})`);
   }
 
-  async sendChatMessage(message: string): Promise<boolean> {
-    console.debug(`[IRacingNativeMock] sendChatMessage("${message}")`);
+  async sendChatMessage(message: string, openToPasteDelayMs?: number, pasteToEnterDelayMs?: number): Promise<boolean> {
+    console.debug(
+      `[IRacingNativeMock] sendChatMessage("${message}", ${openToPasteDelayMs ?? "default"}, ${pasteToEnterDelayMs ?? "default"})`,
+    );
 
     return true;
   }

--- a/packages/iracing-sdk/src/IRacingSDK.test.ts
+++ b/packages/iracing-sdk/src/IRacingSDK.test.ts
@@ -199,8 +199,17 @@ describe("IRacingSDK", () => {
 
       const result = await sdk.sendChatMessage("Hello");
 
-      expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello");
+      expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello", undefined, undefined);
       expect(result).toBe(true);
+    });
+
+    it("should forward timing delays to native when connected", async () => {
+      vi.mocked(mockNative.getVarHeaderEntry).mockReturnValue(null);
+      sdk.connect();
+
+      await sdk.sendChatMessage("Hello", { openToPasteDelayMs: 300, pasteToEnterDelayMs: 450 });
+
+      expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello", 300, 450);
     });
   });
 

--- a/packages/iracing-sdk/src/IRacingSDK.ts
+++ b/packages/iracing-sdk/src/IRacingSDK.ts
@@ -5,7 +5,7 @@
 import { ILogger, silentLogger } from "@iracedeck/logger";
 import yaml from "yaml";
 
-import type { INativeSDK } from "./interfaces.js";
+import type { ChatSendTiming, INativeSDK } from "./interfaces.js";
 import { SessionInfo, TelemetryData, VarHeader, VarType } from "./types.js";
 
 /**
@@ -261,15 +261,16 @@ export class IRacingSDK {
   /**
    * Send a custom chat message to iRacing
    * @param message The message to send
+   * @param timing Optional open→paste and paste→enter delays (ms)
    * @returns Promise resolving to true on success, false on failure
    */
-  sendChatMessage(message: string): Promise<boolean> {
+  sendChatMessage(message: string, timing?: ChatSendTiming): Promise<boolean> {
     if (!this.isConnected()) {
       this.logger.warn("[IRacingSDK] Cannot send chat message - not connected");
 
       return Promise.resolve(false);
     }
 
-    return this.native.sendChatMessage(message);
+    return this.native.sendChatMessage(message, timing?.openToPasteDelayMs, timing?.pasteToEnterDelayMs);
   }
 }

--- a/packages/iracing-sdk/src/SDKController.test.ts
+++ b/packages/iracing-sdk/src/SDKController.test.ts
@@ -186,7 +186,15 @@ describe("SDKController", () => {
     it("should delegate to SDK", async () => {
       await controller.sendChatMessage("Hello");
 
-      expect(mockSdk.sendChatMessage).toHaveBeenCalledWith("Hello");
+      expect(mockSdk.sendChatMessage).toHaveBeenCalledWith("Hello", undefined);
+    });
+
+    it("should forward timing delays to SDK", async () => {
+      const timing = { openToPasteDelayMs: 300, pasteToEnterDelayMs: 450 };
+
+      await controller.sendChatMessage("Hello", timing);
+
+      expect(mockSdk.sendChatMessage).toHaveBeenCalledWith("Hello", timing);
     });
 
     it("should return SDK result", async () => {

--- a/packages/iracing-sdk/src/SDKController.ts
+++ b/packages/iracing-sdk/src/SDKController.ts
@@ -4,6 +4,7 @@
  */
 import { ILogger, silentLogger } from "@iracedeck/logger";
 
+import type { ChatSendTiming } from "./interfaces.js";
 import { IRacingSDK } from "./IRacingSDK.js";
 import { buildTemplateContextFromData, type TemplateContext } from "./template-context.js";
 import { SessionInfo, TelemetryData } from "./types.js";
@@ -313,9 +314,10 @@ export class SDKController {
   /**
    * Send a custom chat message to iRacing
    * @param message The message to send
+   * @param timing Optional open→paste and paste→enter delays (ms)
    * @returns Promise resolving to true on success, false on failure
    */
-  sendChatMessage(message: string): Promise<boolean> {
-    return this.sdk.sendChatMessage(message);
+  sendChatMessage(message: string, timing?: ChatSendTiming): Promise<boolean> {
+    return this.sdk.sendChatMessage(message, timing);
   }
 }

--- a/packages/iracing-sdk/src/commands/ChatCommand.test.ts
+++ b/packages/iracing-sdk/src/commands/ChatCommand.test.ts
@@ -113,7 +113,15 @@ describe("ChatCommand", () => {
 
       await chatCommand.sendMessage("Hello world");
 
-      expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello world");
+      expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello world", undefined, undefined);
+    });
+
+    it("should forward timing delays to native sendChatMessage", async () => {
+      vi.mocked(mockNative.sendChatMessage).mockResolvedValue(true);
+
+      await chatCommand.sendMessage("Hello world", { openToPasteDelayMs: 350, pasteToEnterDelayMs: 500 });
+
+      expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello world", 350, 500);
     });
 
     it("should return true when sendChatMessage succeeds", async () => {
@@ -168,7 +176,7 @@ describe("ChatCommand", () => {
       const result = await chatCommand.sendMessage("Hello! @driver #1 - good race!");
 
       expect(result).toBe(true);
-      expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello! @driver #1 - good race!");
+      expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello! @driver #1 - good race!", undefined, undefined);
     });
   });
 

--- a/packages/iracing-sdk/src/commands/ChatCommand.ts
+++ b/packages/iracing-sdk/src/commands/ChatCommand.ts
@@ -5,7 +5,7 @@
  */
 import { ILogger } from "@iracedeck/logger";
 
-import type { INativeSDK } from "../interfaces.js";
+import type { ChatSendTiming, INativeSDK } from "../interfaces.js";
 import { BroadcastCommand } from "./BroadcastCommand.js";
 import { BroadcastMsg, ChatCommandMode } from "./constants.js";
 
@@ -81,9 +81,11 @@ export class ChatCommand extends BroadcastCommand {
    * remains responsive during the ~400ms native work.
    *
    * @param message The message to send
+   * @param timing Optional open→paste and paste→enter delays (ms). When
+   *   omitted, the native layer uses its built-in default (200 ms each).
    * @returns Promise resolving to true on success, false on failure
    */
-  async sendMessage(message: string): Promise<boolean> {
+  async sendMessage(message: string, timing?: ChatSendTiming): Promise<boolean> {
     if (!message || message.trim().length === 0) {
       this.logger.warn("Cannot send empty message");
 
@@ -93,7 +95,11 @@ export class ChatCommand extends BroadcastCommand {
     try {
       this.logger.info(`Sending chat message: "${message}"`);
 
-      const result = await this.native.sendChatMessage(message);
+      const result = await this.native.sendChatMessage(
+        message,
+        timing?.openToPasteDelayMs,
+        timing?.pasteToEnterDelayMs,
+      );
 
       if (result) {
         this.logger.info("Chat message sent successfully");

--- a/packages/iracing-sdk/src/index.ts
+++ b/packages/iracing-sdk/src/index.ts
@@ -11,7 +11,7 @@ export { IRacingSDK } from "./IRacingSDK.js";
 export { SDKController, TELEMETRY_INTERVAL_MS, TelemetryCallback } from "./SDKController.js";
 
 // Interfaces for dependency injection
-export type { INativeSDK } from "./interfaces.js";
+export type { ChatSendTiming, INativeSDK } from "./interfaces.js";
 
 // Factory functions for easy SDK creation
 export { createSDK, createCommands, type SDKBundle, type Commands } from "./factory.js";

--- a/packages/iracing-sdk/src/interfaces.ts
+++ b/packages/iracing-sdk/src/interfaces.ts
@@ -6,6 +6,22 @@
 import type { BroadcastMsg, IRSDKHeader, VarHeader } from "@iracedeck/iracing-native";
 
 /**
+ * Tunable delays for the Chat > Send Message pipeline (issue #581).
+ *
+ * Both are in milliseconds and optional — when omitted, the native layer
+ * falls back to its built-in default (200 ms). The action layer reads the
+ * `chatOpenToPasteDelayMs` / `chatPasteToEnterDelayMs` global settings and
+ * forwards them here; the SDK and native layers stay decoupled from
+ * `deck-core`.
+ */
+export interface ChatSendTiming {
+  /** Wait after opening the chat window (BeginChat) before pasting. */
+  openToPasteDelayMs?: number;
+  /** Wait after pasting before pressing Enter. */
+  pasteToEnterDelayMs?: number;
+}
+
+/**
  * Interface for the native iRacing SDK
  * Wraps the native addon functionality for dependency injection
  */
@@ -27,5 +43,5 @@ export interface INativeSDK {
   broadcastMsg(msg: BroadcastMsg | number, var1: number, var2?: number, var3?: number): void;
 
   // Chat
-  sendChatMessage(message: string): Promise<boolean>;
+  sendChatMessage(message: string, openToPasteDelayMs?: number, pasteToEnterDelayMs?: number): Promise<boolean>;
 }

--- a/packages/pi-components/partials/global-common-settings.ejs
+++ b/packages/pi-components/partials/global-common-settings.ejs
@@ -63,5 +63,23 @@
       cursor parked mid-lap. Default 400 ms. Slower computers and longer tracks may
       need to increase the value.
     </div>
+    <div class="ird-section-subtitle">Chat</div>
+    <sdpi-item label="Open → Paste delay (ms)">
+      <ird-range-input setting="chatOpenToPasteDelayMs" min="0" max="2000" step="100" default="200" global showlabels></ird-range-input>
+    </sdpi-item>
+    <div class="ird-supporting-text">
+      Time the chat pipeline waits after opening the chat window before pasting the
+      message. Also used by Race Admin "Type in Chat". Too short and the paste can
+      land before iRacing has focused the chat input, dropping the text. Default 200 ms;
+      raise it on slower machines or if a clipboard-manager app interferes.
+    </div>
+    <sdpi-item label="Paste → Enter delay (ms)">
+      <ird-range-input setting="chatPasteToEnterDelayMs" min="0" max="2000" step="100" default="200" global showlabels></ird-range-input>
+    </sdpi-item>
+    <div class="ird-supporting-text">
+      Time the Send Message pipeline waits after pasting before pressing Enter. Too short
+      and Enter can fire before the paste registers, sending an empty or partial message.
+      Default 200 ms. (Race Admin doesn't press Enter, so this delay doesn't affect it.)
+    </div>
   `
 }) %>

--- a/packages/website/src/content/docs/docs/actions/communication/chat.md
+++ b/packages/website/src/content/docs/docs/actions/communication/chat.md
@@ -35,6 +35,15 @@ The text to send. Accepts template variables. Defaults to empty — configure be
 
 Font size (5–36 px) used to render Message Text on the button. Defaults to `11`. Only affects the on-button rendering, not the sent message length.
 
+#### Timing
+
+Sending a message opens the chat window, pastes the text, then presses Enter. Two waits in that pipeline are configurable under **Common Settings → Chat** (both default 200 ms):
+
+- **Open → Paste delay** — wait after opening the chat window before pasting. Too short and the paste can land before iRacing has focused the chat input, dropping the text. (This delay is shared with Race Admin's "Type in Chat".)
+- **Paste → Enter delay** — wait after pasting before pressing Enter. Too short and Enter can fire before the paste registers, sending an empty or partial message.
+
+The Enter keypress is also held briefly so it isn't dropped under load. If messages send empty, partially, or not at all — especially on slower machines or when a clipboard-manager app is running — raise these delays.
+
 ---
 
 ### Chat Macro

--- a/packages/website/src/content/docs/docs/getting-started/troubleshooting.md
+++ b/packages/website/src/content/docs/docs/getting-started/troubleshooting.md
@@ -33,6 +33,17 @@ This means **whatever you had on your clipboard before pressing the button will 
 
 If you need to keep something on your clipboard, copy it again **after** using an iRaceDeck chat action.
 
+### Chat messages send empty, partial, or not at all
+
+The chat-send pipeline opens the chat window, pastes the message, then presses Enter — each step on a short timer. On slower machines, under load, or when a clipboard-manager app briefly steals focus, the default timing can be too tight: the paste lands before the chat input is focused (text lost), Enter fires before the paste registers (empty or partial send), or the keypress is dropped entirely.
+
+If you hit this, increase the two delays under **Common Settings → Chat** in any action's Property Inspector:
+
+- **Open → Paste delay** (default 200 ms) — the wait after opening chat before pasting.
+- **Paste → Enter delay** (default 200 ms) — the wait after pasting before pressing Enter.
+
+Both accept 0–2000 ms. The Enter keypress is also held briefly so it registers reliably. Changes take effect immediately — no restart needed.
+
 ## Need more help?
 
 - **Discord**: [Join the community](https://discord.gg/c6nRYywpah) for real-time support


### PR DESCRIPTION
## Related Issue

Fixes #581

## What changed?

Makes the **Chat > Send Message** pipeline timing tunable and gives the Enter keypress a real hold so messages submit reliably.

Two new global settings (0–2000 ms, default 200, step 100), surfaced in the PI Global Settings under a new **Chat** subsection:

| Setting | Controls |
|---|---|
| `chatOpenToPasteDelayMs` | wait after opening the chat window before pasting |
| `chatPasteToEnterDelayMs` | wait after pasting before pressing Enter |

Plus a fixed ~40 ms native Enter hold (`kChatEnterHoldMs`, not user-configurable): Enter is now sent as key-down → `Sleep(40)` → key-up instead of a zero-duration batch.

Architecture: the action layer reads the global settings and forwards a small `ChatSendTiming` object through the SDK chain (`ChatCommand` → `IRacingSDK`/`SDKController` → `INativeSDK`); the native `sendChatMessage` takes two number params and applies them at the open→paste and paste→enter `Sleep` sites. The cancel→begin and enter→close waits stay on the existing `kChatStepDelayMs`. Delay changes take effect without a plugin rebuild (read live on every send).

`chatOpenToPasteDelayMs` also replaces Race Admin **Type in Chat**'s hardcoded 100 ms open→paste wait, so every paste-into-chat flow tunes from one place. (Race Admin doesn't press Enter, so the paste→enter delay and Enter hold don't apply there.)

Touched packages: `deck-core` (schema), `iracing-sdk` (timing object through the chain), `iracing-native` (`addon.cc` two args + Enter hold, `index.ts`/mock/CLAUDE.md), `iracing-actions` (`chat.ts`, `race-admin.ts`), `pi-components` (PI subsection), `website` (chat action doc + troubleshooting note).

## How to test

1. Open any action's Property Inspector → **Common Settings → Chat**; set Open → Paste and Paste → Enter delays.
2. Fire a **Chat > Send Message** in iRacing — confirm the message pastes and submits reliably; raise the delays on a slower setup if needed.
3. Confirm changing the delays takes effect **without** restarting/rebuilding the plugin.
4. Fire **Race Admin → Type in Chat** — confirm it honors the Open → Paste delay (and still never presses Enter).
5. Verify default behavior with the settings at 200 ms.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable chat timing in Common Settings → Chat: "Open → Paste delay" and "Paste → Enter delay" (0–2000ms, default 200ms)

* **Bug Fixes / Reliability**
  * Chat sending and Race Admin "type-in-chat" now honor the configurable delays to reduce dropped or partial messages

* **Documentation**
  * Updated chat docs and added troubleshooting guidance for timing-related send issues

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niklam/iracedeck/pull/583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->