### PR TITLE
feat(chat): configurable Enter → Close delay and longer Enter hold for Send Message (#589)

### DIFF
--- a/packages/deck-core/src/global-settings.test.ts
+++ b/packages/deck-core/src/global-settings.test.ts
@@ -516,3 +516,33 @@ describe("fastestLapSearchDelayMs (issue #577)", () => {
     expect(() => GlobalSettingsSchema.parse({ fastestLapSearchDelayMs: 1001 })).toThrow();
   });
 });
+
+describe("chatEnterToCloseDelayMs (issue #589)", () => {
+  it("defaults to 200 when not specified", () => {
+    const parsed = GlobalSettingsSchema.parse({}) as Record<string, unknown>;
+    expect(parsed.chatEnterToCloseDelayMs).toBe(200);
+  });
+
+  it("accepts the lower bound (0 ms)", () => {
+    const parsed = GlobalSettingsSchema.parse({ chatEnterToCloseDelayMs: 0 }) as Record<string, unknown>;
+    expect(parsed.chatEnterToCloseDelayMs).toBe(0);
+  });
+
+  it("accepts the upper bound (2000 ms)", () => {
+    const parsed = GlobalSettingsSchema.parse({ chatEnterToCloseDelayMs: 2000 }) as Record<string, unknown>;
+    expect(parsed.chatEnterToCloseDelayMs).toBe(2000);
+  });
+
+  it("coerces a numeric string from the Property Inspector slider", () => {
+    const parsed = GlobalSettingsSchema.parse({ chatEnterToCloseDelayMs: "300" }) as Record<string, unknown>;
+    expect(parsed.chatEnterToCloseDelayMs).toBe(300);
+  });
+
+  it("rejects values below 0", () => {
+    expect(() => GlobalSettingsSchema.parse({ chatEnterToCloseDelayMs: -1 })).toThrow();
+  });
+
+  it("rejects values above 2000", () => {
+    expect(() => GlobalSettingsSchema.parse({ chatEnterToCloseDelayMs: 2001 })).toThrow();
+  });
+});

--- a/packages/deck-core/src/global-settings.ts
+++ b/packages/deck-core/src/global-settings.ts
@@ -605,6 +605,15 @@ export const GlobalSettingsSchema = z
      * Range 0–2000 ms, step 100, default 200.
      */
     chatPasteToEnterDelayMs: z.coerce.number().min(0).max(2000).default(200),
+    /**
+     * Delay in milliseconds the Chat > Send Message pipeline waits after
+     * pressing Enter before closing the chat box (Cancel broadcast) (issue
+     * #589). Too short and the close fires before iRacing has finished
+     * processing the submit, so the Cancel is dropped and the chat window
+     * keeps focus. Race Admin doesn't close the chat, so this delay doesn't
+     * apply there. Range 0–2000 ms, step 100, default 200.
+     */
+    chatEnterToCloseDelayMs: z.coerce.number().min(0).max(2000).default(200),
   })
   .passthrough();
 

--- a/packages/deck-core/src/simhub-service.test.ts
+++ b/packages/deck-core/src/simhub-service.test.ts
@@ -98,6 +98,7 @@ describe("SimHub Service", () => {
       fastestLapSearchDelayMs: 400,
       chatOpenToPasteDelayMs: 200,
       chatPasteToEnterDelayMs: 200,
+      chatEnterToCloseDelayMs: 200,
     });
   });
 
@@ -245,6 +246,7 @@ describe("SimHub Service", () => {
         fastestLapSearchDelayMs: 400,
         chatOpenToPasteDelayMs: 200,
         chatPasteToEnterDelayMs: 200,
+        chatEnterToCloseDelayMs: 200,
       });
 
       initializeSimHub(mockLogger);

--- a/packages/iracing-actions/src/actions/chat/chat.test.ts
+++ b/packages/iracing-actions/src/actions/chat/chat.test.ts
@@ -524,12 +524,20 @@ describe("Chat", () => {
     });
 
     it("should call chat.sendMessage() on keyDown for send-message", async () => {
+      // Mirror the schema-parsed global settings the action sees in production
+      // (getGlobalSettings() always returns the 200 ms defaults, never undefined).
+      mockGetGlobalSettings.mockReturnValueOnce({
+        chatOpenToPasteDelayMs: 200,
+        chatPasteToEnterDelayMs: 200,
+        chatEnterToCloseDelayMs: 200,
+      });
+
       await action.onKeyDown(fakeEvent("action-1", { mode: "send-message", message: "Hello!" }) as any);
 
       expect(mockSendMessage).toHaveBeenCalledWith("Hello!", {
-        openToPasteDelayMs: undefined,
-        pasteToEnterDelayMs: undefined,
-        enterToCloseDelayMs: undefined,
+        openToPasteDelayMs: 200,
+        pasteToEnterDelayMs: 200,
+        enterToCloseDelayMs: 200,
       });
     });
 

--- a/packages/iracing-actions/src/actions/chat/chat.test.ts
+++ b/packages/iracing-actions/src/actions/chat/chat.test.ts
@@ -529,6 +529,7 @@ describe("Chat", () => {
       expect(mockSendMessage).toHaveBeenCalledWith("Hello!", {
         openToPasteDelayMs: undefined,
         pasteToEnterDelayMs: undefined,
+        enterToCloseDelayMs: undefined,
       });
     });
 
@@ -536,6 +537,7 @@ describe("Chat", () => {
       mockGetGlobalSettings.mockReturnValueOnce({
         chatOpenToPasteDelayMs: 350,
         chatPasteToEnterDelayMs: 500,
+        chatEnterToCloseDelayMs: 600,
       });
 
       await action.onKeyDown(fakeEvent("action-1", { mode: "send-message", message: "Hello!" }) as any);
@@ -543,6 +545,7 @@ describe("Chat", () => {
       expect(mockSendMessage).toHaveBeenCalledWith("Hello!", {
         openToPasteDelayMs: 350,
         pasteToEnterDelayMs: 500,
+        enterToCloseDelayMs: 600,
       });
     });
 

--- a/packages/iracing-actions/src/actions/chat/chat.ts
+++ b/packages/iracing-actions/src/actions/chat/chat.ts
@@ -445,6 +445,7 @@ export class Chat extends ConnectionStateAwareAction<ChatSettings> {
     const success = await chat.sendMessage(resolvedMessage, {
       openToPasteDelayMs: globalSettings.chatOpenToPasteDelayMs,
       pasteToEnterDelayMs: globalSettings.chatPasteToEnterDelayMs,
+      enterToCloseDelayMs: globalSettings.chatEnterToCloseDelayMs,
     });
 
     if (success) {

--- a/packages/iracing-native/CLAUDE.md
+++ b/packages/iracing-native/CLAUDE.md
@@ -77,18 +77,19 @@ Pasting is the caller's responsibility — `setClipboardText` only writes. Send 
 
 ## Chat Functions
 
-### `sendChatMessage(message: string, openToPasteDelayMs?: number, pasteToEnterDelayMs?: number): Promise<boolean>`
+### `sendChatMessage(message: string, openToPasteDelayMs?: number, pasteToEnterDelayMs?: number, enterToCloseDelayMs?: number): Promise<boolean>`
 
 Runs the full chat-send pipeline (copy → `Cancel` → `BeginChat` → paste → `Enter` → `Cancel`) on a libuv worker thread and resolves `true` on success, `false` on failure. Concurrent sends are serialized natively via `g_chatSendMutex`.
 
-The two waits flanking the paste are caller-supplied (issue #581) and each default to `200` ms when omitted:
+The three waits around the paste and submit are caller-supplied (issues #581, #589) and each default to `200` ms when omitted:
 
 - `openToPasteDelayMs` — wait after `BeginChat` before pasting. Sourced from the `chatOpenToPasteDelayMs` global setting by the action layer.
 - `pasteToEnterDelayMs` — wait after pasting before pressing `Enter`. Sourced from `chatPasteToEnterDelayMs`.
+- `enterToCloseDelayMs` — wait after pressing `Enter` before the closing `Cancel` (issue #589). Sourced from `chatEnterToCloseDelayMs`. Too short and the `Cancel` lands before iRacing has processed the submit, so it's dropped and the chat window keeps focus.
 
 Each delay is read defensively and clamped into `[0, kMaxChatDelayMs]` (10000 ms). Reading as a double (not `Uint32Value()`) avoids ECMAScript `ToUint32` wrapping a negative value into a huge `DWORD` and turning `Sleep()` into a multi-day stall while `g_chatSendMutex` is held.
 
-The cancel→begin and enter→close waits stay on the fixed `kChatStepDelayMs` (100 ms). The `Enter` keypress is split into key-down → `Sleep(kChatEnterHoldMs)` (40 ms) → key-up so a zero-duration press isn't dropped under load; `kChatEnterHoldMs` is a fixed native constant, not user-configurable.
+The cancel→begin wait stays on the fixed `kChatStepDelayMs` (100 ms). The `Enter` keypress is split into key-down → `Sleep(kChatEnterHoldMs)` (100 ms) → key-up so a zero-duration press isn't dropped under load; `kChatEnterHoldMs` is a fixed native constant, not user-configurable.
 
 ## Cross-Package Sync
 

--- a/packages/iracing-native/src/addon.cc
+++ b/packages/iracing-native/src/addon.cc
@@ -349,15 +349,16 @@ static void sendPaste()
     SendInput(4, inputs, sizeof(INPUT));
 }
 
-// Fixed delay for the two pipeline sleeps that stay non-configurable
-// (cancel→begin and enter→close). The open→paste and paste→enter waits are
-// caller-supplied (issue #581).
+// Fixed delay for the cancel→begin pipeline sleep that stays non-configurable.
+// The open→paste, paste→enter, and enter→close waits are caller-supplied
+// (issues #581, #589).
 static constexpr DWORD kChatStepDelayMs = 100;
 
-// Fixed hold for the Enter keypress (issue #581). A zero-duration down+up can
-// be dropped by iRacing under load; ~40ms gives the key event time to register
-// without feeling sluggish. Intentionally not user-configurable.
-static constexpr DWORD kChatEnterHoldMs = 40;
+// Fixed hold for the Enter keypress (issues #581, #589). A zero-duration down+up
+// can be dropped by iRacing under load; 100ms gives the key event ample time to
+// register so the message reliably submits before the chat box is closed.
+// Intentionally not user-configurable.
+static constexpr DWORD kChatEnterHoldMs = 100;
 
 /**
  * Async worker that runs the full chat-send pipeline on a libuv worker
@@ -369,9 +370,10 @@ static constexpr DWORD kChatEnterHoldMs = 40;
  * ~400ms native pipeline. setTimeout callbacks and Stream Deck events
  * continue to flow while a chat message is being typed.
  *
- * The open→paste and paste→enter waits are caller-supplied (issue #581) so
- * users on slower machines can dial in reliable sends; the cancel→begin and
- * enter→close waits stay on kChatStepDelayMs. Enter is held kChatEnterHoldMs.
+ * The open→paste, paste→enter, and enter→close waits are caller-supplied
+ * (issues #581, #589) so users on slower machines can dial in reliable sends;
+ * the cancel→begin wait stays on kChatStepDelayMs. Enter is held
+ * kChatEnterHoldMs.
  *
  * Serialized via g_chatSendMutex so concurrent sends queue up instead of
  * clobbering each other: iRacing only has one chat window, and two
@@ -380,11 +382,13 @@ static constexpr DWORD kChatEnterHoldMs = 40;
 class ChatSendWorker : public Napi::AsyncWorker
 {
 public:
-    ChatSendWorker(Napi::Env env, std::u16string message, DWORD openToPasteDelayMs, DWORD pasteToEnterDelayMs)
+    ChatSendWorker(Napi::Env env, std::u16string message, DWORD openToPasteDelayMs, DWORD pasteToEnterDelayMs,
+                   DWORD enterToCloseDelayMs)
         : Napi::AsyncWorker(env),
           message_(std::move(message)),
           openToPasteDelayMs_(openToPasteDelayMs),
           pasteToEnterDelayMs_(pasteToEnterDelayMs),
+          enterToCloseDelayMs_(enterToCloseDelayMs),
           deferred_(Napi::Promise::Deferred::New(env)),
           result_(false)
     {
@@ -442,7 +446,10 @@ public:
         enterUp.ki.dwFlags = KEYEVENTF_KEYUP;
         SendInput(1, &enterUp, sizeof(INPUT));
 
-        Sleep(kChatStepDelayMs);
+        // Wait before closing the chat box so iRacing finishes processing the
+        // Enter; otherwise the Cancel below lands too early, gets dropped, and
+        // the chat window keeps focus (issue #589). Caller-supplied.
+        Sleep(enterToCloseDelayMs_);
 
         irsdk_broadcastMsg(irsdk_BroadcastChatComand, irsdk_ChatCommand_Cancel, 0);
 
@@ -465,12 +472,14 @@ private:
     std::u16string message_;
     DWORD openToPasteDelayMs_;
     DWORD pasteToEnterDelayMs_;
+    DWORD enterToCloseDelayMs_;
     Napi::Promise::Deferred deferred_;
     bool result_;
 };
 
-// Fallback delay (ms) used when the caller omits a timing argument. Matches
-// the chatOpenToPasteDelayMs / chatPasteToEnterDelayMs global-settings default.
+// Fallback delay (ms) used when the caller omits a timing argument. Matches the
+// chatOpenToPasteDelayMs / chatPasteToEnterDelayMs / chatEnterToCloseDelayMs
+// global-settings default.
 static constexpr DWORD kChatDefaultDelayMs = 200;
 
 // Safety ceiling (ms) for a caller-supplied chat delay. The Property Inspector
@@ -522,13 +531,14 @@ static DWORD readChatDelayArg(const Napi::CallbackInfo &info, size_t index)
  * The full pipeline runs on a libuv worker thread (see ChatSendWorker),
  * so the JS event loop remains responsive during the ~400ms native work.
  *
- * The open→paste and paste→enter waits are caller-supplied (issue #581),
- * each defaulting to kChatDefaultDelayMs when omitted. The cancel→begin and
- * enter→close waits stay on kChatStepDelayMs; Enter is held kChatEnterHoldMs.
+ * The open→paste, paste→enter, and enter→close waits are caller-supplied
+ * (issues #581, #589), each defaulting to kChatDefaultDelayMs when omitted. The
+ * cancel→begin wait stays on kChatStepDelayMs; Enter is held kChatEnterHoldMs.
  *
  * @param message - The message to send
  * @param openToPasteDelayMs - (optional) ms to wait after opening chat before pasting
  * @param pasteToEnterDelayMs - (optional) ms to wait after pasting before pressing Enter
+ * @param enterToCloseDelayMs - (optional) ms to wait after pressing Enter before closing the chat box
  * @returns Promise<boolean>
  */
 Napi::Value SendChatMessage(const Napi::CallbackInfo &info)
@@ -537,7 +547,7 @@ Napi::Value SendChatMessage(const Napi::CallbackInfo &info)
 
     if (info.Length() < 1 || !info[0].IsString())
     {
-        Napi::TypeError::New(env, "Expected (message: string, openToPasteDelayMs?: number, pasteToEnterDelayMs?: number)")
+        Napi::TypeError::New(env, "Expected (message: string, openToPasteDelayMs?: number, pasteToEnterDelayMs?: number, enterToCloseDelayMs?: number)")
             .ThrowAsJavaScriptException();
         return env.Undefined();
     }
@@ -546,8 +556,9 @@ Napi::Value SendChatMessage(const Napi::CallbackInfo &info)
 
     DWORD openToPasteDelayMs = readChatDelayArg(info, 1);
     DWORD pasteToEnterDelayMs = readChatDelayArg(info, 2);
+    DWORD enterToCloseDelayMs = readChatDelayArg(info, 3);
 
-    ChatSendWorker *worker = new ChatSendWorker(env, std::move(message), openToPasteDelayMs, pasteToEnterDelayMs);
+    ChatSendWorker *worker = new ChatSendWorker(env, std::move(message), openToPasteDelayMs, pasteToEnterDelayMs, enterToCloseDelayMs);
     Napi::Promise promise = worker->GetPromise();
     worker->Queue();
 

--- a/packages/iracing-native/src/index.ts
+++ b/packages/iracing-native/src/index.ts
@@ -185,19 +185,30 @@ export class IRacingNative {
    * thread and returns a Promise, so the JS event loop remains responsive
    * during the ~400ms native work. Concurrent sends are serialized natively.
    *
-   * The open→paste and paste→enter waits are caller-supplied (issue #581);
-   * each defaults to 200 ms when omitted. The Enter keypress is held a fixed
-   * ~40 ms natively (not configurable).
+   * The open→paste, paste→enter, and enter→close waits are caller-supplied
+   * (issues #581, #589); each defaults to 200 ms when omitted. The Enter
+   * keypress is held a fixed 100 ms natively (not configurable).
    *
    * @param message - The message to send
    * @param openToPasteDelayMs - (optional) ms to wait after opening chat before pasting
    * @param pasteToEnterDelayMs - (optional) ms to wait after pasting before pressing Enter
+   * @param enterToCloseDelayMs - (optional) ms to wait after pressing Enter before closing the chat box
    * @returns Promise resolving to true on success, false on failure
    */
-  sendChatMessage(message: string, openToPasteDelayMs?: number, pasteToEnterDelayMs?: number): Promise<boolean> {
+  sendChatMessage(
+    message: string,
+    openToPasteDelayMs?: number,
+    pasteToEnterDelayMs?: number,
+    enterToCloseDelayMs?: number,
+  ): Promise<boolean> {
     return addon
-      ? addon.sendChatMessage(message, openToPasteDelayMs ?? 200, pasteToEnterDelayMs ?? 200)
-      : this.getMock().sendChatMessage(message, openToPasteDelayMs, pasteToEnterDelayMs);
+      ? addon.sendChatMessage(
+          message,
+          openToPasteDelayMs ?? 200,
+          pasteToEnterDelayMs ?? 200,
+          enterToCloseDelayMs ?? 200,
+        )
+      : this.getMock().sendChatMessage(message, openToPasteDelayMs, pasteToEnterDelayMs, enterToCloseDelayMs);
   }
 
   // ============================================================================

--- a/packages/iracing-native/src/mock-impl.test.ts
+++ b/packages/iracing-native/src/mock-impl.test.ts
@@ -131,8 +131,8 @@ describe("IRacingNativeMock", () => {
     });
 
     it("sendChatMessage should accept timing delays and resolve to true", async () => {
-      await expect(mock.sendChatMessage("test", 300, 450)).resolves.toBe(true);
-      expect(console.debug).toHaveBeenCalled();
+      await expect(mock.sendChatMessage("test", 300, 450, 600)).resolves.toBe(true);
+      expect(console.debug).toHaveBeenCalledWith(expect.stringContaining("600"));
     });
 
     it("sendScanKeys should not throw", () => {

--- a/packages/iracing-native/src/mock-impl.ts
+++ b/packages/iracing-native/src/mock-impl.ts
@@ -90,9 +90,14 @@ export class IRacingNativeMock {
     console.debug(`[IRacingNativeMock] broadcastMsg(${msg}, ${var1}, ${var2 ?? 0}, ${var3 ?? 0})`);
   }
 
-  async sendChatMessage(message: string, openToPasteDelayMs?: number, pasteToEnterDelayMs?: number): Promise<boolean> {
+  async sendChatMessage(
+    message: string,
+    openToPasteDelayMs?: number,
+    pasteToEnterDelayMs?: number,
+    enterToCloseDelayMs?: number,
+  ): Promise<boolean> {
     console.debug(
-      `[IRacingNativeMock] sendChatMessage("${message}", ${openToPasteDelayMs ?? "default"}, ${pasteToEnterDelayMs ?? "default"})`,
+      `[IRacingNativeMock] sendChatMessage("${message}", ${openToPasteDelayMs ?? "default"}, ${pasteToEnterDelayMs ?? "default"}, ${enterToCloseDelayMs ?? "default"})`,
     );
 
     return true;

--- a/packages/iracing-sdk/src/IRacingSDK.test.ts
+++ b/packages/iracing-sdk/src/IRacingSDK.test.ts
@@ -199,7 +199,7 @@ describe("IRacingSDK", () => {
 
       const result = await sdk.sendChatMessage("Hello");
 
-      expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello", undefined, undefined);
+      expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello", undefined, undefined, undefined);
       expect(result).toBe(true);
     });
 
@@ -207,9 +207,13 @@ describe("IRacingSDK", () => {
       vi.mocked(mockNative.getVarHeaderEntry).mockReturnValue(null);
       sdk.connect();
 
-      await sdk.sendChatMessage("Hello", { openToPasteDelayMs: 300, pasteToEnterDelayMs: 450 });
+      await sdk.sendChatMessage("Hello", {
+        openToPasteDelayMs: 300,
+        pasteToEnterDelayMs: 450,
+        enterToCloseDelayMs: 600,
+      });
 
-      expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello", 300, 450);
+      expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello", 300, 450, 600);
     });
   });
 

--- a/packages/iracing-sdk/src/IRacingSDK.ts
+++ b/packages/iracing-sdk/src/IRacingSDK.ts
@@ -261,7 +261,7 @@ export class IRacingSDK {
   /**
    * Send a custom chat message to iRacing
    * @param message The message to send
-   * @param timing Optional open→paste and paste→enter delays (ms)
+   * @param timing Optional open→paste, paste→enter, and enter→close delays (ms)
    * @returns Promise resolving to true on success, false on failure
    */
   sendChatMessage(message: string, timing?: ChatSendTiming): Promise<boolean> {
@@ -271,6 +271,11 @@ export class IRacingSDK {
       return Promise.resolve(false);
     }
 
-    return this.native.sendChatMessage(message, timing?.openToPasteDelayMs, timing?.pasteToEnterDelayMs);
+    return this.native.sendChatMessage(
+      message,
+      timing?.openToPasteDelayMs,
+      timing?.pasteToEnterDelayMs,
+      timing?.enterToCloseDelayMs,
+    );
   }
 }

--- a/packages/iracing-sdk/src/SDKController.test.ts
+++ b/packages/iracing-sdk/src/SDKController.test.ts
@@ -190,7 +190,7 @@ describe("SDKController", () => {
     });
 
     it("should forward timing delays to SDK", async () => {
-      const timing = { openToPasteDelayMs: 300, pasteToEnterDelayMs: 450 };
+      const timing = { openToPasteDelayMs: 300, pasteToEnterDelayMs: 450, enterToCloseDelayMs: 600 };
 
       await controller.sendChatMessage("Hello", timing);
 

--- a/packages/iracing-sdk/src/SDKController.ts
+++ b/packages/iracing-sdk/src/SDKController.ts
@@ -314,7 +314,7 @@ export class SDKController {
   /**
    * Send a custom chat message to iRacing
    * @param message The message to send
-   * @param timing Optional open→paste and paste→enter delays (ms)
+   * @param timing Optional open→paste, paste→enter, and enter→close delays (ms)
    * @returns Promise resolving to true on success, false on failure
    */
   sendChatMessage(message: string, timing?: ChatSendTiming): Promise<boolean> {

--- a/packages/iracing-sdk/src/commands/ChatCommand.test.ts
+++ b/packages/iracing-sdk/src/commands/ChatCommand.test.ts
@@ -113,15 +113,19 @@ describe("ChatCommand", () => {
 
       await chatCommand.sendMessage("Hello world");
 
-      expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello world", undefined, undefined);
+      expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello world", undefined, undefined, undefined);
     });
 
     it("should forward timing delays to native sendChatMessage", async () => {
       vi.mocked(mockNative.sendChatMessage).mockResolvedValue(true);
 
-      await chatCommand.sendMessage("Hello world", { openToPasteDelayMs: 350, pasteToEnterDelayMs: 500 });
+      await chatCommand.sendMessage("Hello world", {
+        openToPasteDelayMs: 350,
+        pasteToEnterDelayMs: 500,
+        enterToCloseDelayMs: 600,
+      });
 
-      expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello world", 350, 500);
+      expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello world", 350, 500, 600);
     });
 
     it("should return true when sendChatMessage succeeds", async () => {
@@ -176,7 +180,12 @@ describe("ChatCommand", () => {
       const result = await chatCommand.sendMessage("Hello! @driver #1 - good race!");
 
       expect(result).toBe(true);
-      expect(mockNative.sendChatMessage).toHaveBeenCalledWith("Hello! @driver #1 - good race!", undefined, undefined);
+      expect(mockNative.sendChatMessage).toHaveBeenCalledWith(
+        "Hello! @driver #1 - good race!",
+        undefined,
+        undefined,
+        undefined,
+      );
     });
   });
 

--- a/packages/iracing-sdk/src/commands/ChatCommand.ts
+++ b/packages/iracing-sdk/src/commands/ChatCommand.ts
@@ -81,8 +81,8 @@ export class ChatCommand extends BroadcastCommand {
    * remains responsive during the ~400ms native work.
    *
    * @param message The message to send
-   * @param timing Optional open→paste and paste→enter delays (ms). When
-   *   omitted, the native layer uses its built-in default (200 ms each).
+   * @param timing Optional open→paste, paste→enter, and enter→close delays
+   *   (ms). When omitted, the native layer uses its built-in default (200 ms each).
    * @returns Promise resolving to true on success, false on failure
    */
   async sendMessage(message: string, timing?: ChatSendTiming): Promise<boolean> {
@@ -99,6 +99,7 @@ export class ChatCommand extends BroadcastCommand {
         message,
         timing?.openToPasteDelayMs,
         timing?.pasteToEnterDelayMs,
+        timing?.enterToCloseDelayMs,
       );
 
       if (result) {

--- a/packages/iracing-sdk/src/interfaces.ts
+++ b/packages/iracing-sdk/src/interfaces.ts
@@ -6,19 +6,21 @@
 import type { BroadcastMsg, IRSDKHeader, VarHeader } from "@iracedeck/iracing-native";
 
 /**
- * Tunable delays for the Chat > Send Message pipeline (issue #581).
+ * Tunable delays for the Chat > Send Message pipeline (issues #581, #589).
  *
- * Both are in milliseconds and optional — when omitted, the native layer
+ * All are in milliseconds and optional — when omitted, the native layer
  * falls back to its built-in default (200 ms). The action layer reads the
- * `chatOpenToPasteDelayMs` / `chatPasteToEnterDelayMs` global settings and
- * forwards them here; the SDK and native layers stay decoupled from
- * `deck-core`.
+ * `chatOpenToPasteDelayMs` / `chatPasteToEnterDelayMs` / `chatEnterToCloseDelayMs`
+ * global settings and forwards them here; the SDK and native layers stay
+ * decoupled from `deck-core`.
  */
 export interface ChatSendTiming {
   /** Wait after opening the chat window (BeginChat) before pasting. */
   openToPasteDelayMs?: number;
   /** Wait after pasting before pressing Enter. */
   pasteToEnterDelayMs?: number;
+  /** Wait after pressing Enter before closing the chat box (Cancel) (issue #589). */
+  enterToCloseDelayMs?: number;
 }
 
 /**
@@ -43,5 +45,10 @@ export interface INativeSDK {
   broadcastMsg(msg: BroadcastMsg | number, var1: number, var2?: number, var3?: number): void;
 
   // Chat
-  sendChatMessage(message: string, openToPasteDelayMs?: number, pasteToEnterDelayMs?: number): Promise<boolean>;
+  sendChatMessage(
+    message: string,
+    openToPasteDelayMs?: number,
+    pasteToEnterDelayMs?: number,
+    enterToCloseDelayMs?: number,
+  ): Promise<boolean>;
 }

--- a/packages/pi-components/partials/global-common-settings.ejs
+++ b/packages/pi-components/partials/global-common-settings.ejs
@@ -81,5 +81,14 @@
       and Enter can fire before the paste registers, sending an empty or partial message.
       Default 200 ms. (Race Admin doesn't press Enter, so this delay doesn't affect it.)
     </div>
+    <sdpi-item label="Enter → Close delay (ms)">
+      <ird-range-input setting="chatEnterToCloseDelayMs" min="0" max="2000" step="100" default="200" global showlabels></ird-range-input>
+    </sdpi-item>
+    <div class="ird-supporting-text">
+      Time the Send Message pipeline waits after pressing Enter before closing the chat box.
+      Too short and the close can fire before iRacing has processed the message, leaving the
+      chat window with focus after sending. Default 200 ms; raise it if the chat window keeps
+      focus after you send. (Race Admin doesn't close the chat, so this delay doesn't affect it.)
+    </div>
   `
 }) %>

--- a/packages/website/src/content/docs/docs/actions/communication/chat.md
+++ b/packages/website/src/content/docs/docs/actions/communication/chat.md
@@ -37,12 +37,13 @@ Font size (5–36 px) used to render Message Text on the button. Defaults to `11
 
 #### Timing
 
-Sending a message opens the chat window, pastes the text, then presses Enter. Two waits in that pipeline are configurable under **Common Settings → Chat** (both default 200 ms):
+Sending a message opens the chat window, pastes the text, presses Enter, then closes the chat window. Three waits in that pipeline are configurable under **Common Settings → Chat** (all default 200 ms):
 
 - **Open → Paste delay** — wait after opening the chat window before pasting. Too short and the paste can land before iRacing has focused the chat input, dropping the text. (This delay is shared with Race Admin's "Type in Chat".)
 - **Paste → Enter delay** — wait after pasting before pressing Enter. Too short and Enter can fire before the paste registers, sending an empty or partial message.
+- **Enter → Close delay** — wait after pressing Enter before closing the chat window. Too short and the close can fire before iRacing has processed the message, leaving the chat window with focus after sending.
 
-The Enter keypress is also held briefly so it isn't dropped under load. If messages send empty, partially, or not at all — especially on slower machines or when a clipboard-manager app is running — raise these delays.
+The Enter keypress is also held briefly so it isn't dropped under load. If messages send empty, partially, or not at all — or the chat window keeps focus after you send — especially on slower machines or when a clipboard-manager app is running — raise these delays.
 
 ---
 

--- a/packages/website/src/content/docs/docs/getting-started/troubleshooting.md
+++ b/packages/website/src/content/docs/docs/getting-started/troubleshooting.md
@@ -35,14 +35,15 @@ If you need to keep something on your clipboard, copy it again **after** using a
 
 ### Chat messages send empty, partial, or not at all
 
-The chat-send pipeline opens the chat window, pastes the message, then presses Enter — each step on a short timer. On slower machines, under load, or when a clipboard-manager app briefly steals focus, the default timing can be too tight: the paste lands before the chat input is focused (text lost), Enter fires before the paste registers (empty or partial send), or the keypress is dropped entirely.
+The chat-send pipeline opens the chat window, pastes the message, presses Enter, then closes the chat window — each step on a short timer. On slower machines, under load, or when a clipboard-manager app briefly steals focus, the default timing can be too tight: the paste lands before the chat input is focused (text lost), Enter fires before the paste registers (empty or partial send), the keypress is dropped entirely, or the window closes before iRacing processes the message and keeps focus afterward.
 
-If you hit this, increase the two delays under **Common Settings → Chat** in any action's Property Inspector:
+If you hit this, increase the three delays under **Common Settings → Chat** in any action's Property Inspector:
 
 - **Open → Paste delay** (default 200 ms) — the wait after opening chat before pasting.
 - **Paste → Enter delay** (default 200 ms) — the wait after pasting before pressing Enter.
+- **Enter → Close delay** (default 200 ms) — the wait after pressing Enter before closing the chat window. Raise this if the chat window keeps focus after you send.
 
-Both accept 0–2000 ms. The Enter keypress is also held briefly so it registers reliably. Changes take effect immediately — no restart needed.
+All accept 0–2000 ms. The Enter keypress is also held briefly so it registers reliably. Changes take effect immediately — no restart needed.
 
 ## Need more help?
 


### PR DESCRIPTION
## Related Issue

Fixes #589

## What changed?

Adds a third tunable delay to the **Chat > Send Message** pipeline — `chatEnterToCloseDelayMs`, the wait between pressing **Enter** and the `Cancel` broadcast that closes the chat box — and raises the fixed Enter-key hold from 40 ms to 100 ms.

Follow-up to #581. That issue made the open→paste and paste→enter waits configurable but left the enter→close wait fixed at 100 ms (`kChatStepDelayMs`). On some machines that's too short: the `Cancel` lands before iRacing has processed the submit, gets dropped, and the chat window keeps focus after sending.

- **deck-core** — `chatEnterToCloseDelayMs` global setting (0–2000 ms, step 100, default 200) + schema tests
- **iracing-sdk** — `ChatSendTiming.enterToCloseDelayMs` forwarded through `ChatCommand` / `IRacingSDK` / `SDKController` / `INativeSDK`
- **iracing-native** — third delay threaded through `ChatSendWorker`, used at the enter→close `Sleep`; `kChatEnterHoldMs` 40 → 100 ms; `index.ts` / `mock-impl.ts` / `CLAUDE.md`
- **iracing-actions** — Chat action reads & forwards the setting (Race Admin unaffected — it doesn't press Enter or close the chat)
- **pi-components** — "Enter → Close delay (ms)" slider in the Chat subsection
- **website** — Chat action + troubleshooting docs

## How to test

1. In any action's Property Inspector, open **Common Settings → Chat** — confirm the new **Enter → Close delay (ms)** slider (0–2000, default 200) appears alongside the existing two.
2. In iRacing, trigger Chat > Send Message and confirm the message sends and focus returns to iRacing (the chat window no longer keeps focus after sending).
3. If the window still keeps focus on a slower machine, raise the Enter → Close delay and re-test.

Automated: `pnpm build` (18/18, incl. native node-gyp rebuild), `pnpm test` (4394 passing, 6 new), `pnpm lint:fix`, `pnpm format:fix` all green.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Enter → Close delay" setting to Common Settings (0–2000 ms, default 200 ms) and applied it to chat sending so the client waits before closing the chat after pressing Enter.

* **Documentation**
  * Updated troubleshooting and "Send Custom Message" docs to describe the three-step timing pipeline (Open → Paste, Paste → Enter, Enter → Close) and guidance for adjusting delays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niklam/iracedeck/pull/592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->