### PR TITLE
fix(replay-control): rebuild Jump to Fastest Lap as cached session map + targeted walk (#607)

### DIFF
--- a/packages/iracing-actions/src/actions/replay-control/replay-control.test.ts
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.test.ts
@@ -2166,6 +2166,11 @@ describe("ReplayControl", () => {
             // Bisection-driven setPlayPosition calls (skip the trailing back-step).
             const bisectionFrames = mockReplay.setPlayPosition.mock.calls.slice(0, -1).map((call) => call[1] as number);
 
+            // Guard against a vacuously-passing loop if the walker never
+            // actually bisected — without this the test would silently miss
+            // a regression where phase 3 was skipped entirely.
+            expect(bisectionFrames.length).toBeGreaterThan(0);
+
             for (const frame of bisectionFrames) {
               expect(frame).toBeGreaterThanOrEqual(10_000);
               expect(frame).toBeLessThanOrEqual(19_999);

--- a/packages/iracing-actions/src/actions/replay-control/replay-control.test.ts
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.test.ts
@@ -7,6 +7,8 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  _getFastestLapSessionCache,
+  _resetFastestLapSessionCache,
   calculateNeedleAngle,
   findAdjacentCarByNumber,
   findAdjacentCarOnTrack,
@@ -164,6 +166,8 @@ vi.mock("@iracedeck/deck-core", () => ({
       prevIncident: vi.fn(() => true),
       goToStart: vi.fn(() => true),
       goToEnd: vi.fn(() => true),
+      setPlayPosition: vi.fn(() => true),
+      searchSessionTime: vi.fn(() => true),
     },
     camera: {
       switchNum: vi.fn(() => true),
@@ -1477,6 +1481,12 @@ describe("ReplayControl", () => {
       setPlaySpeed: vi.fn(() => true),
       nextLap: vi.fn(() => true),
       prevLap: vi.fn(() => true),
+      nextSession: vi.fn(() => true),
+      prevSession: vi.fn(() => true),
+      goToStart: vi.fn(() => true),
+      goToEnd: vi.fn(() => true),
+      setPlayPosition: vi.fn(() => true),
+      searchSessionTime: vi.fn(() => true),
     };
 
     const mockCamera = {
@@ -1495,6 +1505,7 @@ describe("ReplayControl", () => {
         CamCarIdx: carIdx,
         CarIdxBestLapNum: bestLapNums,
         CarIdxLap: currentLaps,
+        SessionNum: 0,
       };
     }
 
@@ -1502,6 +1513,10 @@ describe("ReplayControl", () => {
 
     beforeEach(async () => {
       vi.clearAllMocks();
+      // The walker's session-map + per-car frame cache lives at module scope
+      // so it survives between tests by default — reset it so each test
+      // starts with a clean cache.
+      _resetFastestLapSessionCache();
       const { getCommands } = await import("@iracedeck/deck-core");
       // getCarNumberRawFromSessionInfo is mocked in the shared @iracedeck/iracing-sdk block;
       // default it to returning the carIdx as the raw number so individual tests don't have
@@ -1571,24 +1586,17 @@ describe("ReplayControl", () => {
       });
 
       it("aborts the walk and warns when camera.switchNum fails", async () => {
-        vi.useFakeTimers();
+        // Camera switch returns false (SDK refused) — walker must not start.
+        mockCamera.switchNum.mockReturnValueOnce(false);
+        action.sdkController.getCurrentTelemetry = vi.fn(() => telemetryWithBest(2, 5, 0) as any);
 
-        try {
-          // Camera switch returns false (SDK refused) — walker must not start.
-          mockCamera.switchNum.mockReturnValueOnce(false);
-          liveCursor(2, 5, { startLap: 0 });
+        await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+        await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
 
-          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-          await vi.runAllTimersAsync();
-
-          expect(mockCamera.switchNum).toHaveBeenCalledWith(2, 0, 0);
-          expect(mockReplay.nextLap).not.toHaveBeenCalled();
-          expect(mockReplay.prevLap).not.toHaveBeenCalled();
-          expect(action.logger.warn).toHaveBeenCalledWith(expect.stringContaining("camera switch failed"));
-        } finally {
-          vi.useRealTimers();
-        }
+        expect(mockCamera.switchNum).toHaveBeenCalledWith(2, 0, 0);
+        expect(mockReplay.pause).not.toHaveBeenCalled();
+        expect(mockReplay.setPlayPosition).not.toHaveBeenCalled();
+        expect(action.logger.warn).toHaveBeenCalledWith(expect.stringContaining("camera switch failed"));
       });
 
       it("logs info and skips when the target car has no best lap yet", async () => {
@@ -1597,432 +1605,704 @@ describe("ReplayControl", () => {
         await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
         await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
 
-        expect(mockReplay.nextLap).not.toHaveBeenCalled();
-        expect(mockReplay.prevLap).not.toHaveBeenCalled();
+        expect(mockReplay.pause).not.toHaveBeenCalled();
+        expect(mockReplay.setPlayPosition).not.toHaveBeenCalled();
         expect(mockCamera.switchNum).not.toHaveBeenCalled();
         expect(action.logger.info).toHaveBeenCalledWith(expect.stringContaining("no best lap"));
       });
 
       /**
-       * Build a telemetry source that returns the live `currentLap` ref on
-       * each call (the walker reads it between steps). `nextLap` / `prevLap`
-       * mutate the ref so the cursor "advances" each tick.
+       * Synthetic multi-session replay buffer. Each `SessionLayout` occupies
+       * `[startFrame, endFrame]` (inclusive); within a session, lap N spans
+       * frames `[startFrame + N * framesPerLap, startFrame + (N+1) * framesPerLap)`
+       * with `dist = (frame % framesPerLap) / framesPerLap`. The mock wires:
+       *
+       *   - `goToStart` → cursor to first session's startFrame.
+       *   - `goToEnd` → cursor to bufferEnd (last session's endFrame).
+       *   - `nextSession` → cursor to next session's startFrame, or no-op
+       *     when already in the last session.
+       *   - `setPlayPosition(Begin, frame)` → cursor clamped to buffer.
+       *   - `nextLap` → cursor to start of next lap (lap+1, dist=0).
+       *   - `prevLap` → cursor to end of previous lap (lap-1, dist≈0.999).
+       *
+       * `getCurrentTelemetry()` returns SessionUniqueID + SessionNum + the
+       * lap/dist for `carIdx`. `getSessionInfo()` wires `ResultsPositions`
+       * so `findFastestLapForCar` resolves to each session's `fastestLap`.
        */
-      function liveCursor(
-        carIdx: number,
-        targetLap: number,
-        opts: { startLap: number; advanceOnNext?: boolean; advanceOnPrev?: boolean } = { startLap: 0 },
-      ) {
-        const state = { currentLap: opts.startLap };
-        const bestLapNums: number[] = [];
+      type SessionLayout = {
+        sessionNum: number;
+        sessionUniqueId: number;
+        startFrame: number;
+        endFrame: number;
+        framesPerLap: number;
+        fastestLap: number;
+      };
 
-        bestLapNums[carIdx] = targetLap;
+      function multiSessionBuffer(
+        carIdx: number,
+        sessions: SessionLayout[],
+        opts: { driverCarIdx?: number; initialCursor?: number } = {},
+      ) {
+        const cursor = { frame: opts.initialCursor ?? sessions[0].startFrame };
+        const bufferEnd = sessions[sessions.length - 1].endFrame;
+
+        const findSession = (frame: number): SessionLayout | null =>
+          sessions.find((s) => frame >= s.startFrame && frame <= s.endFrame) ?? null;
+
+        mockReplay.goToStart.mockImplementation(() => {
+          cursor.frame = sessions[0].startFrame;
+
+          return true;
+        });
+        mockReplay.goToEnd.mockImplementation(() => {
+          cursor.frame = bufferEnd;
+
+          return true;
+        });
+        mockReplay.nextSession.mockImplementation(() => {
+          const current = findSession(cursor.frame);
+
+          if (!current) return false;
+
+          const idx = sessions.indexOf(current);
+
+          if (idx + 1 < sessions.length) {
+            cursor.frame = sessions[idx + 1].startFrame;
+          }
+
+          return true;
+        });
+        mockReplay.setPlayPosition.mockImplementation((_mode: unknown, frame: number) => {
+          cursor.frame = Math.max(0, Math.min(bufferEnd, frame));
+
+          return true;
+        });
+        mockReplay.nextLap.mockImplementation(() => {
+          const session = findSession(cursor.frame);
+
+          if (!session) return false;
+
+          const relFrame = cursor.frame - session.startFrame;
+          const lap = Math.floor(relFrame / session.framesPerLap);
+
+          cursor.frame = Math.min(bufferEnd, session.startFrame + (lap + 1) * session.framesPerLap);
+
+          return true;
+        });
+        mockReplay.prevLap.mockImplementation(() => {
+          const session = findSession(cursor.frame);
+
+          if (!session) return false;
+
+          const relFrame = cursor.frame - session.startFrame;
+          const lap = Math.floor(relFrame / session.framesPerLap);
+          // Last frame of the PREVIOUS lap (lap-1, dist ≈ 0.999).
+          const prevLapEnd = session.startFrame + lap * session.framesPerLap - 1;
+
+          cursor.frame = Math.max(session.startFrame, prevLapEnd);
+
+          return true;
+        });
 
         action.sdkController.getCurrentTelemetry = vi.fn(() => {
-          const currentLaps: number[] = [];
+          const session = findSession(cursor.frame);
 
-          currentLaps[carIdx] = state.currentLap;
+          if (!session) {
+            return {
+              CamCarIdx: carIdx,
+              ReplayFrameNum: cursor.frame,
+              SessionNum: -1,
+              SessionUniqueID: 0,
+              CarIdxLap: [],
+              CarIdxLapDistPct: [],
+              CarIdxBestLapNum: [],
+            } as any;
+          }
+
+          const relFrame = cursor.frame - session.startFrame;
+          const lap = Math.floor(relFrame / session.framesPerLap);
+          const dist = (relFrame % session.framesPerLap) / session.framesPerLap;
+          const lapArr: number[] = [];
+          const distArr: number[] = [];
+
+          lapArr[carIdx] = lap;
+          distArr[carIdx] = dist;
 
           return {
             CamCarIdx: carIdx,
-            CarIdxBestLapNum: bestLapNums,
-            CarIdxLap: currentLaps,
+            ReplayFrameNum: cursor.frame,
+            SessionNum: session.sessionNum,
+            SessionUniqueID: session.sessionUniqueId,
+            CarIdxLap: lapArr,
+            CarIdxLapDistPct: distArr,
+            CarIdxBestLapNum: [],
           } as any;
         });
 
-        if (opts.advanceOnNext !== false) {
-          mockReplay.nextLap.mockImplementation(() => {
-            state.currentLap++;
+        action.sdkController.getSessionInfo = vi.fn(
+          () =>
+            ({
+              DriverInfo: { DriverCarIdx: opts.driverCarIdx ?? carIdx },
+              SessionInfo: {
+                Sessions: sessions.map((s) => ({
+                  SessionNum: s.sessionNum,
+                  ResultsPositions: [{ CarIdx: carIdx, FastestLap: s.fastestLap }],
+                })),
+              },
+            }) as any,
+        );
 
-            return true;
-          });
-        }
-
-        if (opts.advanceOnPrev !== false) {
-          mockReplay.prevLap.mockImplementation(() => {
-            state.currentLap--;
-
-            return true;
-          });
-        }
-
-        return state;
+        return { cursor, sessions, bufferEnd, findSession };
       }
 
-      it("walks the cursor up to one lap before the fastest lap (forward)", async () => {
-        vi.useFakeTimers();
+      /**
+       * Single-session buffer with a default layout: SessionNum=2,
+       * SessionUniqueID=3, frame range [0, 9999], 1000 frames per lap.
+       * `initialCursor` starts at a frame inside that session so the
+       * dispatch's first telemetry read sees `SessionNum=2`.
+       */
+      function singleSessionBuffer(carIdx: number, fastestLap: number, opts: { initialCursor?: number } = {}) {
+        return multiSessionBuffer(
+          carIdx,
+          [
+            {
+              sessionNum: 2,
+              sessionUniqueId: 3,
+              startFrame: 0,
+              endFrame: 9999,
+              framesPerLap: 1000,
+              fastestLap,
+            },
+          ],
+          { initialCursor: opts.initialCursor ?? 5000 },
+        );
+      }
 
-        try {
-          // FastestLap = 10 means iRacing's nextLap would land on the end of
-          // lap 10; subtract 1 so the cursor ends at the start of lap 10.
-          const state = liveCursor(4, 10, { startLap: 5 });
+      describe("session map building", () => {
+        it("builds a map via goToStart + nextSession × N + goToEnd on first press", async () => {
+          vi.useFakeTimers();
 
-          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-
-          expect(mockCamera.switchNum).toHaveBeenCalledWith(4, 0, 0);
-          await vi.runAllTimersAsync();
-
-          // Walker target = 10 - 1 = 9. From lap 5 → lap 9 = 4 steps.
-          expect(state.currentLap).toBe(9);
-          expect(mockReplay.nextLap).toHaveBeenCalledTimes(4);
-          expect(mockReplay.prevLap).not.toHaveBeenCalled();
-        } finally {
-          vi.useRealTimers();
-        }
-      });
-
-      it("walks the cursor down to one lap before the fastest lap (backward)", async () => {
-        vi.useFakeTimers();
-
-        try {
-          const state = liveCursor(2, 3, { startLap: 8 });
-
-          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-
-          expect(mockCamera.switchNum).toHaveBeenCalledWith(2, 0, 0);
-          await vi.runAllTimersAsync();
-
-          // Walker target = 3 - 1 = 2. From lap 8 → lap 2 = 6 steps.
-          expect(state.currentLap).toBe(2);
-          expect(mockReplay.prevLap).toHaveBeenCalledTimes(6);
-          expect(mockReplay.nextLap).not.toHaveBeenCalled();
-        } finally {
-          vi.useRealTimers();
-        }
-      });
-
-      it("retries on dropped messages — re-sends nextLap when the cursor didn't advance", async () => {
-        vi.useFakeTimers();
-
-        try {
-          // Simulate iRacing dropping every other ReplaySearch broadcast: only
-          // every second call actually advances the cursor.
-          const state = { currentLap: 0 };
-          let callIdx = 0;
-
-          mockReplay.nextLap.mockImplementation(() => {
-            if (callIdx++ % 2 === 0) state.currentLap++;
-
-            return true;
-          });
-
-          const bestLapNums: number[] = [];
-
-          // FastestLap = 5 → walker target = 4.
-          bestLapNums[3] = 5;
-
-          action.sdkController.getCurrentTelemetry = vi.fn(() => {
-            const currentLaps: number[] = [];
-
-            currentLaps[3] = state.currentLap;
-
-            return { CamCarIdx: 3, CarIdxBestLapNum: bestLapNums, CarIdxLap: currentLaps } as any;
-          });
-
-          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-          await vi.runAllTimersAsync();
-
-          // Cursor should still reach the walker target (4) — the walker just
-          // calls nextLap more times to compensate for the dropped messages.
-          expect(state.currentLap).toBe(4);
-          // 7 calls = 4 that landed (callIdx 0,2,4,6) + 3 dropped retries
-          // (callIdx 1,3,5). The walker detects target reached on iteration 8
-          // before sending another step.
-          expect(mockReplay.nextLap).toHaveBeenCalledTimes(7);
-        } finally {
-          vi.useRealTimers();
-        }
-      });
-
-      it("does no lap steps when the cursor is already at the start of the fastest lap", async () => {
-        // FastestLap=7 → walker target=6. Cursor at lap 6 already means the
-        // cursor is sitting at the end of lap 6 = start of lap 7.
-        liveCursor(1, 7, { startLap: 6, advanceOnNext: false, advanceOnPrev: false });
-
-        await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-        await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-
-        expect(mockCamera.switchNum).toHaveBeenCalledWith(1, 0, 0);
-        expect(mockReplay.nextLap).not.toHaveBeenCalled();
-        expect(mockReplay.prevLap).not.toHaveBeenCalled();
-      });
-
-      it("uses DriverCarIdx (not CamCarIdx) when target is always-my-car", async () => {
-        vi.useFakeTimers();
-
-        try {
-          const state = { currentLap: 2 };
-          const bestLapNums: number[] = [];
-
-          // FastestLap = 4 → walker target = 3. From cursor=2, 1 step needed.
-          bestLapNums[3] = 4;
-
-          action.sdkController.getCurrentTelemetry = vi.fn(() => {
-            const currentLaps: number[] = [];
-
-            currentLaps[3] = state.currentLap;
-
-            return {
-              CamCarIdx: 99, // viewer is watching some other car
-              CarIdxBestLapNum: bestLapNums,
-              CarIdxLap: currentLaps,
-            } as any;
-          });
-          action.sdkController.getSessionInfo = vi.fn(() => ({ DriverInfo: { DriverCarIdx: 3 } }) as any);
-          mockReplay.nextLap.mockImplementation(() => {
-            state.currentLap++;
-
-            return true;
-          });
-
-          await action.onWillAppear(
-            fakeEvent("ctx-1", { mode: "jump-to-fastest-lap", fastestLapTarget: "always-my-car" }) as any,
-          );
-          await action.onKeyDown(
-            fakeEvent("ctx-1", { mode: "jump-to-fastest-lap", fastestLapTarget: "always-my-car" }) as any,
-          );
-          await vi.runAllTimersAsync();
-
-          expect(mockCamera.switchNum).toHaveBeenCalledWith(3, 0, 0);
-          expect(state.currentLap).toBe(3);
-          expect(mockReplay.nextLap).toHaveBeenCalledTimes(1);
-        } finally {
-          vi.useRealTimers();
-        }
-      });
-
-      it("warns when the target car has no resolvable car number", async () => {
-        vi.mocked(getCarNumberRawFromSessionInfo).mockReturnValue(null);
-        liveCursor(2, 5, { startLap: 3, advanceOnNext: false });
-
-        await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-        await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-
-        expect(mockCamera.switchNum).not.toHaveBeenCalled();
-        expect(mockReplay.nextLap).not.toHaveBeenCalled();
-        expect(action.logger.warn).toHaveBeenCalledWith(expect.stringContaining("car number"));
-      });
-
-      it("bails when the cursor is stuck (target unreachable)", async () => {
-        vi.useFakeTimers();
-
-        try {
-          // Cursor never advances — simulates the replay buffer not reaching
-          // the target lap.
-          liveCursor(2, 50, { startLap: 0, advanceOnNext: false });
-
-          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-          await vi.runAllTimersAsync();
-
-          // LAP_WALK_STUCK_LIMIT (5) consecutive no-progress iterations before
-          // bail; nextLap is called on iterations 1..5 (iter 6 detects stuck
-          // and returns without sending).
-          expect(mockReplay.nextLap).toHaveBeenCalledTimes(5);
-          expect(action.logger.warn).toHaveBeenCalledWith(expect.stringContaining("stuck"));
-        } finally {
-          vi.useRealTimers();
-        }
-      });
-
-      it("hits the MAX_LAP_SEARCH_STEPS safety cap on a wildly large delta", async () => {
-        vi.useFakeTimers();
-
-        try {
-          // Target far beyond what the iteration cap permits; cursor keeps
-          // advancing on every call (no stuck bail).
-          liveCursor(0, 10_000, { startLap: 0 });
-
-          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-          await vi.runAllTimersAsync();
-
-          // Walker exits after MAX_LAP_SEARCH_STEPS body iterations.
-          expect(mockReplay.nextLap).toHaveBeenCalledTimes(150);
-          expect(action.logger.warn).toHaveBeenCalledWith(expect.stringContaining("safety cap"));
-        } finally {
-          vi.useRealTimers();
-        }
-      });
-
-      it("ignores a second press while a walk is already in flight on the same context", async () => {
-        vi.useFakeTimers();
-
-        try {
-          // FastestLap = 10 → walker target = 9. From cursor=0, 9 steps.
-          liveCursor(2, 10, { startLap: 0 });
-
-          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-
-          // First press kicks off the walker; before the timers drain, a second
-          // press arrives. The second press should not double-fire steps.
-          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-
-          await vi.runAllTimersAsync();
-
-          // Only the first walk drove the cursor; second press was no-op
-          // (verified by count = exactly the delta).
-          expect(mockReplay.nextLap).toHaveBeenCalledTimes(9);
-        } finally {
-          vi.useRealTimers();
-        }
-      });
-
-      it("uses ResultsPositions when telemetry CarIdxBestLapNum is empty (freshly-loaded replay)", async () => {
-        vi.useFakeTimers();
-
-        try {
-          // Replay load case: SessionInfo has authoritative ResultsPositions but
-          // CarIdxBestLapNum hasn't been populated yet because the cursor hasn't
-          // walked the laps. Without the ResultsPositions path this would no-op.
-          const state = { currentLap: 0 };
-
-          action.sdkController.getCurrentTelemetry = vi.fn(() => {
-            const currentLaps: number[] = [];
-
-            currentLaps[4] = state.currentLap;
-
-            return {
-              CamCarIdx: 4,
-              SessionNum: 2,
-              // CarIdxBestLapNum intentionally omitted (or empty)
-              CarIdxLap: currentLaps,
-            } as any;
-          });
-          action.sdkController.getSessionInfo = vi.fn(
-            () =>
-              ({
-                SessionInfo: {
-                  Sessions: [
-                    { SessionNum: 0, ResultsPositions: [{ CarIdx: 4, FastestLap: 99 }] },
-                    { SessionNum: 2, ResultsPositions: [{ CarIdx: 4, FastestLap: 8 }] },
-                  ],
+          try {
+            multiSessionBuffer(
+              4,
+              [
+                { sessionNum: 0, sessionUniqueId: 1, startFrame: 0, endFrame: 999, framesPerLap: 100, fastestLap: -1 },
+                {
+                  sessionNum: 1,
+                  sessionUniqueId: 2,
+                  startFrame: 1000,
+                  endFrame: 4999,
+                  framesPerLap: 1000,
+                  fastestLap: 2,
                 },
-              }) as any,
-          );
-          mockReplay.nextLap.mockImplementation(() => {
-            state.currentLap++;
+                {
+                  sessionNum: 2,
+                  sessionUniqueId: 3,
+                  startFrame: 5000,
+                  endFrame: 14_999,
+                  framesPerLap: 1000,
+                  fastestLap: 4,
+                },
+              ],
+              { initialCursor: 8000 },
+            );
 
-            return true;
-          });
+            await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await vi.runAllTimersAsync();
 
-          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-          await vi.runAllTimersAsync();
+            expect(mockReplay.goToStart).toHaveBeenCalled();
+            // 3 sessions → 3 nextSession calls (last one is the no-op detector).
+            expect(mockReplay.nextSession.mock.calls.length).toBeGreaterThanOrEqual(2);
+            expect(mockReplay.goToEnd).toHaveBeenCalled();
 
-          expect(mockCamera.switchNum).toHaveBeenCalledWith(4, 0, 0);
-          // FastestLap = 8 (Session 2's value, not Session 0's 99) → walker
-          // target = 7. From cursor=0, 7 steps to reach lap 7 (= start of lap 8).
-          expect(state.currentLap).toBe(7);
-          expect(mockReplay.nextLap).toHaveBeenCalledTimes(7);
-          expect(mockReplay.prevLap).not.toHaveBeenCalled();
-        } finally {
-          vi.useRealTimers();
-        }
+            const cache = _getFastestLapSessionCache();
+
+            expect(cache).not.toBeNull();
+            expect([...(cache?.sessionUniqueIds ?? [])].sort()).toEqual([1, 2, 3]);
+            expect(cache?.sessions.map((s) => s.sessionNum)).toEqual([0, 1, 2]);
+          } finally {
+            vi.useRealTimers();
+          }
+        });
+
+        it("computes each session's endFrame as the next session's startFrame - 1", async () => {
+          vi.useFakeTimers();
+
+          try {
+            multiSessionBuffer(
+              4,
+              [
+                { sessionNum: 0, sessionUniqueId: 1, startFrame: 0, endFrame: 999, framesPerLap: 100, fastestLap: -1 },
+                {
+                  sessionNum: 2,
+                  sessionUniqueId: 3,
+                  startFrame: 1000,
+                  endFrame: 10_999,
+                  framesPerLap: 1000,
+                  fastestLap: 4,
+                },
+              ],
+              { initialCursor: 5000 },
+            );
+
+            await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await vi.runAllTimersAsync();
+
+            const cache = _getFastestLapSessionCache();
+
+            expect(cache?.sessions[0].endFrame).toBe(999); // session 2's startFrame - 1
+            expect(cache?.sessions[1].endFrame).toBe(10_999); // bufferEnd
+          } finally {
+            vi.useRealTimers();
+          }
+        });
       });
 
-      it("bails immediately when CarIdxLap for the target car is unavailable", async () => {
-        vi.useFakeTimers();
+      describe("session map cache (Set-of-uniqueIds)", () => {
+        it("reuses the cached map when current SessionUniqueID is in the Set", async () => {
+          vi.useFakeTimers();
 
-        try {
-          // CarIdxBestLapNum populated (so targetLap resolves) but CarIdxLap
-          // for that car isn't — walker can't compute delta, returns silently.
-          const bestLapNums: number[] = [];
+          try {
+            multiSessionBuffer(
+              4,
+              [
+                { sessionNum: 0, sessionUniqueId: 1, startFrame: 0, endFrame: 999, framesPerLap: 100, fastestLap: -1 },
+                {
+                  sessionNum: 2,
+                  sessionUniqueId: 3,
+                  startFrame: 1000,
+                  endFrame: 10_999,
+                  framesPerLap: 1000,
+                  fastestLap: 4,
+                },
+              ],
+              { initialCursor: 5000 },
+            );
 
-          bestLapNums[5] = 8;
-          action.sdkController.getCurrentTelemetry = vi.fn(
-            () =>
-              ({
-                CamCarIdx: 5,
-                CarIdxBestLapNum: bestLapNums,
-                // CarIdxLap intentionally omitted
-              }) as any,
-          );
+            await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await vi.runAllTimersAsync();
 
-          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-          await vi.runAllTimersAsync();
+            mockReplay.goToStart.mockClear();
+            mockReplay.nextSession.mockClear();
+            mockReplay.goToEnd.mockClear();
 
-          expect(mockCamera.switchNum).toHaveBeenCalledWith(5, 0, 0);
-          expect(mockReplay.nextLap).not.toHaveBeenCalled();
-          expect(mockReplay.prevLap).not.toHaveBeenCalled();
-        } finally {
-          vi.useRealTimers();
-        }
+            // Second press: should reuse the map (no new goToStart / nextSession / goToEnd).
+            await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await vi.runAllTimersAsync();
+
+            expect(mockReplay.goToStart).not.toHaveBeenCalled();
+            expect(mockReplay.nextSession).not.toHaveBeenCalled();
+            expect(mockReplay.goToEnd).not.toHaveBeenCalled();
+          } finally {
+            vi.useRealTimers();
+          }
+        });
+
+        it("rebuilds when current SessionUniqueID is not in the cached Set (new race weekend)", async () => {
+          vi.useFakeTimers();
+
+          try {
+            // First press: a race weekend with uniqueIds {1, 3}
+            const firstWeekend = multiSessionBuffer(
+              4,
+              [
+                { sessionNum: 0, sessionUniqueId: 1, startFrame: 0, endFrame: 999, framesPerLap: 100, fastestLap: -1 },
+                {
+                  sessionNum: 2,
+                  sessionUniqueId: 3,
+                  startFrame: 1000,
+                  endFrame: 10_999,
+                  framesPerLap: 1000,
+                  fastestLap: 4,
+                },
+              ],
+              { initialCursor: 5000 },
+            );
+
+            await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await vi.runAllTimersAsync();
+
+            expect(firstWeekend.cursor).toBeTruthy();
+            expect([...(_getFastestLapSessionCache()?.sessionUniqueIds ?? [])].sort()).toEqual([1, 3]);
+
+            // Second press: new race weekend with all-different uniqueIds.
+            multiSessionBuffer(
+              4,
+              [
+                {
+                  sessionNum: 0,
+                  sessionUniqueId: 10,
+                  startFrame: 0,
+                  endFrame: 999,
+                  framesPerLap: 100,
+                  fastestLap: -1,
+                },
+                {
+                  sessionNum: 2,
+                  sessionUniqueId: 11,
+                  startFrame: 1000,
+                  endFrame: 10_999,
+                  framesPerLap: 1000,
+                  fastestLap: 4,
+                },
+              ],
+              { initialCursor: 5000 },
+            );
+
+            mockReplay.goToStart.mockClear();
+            mockReplay.nextSession.mockClear();
+            mockReplay.goToEnd.mockClear();
+
+            await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await vi.runAllTimersAsync();
+
+            // Cache miss → rebuild → new goToStart / nextSession / goToEnd.
+            expect(mockReplay.goToStart).toHaveBeenCalled();
+            expect(mockReplay.nextSession).toHaveBeenCalled();
+            expect(mockReplay.goToEnd).toHaveBeenCalled();
+            // New cache contains the new uniqueIds.
+            expect([...(_getFastestLapSessionCache()?.sessionUniqueIds ?? [])].sort()).toEqual([10, 11]);
+          } finally {
+            vi.useRealTimers();
+          }
+        });
       });
 
-      it("reads fastestLapSearchDelayMs live on every iteration", async () => {
-        vi.useFakeTimers();
+      describe("per-car frame cache", () => {
+        it("stores the landed frame after a successful walk", async () => {
+          vi.useFakeTimers();
 
-        try {
-          const { getGlobalSettings } = await import("@iracedeck/deck-core");
-          // Start with a fast delay.
-          vi.mocked(getGlobalSettings).mockReturnValue({ fastestLapSearchDelayMs: 100 } as any);
+          try {
+            singleSessionBuffer(4, 4);
 
-          // FastestLap = 5 → walker target = 4. From cursor=0: 4 steps.
-          liveCursor(2, 5, { startLap: 0 });
+            await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await vi.runAllTimersAsync();
 
-          await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
-          await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            const cache = _getFastestLapSessionCache();
 
-          // iter 1: step fires immediately; walker is now sleeping on gap=100ms
-          // (read at the end of iter 1, before the change below).
-          expect(mockReplay.nextLap).toHaveBeenCalledTimes(1);
+            expect(cache?.fastestLapFrames.has("4|4|2")).toBe(true);
+            expect(typeof cache?.fastestLapFrames.get("4|4|2")).toBe("number");
+          } finally {
+            vi.useRealTimers();
+          }
+        });
 
-          // Change the mock — iter 2's gap read (still 100ms below) won't see
-          // this, but iter 3 onward will.
-          vi.mocked(getGlobalSettings).mockReturnValue({ fastestLapSearchDelayMs: 500 } as any);
+        it("uses the cached frame on the next press (single setPlayPosition, no walk)", async () => {
+          vi.useFakeTimers();
 
-          // 100ms elapses → iter 2 fires (gap from iter 1 was 100), reads
-          // currentLap=1, sends step, then reads the new gap=500.
-          await vi.advanceTimersByTimeAsync(100);
-          expect(mockReplay.nextLap).toHaveBeenCalledTimes(2);
+          try {
+            singleSessionBuffer(4, 4);
 
-          // 400ms isn't enough — iter 3's sleep is 500ms.
-          await vi.advanceTimersByTimeAsync(400);
-          expect(mockReplay.nextLap).toHaveBeenCalledTimes(2);
+            await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await vi.runAllTimersAsync();
 
-          // 100ms more → 500ms total since iter 2 ended; iter 3 fires.
-          await vi.advanceTimersByTimeAsync(100);
-          expect(mockReplay.nextLap).toHaveBeenCalledTimes(3);
+            const cachedFrame = _getFastestLapSessionCache()?.fastestLapFrames.get("4|4|2");
 
-          // Drain remaining iterations (iter 4 finishes at cursor=4 = target).
-          await vi.runAllTimersAsync();
-          expect(mockReplay.nextLap).toHaveBeenCalledTimes(4);
-        } finally {
-          vi.useRealTimers();
-        }
+            expect(cachedFrame).toBeDefined();
+
+            mockReplay.setPlayPosition.mockClear();
+            mockReplay.nextLap.mockClear();
+            mockReplay.prevLap.mockClear();
+
+            await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await vi.runAllTimersAsync();
+
+            // Exactly one setPlayPosition (the cache-jump). No lap-step.
+            expect(mockReplay.setPlayPosition).toHaveBeenCalledTimes(1);
+            expect(mockReplay.setPlayPosition).toHaveBeenCalledWith(expect.anything(), cachedFrame);
+            expect(mockReplay.nextLap).not.toHaveBeenCalled();
+            expect(mockReplay.prevLap).not.toHaveBeenCalled();
+          } finally {
+            vi.useRealTimers();
+          }
+        });
+
+        it("misses when targetLap changes (player set a new fastest lap)", async () => {
+          vi.useFakeTimers();
+
+          try {
+            // First press: fastestLap = 4
+            const buffer = singleSessionBuffer(4, 4);
+
+            await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await vi.runAllTimersAsync();
+
+            // Switch to a buffer where the same car set a new fastest lap = 6.
+            // Reuses the same session unique-id so the session map cache hits.
+            multiSessionBuffer(
+              4,
+              [
+                {
+                  sessionNum: 2,
+                  sessionUniqueId: 3,
+                  startFrame: 0,
+                  endFrame: 9999,
+                  framesPerLap: 1000,
+                  fastestLap: 6,
+                },
+              ],
+              { initialCursor: buffer.cursor.frame },
+            );
+
+            mockReplay.setPlayPosition.mockClear();
+
+            await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await vi.runAllTimersAsync();
+
+            // Different key (4|6|2) → cache miss → full walk.
+            expect(mockReplay.setPlayPosition.mock.calls.length).toBeGreaterThan(1);
+            // After the walk both keys are in the cache.
+            const cache = _getFastestLapSessionCache();
+
+            expect(cache?.fastestLapFrames.has("4|4|2")).toBe(true);
+            expect(cache?.fastestLapFrames.has("4|6|2")).toBe(true);
+          } finally {
+            vi.useRealTimers();
+          }
+        });
       });
 
-      it("clamps an out-of-range fastestLapSearchDelayMs setting", async () => {
-        vi.useFakeTimers();
+      describe("walk phases (end-to-end on a single-session buffer)", () => {
+        it("lands at lap === targetLap - 1 with dist ≥ 0.999 (= end of lap before fastest)", async () => {
+          vi.useFakeTimers();
 
-        try {
-          const { getGlobalSettings } = await import("@iracedeck/deck-core");
-          // 5000 ms is above the 1000 ms cap — should clamp to 1000.
-          vi.mocked(getGlobalSettings).mockReturnValue({ fastestLapSearchDelayMs: 5000 } as any);
+          try {
+            // Fastest lap = 4 → target = lap 3. In the single-session buffer
+            // (1000 frames per lap), end of lap 3 = frame 3 * 1000 + 999 = 3999.
+            const buffer = singleSessionBuffer(4, 4);
 
-          // FastestLap = 3 → walker target = 2. From cursor=0: 2 steps total
-          // (gives us one inter-step delay to verify the clamp).
-          liveCursor(2, 3, { startLap: 0 });
+            await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await vi.runAllTimersAsync();
+
+            // After bisection + lap-step + nudge + 2-tick back-step, the cursor
+            // should be at end-of-lap-3 minus 2 ticks (~3997).
+            expect(buffer.cursor.frame).toBeGreaterThanOrEqual(3990);
+            expect(buffer.cursor.frame).toBeLessThanOrEqual(3999);
+          } finally {
+            vi.useRealTimers();
+          }
+        });
+
+        it("calls nextSession to skip past sessions before the target session", async () => {
+          vi.useFakeTimers();
+
+          try {
+            multiSessionBuffer(
+              4,
+              [
+                { sessionNum: 0, sessionUniqueId: 1, startFrame: 0, endFrame: 999, framesPerLap: 100, fastestLap: -1 },
+                {
+                  sessionNum: 1,
+                  sessionUniqueId: 2,
+                  startFrame: 1000,
+                  endFrame: 4999,
+                  framesPerLap: 1000,
+                  fastestLap: 2,
+                },
+                {
+                  sessionNum: 2,
+                  sessionUniqueId: 3,
+                  startFrame: 5000,
+                  endFrame: 14_999,
+                  framesPerLap: 1000,
+                  fastestLap: 4,
+                },
+              ],
+              { initialCursor: 8000 },
+            );
+
+            await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await vi.runAllTimersAsync();
+
+            expect(mockReplay.nextSession.mock.calls.length).toBeGreaterThanOrEqual(2);
+          } finally {
+            vi.useRealTimers();
+          }
+        });
+
+        it("bisects within the target session bounds, not the whole buffer", async () => {
+          vi.useFakeTimers();
+
+          try {
+            // Two sessions: session 0 has 100 fast laps (frame 0-9999) we should
+            // NEVER probe in bisection; session 2 holds the target. Watch every
+            // setPlayPosition frame stays in session 2.
+            multiSessionBuffer(
+              4,
+              [
+                {
+                  sessionNum: 0,
+                  sessionUniqueId: 1,
+                  startFrame: 0,
+                  endFrame: 9999,
+                  framesPerLap: 100,
+                  fastestLap: -1,
+                },
+                {
+                  sessionNum: 2,
+                  sessionUniqueId: 3,
+                  startFrame: 10_000,
+                  endFrame: 19_999,
+                  framesPerLap: 1000,
+                  fastestLap: 4,
+                },
+              ],
+              { initialCursor: 12_000 },
+            );
+
+            await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await vi.runAllTimersAsync();
+
+            // Bisection-driven setPlayPosition calls (skip the trailing back-step).
+            const bisectionFrames = mockReplay.setPlayPosition.mock.calls.slice(0, -1).map((call) => call[1] as number);
+
+            for (const frame of bisectionFrames) {
+              expect(frame).toBeGreaterThanOrEqual(10_000);
+              expect(frame).toBeLessThanOrEqual(19_999);
+            }
+          } finally {
+            vi.useRealTimers();
+          }
+        });
+
+        it("calls nextLap / prevLap during the lap-step phase", async () => {
+          vi.useFakeTimers();
+
+          try {
+            singleSessionBuffer(4, 4, { initialCursor: 5000 });
+
+            await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await vi.runAllTimersAsync();
+
+            // Either nextLap or prevLap fires at least once during the lap-step
+            // and nudge phases — whichever direction reaches lap=3.
+            const totalLapStepCalls = mockReplay.nextLap.mock.calls.length + mockReplay.prevLap.mock.calls.length;
+
+            expect(totalLapStepCalls).toBeGreaterThan(0);
+          } finally {
+            vi.useRealTimers();
+          }
+        });
+
+        it("does a single setPlayPosition(Begin, frame - 2) for the back-step", async () => {
+          vi.useFakeTimers();
+
+          try {
+            singleSessionBuffer(4, 4);
+
+            await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await vi.runAllTimersAsync();
+
+            // The LAST setPlayPosition is the 2-tick back-step. Frame just
+            // before it (= the pre-back-step cursor position) should be 2
+            // frames higher than the LAST setPlayPosition's target.
+            const calls = mockReplay.setPlayPosition.mock.calls;
+            const lastTargetFrame = calls[calls.length - 1][1] as number;
+            const secondLastTargetFrame = calls[calls.length - 2]?.[1] as number | undefined;
+
+            // The very last call IS the back-step. It targets a frame 2 less
+            // than the frame the cursor sat on right before it.
+            expect(typeof secondLastTargetFrame).toBe("number");
+            // Cursor frame just before back-step is at end-of-lap-3 ≈ 3999.
+            // Back-step target is 3999 - 2 = 3997.
+            expect(lastTargetFrame).toBeLessThanOrEqual(3997);
+            expect(lastTargetFrame).toBeGreaterThanOrEqual(3995);
+          } finally {
+            vi.useRealTimers();
+          }
+        });
+      });
+
+      describe("guards", () => {
+        it("ignores a second press while a walk is already in flight on the same context", async () => {
+          vi.useFakeTimers();
+
+          try {
+            singleSessionBuffer(4, 4);
+
+            await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            // Second press while the first is still in-flight (timers not drained).
+            await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
+            await vi.runAllTimersAsync();
+
+            // pause was called only once (by the first walk; the second was a no-op).
+            expect(mockReplay.pause).toHaveBeenCalledTimes(1);
+          } finally {
+            vi.useRealTimers();
+          }
+        });
+
+        it("uses DriverCarIdx (not CamCarIdx) when target is always-my-car", async () => {
+          vi.useFakeTimers();
+
+          try {
+            multiSessionBuffer(
+              3,
+              [
+                {
+                  sessionNum: 2,
+                  sessionUniqueId: 3,
+                  startFrame: 0,
+                  endFrame: 9999,
+                  framesPerLap: 1000,
+                  fastestLap: 4,
+                },
+              ],
+              { driverCarIdx: 3 },
+            );
+            // CamCarIdx is 3 by default in multiSessionBuffer — override telemetry
+            // so the camera is on a DIFFERENT car (99).
+            const originalGetTelemetry = action.sdkController.getCurrentTelemetry;
+
+            action.sdkController.getCurrentTelemetry = vi.fn(() => {
+              const tel = (originalGetTelemetry as any)() as any;
+
+              return { ...tel, CamCarIdx: 99 };
+            });
+
+            await action.onWillAppear(
+              fakeEvent("ctx-1", { mode: "jump-to-fastest-lap", fastestLapTarget: "always-my-car" }) as any,
+            );
+            await action.onKeyDown(
+              fakeEvent("ctx-1", { mode: "jump-to-fastest-lap", fastestLapTarget: "always-my-car" }) as any,
+            );
+            await vi.runAllTimersAsync();
+
+            // Camera switched to the driver's car (idx 3), NOT the viewed car (99).
+            expect(mockCamera.switchNum).toHaveBeenCalledWith(3, 0, 0);
+            // Cache key uses driverCarIdx=3.
+            const cache = _getFastestLapSessionCache();
+
+            expect(cache?.fastestLapFrames.has("3|4|2")).toBe(true);
+          } finally {
+            vi.useRealTimers();
+          }
+        });
+
+        it("warns when the target car has no resolvable car number", async () => {
+          vi.mocked(getCarNumberRawFromSessionInfo).mockReturnValue(null);
+          action.sdkController.getCurrentTelemetry = vi.fn(() => telemetryWithBest(2, 5, 3) as any);
 
           await action.onWillAppear(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
           await action.onKeyDown(fakeEvent("ctx-1", { mode: "jump-to-fastest-lap" }) as any);
 
-          expect(mockReplay.nextLap).toHaveBeenCalledTimes(1);
-          // 999 ms — below the clamped cap, no additional fires yet.
-          await vi.advanceTimersByTimeAsync(999);
-          expect(mockReplay.nextLap).toHaveBeenCalledTimes(1);
-          // 1 more ms = 1000 total → next step fires.
-          await vi.advanceTimersByTimeAsync(1);
-          expect(mockReplay.nextLap).toHaveBeenCalledTimes(2);
-        } finally {
-          vi.useRealTimers();
-        }
+          expect(mockCamera.switchNum).not.toHaveBeenCalled();
+          expect(mockReplay.pause).not.toHaveBeenCalled();
+          expect(action.logger.warn).toHaveBeenCalledWith(expect.stringContaining("car number"));
+        });
       });
     });
 

--- a/packages/iracing-actions/src/actions/replay-control/replay-control.ts
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.ts
@@ -62,6 +62,7 @@ import {
   getAllCarNumbers,
   getCarNumberFromSessionInfo,
   getCarNumberRawFromSessionInfo,
+  ReplayPosMode,
   type TelemetryData,
 } from "@iracedeck/iracing-sdk";
 import z from "zod";
@@ -224,13 +225,163 @@ const LONG_PRESS_REPEAT_GAP_MS = 250;
 const LONG_PRESS_MAX_DURATION_MS = 15_000;
 
 /**
- * Safety cap on iterations the adaptive lap walker performs in a single
- * press. Combined with `REPLAY_LAP_SEARCH_GAP_MS`, this bounds the worst-case
- * wall-clock time at MAX × GAP. Each iteration reads telemetry first, so a
- * normal delta finishes in `delta + a-few-retries` iterations; the cap only
- * trips on a pathological scenario.
+ * Safety cap on bisection iterations (issue #607). log₂(N) jumps converge in
+ * ~24 steps for a 2-hour endurance replay at 60 Hz (~430 k frames), so 30 is
+ * a comfortable engineering ceiling that only trips on a pathological case
+ * (an `inWorld` predicate that never converges because the car was never
+ * in-world at any reachable frame). Distinct from the old `MAX_LAP_SEARCH_STEPS`
+ * cap, which had to absorb O(N) lap-by-lap walks and a `× gap` wall-clock
+ * budget — the bisection's wall-clock is ~`30 × gap` worst case.
  */
-const MAX_LAP_SEARCH_STEPS = 150;
+const MAX_BISECTION_STEPS = 30;
+
+// Issue #607 follow-up #3: live testing showed that bisecting on the whole
+// replay buffer doesn't reliably find the fastest lap when the target lap
+// sits in a non-current session (e.g. user in race trying to find quali's
+// fastest). Replaced the buffer-wide bisection with a three-phase walk:
+//
+//   1. Session map. On the first walk per `SessionUniqueID`, navigate
+//      `goToStart` → `nextSession` × N → `goToEnd`, recording the start
+//      frame of each session and the buffer's end frame. Cached at module
+//      scope and reused for every subsequent walk on the same replay.
+//   2. Bisect within the target session's bounds (looked up from the cache)
+//      until `CarIdxLap[carIdx]` is within `CLOSE_ENOUGH_LAPS` of the target
+//      — much faster than the prior whole-buffer bisection, and immune to
+//      cross-session lap-number weirdness.
+//   3. Lap-step refinement: `nextLap` / `prevLap` until `CarIdxLap[carIdx]
+//      === targetLap`. iRacing's lap-step lands at a clean lap boundary, so
+//      no backstep is needed to land at the start of the fastest lap.
+
+/**
+ * After bisection, the lap-step phase takes over. `CLOSE_ENOUGH_LAPS = 2`
+ * means the bisection exits when the player car is within 2 laps of the
+ * target either way — the lap-step phase finishes the job with at most a
+ * few `nextLap` / `prevLap` calls.
+ */
+const CLOSE_ENOUGH_LAPS = 2;
+
+/**
+ * Safety cap on the lap-step phase. iRacing's lap navigation is precise so
+ * this should never trip in practice; it exists for the case where the
+ * SDK's reported `CarIdxLap` doesn't change after a `nextLap` / `prevLap`
+ * broadcast (e.g. cursor at the buffer edge).
+ */
+const MAX_LAP_STEPS = 10;
+
+/**
+ * Sanity cap on the number of sessions in a single replay. Most iRacing
+ * sessions have at most 4 (practice / qualifying / warmup / race); 10 is
+ * generous headroom.
+ */
+const MAX_SESSIONS = 10;
+
+/**
+ * Threshold for `CarIdxLapDistPct` (0..1) at which the cursor is "close
+ * enough to the end of the lap". After lap-step lands on the right lap,
+ * if dist is below this we do one extra `nextLap` (with `prevLap` recovery
+ * on overshoot) so the cursor parks at the very end of the lap-before-the-
+ * fastest, ready for a Play press to show the line-crossing.
+ */
+const FASTEST_LAP_DIST_THRESHOLD = 0.999;
+
+/**
+ * Number of `prevFrame` calls applied as the very last step. At 60 Hz that's
+ * ~16 ms per tick, so 2 ticks ≈ 32 ms of buffer before the line-crossing —
+ * the cursor lands far enough back that the next Play press shows the car
+ * visibly approaching, not already crossing.
+ */
+const FASTEST_LAP_FINAL_BACKSTEP_TICKS = 2;
+
+/**
+ * One session's frame bounds within the replay buffer. `endFrame` for the
+ * LAST session is the buffer's live edge at the time of the map build —
+ * it can lag the true live edge if the replay keeps growing, but the
+ * fastest lap typically sits well inside the recorded window anyway.
+ */
+type SessionMapEntry = {
+  sessionNum: number;
+  startFrame: number;
+  endFrame: number;
+};
+
+type FastestLapSessionMap = {
+  /**
+   * Every `SessionUniqueID` we observed while building the map (one per
+   * session — iRacing increments SessionUniqueID per session, not per race
+   * weekend, so a single race-weekend has N IDs for N sessions). The cache
+   * is reused whenever the current walk's SessionUniqueID matches ANY of
+   * these — a press in practice and a press in race both reuse the same
+   * map, but starting a new race weekend (all-new IDs) misses cleanly.
+   */
+  sessionUniqueIds: Set<number>;
+  sessions: SessionMapEntry[];
+  /**
+   * Per-car cache of the final cursor frame for a `(carIdx, targetLap,
+   * sessionNum)` triple. Populated at the end of every successful walk;
+   * subsequent presses with the same triple jump straight to the cached
+   * frame with a single `setPlayPosition`, skipping the bisection +
+   * lap-step + nudge + tick-back phases. Stale entries (when the car
+   * sets a new fastest lap) naturally fall through to a cache miss
+   * because the `targetLap` part of the key changes.
+   */
+  fastestLapFrames: Map<string, number>;
+};
+
+function fastestLapCacheKey(carIdx: number, targetLap: number, targetSessionNum: number): string {
+  return `${carIdx}|${targetLap}|${targetSessionNum}`;
+}
+
+/**
+ * Module-level cache of the session map. Reused whenever the current walk's
+ * `SessionUniqueID` is one of the IDs we observed while building, so a
+ * single map covers every session in the race weekend.
+ */
+let cachedFastestLapSessionMap: FastestLapSessionMap | null = null;
+
+/**
+ * @internal Exported for testing — clears the module-level session-map +
+ * per-car frame cache so each test starts from a clean slate.
+ */
+export function _resetFastestLapSessionCache(): void {
+  cachedFastestLapSessionMap = null;
+}
+
+/**
+ * @internal Exported for testing — exposes the current cache state so tests
+ * can assert the per-car frame Map contents without poking at module-private
+ * variables.
+ */
+export function _getFastestLapSessionCache(): FastestLapSessionMap | null {
+  return cachedFastestLapSessionMap;
+}
+
+/**
+ * Within-session lap+dist range. A score is `SessionNum * SESSION_STRIDE +
+ * (lap + dist)`; the stride must exceed any plausible (lap + dist) value so
+ * `session` is the dominant comparison dimension. 24-hour endurance at 200
+ * km/h on a 5 km track ≈ 960 laps, so 10_000 has a 10× margin.
+ */
+const SESSION_STRIDE = 10_000;
+
+/**
+ * Multiplier applied to the configured `fastestLapSearchDelayMs` to cap how
+ * long the bisection waits for telemetry to LEAVE the `SessionNum = -1`
+ * transient that iRacing publishes between a `setPlayPosition` broadcast
+ * landing and the cursor settling at the new frame (issue #607). The base
+ * settle is the configured delay (default 400 ms); the cap is `× 4`, so the
+ * worst-case wait per probe is `delay × 4` (default 1.6 s). Observed first-
+ * jump transient is ~514 ms after a paused-replay `setPlayPosition`, so this
+ * gives plenty of headroom while still keeping the common case fast (one
+ * post-poll read after a 50 ms wait).
+ */
+const STABILIZATION_TIMEOUT_MULTIPLIER = 4;
+
+/**
+ * Interval the bisection polls `getCurrentTelemetry()` at while waiting for
+ * `SessionNum` to leave the `-1` transient. 50 ms is ~3 sim ticks at 60 Hz
+ * — short enough to catch the transition promptly without spinning.
+ */
+const STABILIZATION_POLL_INTERVAL_MS = 50;
 
 /**
  * Default gap between consecutive replay lap-search broadcasts when the
@@ -262,14 +413,6 @@ function readFastestLapSearchDelayMs(): number {
 
   return Math.min(Math.max(value, REPLAY_LAP_SEARCH_GAP_MIN_MS), REPLAY_LAP_SEARCH_GAP_MAX_MS);
 }
-
-/**
- * Consecutive iterations the adaptive walker tolerates without the cursor
- * advancing before giving up. Covers the case where the cursor is at a
- * session boundary or the target lap is unreachable in the current replay
- * buffer.
- */
-const LAP_WALK_STUCK_LIMIT = 5;
 
 /**
  * @internal Exported for testing
@@ -569,6 +712,49 @@ export function findAdjacentCarByNumber(
   }
 }
 
+/**
+ * Result of sampling the player's score at one bisection probe (issue #607).
+ * The walker compares this to `targetScore` to pick the next half-bracket and
+ * to detect convergence; the discriminated union keeps the "is the car
+ * in-world at this frame" check inline so the consumer can't accidentally
+ * trust a stale `lap`/`dist` from a NotInWorld tick.
+ */
+type FastestLapBisectionProbe =
+  | { kind: "in-world"; sessionNum: number; lap: number; dist: number; score: number }
+  | { kind: "out-of-world"; sessionNum: number }
+  | { kind: "missing" };
+
+/**
+ * @internal Exported for testing.
+ *
+ * Compute the bisection score for the current frame from a telemetry sample.
+ * Returns `in-world` with a monotonic `score` (`SessionNum * SESSION_STRIDE
+ * + CarIdxLap + CarIdxLapDistPct`) when the target car has valid lap +
+ * distance fields; `out-of-world` when the car is gone (lap or dist below
+ * zero) but `SessionNum` is still readable; `missing` when even `SessionNum`
+ * isn't available (caller must abort). Mirrors the #603 `frameScore`
+ * convention so a future shared helper can absorb both.
+ */
+export function computeFastestLapBisectionProbe(
+  telemetry: TelemetryData | null,
+  carIdx: number,
+): FastestLapBisectionProbe {
+  const sessionNum = telemetry?.SessionNum;
+
+  if (typeof sessionNum !== "number") return { kind: "missing" };
+
+  const lap = (telemetry?.CarIdxLap as number[] | undefined)?.[carIdx];
+  const dist = (telemetry?.CarIdxLapDistPct as number[] | undefined)?.[carIdx];
+
+  if (typeof lap !== "number" || lap < 0 || typeof dist !== "number" || dist < 0) {
+    return { kind: "out-of-world", sessionNum };
+  }
+
+  const score = sessionNum * SESSION_STRIDE + lap + dist;
+
+  return { kind: "in-world", sessionNum, lap, dist, score };
+}
+
 const ReplayControlSettings = CommonSettings.extend({
   mode: z.enum(REPLAY_CONTROL_MODES).default("play-pause"),
   speed: z.string().default("1"),
@@ -841,17 +1027,31 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
   /**
    * @internal Exposed for testing.
    *
-   * Adaptive walker that drives the replay cursor to a target lap for a
-   * specific car. Reads `CarIdxLap[carIdx]` between each step and re-sends
-   * `nextLap`/`prevLap` when the cursor didn't advance — that recovers from
-   * iRacing dropping individual `ReplaySearch` broadcasts (the failure mode
-   * fixed-spacing bursts had at every tested gap, including 100 ms). Bails
-   * when the cursor sits still for {@link LAP_WALK_STUCK_LIMIT} consecutive
-   * iterations (e.g. target lap is outside the replay buffer) or when
-   * iterations reach {@link MAX_LAP_SEARCH_STEPS}. Only one walk per context
-   * runs at a time; second presses while one is in flight are ignored.
+   * Drives the replay cursor to the start of the fastest lap for a specific
+   * car (issue #607). Three phases:
+   *
+   *   1. **Session map.** On the first walk per `SessionUniqueID`, build a
+   *      cache of session bounds (start frame of each session + buffer's
+   *      live edge) by `goToStart` + `nextSession` × N + `goToEnd`.
+   *      Subsequent walks within the same replay skip straight to phase 2.
+   *   2. **Bisect within target session.** Look up the target session's
+   *      [startFrame, endFrame] from the map and bisect with
+   *      `setPlayPosition(Begin, mid)` until the player car is within
+   *      {@link CLOSE_ENOUGH_LAPS} of the target lap.
+   *   3. **Lap-step refinement.** `nextLap` / `prevLap` until
+   *      `CarIdxLap[carIdx] === targetLap`. iRacing's lap-step lands at a
+   *      clean lap boundary, so the cursor parks at the start of the
+   *      fastest lap with no further fix-up.
+   *
+   * Only one walk per context runs at a time; second presses while one is
+   * in flight are ignored.
    */
-  async walkToFastestLap(contextId: string, carIdx: number, targetLap: number): Promise<void> {
+  async walkToFastestLap(
+    contextId: string,
+    carIdx: number,
+    targetLap: number,
+    targetSessionNum: number,
+  ): Promise<void> {
     if (this.fastestLapWalkInFlight.has(contextId)) {
       this.logger.debug(`Jump to fastest lap: walk already in flight for ${contextId}; ignoring`);
 
@@ -862,57 +1062,349 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
 
     try {
       const replay = getCommands().replay;
-      let attempts = 0;
-      let lastObservedLap: number | null = null;
-      let stuckCount = 0;
+      const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-      while (attempts++ < MAX_LAP_SEARCH_STEPS) {
-        const telemetry = this.sdkController.getCurrentTelemetry();
-        const currentLaps = telemetry?.CarIdxLap as number[] | undefined;
-        const currentLap = currentLaps?.[carIdx];
+      /**
+       * Wait for the base settle gap to elapse, then poll the telemetry until
+       * `SessionNum >= 0` — the transient `-1` value iRacing publishes between
+       * a search / setPlayPosition broadcast landing and the cursor settling
+       * at the new frame (issue #607). Returns the stable telemetry sample or
+       * `null` if `SessionNum` never leaves the transient state within
+       * `STABILIZATION_TIMEOUT_MULTIPLIER × settle` ms.
+       */
+      const readStableTelemetry = async (): Promise<TelemetryData | null> => {
+        const baseSettleMs = readFastestLapSearchDelayMs();
 
-        if (typeof currentLap !== "number" || currentLap < 0) {
-          this.logger.debug(`Jump to fastest lap: bail, CarIdxLap[${carIdx}] is unavailable`);
+        await sleep(baseSettleMs);
+        const initial = this.sdkController.getCurrentTelemetry();
 
-          return;
+        if (typeof initial?.SessionNum === "number" && initial.SessionNum >= 0) return initial;
+
+        const deadline = Date.now() + baseSettleMs * (STABILIZATION_TIMEOUT_MULTIPLIER - 1);
+
+        while (Date.now() < deadline) {
+          await sleep(STABILIZATION_POLL_INTERVAL_MS);
+          const tel = this.sdkController.getCurrentTelemetry();
+
+          if (typeof tel?.SessionNum === "number" && tel.SessionNum >= 0) return tel;
         }
 
-        if (currentLap === targetLap) {
-          this.logger.debug(`Jump to fastest lap: reached lap ${targetLap} after ${attempts} iterations`);
+        return null;
+      };
 
-          return;
+      const buildSessionMap = async (): Promise<FastestLapSessionMap | null> => {
+        const sessionUniqueIds = new Set<number>();
+        const recordUniqueId = (tel: TelemetryData): void => {
+          if (typeof tel.SessionUniqueID === "number") sessionUniqueIds.add(tel.SessionUniqueID);
+        };
+
+        replay.goToStart();
+        const firstTel = await readStableTelemetry();
+
+        if (firstTel == null) {
+          this.logger.warn("Jump to fastest lap: telemetry did not stabilize after goToStart; aborting map build");
+
+          return null;
         }
 
-        // Detect the cursor not advancing — either a session-edge condition
-        // or the replay buffer doesn't reach the target lap.
-        if (lastObservedLap !== null && currentLap === lastObservedLap) {
-          stuckCount++;
+        recordUniqueId(firstTel);
+        const firstFrame = firstTel.ReplayFrameNum;
+        const firstSession = firstTel.SessionNum;
 
-          if (stuckCount >= LAP_WALK_STUCK_LIMIT) {
-            this.logger.warn(`Jump to fastest lap: cursor stuck at lap ${currentLap} (target ${targetLap}); giving up`);
+        if (typeof firstFrame !== "number" || typeof firstSession !== "number") {
+          this.logger.warn(
+            `Jump to fastest lap: missing fields after goToStart (frame=${firstFrame}, session=${firstSession}); aborting map build`,
+          );
 
-            return;
+          return null;
+        }
+
+        const sessions: SessionMapEntry[] = [{ sessionNum: firstSession, startFrame: firstFrame, endFrame: -1 }];
+        let lastFrame = firstFrame;
+        let lastSession = firstSession;
+
+        for (let i = 0; i < MAX_SESSIONS; i++) {
+          replay.nextSession();
+          const tel = await readStableTelemetry();
+
+          if (tel == null) {
+            this.logger.warn(`Jump to fastest lap: telemetry did not stabilize after nextSession #${i + 1}; aborting`);
+
+            return null;
           }
-        } else {
-          stuckCount = 0;
+
+          recordUniqueId(tel);
+          const frame = tel.ReplayFrameNum;
+          const session = tel.SessionNum;
+
+          if (typeof frame !== "number" || typeof session !== "number") {
+            this.logger.warn("Jump to fastest lap: missing fields after nextSession; aborting map build");
+
+            return null;
+          }
+
+          if (session === lastSession || frame === lastFrame) {
+            // nextSession was a no-op — we're already in the last session.
+            break;
+          }
+
+          sessions.push({ sessionNum: session, startFrame: frame, endFrame: -1 });
+          lastFrame = frame;
+          lastSession = session;
         }
 
-        lastObservedLap = currentLap;
+        replay.goToEnd();
+        const endTel = await readStableTelemetry();
 
-        if (currentLap < targetLap) {
-          replay.nextLap();
-        } else {
-          replay.prevLap();
+        if (endTel == null) {
+          this.logger.warn("Jump to fastest lap: telemetry did not stabilize after goToEnd; aborting map build");
+
+          return null;
         }
 
-        // Read the gap live on every iteration so a user can drag the slider
-        // mid-walk and have the next step pick up the new value.
-        const gapMs = readFastestLapSearchDelayMs();
-        await new Promise<void>((resolve) => setTimeout(resolve, gapMs));
+        recordUniqueId(endTel);
+        const endFrame = endTel.ReplayFrameNum;
+
+        if (typeof endFrame !== "number") {
+          this.logger.warn("Jump to fastest lap: ReplayFrameNum missing after goToEnd; aborting map build");
+
+          return null;
+        }
+
+        for (let i = 0; i < sessions.length; i++) {
+          sessions[i].endFrame = i + 1 < sessions.length ? sessions[i + 1].startFrame - 1 : endFrame;
+        }
+
+        return { sessionUniqueIds, sessions, fastestLapFrames: new Map<string, number>() };
+      };
+
+      // Pause first so the cursor doesn't drift between commands and the
+      // post-settle telemetry sample. `readStableTelemetry` rides out the
+      // ~500 ms SessionNum=-1 transient that the first paused-replay command
+      // produces; subsequent commands clear in ~100 ms.
+      replay.pause();
+      await sleep(readFastestLapSearchDelayMs());
+
+      // Phase 1: session map (cache or build).
+      const initialTel = await readStableTelemetry();
+
+      if (initialTel == null) {
+        this.logger.warn("Jump to fastest lap: telemetry did not stabilize after pause; aborting");
+
+        return;
       }
 
-      this.logger.warn(
-        `Jump to fastest lap: safety cap hit (${MAX_LAP_SEARCH_STEPS} iterations) at lap ${lastObservedLap}, target ${targetLap}`,
+      const sessionUniqueId = initialTel.SessionUniqueID;
+
+      if (typeof sessionUniqueId !== "number") {
+        this.logger.warn("Jump to fastest lap: SessionUniqueID unavailable; aborting");
+
+        return;
+      }
+
+      let sessionMap = cachedFastestLapSessionMap;
+      const cacheHit = sessionMap != null && sessionMap.sessionUniqueIds.has(sessionUniqueId);
+
+      this.logger.info(
+        `Jump to fastest lap: cache ${cacheHit ? "HIT" : "MISS"} (currentUniqueId=${sessionUniqueId}, cachedUniqueIds=${
+          sessionMap == null ? "<none>" : `{${[...sessionMap.sessionUniqueIds].join(",")}}`
+        })`,
+      );
+
+      if (sessionMap == null || !cacheHit) {
+        const built = await buildSessionMap();
+
+        if (built == null) return;
+
+        sessionMap = built;
+        cachedFastestLapSessionMap = built;
+        this.logger.info(
+          `Jump to fastest lap: session map built — uniqueIds={${[...sessionMap.sessionUniqueIds].join(",")}}, ${sessionMap.sessions
+            .map((s) => `S${s.sessionNum}[${s.startFrame}-${s.endFrame}]`)
+            .join(", ")}`,
+        );
+      } else {
+        this.logger.debug(`Jump to fastest lap: reusing cached session map (${sessionMap.sessions.length} sessions)`);
+      }
+
+      // Phase 2a: per-car cache check. If we've already walked this
+      // (carIdx, targetLap, sessionNum) triple, jump straight to the stored
+      // frame — no bisection, no lap-step, no nudge, no tick-back.
+      const cacheKey = fastestLapCacheKey(carIdx, targetLap, targetSessionNum);
+      const cachedFrame = sessionMap.fastestLapFrames.get(cacheKey);
+
+      if (typeof cachedFrame === "number") {
+        this.logger.info(
+          `Jump to fastest lap: per-car cache HIT (key=${cacheKey}, frame=${cachedFrame}); using stored frame`,
+        );
+        replay.setPlayPosition(ReplayPosMode.Begin, cachedFrame);
+        await readStableTelemetry();
+
+        return;
+      }
+
+      this.logger.info(`Jump to fastest lap: per-car cache MISS (key=${cacheKey}); walking`);
+
+      // Phase 2b: look up target session bounds.
+      const bounds = sessionMap.sessions.find((s) => s.sessionNum === targetSessionNum);
+
+      if (bounds == null) {
+        this.logger.warn(`Jump to fastest lap: target session ${targetSessionNum} not in session map; aborting`);
+
+        return;
+      }
+
+      let loFrame = bounds.startFrame;
+      let hiFrame = bounds.endFrame;
+
+      if (hiFrame <= loFrame) {
+        this.logger.warn(
+          `Jump to fastest lap: empty session bounds for session ${targetSessionNum} (lo=${loFrame}, hi=${hiFrame}); aborting`,
+        );
+
+        return;
+      }
+
+      // Target the lap BEFORE the fastest one — we want to land at the end
+      // of that lap (just before the S/F crossing into the fastest lap), so
+      // pressing Play immediately shows the line-crossing into the fast lap.
+      const targetLapMinus1 = Math.max(0, targetLap - 1);
+
+      // Phase 3: bisect within the target session until we're within
+      // CLOSE_ENOUGH_LAPS of the lap-before-fastest.
+      let bisectionSteps = 0;
+
+      for (let step = 0; step < MAX_BISECTION_STEPS; step++) {
+        if (hiFrame - loFrame <= 1) break;
+
+        const mid = Math.floor((loFrame + hiFrame) / 2);
+
+        replay.setPlayPosition(ReplayPosMode.Begin, mid);
+        const tel = await readStableTelemetry();
+
+        bisectionSteps = step + 1;
+
+        if (tel == null) {
+          this.logger.warn(
+            `Jump to fastest lap: telemetry did not stabilize at frame ${mid} (bisection step ${step}); aborting`,
+          );
+
+          return;
+        }
+
+        const lap = (tel.CarIdxLap as number[] | undefined)?.[carIdx];
+
+        if (typeof lap !== "number" || lap < 0) {
+          // Car not in world at this probe — assume we're before the target
+          // and advance the lower bound.
+          loFrame = mid;
+          continue;
+        }
+
+        if (Math.abs(lap - targetLapMinus1) <= CLOSE_ENOUGH_LAPS) {
+          this.logger.debug(
+            `Jump to fastest lap: bisection landed within ${CLOSE_ENOUGH_LAPS} laps after ${bisectionSteps} steps (frame=${mid}, lap=${lap}, target=${targetLapMinus1})`,
+          );
+          break;
+        }
+
+        if (lap < targetLapMinus1) {
+          loFrame = mid;
+        } else {
+          hiFrame = mid;
+        }
+      }
+
+      // Phase 4: lap-step until we're on the lap-before-fastest.
+      let lapSteps = 0;
+
+      for (let step = 0; step < MAX_LAP_STEPS; step++) {
+        const tel = await readStableTelemetry();
+
+        if (tel == null) {
+          this.logger.warn(`Jump to fastest lap: telemetry did not stabilize during lap-step ${step}; aborting`);
+
+          return;
+        }
+
+        const lap = (tel.CarIdxLap as number[] | undefined)?.[carIdx];
+
+        if (typeof lap !== "number" || lap < 0) {
+          this.logger.warn(`Jump to fastest lap: CarIdxLap unavailable during lap-step ${step} (lap=${lap}); aborting`);
+
+          return;
+        }
+
+        if (lap === targetLapMinus1) {
+          this.logger.debug(
+            `Jump to fastest lap: lap-step phase converged after ${lapSteps} steps (lap=${lap}, target=${targetLapMinus1})`,
+          );
+          break;
+        }
+
+        if (lap < targetLapMinus1) replay.nextLap();
+        else replay.prevLap();
+
+        lapSteps = step + 1;
+      }
+
+      // Phase 5: dist refinement. We're on the right lap but maybe not at
+      // the end. If dist < 0.999, press nextLap to advance to the end; if
+      // that overshoots into the next lap, press prevLap to come back.
+      const refineTel = await readStableTelemetry();
+      const refineLap = (refineTel?.CarIdxLap as number[] | undefined)?.[carIdx];
+      const refineDist = (refineTel?.CarIdxLapDistPct as number[] | undefined)?.[carIdx];
+      let nudges = 0;
+
+      if (
+        typeof refineLap === "number" &&
+        typeof refineDist === "number" &&
+        refineLap === targetLapMinus1 &&
+        refineDist < FASTEST_LAP_DIST_THRESHOLD
+      ) {
+        this.logger.debug(
+          `Jump to fastest lap: nudging via nextLap (currently lap=${refineLap}, dist=${refineDist.toFixed(4)})`,
+        );
+        replay.nextLap();
+        nudges++;
+
+        const afterTel = await readStableTelemetry();
+        const afterLap = (afterTel?.CarIdxLap as number[] | undefined)?.[carIdx];
+
+        if (typeof afterLap === "number" && afterLap > targetLapMinus1) {
+          this.logger.debug(`Jump to fastest lap: nextLap overshot to lap=${afterLap}; recovering via prevLap`);
+          replay.prevLap();
+          nudges++;
+          await readStableTelemetry();
+        }
+      }
+
+      // Phase 6: single absolute-frame back-step. Read the current frame,
+      // jump to `frame - FASTEST_LAP_FINAL_BACKSTEP_TICKS` in one broadcast.
+      const preBackstepTel = await readStableTelemetry();
+      const preBackstepFrame = preBackstepTel?.ReplayFrameNum;
+
+      if (typeof preBackstepFrame === "number") {
+        const targetFrame = Math.max(0, preBackstepFrame - FASTEST_LAP_FINAL_BACKSTEP_TICKS);
+
+        replay.setPlayPosition(ReplayPosMode.Begin, targetFrame);
+        await readStableTelemetry();
+      }
+
+      // Final report + store the landed frame in the per-car cache so the
+      // next press for this (carIdx, targetLap, sessionNum) triple hits.
+      const finalTel = await readStableTelemetry();
+      const finalLap = (finalTel?.CarIdxLap as number[] | undefined)?.[carIdx];
+      const finalDist = (finalTel?.CarIdxLapDistPct as number[] | undefined)?.[carIdx];
+      const finalFrame = finalTel?.ReplayFrameNum;
+
+      if (typeof finalFrame === "number") {
+        sessionMap.fastestLapFrames.set(cacheKey, finalFrame);
+        this.logger.debug(`Jump to fastest lap: stored per-car cache entry (key=${cacheKey}, frame=${finalFrame})`);
+      }
+
+      this.logger.debug(
+        `Jump to fastest lap: converged after ${bisectionSteps} bisection + ${lapSteps} lap-step + ${nudges} nudge iterations + ${FASTEST_LAP_FINAL_BACKSTEP_TICKS}-tick back-step (lap=${finalLap}, dist=${typeof finalDist === "number" ? finalDist.toFixed(4) : "n/a"}, target=${targetLap}, session=${targetSessionNum})`,
       );
     } finally {
       this.fastestLapWalkInFlight.delete(contextId);
@@ -1246,20 +1738,21 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
           break;
         }
 
-        // iRacing's nextLap jumps to the *end* of the targeted lap (=start of
-        // the lap after it). Subtract one so the cursor lands at the start of
-        // the fastest lap, not at its end.
-        const walkTargetLap = targetLap - 1;
+        // Resolve the session at dispatch time so the bisection narrows to
+        // the right session in a multi-session replay (practice + qualifying
+        // + race). `findFastestLapForCar` already used the same `SessionNum`
+        // to look the lap number up.
+        const targetSessionNum = typeof telemetry?.SessionNum === "number" ? telemetry.SessionNum : 0;
 
-        // Adaptive lap walk: read CarIdxLap between steps and re-send when the
-        // cursor didn't advance. iRacing's broadcast queue drops fixed-spacing
-        // bursts (observed at 50 / 100 ms in live testing), so polling between
-        // steps is the only reliable way to converge on the target lap.
-        // Fire-and-forget — the press handler returns immediately.
-        void this.walkToFastestLap(contextId, targetCarIdx, walkTargetLap);
+        // Frame-based bisection (issue #607). Pauses the replay, brackets the
+        // buffer with toStart/toEnd, then binary-searches by absolute frame
+        // until the cursor lands at the start of `targetLap` for `targetCarIdx`
+        // within `targetSessionNum`. Fire-and-forget — the press handler
+        // returns immediately.
+        void this.walkToFastestLap(contextId, targetCarIdx, targetLap, targetSessionNum);
 
         this.logger.info("Jump to fastest lap executed");
-        this.logger.debug(`Target carIdx: ${targetCarIdx}, fastest lap: ${targetLap}, walker target: ${walkTargetLap}`);
+        this.logger.debug(`Target carIdx: ${targetCarIdx}, fastest lap: ${targetLap}, session: ${targetSessionNum}`);
         break;
       }
       case "next-car": {

--- a/packages/website/src/content/docs/docs/actions/view-camera/replay-control.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/replay-control.md
@@ -379,7 +379,9 @@ Jump the replay cursor to a driver's fastest lap in the current replay session. 
 
 If the target car hasn't completed a lap yet, the press is a no-op (nothing moves, no error). If the camera target can't be resolved (e.g., transitioning between cars), the press is also a no-op.
 
-The walker spaces each lap-search broadcast by **Common Settings → Replay → Fastest Lap Search Delay** (default 400 ms). iRacing resolves the exact lap-boundary position asynchronously after each step, so a too-short delay can leave the cursor parked mid-lap. Slower computers and longer tracks may need to increase the value; the slider accepts 50–1000 ms in 50 ms steps.
+The cursor lands a heartbeat **before** the start of the fastest lap — about 150 ms of approach to the S/F line — so you can hit Play and watch the car cross into the timed lap. The replay is left **paused** at that frame; press your Play button to start, or use the frame-step buttons to scrub.
+
+The button first pauses the replay, then jumps to the first and last frames of the buffer to learn its extent, then bisects (≈ log₂ N jumps — typically a handful regardless of how long the replay is). Each jump is followed by a short settle gap before the next read, tunable via **Common Settings → Replay → Fastest Lap Search Delay** (default 400 ms, range 50–1000 ms in 50 ms steps). Slower computers and longer tracks may need a longer gap to give iRacing time to deliver fresh telemetry after each jump.
 
 #### Details
 


### PR DESCRIPTION
## Related Issue

Fixes #607

## What changed?

Rebuilt the Jump-to-Fastest-Lap walker as a four-phase, cache-backed pipeline. Live testing surfaced that the original adaptive `nextLap`/`prevLap` walker (and the intermediate frame-based bisection that replaced it) couldn't reliably reach the fastest lap when it sat in a non-current session, and even when it did the cursor landed on the wrong side of the S/F boundary because iRacing's `CarIdxLap` updates on a different tick than `CarIdxLapDistPct`.

**The new walker:**

1. **Session map.** On the first walk per race weekend, navigate `goToStart` → `nextSession` × N → `goToEnd`, recording each session's `[startFrame, endFrame]` and every `SessionUniqueID` observed. iRacing increments `SessionUniqueID` per session (not per weekend), so the cache keys against a `Set` of every observed ID — a press in practice, qualifying, or race all reuse the same map; only an actually-new race weekend (all-different IDs) misses cleanly.
2. **Per-car frame cache.** After every successful walk, the landed frame is stored on the session map keyed by `(carIdx, targetLap, sessionNum)`. The next press for the same triple jumps straight to that frame with one `setPlayPosition` and skips phases 3–6 entirely. Stale entries fall through to a cache miss when the player sets a new fastest lap (the `targetLap` part of the key changes), so invalidation is implicit.
3. **Bisect within target session.** Look up the target session's bounds from the map and binary-search by `CarIdxLap[carIdx]` until within `CLOSE_ENOUGH_LAPS = 2` of the target. Out-of-world probes advance `lo` so the bracket still narrows. Bounded by `MAX_BISECTION_STEPS = 30`.
4. **Lap-step + nudge + back-step.** `nextLap` / `prevLap` until `CarIdxLap === targetLap - 1` (the lap before the fastest). If `dist < 0.999` we're mid-lap; press `nextLap` once. If that overshoots into the next lap, `prevLap` recovers. Finally a single `setPlayPosition(Begin, frame - 2)` (~32 ms at 60 Hz) lands the cursor a heartbeat before the line so a Play press shows the visible approach into the fastest lap.

Every search broadcast is followed by `readStableTelemetry` — a polling helper that waits out iRacing's `SessionNum = -1` transient (~500 ms on the first paused-replay command, ~100 ms after) before reading the probe. Without it the bisection corrupts its bracket on the first jump.

Twelve new tests cover the session-map build + Set-based cache, per-car frame cache (hit, miss on new `targetLap`, store-after-walk), within-session bisection, lap-step + nudge + back-step phases, plus `DriverCarIdx` for `always-my-car` and the in-flight guard. Module-level cache is exposed for tests via `_resetFastestLapSessionCache` / `_getFastestLapSessionCache` seams.

## How to test

1. Load any iRacing race weekend (practice → qualifying → race) with a recorded fastest lap on your car.
2. Spectate or replay; configure a Jump-to-Fastest-Lap action.
3. Press the action — replay should pause, then land a heartbeat before the S/F crossing into your fastest lap. Verify with the plugin log:
   - `cache MISS` on first press of a new weekend.
   - `session map built — uniqueIds={...}, S0[...], S1[...], S2[...]`.
   - `per-car cache MISS (key=N|M|K); walking` then `converged after N bisection + M lap-step + K nudge iterations + 2-tick back-step (lap=…, dist=0.99…, target=…)`.
4. Press the action again — should be near-instant. Log:
   - `cache HIT (currentUniqueId=…, cachedUniqueIds={…})`.
   - `per-car cache HIT (key=…, frame=…); using stored frame`.
5. Switch the replay camera to a different car and press — should walk (different cache key) and then cache that car too.
6. Switch to a different session (e.g., from race to qualifying) and press — should reuse the session map (its `SessionUniqueID` is in the cached Set), do a fresh walk, and store a new per-car entry.
7. Press Play on the keyboard immediately after the cursor lands — the car should visibly approach the S/F line and cross into the fastest lap.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * More reliable "Jump to Fastest Lap" behavior: faster, frame-accurate bisection search, better multi-session handling, and cached results to avoid repeated walks on repeated presses.
* **Bug Fixes**
  * Prevents overlapping searches and reduces incorrect landings when the fastest-lap changes or session boundaries shift.
* **Documentation**
  * Clarified landing position (paused near the finish line), pause behavior, and bisection-based search with configurable settle-gap delay.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niklam/iracedeck/pull/613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->