### PR TITLE
fix(race-engineer): stop in-flight callout and ambient when toggled off (#587)

### DIFF
--- a/packages/audio-scenarios/src/catalog/pit-crew/index.ts
+++ b/packages/audio-scenarios/src/catalog/pit-crew/index.ts
@@ -48,7 +48,7 @@ import type { IEventBus, PitReadbackSnapshot, SessionStartSnapshot } from "@irac
 import type { ILogger } from "@iracedeck/logger";
 
 import type { Scenario } from "../../dsl.js";
-import { getScenarioEngine } from "../../interpreter.js";
+import { getScenarioEngine, isAudioScenariosInitialized } from "../../interpreter.js";
 import { DAMAGE_ALERTS } from "./damage-alerts.js";
 import { FLAG_ALERTS } from "./flag-alerts.js";
 import { INCIDENT_ALERTS } from "./incidents.js";
@@ -125,6 +125,20 @@ import {
   WINDSHIELD_TOGGLE_SCENARIOS,
 } from "./toggle-confirmations.js";
 import { TRACK_CONDITIONS_ALERTS } from "./track-conditions.js";
+
+/**
+ * Stop any in-flight Race Engineer callout (and its looping ambient bed) and
+ * free the scenario bus. Call this when the Race Engineer master gate is
+ * toggled off so a mid-callout disable stops cleanly — otherwise the ambient
+ * loop is orphaned (only muted by the bus volume, audible again on re-enable)
+ * and the stuck `playingId` drops every later callout as "bus busy" for the
+ * rest of the session (issue #587). No-op before the engine is initialized.
+ */
+export function stopRaceEngineerScenarios(): void {
+  if (!isAudioScenariosInitialized()) return;
+
+  getScenarioEngine().stopAll();
+}
 
 export { isBackgroundTestInFlight, playBackgroundTest } from "./background-test.js";
 export {

--- a/packages/audio-scenarios/src/interpreter.test.ts
+++ b/packages/audio-scenarios/src/interpreter.test.ts
@@ -858,3 +858,55 @@ describe("ambient side-effects", () => {
     expect(audio.stopChannel).toHaveBeenCalledWith(AudioChannel.Ambient);
   });
 });
+
+// ─── stopAll (Race Engineer toggle-off cleanup, issue #587) ─────────────────
+
+describe("stopAll", () => {
+  it("stops a mid-flight callout's ambient bed and frees the bus", () => {
+    engine.defineScenario({
+      id: "test.callout",
+      channel: AudioChannel.Voice,
+      bus: AudioBus.Voice,
+      base: "pit-crew",
+      sequence: [{ ambient: "start" }, "greeting/a.mp3", "greeting/b.mp3", { ambient: "stop" }],
+    });
+    engine.defineScenario({
+      id: "test.next",
+      channel: AudioChannel.Voice,
+      bus: AudioBus.Voice,
+      base: "pit-crew",
+      sequence: ["names/alice.mp3"],
+    });
+
+    // Fire but DON'T flush — the callout is mid-flight: the ambient bed is
+    // looping and the engine is waiting on the first voice clip's completion,
+    // so the trailing `ambient: "stop"` has not run yet.
+    engine.fire("test.callout");
+
+    expect(audio._played).toContainEqual({
+      channel: AudioChannel.Ambient,
+      path: "sfx/IRD-ambient-pit.mp3",
+      loop: true,
+    });
+    expect(audio._stopped).not.toContain(AudioChannel.Ambient);
+
+    engine.stopAll();
+
+    // The ambient channel is explicitly stopped (it's in the fire's
+    // `usedChannels`), so the orphaned loop can't linger.
+    expect(audio._stopped).toContain(AudioChannel.Ambient);
+
+    // The bus is no longer wedged: a fresh callout plays instead of being
+    // dropped as "bus busy" (the pre-fix failure mode).
+    engine.fire("test.next");
+    flushVoiceAndSfx(audio);
+
+    const voicePlays = audio._played.filter((p) => p.channel === AudioChannel.Voice).map((p) => p.path);
+    expect(voicePlays).toContain("pit-crew/names/alice.mp3");
+  });
+
+  it("is a no-op when nothing is playing", () => {
+    expect(() => engine.stopAll()).not.toThrow();
+    expect(audio._stopped).toEqual([]);
+  });
+});

--- a/packages/audio-scenarios/src/interpreter.ts
+++ b/packages/audio-scenarios/src/interpreter.ts
@@ -42,6 +42,7 @@ export interface IScenarioEngine {
   defineVar(name: string, resolver: () => string | null): void;
   setEnabled(scenarioId: string, enabled: boolean): void;
   fire(scenarioId: string): void;
+  stopAll(): void;
 }
 
 type PoolState = { clips: string[]; lastIndex: number };
@@ -296,6 +297,26 @@ class ScenarioEngine implements IScenarioEngine {
     }
 
     this.attemptFire(entry, null);
+  }
+
+  /**
+   * Cancel every in-flight fire on all buses and drop any pending deferred
+   * replays. Used when the Race Engineer master gate flips off so a callout
+   * caught mid-playback is stopped immediately — including its looping
+   * ambient bed (in each fire's `usedChannels`) — and `playingId` is cleared
+   * so the bus isn't wedged. Without this the gate-off path only mutes the
+   * buses: the ambient loop is orphaned (and becomes audible again on
+   * re-enable) and the stuck `playingId` makes `attemptFire` drop every later
+   * callout as "bus busy" for the rest of the session (issue #587).
+   *
+   * `cancelActiveFire` is a no-op on a bus with no active fire, so this is
+   * safe to call whether or not anything is playing.
+   */
+  stopAll(): void {
+    for (const state of this.busState.values()) {
+      this.cancelActiveFire(state);
+      state.deferredLowFire = null;
+    }
   }
 
   // ── Event wiring ──

--- a/packages/iracing-actions/src/actions/pit-crew/pit-crew.test.ts
+++ b/packages/iracing-actions/src/actions/pit-crew/pit-crew.test.ts
@@ -36,6 +36,7 @@ const hoisted = vi.hoisted(() => {
   const playRadarTest = vi.fn();
   const playBackgroundTest = vi.fn();
   const isBackgroundTestInFlight = vi.fn(() => false);
+  const stopRaceEngineerScenarios = vi.fn();
 
   let globalSettings: Record<string, unknown> = {};
   const updateGlobalSettings = vi.fn((partial: Record<string, unknown>) => {
@@ -78,6 +79,7 @@ const hoisted = vi.hoisted(() => {
     playRadarTest,
     playBackgroundTest,
     isBackgroundTestInFlight,
+    stopRaceEngineerScenarios,
     updateGlobalSettings,
     getGlobalSettings,
     globalSettingsListeners,
@@ -122,6 +124,7 @@ vi.mock("@iracedeck/audio-scenarios/pit-crew", () => ({
   playBackgroundTest: hoisted.playBackgroundTest,
   playRadarTest: hoisted.playRadarTest,
   setRadarEnabled: hoisted.setRadarEnabled,
+  stopRaceEngineerScenarios: hoisted.stopRaceEngineerScenarios,
 }));
 
 vi.mock("@iracedeck/audio-service", () => ({
@@ -694,6 +697,30 @@ describe("PitCrew action", () => {
       await action.onKeyDown(buildAppearEvent({ mode: "race-engineer" }) as never);
 
       expect(hoisted.updateGlobalSettings).toHaveBeenCalledWith({ pitCrewRaceEngineerEnabled: true });
+    });
+
+    it("stops in-flight scenarios (and the orphaned ambient) when disabling (#587)", async () => {
+      hoisted.setGlobalSettings({ pitCrewRaceEngineerEnabled: true, raceEngineerVolume: 80 });
+      const action = new PitCrew();
+      await action.onWillAppear(buildAppearEvent({ mode: "race-engineer" }) as never);
+      vi.clearAllMocks();
+
+      await action.onKeyDown(buildAppearEvent({ mode: "race-engineer" }) as never);
+
+      expect(hoisted.updateGlobalSettings).toHaveBeenCalledWith({ pitCrewRaceEngineerEnabled: false });
+      expect(hoisted.stopRaceEngineerScenarios).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not stop scenarios when enabling — nothing is playing while gated off (#587)", async () => {
+      hoisted.setGlobalSettings({ pitCrewRaceEngineerEnabled: false, raceEngineerVolume: 80 });
+      const action = new PitCrew();
+      await action.onWillAppear(buildAppearEvent({ mode: "race-engineer" }) as never);
+      vi.clearAllMocks();
+
+      await action.onKeyDown(buildAppearEvent({ mode: "race-engineer" }) as never);
+
+      expect(hoisted.updateGlobalSettings).toHaveBeenCalledWith({ pitCrewRaceEngineerEnabled: true });
+      expect(hoisted.stopRaceEngineerScenarios).not.toHaveBeenCalled();
     });
 
     it("does not touch pitCrewRadarEnabled when toggling race engineer (independent feature gates)", async () => {

--- a/packages/iracing-actions/src/actions/pit-crew/pit-crew.ts
+++ b/packages/iracing-actions/src/actions/pit-crew/pit-crew.ts
@@ -3,6 +3,7 @@ import {
   playBackgroundTest,
   playRadarTest,
   setRadarEnabled,
+  stopRaceEngineerScenarios,
 } from "@iracedeck/audio-scenarios/pit-crew";
 import { AudioBus, AudioChannel, getAudio } from "@iracedeck/audio-service";
 import {
@@ -713,6 +714,17 @@ export class PitCrew extends ConnectionStateAwareAction<PitCrewSettings> {
     // immediately on the same tick.
     updateGlobalSettings({ pitCrewRaceEngineerEnabled: next });
     applyRaceEngineerAudio();
+
+    // Toggling off mid-callout must stop the in-flight scenario (and its
+    // looping ambient bed) and free the scenario bus. applyRaceEngineerAudio
+    // only mutes the buses — it doesn't stop the ambient loop, so without this
+    // the ambient is orphaned (audible again on re-enable) and the stuck
+    // `playingId` drops every later callout as "bus busy". The going-silent
+    // ack below plays directly on Voice, not through the engine, so it is
+    // unaffected by the cancel (issue #587).
+    if (!next) {
+      stopRaceEngineerScenarios();
+    }
 
     if (isToggleAckEnabled()) {
       this.playToggleAck(next ? "resuming-01" : "going-silent-01");


### PR DESCRIPTION
## Related Issue

Fixes #587

## What changed?

Toggling Race Engineer off while a voice callout was mid-playback left the looping pit ambient bed playing and wedged the scenario bus for the rest of the session (every later callout dropped as "bus busy"). Root cause: the "going silent" ack plays on the Voice channel via `playVoiceSequence`, overwriting the scenario engine's Voice completion callback — so the in-flight scenario never reached its trailing `ambient:stop` and never called `finishFire`, orphaning the ambient loop (only muted by the bus, so it became audible again on re-enable) and leaving `playingId` stuck.

- Added `IScenarioEngine.stopAll()` — cancels in-flight fires on every bus via the existing `cancelActiveFire` (stops each fire's used channels including Ambient, clears `playingId` + deferred replays).
- Exposed it as `stopRaceEngineerScenarios()` on the `@iracedeck/audio-scenarios/pit-crew` subpath.
- `toggleRaceEngineer()` calls it on the **off** transition. The going-silent ack is unaffected (it plays directly on Voice, not through the engine).

## How to test

1. Enable Race Engineer; trigger a callout that uses the ambient bed (session start / pit status / overtake) so a line is actively playing.
2. Toggle Race Engineer off mid-line → the pit ambient cuts immediately.
3. Re-enable → later telemetry callouts still fire (bus not wedged) and no ambient lingers.

Verified in a live session log (toggled off mid-`race-start`; callouts kept firing afterward). `pnpm build` + `pnpm test` (4392 passed, incl. new `stopAll` + toggle tests) + `lint:fix`/`format:fix` clean.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — shared `audio-scenarios` / `iracing-actions` fix; both plugins consume it, no per-plugin registration needed
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Race Engineer voice callouts continuing to play after the feature is disabled.
  * Improved audio bus cleanup to prevent blocked scenarios from persisting.

* **New Features**
  * Added centralized mechanism to stop all active audio scenarios for better system control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niklam/iracedeck/pull/593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->