### PR TITLE
feat(actions): add class position to Session Info position mode (#234)

### DIFF
--- a/docs/reference/actions.json
+++ b/docs/reference/actions.json
@@ -22,7 +22,11 @@
               "description": "Session time left, flashes when < 5 min"
             },
             { "value": "laps", "label": "Laps", "description": "Current lap number" },
-            { "value": "position", "label": "Position", "description": "Race position, optionally shows total cars" },
+            {
+              "value": "position",
+              "label": "Position",
+              "description": "Class (default) or overall race position, optionally shows total cars (scoped to class or full field)"
+            },
             { "value": "fuel", "label": "Fuel", "description": "Fuel level as amount or percentage" },
             { "value": "flags", "label": "Flags", "description": "Active race flags with colors and pulsing" },
             {

--- a/docs/superpowers/specs/2026-05-31-class-position-session-info-design.md
+++ b/docs/superpowers/specs/2026-05-31-class-position-session-info-design.md
@@ -219,8 +219,9 @@ scoped totals) before any push / PR.
 
 ## Out of scope / non-goals
 
-- No calculated (hand-rolled) class position — `PlayerCarClassPosition` is
-  authoritative and the codebase's established class source.
+- No change to overtake **detection** — `diffOvertakes` still reads
+  `PlayerCarClassPosition` directly; only the position *display* / readout uses the
+  order-derived class value (see the class-derivation follow-up above).
 - No adaptive class/overall switching — "Class" is explicit per the brainstorming
   decision.
 - No new distinct prefix for class (`P` shared) — per the brainstorming decision.

--- a/docs/superpowers/specs/2026-05-31-class-position-session-info-design.md
+++ b/docs/superpowers/specs/2026-05-31-class-position-session-info-design.md
@@ -1,0 +1,215 @@
+# Class position support in Session Info position mode (#234)
+
+## Summary
+
+Add a `positionType` setting to the Session Info action's **Position** mode so users
+can display their **class** position in multi-class races, not just overall race
+position. Class position is the default. Both render with the `P` prefix; the
+optional "Show Total Cars" count is scoped to the chosen type (overall field size
+vs. cars in the player's class).
+
+## Motivation
+
+Issue #234: in multi-class races, overall position is noise — drivers care about
+where they sit within their own class. The position mode currently only shows
+overall race position.
+
+## Decisions (settled during brainstorming)
+
+- **Setting:** `positionType: "class" | "overall"`, default **`"class"`**.
+- **Class semantics — explicit:** when "Class" is selected the action always shows
+  class position, even in a single-class race (where the class rank equals the
+  overall rank — only the scoped total differs).
+- **Display format — `P` prefix for both.** Class does not get a distinct prefix;
+  it differs only in which position number and which total are shown:
+  - Overall → `P5` / `P5/24` (overall field size)
+  - Class → `P2` / `P2/8` (cars in the player's class)
+- **Sourcing — Approach B (adopt `getLivePosition()`).** In a race, on track, the
+  numbers come from `@iracedeck/sim-events-iracing`'s `getLivePosition()`, which
+  returns the **frozen** overall race position (#603 — handles blipped / retired /
+  teleported cars) and the **authoritative** class position
+  (`PlayerCarClassPosition`, the source the Race Engineer trusts because iRacing
+  recomputes it correctly when cars leave — #588 / #599 / #603). This deliberately
+  upgrades the existing on-track-race **overall** number to the frozen calc so the
+  button matches the Race Engineer's voice.
+
+## Architecture
+
+The whole change lives in the shared `@iracedeck/iracing-actions` package plus its
+PI template and the docs. No new global setting, no plugin wiring, no manifest /
+icon changes. Both plugins (Stream Deck + Mirabox) inherit it automatically because
+they register the same action and compile the same shared PI template.
+
+### Data sources
+
+`@iracedeck/sim-events-iracing` already exports `getLivePosition(): LivePosition | null`:
+
+```ts
+type LivePosition = {
+  position: number;      // 1-based frozen overall race position (#603)
+  classPosition: number; // 1-based PlayerCarClassPosition; 0 when unavailable
+  isMultiClass: boolean;
+};
+```
+
+It is a translator-singleton read (no args) and returns `null` when telemetry /
+session info / player car index aren't resolvable, or the computed overall
+position is 0 (inactive). It is **not** session-type aware — its `position` is the
+on-track lap-order, which is *not* the standings in practice/qualifying — so it is
+gated to race sessions only.
+
+`@iracedeck/iracing-actions` already declares `@iracedeck/sim-events-iracing` as a
+dependency, so the import adds no new package coupling.
+
+## Detailed behavior
+
+### Settings schema (`session-info.ts`)
+
+Add to `SessionInfoSettings`:
+
+```ts
+positionType: z.enum(["class", "overall"]).default("class"),
+```
+
+### Position branch of `extractDisplayValue`
+
+Replace the current position branch with logic that resolves both an overall and a
+class number, then picks based on `positionType`:
+
+```text
+isClass = settings.positionType === "class"
+
+if isRaceSession(telemetry):
+  if telemetry.OnPitRoad:                      # keep existing pit special-case
+    overall = telemetry.PlayerCarPosition
+    klass   = telemetry.PlayerCarClassPosition
+  else:
+    live    = getLivePosition()                # singleton; null when unavailable
+    overall = (live && live.position > 0)      ? live.position      : telemetry.PlayerCarPosition
+    klass   = (live && live.classPosition > 0) ? live.classPosition : telemetry.PlayerCarClassPosition
+else:                                          # non-race: standings, not lap order
+  overall = telemetry.PlayerCarPosition
+  klass   = telemetry.PlayerCarClassPosition
+
+pos = isClass ? klass : overall
+
+if pos === undefined: return settings.positionShowTotal ? "P-/-" : "P-"
+
+if settings.positionShowTotal:
+  total = isClass ? countActiveDriversInPlayerClass(sessionInfo)
+                  : countActiveDrivers(sessionInfo)        # existing
+  return total > 0 ? `P${pos}/${total}` : `P${pos}`
+
+return `P${pos}`
+```
+
+Notes:
+- The `no telemetry` early-return block already produces `P-` / `P-/-`; it stays as
+  is (the `P` prefix is shared by both types).
+- `getLivePosition()` is called only in the race + on-track branch. Pits and
+  non-race read official telemetry, preserving today's overall-in-pits behavior.
+- Class position from `getLivePosition().classPosition` is identical to
+  `PlayerCarClassPosition` — the official field — so class is authoritative in all
+  branches.
+
+### New helper (`session-info.ts`, `@internal` for testing)
+
+```ts
+export function countActiveDriversInPlayerClass(sessionInfo: SessionInfo | null): number
+```
+
+- Resolve the player's `CarClassID` from `DriverInfo.Drivers` (match
+  `CarIdx === DriverInfo.DriverCarIdx`).
+- Count drivers sharing that `CarClassID`, excluding pace car (`CarIsPaceCar === 1`)
+  and spectators (`IsSpectator === 1`) — same filter as `countActiveDrivers`.
+- Return `0` when the player's class can't be resolved (so the `/total` is dropped,
+  mirroring the overall path's `total > 0` guard).
+
+The action wraps it in a private `countCarsInPlayerClass()` paralleling the existing
+`countActiveCars()`.
+
+### Property Inspector (`session-info.ejs`)
+
+Add a Position Type dropdown inside the existing `#position-settings` group (which is
+already shown/hidden by the position-mode visibility JS — no new wiring), placed
+above "Show Total Cars":
+
+```html
+<sdpi-item id="position-type-settings" label="Position Type" class="hidden">
+  <sdpi-select setting="positionType" default="class">
+    <option value="class">Class</option>
+    <option value="overall">Overall</option>
+  </sdpi-select>
+</sdpi-item>
+```
+
+Extend `updateVisibility()` to toggle `#position-type-settings` on `mode === "position"`
+alongside the existing `#position-settings`.
+
+## Files touched
+
+1. `packages/iracing-actions/src/actions/session-info/session-info.ts`
+   - `positionType` schema field
+   - rewritten position branch in `extractDisplayValue`
+   - `countActiveDriversInPlayerClass` helper + private `countCarsInPlayerClass()`
+   - `getLivePosition` import from `@iracedeck/sim-events-iracing`
+2. `packages/iracing-actions/src/actions/session-info/session-info.ejs`
+   - Position Type dropdown + visibility toggle
+3. `packages/iracing-actions/src/actions/session-info/session-info.test.ts`
+   - mock `@iracedeck/sim-events-iracing` `getLivePosition`
+   - rewrite on-track-race position tests to the new source
+   - add: default-is-class, class number, class total, overall unchanged, fallback paths
+   - extend the `CommonSettings` mock defaults/coercion with `positionType`
+4. `packages/website/src/content/docs/docs/actions/display-session/session-info.md`
+   - document the Position Type setting under the Position mode
+5. `docs/reference/actions.json`
+   - tweak the `position` mode description to mention class/overall
+
+Not touched: no new global setting (`deck-core`), no `plugin.ts` (both plugins), no
+`manifest.json`, no icons, no `README` (not a new action or mode — mode count stays
+7). Compiled `ui/*.html` is gitignored build output (regenerated by build, never
+committed).
+
+## Testing strategy
+
+Unit tests (Vitest) in `session-info.test.ts`:
+
+- **Schema:** `positionType` defaults to `"class"`; parses `"overall"`.
+- **Class, race, on track:** `getLivePosition()` returns `{ classPosition: 2, ... }`
+  → renders `P2`; with Show Total and a 8-car class → `P2/8`.
+- **Overall, race, on track:** uses `getLivePosition().position` (frozen) → `P5`;
+  with Show Total → `P5/24`.
+- **Pits:** class → `PlayerCarClassPosition`; overall → `PlayerCarPosition`
+  (getLivePosition not consulted).
+- **Non-race:** both read official telemetry.
+- **Fallbacks:** `getLivePosition()` null → official; `classPosition === 0` →
+  `PlayerCarClassPosition`.
+- **`countActiveDriversInPlayerClass`:** mixed-class driver list, pace-car /
+  spectator exclusion, unresolved player class → 0, null session info → 0.
+- **Placeholders:** no telemetry → `P-` / `P-/-` for both types.
+
+`getLivePosition` is mocked via `vi.mock("@iracedeck/sim-events-iracing", ...)`; the
+existing real `@iracedeck/iracing-sdk` mock stays for `calculateRacePositions` /
+enums used elsewhere.
+
+## Verification
+
+```bash
+pnpm install
+pnpm build        # tsc — catches type issues vitest's esbuild path misses
+pnpm test
+pnpm lint:fix
+pnpm format:fix
+```
+
+Then manual iRacing test (multi-class session: confirm class vs overall numbers and
+scoped totals) before any push / PR.
+
+## Out of scope / non-goals
+
+- No calculated (hand-rolled) class position — `PlayerCarClassPosition` is
+  authoritative and the codebase's established class source.
+- No adaptive class/overall switching — "Class" is explicit per the brainstorming
+  decision.
+- No new distinct prefix for class (`P` shared) — per the brainstorming decision.
+- No change to other Session Info modes.

--- a/docs/superpowers/specs/2026-05-31-class-position-session-info-design.md
+++ b/docs/superpowers/specs/2026-05-31-class-position-session-info-design.md
@@ -27,11 +27,22 @@ overall race position.
 - **Sourcing — Approach B (adopt `getLivePosition()`).** In a race, on track, the
   numbers come from `@iracedeck/sim-events-iracing`'s `getLivePosition()`, which
   returns the **frozen** overall race position (#603 — handles blipped / retired /
-  teleported cars) and the **authoritative** class position
-  (`PlayerCarClassPosition`, the source the Race Engineer trusts because iRacing
-  recomputes it correctly when cars leave — #588 / #599 / #603). This deliberately
-  upgrades the existing on-track-race **overall** number to the frozen calc so the
-  button matches the Race Engineer's voice.
+  teleported cars) and a **live class position derived from that same frozen
+  order**. This deliberately upgrades the existing on-track-race **overall** number
+  to the frozen calc so the button matches the Race Engineer's voice.
+- **Class is derived, not read from iRacing's official field (follow-up).** The
+  first implementation took class position from iRacing's `PlayerCarClassPosition`,
+  but that field only refreshes at the start/finish line, so the (default) class
+  display looked frozen between crossings. There is no existing function that
+  computes a *live* class position — every existing class source is the official
+  field. So `getLivePosition().classPosition` now reuses the **existing** overall
+  order (`calculateFrozenRacePositions`) and counts same-class cars (`CarIdxClass`)
+  ranked ahead — the new `classPositionFromOrder` glue in `@iracedeck/iracing-sdk`,
+  the same counting `resolveStartingClassPosition` (#599) does for the grid. It
+  falls back to `PlayerCarClassPosition` only when `CarIdxClass` is unavailable.
+  Because the Race Engineer also reads `getLivePosition().classPosition`, its spoken
+  class position becomes live too (overtake *detection* in `diffOvertakes` is
+  unchanged — it still reads `PlayerCarClassPosition` directly).
 
 ## Architecture
 
@@ -47,7 +58,8 @@ they register the same action and compile the same shared PI template.
 ```ts
 type LivePosition = {
   position: number;      // 1-based frozen overall race position (#603)
-  classPosition: number; // 1-based PlayerCarClassPosition; 0 when unavailable
+  classPosition: number; // 1-based, derived from the frozen order via classPositionFromOrder;
+                         // falls back to PlayerCarClassPosition; 0 when unavailable
   isMultiClass: boolean;
 };
 ```

--- a/packages/iracing-actions/src/actions/session-info/session-info.ejs
+++ b/packages/iracing-actions/src/actions/session-info/session-info.ejs
@@ -22,6 +22,13 @@
 			<ird-range-input setting="fontSize" min="5" max="36" step="1" default="14" showlabels></ird-range-input>
 		</sdpi-item>
 
+		<sdpi-item id="position-type-settings" label="Position Type" class="hidden">
+			<sdpi-select setting="positionType" default="class">
+				<option value="class">Class</option>
+				<option value="overall">Overall</option>
+			</sdpi-select>
+		</sdpi-item>
+
 		<sdpi-item id="position-settings" label="Show Total Cars" class="hidden">
 			<sdpi-checkbox setting="positionShowTotal"></sdpi-checkbox>
 		</sdpi-item>
@@ -60,10 +67,14 @@
 			}
 
 			function updateVisibility(mode) {
+				const positionTypeSettings = document.getElementById("position-type-settings");
 				const positionSettings = document.getElementById("position-settings");
 				const fuelSettings = document.getElementById("fuel-settings");
 				const flagsSettings = document.getElementById("flags-settings");
 
+				if (positionTypeSettings) {
+					positionTypeSettings.classList.toggle("hidden", mode !== "position");
+				}
 				if (positionSettings) {
 					positionSettings.classList.toggle("hidden", mode !== "position");
 				}

--- a/packages/iracing-actions/src/actions/session-info/session-info.test.ts
+++ b/packages/iracing-actions/src/actions/session-info/session-info.test.ts
@@ -1,8 +1,10 @@
 import { FLAG_DEFINITIONS, resolveActiveFlag, TrackWetness } from "@iracedeck/iracing-sdk";
+import { getLivePosition } from "@iracedeck/sim-events-iracing";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   countActiveDrivers,
+  countActiveDriversInPlayerClass,
   formatFuelAmount,
   formatSessionTime,
   generateSessionInfoSvg,
@@ -17,10 +19,22 @@ vi.mock("@iracedeck/iracing-sdk", async () => {
   return actual;
 });
 
+// getLivePosition is the translator-singleton class-aware resolver; mock it so the
+// position-mode tests control the frozen overall + authoritative class numbers.
+vi.mock("@iracedeck/sim-events-iracing", () => ({
+  getLivePosition: vi.fn(() => null),
+}));
+
 vi.mock("@iracedeck/deck-core", () => ({
   CommonSettings: {
     extend: () => {
-      const defaults = { mode: "incidents", positionShowTotal: false, fuelFormat: "amount", blankWhenNoFlag: false };
+      const defaults = {
+        mode: "incidents",
+        positionType: "class",
+        positionShowTotal: false,
+        fuelFormat: "amount",
+        blankWhenNoFlag: false,
+      };
       const validModes = ["incidents", "time-remaining", "laps", "position", "fuel", "flags", "track-wetness"];
       const coerceBool = (v: unknown): boolean => v === true || v === "true";
       const merge = (data: Record<string, unknown>) => {
@@ -102,6 +116,7 @@ function defaultSettings(
   overrides: Partial<{
     mode: "incidents" | "time-remaining" | "laps" | "position" | "fuel" | "flags" | "track-wetness";
     fontSize: number;
+    positionType: "class" | "overall";
     positionShowTotal: boolean;
     fuelFormat: "amount" | "percentage";
     blankWhenNoFlag: boolean;
@@ -109,6 +124,7 @@ function defaultSettings(
 ) {
   return {
     mode: "incidents" as const,
+    positionType: "class" as const,
     positionShowTotal: false,
     fuelFormat: "amount" as const,
     blankWhenNoFlag: false,
@@ -268,6 +284,73 @@ describe("SessionInfo", () => {
 
     it("should return 0 for empty Drivers array", () => {
       expect(countActiveDrivers({ DriverInfo: { Drivers: [] } })).toBe(0);
+    });
+  });
+
+  describe("countActiveDriversInPlayerClass", () => {
+    it("should return 0 for null session info", () => {
+      expect(countActiveDriversInPlayerClass(null)).toBe(0);
+    });
+
+    it("should return 0 when DriverInfo is missing", () => {
+      expect(countActiveDriversInPlayerClass({ WeekendInfo: {} })).toBe(0);
+    });
+
+    it("should return 0 when the player's class cannot be resolved", () => {
+      // DriverCarIdx points at a car with no Drivers entry → class unknown.
+      const sessionInfo = {
+        DriverInfo: {
+          DriverCarIdx: 9,
+          Drivers: [{ CarIdx: 1, CarClassID: 10, CarIsPaceCar: 0, IsSpectator: 0 }],
+        },
+      };
+
+      expect(countActiveDriversInPlayerClass(sessionInfo)).toBe(0);
+    });
+
+    it("should count only drivers sharing the player's class", () => {
+      const sessionInfo = {
+        DriverInfo: {
+          DriverCarIdx: 1,
+          Drivers: [
+            { CarIdx: 1, CarClassID: 10, CarIsPaceCar: 0, IsSpectator: 0 }, // player
+            { CarIdx: 2, CarClassID: 10, CarIsPaceCar: 0, IsSpectator: 0 },
+            { CarIdx: 3, CarClassID: 20, CarIsPaceCar: 0, IsSpectator: 0 }, // other class
+            { CarIdx: 4, CarClassID: 10, CarIsPaceCar: 0, IsSpectator: 0 },
+          ],
+        },
+      };
+
+      // Class 10 has 3 cars (the player + two others).
+      expect(countActiveDriversInPlayerClass(sessionInfo)).toBe(3);
+    });
+
+    it("should exclude pace car and spectators from the class count", () => {
+      const sessionInfo = {
+        DriverInfo: {
+          DriverCarIdx: 1,
+          Drivers: [
+            { CarIdx: 0, CarClassID: 10, CarIsPaceCar: 1, IsSpectator: 0 }, // pace car, class 10
+            { CarIdx: 1, CarClassID: 10, CarIsPaceCar: 0, IsSpectator: 0 }, // player
+            { CarIdx: 2, CarClassID: 10, CarIsPaceCar: 0, IsSpectator: 1 }, // spectator, class 10
+            { CarIdx: 3, CarClassID: 10, CarIsPaceCar: 0, IsSpectator: 0 },
+          ],
+        },
+      };
+
+      // Only the player and CarIdx 3 are active class-10 cars.
+      expect(countActiveDriversInPlayerClass(sessionInfo)).toBe(2);
+    });
+
+    it("should return 1 for a lone driver in their class (single-class field)", () => {
+      const sessionInfo = {
+        DriverInfo: {
+          DriverCarIdx: 1,
+          Drivers: [{ CarIdx: 1, CarClassID: 10, CarIsPaceCar: 0, IsSpectator: 0 }],
+        },
+      };
+
+      expect(countActiveDriversInPlayerClass(sessionInfo)).toBe(1);
     });
   });
 
@@ -933,41 +1016,46 @@ describe("SessionInfo", () => {
       clearInterval(timer);
     });
 
-    describe("position mode with calculated positions", () => {
-      function makeRaceSessionInfo(driverCarIdx: number) {
+    describe("position mode display", () => {
+      // Multi-class field: player (CarIdx 0) is in class 10 with one class-mate;
+      // class 20 has three cars. Class-10 active = 2, overall active = 5.
+      const multiClassDrivers = [
+        { CarIdx: 0, CarClassID: 10, CarIsPaceCar: 0, IsSpectator: 0 },
+        { CarIdx: 1, CarClassID: 10, CarIsPaceCar: 0, IsSpectator: 0 },
+        { CarIdx: 2, CarClassID: 20, CarIsPaceCar: 0, IsSpectator: 0 },
+        { CarIdx: 3, CarClassID: 20, CarIsPaceCar: 0, IsSpectator: 0 },
+        { CarIdx: 4, CarClassID: 20, CarIsPaceCar: 0, IsSpectator: 0 },
+      ];
+
+      function makeRaceSessionInfo(driverCarIdx: number, drivers?: unknown[]) {
         return {
-          SessionInfo: {
-            Sessions: [{ SessionType: "Race" }],
-          },
-          DriverInfo: {
-            DriverCarIdx: driverCarIdx,
-          },
+          SessionInfo: { Sessions: [{ SessionType: "Race" }] },
+          DriverInfo: { DriverCarIdx: driverCarIdx, ...(drivers ? { Drivers: drivers } : {}) },
         };
       }
 
-      function makePracticeSessionInfo(driverCarIdx: number) {
+      function makePracticeSessionInfo(driverCarIdx: number, drivers?: unknown[]) {
         return {
-          SessionInfo: {
-            Sessions: [{ SessionType: "Practice" }],
-          },
-          DriverInfo: {
-            DriverCarIdx: driverCarIdx,
-          },
+          SessionInfo: { Sessions: [{ SessionType: "Practice" }] },
+          DriverInfo: { DriverCarIdx: driverCarIdx, ...(drivers ? { Drivers: drivers } : {}) },
         };
       }
 
       /**
-       * Helper: start with null telemetry so initial state is "P-",
-       * then fire the callback with real telemetry to trigger a state change and updateKeyImage call.
+       * Helper: start with null telemetry so initial state is "P-", then fire the
+       * subscribe callback with real telemetry to trigger a state change and an
+       * updateKeyImage call. Returns the decoded SVG of the last update.
        */
-      async function triggerPositionUpdate(sessionInfo: unknown, telemetry: Record<string, unknown>): Promise<string> {
-        // onWillAppear with no telemetry → initial state "P-" via setKeyImage
+      async function triggerPositionUpdate(
+        sessionInfo: unknown,
+        telemetry: Record<string, unknown>,
+        settings: Record<string, unknown> = { mode: "position" },
+      ): Promise<string> {
         action["sdkController"].getCurrentTelemetry = vi.fn().mockReturnValue(null);
         action["sdkController"].getSessionInfo = vi.fn().mockReturnValue(sessionInfo);
 
-        await action.onWillAppear(fakeEvent("action-1", { mode: "position" }) as any);
+        await action.onWillAppear(fakeEvent("action-1", settings) as any);
 
-        // Now switch to real telemetry and fire the callback
         action["sdkController"].getCurrentTelemetry = vi.fn().mockReturnValue(telemetry);
 
         const subscribeCall = action["sdkController"].subscribe.mock.calls[0];
@@ -982,126 +1070,167 @@ describe("SessionInfo", () => {
         return decodeURIComponent(lastCall[1] as string);
       }
 
-      it("should use calculateRacePositions in race session (shows P1 when car has more laps)", async () => {
-        // Car 0 has more laps completed (10 vs 5) so is P1, but PlayerCarPosition=2
-        const telemetry = {
-          SessionNum: 0,
-          PlayerCarPosition: 2,
-          CarIdxLapCompleted: [10, 5],
-          CarIdxLapDistPct: [0.9, 0.1],
-        };
+      it("should default to class position (no positionType setting)", async () => {
+        vi.mocked(getLivePosition).mockReturnValue({ position: 5, classPosition: 2, isMultiClass: true });
+        const telemetry = { SessionNum: 0, OnPitRoad: false, PlayerCarPosition: 5, PlayerCarClassPosition: 2 };
 
-        const decoded = await triggerPositionUpdate(makeRaceSessionInfo(0), telemetry);
+        const decoded = await triggerPositionUpdate(makeRaceSessionInfo(0), telemetry, { mode: "position" });
 
-        expect(decoded).toContain("P1");
-        expect(decoded).not.toContain("P2");
+        // Class is the default → class position (2), not overall (5).
+        expect(decoded).toContain("P2");
+        expect(decoded).not.toContain("P5");
       });
 
-      it("should use PlayerCarPosition in non-race session", async () => {
-        // Same telemetry — car 0 would be P1 by laps, but session is Practice so use PlayerCarPosition=2
-        const telemetry = {
-          SessionNum: 0,
-          PlayerCarPosition: 2,
-          CarIdxLapCompleted: [10, 5],
-          CarIdxLapDistPct: [0.9, 0.1],
-        };
+      it("should show class position from getLivePosition when positionType is class (race, on track)", async () => {
+        vi.mocked(getLivePosition).mockReturnValue({ position: 5, classPosition: 2, isMultiClass: true });
+        const telemetry = { SessionNum: 0, OnPitRoad: false, PlayerCarPosition: 5, PlayerCarClassPosition: 2 };
 
-        const decoded = await triggerPositionUpdate(makePracticeSessionInfo(0), telemetry);
+        const decoded = await triggerPositionUpdate(makeRaceSessionInfo(0), telemetry, {
+          mode: "position",
+          positionType: "class",
+        });
 
         expect(decoded).toContain("P2");
+        expect(decoded).not.toContain("P5");
       });
 
-      it("should fall back to PlayerCarPosition when player carIdx is out of bounds in race session", async () => {
-        // carIdx=5 but only 2 entries → calculated positions[5] is undefined → falls back to PlayerCarPosition
-        const telemetry = {
-          SessionNum: 0,
-          PlayerCarPosition: 3,
-          OnPitRoad: false,
-          CarIdxLapCompleted: [10, 5],
-          CarIdxLapDistPct: [0.9, 0.1],
-        };
+      it("should show frozen overall position from getLivePosition when positionType is overall (race, on track)", async () => {
+        vi.mocked(getLivePosition).mockReturnValue({ position: 5, classPosition: 2, isMultiClass: true });
+        const telemetry = { SessionNum: 0, OnPitRoad: false, PlayerCarPosition: 9, PlayerCarClassPosition: 2 };
 
-        const decoded = await triggerPositionUpdate(makeRaceSessionInfo(5), telemetry);
+        const decoded = await triggerPositionUpdate(makeRaceSessionInfo(0), telemetry, {
+          mode: "position",
+          positionType: "overall",
+        });
 
-        // calculated[5] is undefined → falls back to PlayerCarPosition=3
-        expect(decoded).toContain("P3");
+        // Uses getLivePosition().position (5), not the raw PlayerCarPosition (9).
+        expect(decoded).toContain("P5");
+        expect(decoded).not.toContain("P9");
       });
 
-      it("should use PlayerCarPosition when player is on pit road in race session", async () => {
-        const telemetry = {
-          SessionNum: 0,
-          PlayerCarPosition: 2,
-          OnPitRoad: true,
-          CarIdxLapCompleted: [10, 5],
-          CarIdxLapDistPct: [0.9, 0.1],
-        };
+      it("should append the class field size for class position with Show Total", async () => {
+        vi.mocked(getLivePosition).mockReturnValue({ position: 4, classPosition: 1, isMultiClass: true });
+        const telemetry = { SessionNum: 0, OnPitRoad: false, PlayerCarPosition: 4, PlayerCarClassPosition: 1 };
 
-        const decoded = await triggerPositionUpdate(makeRaceSessionInfo(0), telemetry);
+        const decoded = await triggerPositionUpdate(makeRaceSessionInfo(0, multiClassDrivers), telemetry, {
+          mode: "position",
+          positionType: "class",
+          positionShowTotal: true,
+        });
 
-        // On pit road: should use PlayerCarPosition=2, not calculated P1
-        expect(decoded).toContain("P2");
+        // Class 10 has 2 active cars.
+        expect(decoded).toContain("P1/2");
       });
 
-      it("should use calculated position when player is NOT on pit road in race session", async () => {
-        const telemetry = {
-          SessionNum: 0,
-          PlayerCarPosition: 2,
-          OnPitRoad: false,
-          CarIdxLapCompleted: [10, 5],
-          CarIdxLapDistPct: [0.9, 0.1],
-        };
+      it("should append the overall field size for overall position with Show Total", async () => {
+        vi.mocked(getLivePosition).mockReturnValue({ position: 4, classPosition: 1, isMultiClass: true });
+        const telemetry = { SessionNum: 0, OnPitRoad: false, PlayerCarPosition: 4, PlayerCarClassPosition: 1 };
 
-        const decoded = await triggerPositionUpdate(makeRaceSessionInfo(0), telemetry);
+        const decoded = await triggerPositionUpdate(makeRaceSessionInfo(0, multiClassDrivers), telemetry, {
+          mode: "position",
+          positionType: "overall",
+          positionShowTotal: true,
+        });
 
-        // Not on pit road: should use calculated P1
-        expect(decoded).toContain("P1");
-        expect(decoded).not.toContain("P2");
+        // 5 active cars overall.
+        expect(decoded).toContain("P4/5");
       });
 
-      it("should fall back to PlayerCarPosition when calculated position is 0 (inactive) in race session", async () => {
-        const telemetry = {
-          SessionNum: 0,
-          PlayerCarPosition: 3,
-          OnPitRoad: false,
-          CarIdxLapCompleted: [-1, 5, 4],
-          CarIdxLapDistPct: [-1, 0.7, 0.3],
-        };
+      it("should use PlayerCarClassPosition for class position when on pit road (ignores getLivePosition)", async () => {
+        // getLivePosition would say class 9, but the pit branch reads official telemetry.
+        vi.mocked(getLivePosition).mockReturnValue({ position: 9, classPosition: 9, isMultiClass: true });
+        const telemetry = { SessionNum: 0, OnPitRoad: true, PlayerCarPosition: 2, PlayerCarClassPosition: 3 };
 
-        // Car 0 is inactive (lapCompleted=-1) → calculated position = 0
-        // Should fall back to PlayerCarPosition=3
-        const decoded = await triggerPositionUpdate(makeRaceSessionInfo(0), telemetry);
+        const decoded = await triggerPositionUpdate(makeRaceSessionInfo(0), telemetry, {
+          mode: "position",
+          positionType: "class",
+        });
 
         expect(decoded).toContain("P3");
       });
 
-      it("should fall back to PlayerCarPosition when session info is null", async () => {
-        // No session info → isRaceSession returns false → use PlayerCarPosition=3
-        const initialTelemetry = { SessionNum: 0, PlayerCarPosition: 5 };
-        const realTelemetry = {
-          SessionNum: 0,
-          PlayerCarPosition: 3,
-          CarIdxLapCompleted: [10, 5],
-          CarIdxLapDistPct: [0.9, 0.1],
-        };
+      it("should use PlayerCarPosition for overall position when on pit road", async () => {
+        vi.mocked(getLivePosition).mockReturnValue({ position: 9, classPosition: 9, isMultiClass: true });
+        const telemetry = { SessionNum: 0, OnPitRoad: true, PlayerCarPosition: 2, PlayerCarClassPosition: 3 };
 
-        // Start with P5 as initial state, then change to P3
-        action["sdkController"].getCurrentTelemetry = vi.fn().mockReturnValue(initialTelemetry);
+        const decoded = await triggerPositionUpdate(makeRaceSessionInfo(0), telemetry, {
+          mode: "position",
+          positionType: "overall",
+        });
+
+        expect(decoded).toContain("P2");
+      });
+
+      it("should use PlayerCarClassPosition for class position in a non-race session", async () => {
+        // getLivePosition is on-track lap order, not standings → not used outside races.
+        vi.mocked(getLivePosition).mockReturnValue({ position: 9, classPosition: 9, isMultiClass: true });
+        const telemetry = { SessionNum: 0, OnPitRoad: false, PlayerCarPosition: 6, PlayerCarClassPosition: 4 };
+
+        const decoded = await triggerPositionUpdate(makePracticeSessionInfo(0), telemetry, {
+          mode: "position",
+          positionType: "class",
+        });
+
+        expect(decoded).toContain("P4");
+      });
+
+      it("should use PlayerCarPosition for overall position in a non-race session", async () => {
+        const telemetry = { SessionNum: 0, OnPitRoad: false, PlayerCarPosition: 2, PlayerCarClassPosition: 4 };
+
+        const decoded = await triggerPositionUpdate(makePracticeSessionInfo(0), telemetry, {
+          mode: "position",
+          positionType: "overall",
+        });
+
+        expect(decoded).toContain("P2");
+      });
+
+      it("should fall back to official telemetry when getLivePosition returns null (race, on track)", async () => {
+        vi.mocked(getLivePosition).mockReturnValue(null);
+        const telemetry = { SessionNum: 0, OnPitRoad: false, PlayerCarPosition: 3, PlayerCarClassPosition: 6 };
+
+        const classDecoded = await triggerPositionUpdate(makeRaceSessionInfo(0), telemetry, {
+          mode: "position",
+          positionType: "class",
+        });
+
+        expect(classDecoded).toContain("P6");
+      });
+
+      it("should fall back to PlayerCarClassPosition when getLivePosition class position is 0", async () => {
+        vi.mocked(getLivePosition).mockReturnValue({ position: 5, classPosition: 0, isMultiClass: true });
+        const telemetry = { SessionNum: 0, OnPitRoad: false, PlayerCarPosition: 5, PlayerCarClassPosition: 7 };
+
+        const decoded = await triggerPositionUpdate(makeRaceSessionInfo(0), telemetry, {
+          mode: "position",
+          positionType: "class",
+        });
+
+        expect(decoded).toContain("P7");
+      });
+
+      it("should fall back to PlayerCarPosition for overall when session info is null", async () => {
+        // No session info → isRaceSession false → official PlayerCarPosition.
+        const telemetry = { SessionNum: 0, PlayerCarPosition: 3, PlayerCarClassPosition: 8 };
+
+        const decoded = await triggerPositionUpdate(null, telemetry, { mode: "position", positionType: "overall" });
+
+        expect(decoded).toContain("P3");
+      });
+
+      it("should render P-/- placeholder with Show Total and no telemetry", async () => {
+        action["sdkController"].getCurrentTelemetry = vi.fn().mockReturnValue(null);
         action["sdkController"].getSessionInfo = vi.fn().mockReturnValue(null);
 
-        await action.onWillAppear(fakeEvent("action-1", { mode: "position" }) as any);
+        await action.onWillAppear(
+          fakeEvent("action-1", { mode: "position", positionType: "class", positionShowTotal: true }) as any,
+        );
 
-        const subscribeCall = action["sdkController"].subscribe.mock.calls[0];
-        const telemetryCallback = subscribeCall[1];
-
-        await telemetryCallback(realTelemetry);
-
-        const calls = action["updateKeyImage"].mock.calls;
-        expect(calls.length).toBeGreaterThan(0);
+        const calls = action["setKeyImage"].mock.calls;
         const lastCall = calls[calls.length - 1];
         const decoded = decodeURIComponent(lastCall[1] as string);
 
-        // Falls back to PlayerCarPosition=3
-        expect(decoded).toContain("P3");
+        expect(decoded).toContain("P-/-");
       });
     });
   });

--- a/packages/iracing-actions/src/actions/session-info/session-info.test.ts
+++ b/packages/iracing-actions/src/actions/session-info/session-info.test.ts
@@ -1071,19 +1071,23 @@ describe("SessionInfo", () => {
       }
 
       it("should default to class position (no positionType setting)", async () => {
+        // Live class (2) diverges from official PlayerCarClassPosition (9) so the
+        // assertion proves the live value is used, not the telemetry fallback.
         vi.mocked(getLivePosition).mockReturnValue({ position: 5, classPosition: 2, isMultiClass: true });
-        const telemetry = { SessionNum: 0, OnPitRoad: false, PlayerCarPosition: 5, PlayerCarClassPosition: 2 };
+        const telemetry = { SessionNum: 0, OnPitRoad: false, PlayerCarPosition: 5, PlayerCarClassPosition: 9 };
 
         const decoded = await triggerPositionUpdate(makeRaceSessionInfo(0), telemetry, { mode: "position" });
 
-        // Class is the default → class position (2), not overall (5).
+        // Class is the default → live class position (2), not overall (5) or official class (9).
         expect(decoded).toContain("P2");
         expect(decoded).not.toContain("P5");
+        expect(decoded).not.toContain("P9");
       });
 
       it("should show class position from getLivePosition when positionType is class (race, on track)", async () => {
+        // Live class (2) diverges from official PlayerCarClassPosition (9).
         vi.mocked(getLivePosition).mockReturnValue({ position: 5, classPosition: 2, isMultiClass: true });
-        const telemetry = { SessionNum: 0, OnPitRoad: false, PlayerCarPosition: 5, PlayerCarClassPosition: 2 };
+        const telemetry = { SessionNum: 0, OnPitRoad: false, PlayerCarPosition: 5, PlayerCarClassPosition: 9 };
 
         const decoded = await triggerPositionUpdate(makeRaceSessionInfo(0), telemetry, {
           mode: "position",
@@ -1092,6 +1096,7 @@ describe("SessionInfo", () => {
 
         expect(decoded).toContain("P2");
         expect(decoded).not.toContain("P5");
+        expect(decoded).not.toContain("P9");
       });
 
       it("should show frozen overall position from getLivePosition when positionType is overall (race, on track)", async () => {

--- a/packages/iracing-actions/src/actions/session-info/session-info.ts
+++ b/packages/iracing-actions/src/actions/session-info/session-info.ts
@@ -16,7 +16,6 @@ import {
   svgToDataUri,
 } from "@iracedeck/deck-core";
 import {
-  calculateRacePositions,
   DisplayUnits,
   type FlagInfo,
   type SessionInfo as IRacingSessionInfo,
@@ -24,6 +23,7 @@ import {
   type TelemetryData,
   TrackWetness,
 } from "@iracedeck/iracing-sdk";
+import { getLivePosition } from "@iracedeck/sim-events-iracing";
 import z from "zod";
 
 import sessionInfoTemplate from "../../../icons/session-info.svg";
@@ -51,6 +51,7 @@ const SessionInfoSettings = CommonSettings.extend({
     (val) => (val === "" || val === null || val === undefined ? undefined : val),
     z.coerce.number().min(5).max(36).optional(),
   ),
+  positionType: z.enum(["class", "overall"]).default("class"),
   positionShowTotal: z
     .union([z.boolean(), z.string()])
     .transform((val) => val === true || val === "true")
@@ -118,6 +119,36 @@ export function countActiveDrivers(sessionInfo: IRacingSessionInfo | null): numb
   if (!Array.isArray(drivers)) return 0;
 
   return drivers.filter((d) => d.CarIsPaceCar !== 1 && d.IsSpectator !== 1).length;
+}
+
+/**
+ * @internal Exported for testing
+ *
+ * Counts the active drivers sharing the player's car class — the field size
+ * used when "Show Total Cars" is enabled and the action is showing class
+ * position. The player's class is resolved from `DriverInfo.Drivers` via
+ * `DriverInfo.DriverCarIdx`; the same pace-car / spectator filter as
+ * `countActiveDrivers` applies.
+ *
+ * Returns 0 when the player's class can't be resolved, so the caller drops the
+ * `/total` suffix (mirroring the overall-position path's `total > 0` guard).
+ */
+export function countActiveDriversInPlayerClass(sessionInfo: IRacingSessionInfo | null): number {
+  if (!sessionInfo) return 0;
+
+  const driverInfo = sessionInfo.DriverInfo as
+    | { Drivers?: Array<Record<string, unknown>>; DriverCarIdx?: number }
+    | undefined;
+  const drivers = driverInfo?.Drivers;
+
+  if (!Array.isArray(drivers)) return 0;
+
+  const playerCarIdx = driverInfo?.DriverCarIdx;
+  const playerClassId = drivers.find((d) => d.CarIdx === playerCarIdx)?.CarClassID;
+
+  if (playerClassId === undefined) return 0;
+
+  return drivers.filter((d) => d.CarClassID === playerClassId && d.CarIsPaceCar !== 1 && d.IsSpectator !== 1).length;
 }
 
 /**
@@ -427,28 +458,38 @@ export class SessionInfo extends ConnectionStateAwareAction<SessionInfoSettings>
     }
 
     if (settings.mode === "position") {
-      let pos: number | undefined;
+      const isClass = settings.positionType === "class";
+
+      // Class position is always iRacing's authoritative `PlayerCarClassPosition`
+      // (the source the Race Engineer trusts — iRacing recomputes it correctly when
+      // cars retire). Overall position uses the class-aware live resolver
+      // `getLivePosition()` while racing on track (its `.position` is the frozen
+      // calculated order), and official telemetry in pits / non-race where the
+      // calculated lap-order isn't the standings.
+      let overall: number | undefined;
+      let klass: number | undefined;
 
       if (this.isRaceSession(telemetry)) {
         if (telemetry.OnPitRoad) {
-          // In pits: use official position
-          pos = telemetry.PlayerCarPosition;
+          overall = telemetry.PlayerCarPosition;
+          klass = telemetry.PlayerCarClassPosition;
         } else {
-          // On track: use calculated, fall back to official
-          const positions = calculateRacePositions(telemetry);
-          const playerCarIdx = this.getPlayerCarIdx();
-          const calculated = playerCarIdx >= 0 ? positions[playerCarIdx] : undefined;
+          const live = getLivePosition();
 
-          pos = calculated && calculated > 0 ? calculated : telemetry.PlayerCarPosition;
+          overall = live && live.position > 0 ? live.position : telemetry.PlayerCarPosition;
+          klass = live && live.classPosition > 0 ? live.classPosition : telemetry.PlayerCarClassPosition;
         }
       } else {
-        pos = telemetry.PlayerCarPosition;
+        overall = telemetry.PlayerCarPosition;
+        klass = telemetry.PlayerCarClassPosition;
       }
+
+      const pos = isClass ? klass : overall;
 
       if (pos === undefined) return settings.positionShowTotal ? "P-/-" : "P-";
 
       if (settings.positionShowTotal) {
-        const totalCars = this.countActiveCars();
+        const totalCars = isClass ? this.countCarsInPlayerClass() : this.countActiveCars();
 
         return totalCars > 0 ? `P${pos}/${totalCars}` : `P${pos}`;
       }
@@ -494,6 +535,10 @@ export class SessionInfo extends ConnectionStateAwareAction<SessionInfoSettings>
     return countActiveDrivers(this.sdkController.getSessionInfo());
   }
 
+  private countCarsInPlayerClass(): number {
+    return countActiveDriversInPlayerClass(this.sdkController.getSessionInfo());
+  }
+
   private isRaceSession(telemetry: TelemetryData | null): boolean {
     const sessionInfo = this.sdkController.getSessionInfo();
 
@@ -505,16 +550,6 @@ export class SessionInfo extends ConnectionStateAwareAction<SessionInfoSettings>
     const currentSession = sessionList?.[sessionNum as number];
 
     return (currentSession?.SessionType as string) === "Race";
-  }
-
-  private getPlayerCarIdx(): number {
-    const sessionInfo = this.sdkController.getSessionInfo();
-
-    if (!sessionInfo) return -1;
-
-    const driverInfo = (sessionInfo as Record<string, unknown>).DriverInfo as Record<string, unknown> | undefined;
-
-    return (driverInfo?.DriverCarIdx as number) ?? -1;
   }
 
   private resolveFlagColorOverride(

--- a/packages/iracing-sdk/src/index.ts
+++ b/packages/iracing-sdk/src/index.ts
@@ -117,7 +117,7 @@ export {
 export { findNearestCarOnTrack, type FindNearestCarOptions } from "./track-utils.js";
 
 // Position utilities
-export { calculateRacePositions } from "./position-utils.js";
+export { calculateRacePositions, classPositionFromOrder } from "./position-utils.js";
 
 // Flag utilities
 export { type FlagInfo, FLAG_DEFINITIONS, resolveActiveFlag, resolveAllActiveFlags } from "./flag-utils.js";

--- a/packages/iracing-sdk/src/position-utils.test.ts
+++ b/packages/iracing-sdk/src/position-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { calculateRacePositions } from "./position-utils.js";
+import { calculateRacePositions, classPositionFromOrder } from "./position-utils.js";
 import type { TelemetryData } from "./types.js";
 
 function makeTelemetry(overrides: Partial<TelemetryData> = {}): TelemetryData {
@@ -114,5 +114,72 @@ describe("calculateRacePositions", () => {
     const result = calculateRacePositions(telemetry);
     expect(result[0]).toBe(1);
     expect(result[1]).toBe(2);
+  });
+});
+
+describe("classPositionFromOrder", () => {
+  it("should equal the overall position in a single-class field", () => {
+    // positions = overall ranks; everyone in class 10.
+    const positions = [2, 1, 3];
+    const carIdxClass = [10, 10, 10];
+
+    expect(classPositionFromOrder(positions, carIdxClass, 0)).toBe(2);
+    expect(classPositionFromOrder(positions, carIdxClass, 1)).toBe(1);
+    expect(classPositionFromOrder(positions, carIdxClass, 2)).toBe(3);
+  });
+
+  it("should count only same-class cars ranked ahead in a multi-class field", () => {
+    // Overall order: car0 (cls10), car1 (cls20), car2 (cls10), car3 (cls20).
+    const positions = [1, 2, 3, 4];
+    const carIdxClass = [10, 20, 10, 20];
+
+    // car2 is overall P3 but only car0 (class 10) is ahead in class → class P2.
+    expect(classPositionFromOrder(positions, carIdxClass, 2)).toBe(2);
+    // car0 leads class 10 → class P1.
+    expect(classPositionFromOrder(positions, carIdxClass, 0)).toBe(1);
+    // car3 is overall P4 but only car1 (class 20) is ahead in class → class P2.
+    expect(classPositionFromOrder(positions, carIdxClass, 3)).toBe(2);
+  });
+
+  it("should ignore other-class cars ahead overall (class leader despite cars in front)", () => {
+    // Two class-20 cars lead overall; the lone class-10 car is overall P3 but class P1.
+    const positions = [1, 2, 3];
+    const carIdxClass = [20, 20, 10];
+
+    expect(classPositionFromOrder(positions, carIdxClass, 2)).toBe(1);
+  });
+
+  it("should ignore cars omitted from the order (rank 0)", () => {
+    // car1 is omitted (rank 0, e.g. never seen / not in world).
+    const positions = [1, 0, 2];
+    const carIdxClass = [10, 10, 10];
+
+    expect(classPositionFromOrder(positions, carIdxClass, 2)).toBe(2);
+  });
+
+  it("should return 0 when the player is omitted from the order", () => {
+    const positions = [1, 0, 2];
+    const carIdxClass = [10, 10, 10];
+
+    expect(classPositionFromOrder(positions, carIdxClass, 1)).toBe(0);
+  });
+
+  it("should return 0 when CarIdxClass is unavailable", () => {
+    expect(classPositionFromOrder([2, 1, 3], undefined, 0)).toBe(0);
+  });
+
+  it("should return 0 for a negative or out-of-range carIdx", () => {
+    const positions = [1, 2];
+    const carIdxClass = [10, 10];
+
+    expect(classPositionFromOrder(positions, carIdxClass, -1)).toBe(0);
+    expect(classPositionFromOrder(positions, carIdxClass, 5)).toBe(0);
+  });
+
+  it("should return 0 when the player's class id is missing", () => {
+    const positions = [1, 2];
+    const carIdxClass = [10]; // no class for carIdx 1
+
+    expect(classPositionFromOrder(positions, carIdxClass, 1)).toBe(0);
   });
 });

--- a/packages/iracing-sdk/src/position-utils.ts
+++ b/packages/iracing-sdk/src/position-utils.ts
@@ -34,3 +34,46 @@ export function calculateRacePositions(telemetry: TelemetryData | null): number[
 
   return result;
 }
+
+/**
+ * Derives a car's class position from an already-computed overall race order.
+ *
+ * This does NOT compute positions — it reuses an existing 1-based overall-rank
+ * array (e.g. from {@link calculateRacePositions} or the frozen
+ * `calculateFrozenRacePositions`) and counts how many same-class cars rank ahead
+ * of `carIdx`, +1. Same counting as the qualifying-grid `resolveStartingClassPosition`
+ * (issue #599), applied to the live order instead of the grid. Cars omitted from
+ * the order (rank `0`) are ignored, so retired / not-in-world cars don't inflate
+ * the count.
+ *
+ * @param positions   1-based overall ranks indexed by carIdx (`0` = omitted).
+ * @param carIdxClass `CarIdxClass` telemetry (class id per carIdx); may be undefined.
+ * @param carIdx      The player's car index.
+ * @returns 1-based class position, or `0` when it can't be derived (player omitted,
+ *          missing class data, or out-of-range carIdx).
+ */
+export function classPositionFromOrder(positions: number[], carIdxClass: number[] | undefined, carIdx: number): number {
+  if (carIdx < 0 || carIdx >= positions.length) return 0;
+
+  if (!Array.isArray(carIdxClass)) return 0;
+
+  const myRank = positions[carIdx];
+
+  if (myRank === undefined || myRank <= 0) return 0;
+
+  const myClass = carIdxClass[carIdx];
+
+  if (myClass === undefined) return 0;
+
+  let ahead = 0;
+
+  for (let i = 0; i < positions.length; i++) {
+    if (i === carIdx) continue;
+
+    const rank = positions[i];
+
+    if (rank > 0 && rank < myRank && carIdxClass[i] === myClass) ahead++;
+  }
+
+  return ahead + 1;
+}

--- a/packages/sim-events-iracing/src/translator.test.ts
+++ b/packages/sim-events-iracing/src/translator.test.ts
@@ -25,6 +25,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   _resetSimEventsIracing,
   getLatestTelemetry,
+  getLivePosition,
   getRaceStartConditions,
   getSessionStartConditions,
   initializeSimEventsIracing,
@@ -156,6 +157,60 @@ describe("sim-events-iracing translator", () => {
       controller.__tick(telemetry({ OnPitRoad: true }));
       controller.__tick(null, false);
       expect(getLatestTelemetry()).toBeNull();
+    });
+  });
+
+  describe("getLivePosition", () => {
+    // Multi-class field: car0 (cls10, player), car1 (cls20), car2 (cls10), car3 (cls20).
+    // Lap scores put the overall order at car1 > car2 > car0 > car3.
+    const multiClassSessionInfo = {
+      DriverInfo: {
+        DriverCarIdx: 0,
+        Drivers: [
+          { CarIdx: 0, CarClassID: 10 },
+          { CarIdx: 1, CarClassID: 20 },
+          { CarIdx: 2, CarClassID: 10 },
+          { CarIdx: 3, CarClassID: 20 },
+        ],
+      },
+    };
+
+    function multiClassTelemetry(overrides: Partial<TelemetryData> = {}): TelemetryData {
+      return telemetry({
+        CarIdxLapCompleted: [10, 10, 10, 9],
+        CarIdxLapDistPct: [0.0, 0.5, 0.2, 0.5],
+        CarIdxClass: [10, 20, 10, 20],
+        ...overrides,
+      });
+    }
+
+    it("derives class position from the live order, not the lagging official field", () => {
+      const controller = createMockController();
+      controller.__setSessionInfo(multiClassSessionInfo);
+      initializeSimEventsIracing(getEventBus(), controller, createMockLogger());
+
+      // Official PlayerCarClassPosition is deliberately stale (9) to prove the
+      // derived value wins.
+      controller.__tick(multiClassTelemetry({ PlayerCarClassPosition: 9 }));
+
+      const live = getLivePosition();
+
+      // Overall: car1 P1, car2 P2, car0 P3, car3 P4 → player (car0) overall P3.
+      // Class 10 ahead of the player: only car2 → class P2.
+      expect(live).not.toBeNull();
+      expect(live?.position).toBe(3);
+      expect(live?.classPosition).toBe(2);
+      expect(live?.isMultiClass).toBe(true);
+    });
+
+    it("falls back to PlayerCarClassPosition when CarIdxClass is unavailable", () => {
+      const controller = createMockController();
+      controller.__setSessionInfo(multiClassSessionInfo);
+      initializeSimEventsIracing(getEventBus(), controller, createMockLogger());
+
+      controller.__tick(multiClassTelemetry({ CarIdxClass: undefined, PlayerCarClassPosition: 5 }));
+
+      expect(getLivePosition()?.classPosition).toBe(5);
     });
   });
 

--- a/packages/sim-events-iracing/src/translator.ts
+++ b/packages/sim-events-iracing/src/translator.ts
@@ -27,7 +27,14 @@ import type {
   SimEventName,
 } from "@iracedeck/event-bus";
 import { TrackWetness } from "@iracedeck/event-bus";
-import { CarLeftRight, type SDKController, SessionState, type TelemetryData, TrkLoc } from "@iracedeck/iracing-sdk";
+import {
+  CarLeftRight,
+  classPositionFromOrder,
+  type SDKController,
+  SessionState,
+  type TelemetryData,
+  TrkLoc,
+} from "@iracedeck/iracing-sdk";
 import { type ILogger, silentLogger } from "@iracedeck/logger";
 
 import { diffDamage } from "./diff/damage.js";
@@ -508,7 +515,13 @@ export function getQualifyingInvalidationSnapshot(): QualifyingInvalidationSnaps
 export type LivePosition = {
   /** Live overall race position (1-based) from the calculated order. */
   position: number;
-  /** Live class position (1-based) from `PlayerCarClassPosition`; 0 when unavailable. */
+  /**
+   * Live class position (1-based) derived from the same frozen overall order as
+   * {@link position} — the count of same-class cars (`CarIdxClass`) ranked ahead,
+   * +1 (see `classPositionFromOrder`). Falls back to the iRacing-authoritative
+   * `PlayerCarClassPosition` when the order-based value can't be derived (no
+   * `CarIdxClass`). `0` when unavailable. Updates continuously, not only at S/F.
+   */
   classPosition: number;
   /** Whether the session has more than one car class on track. */
   isMultiClass: boolean;
@@ -525,17 +538,23 @@ export function getLivePosition(): LivePosition | null {
 
   // Frozen positions (issue #603): finished cars that left the world stay
   // counted at their finishing rank, so the spoken overall position is correct
-  // and stable while leaders peel into the garage. Class position comes from
-  // `PlayerCarClassPosition` (iRacing-authoritative) and needs no freeze.
+  // and stable while leaders peel into the garage.
   const positions = calculateFrozenRacePositions(instance.state, telemetry);
   const position = positions[playerCarIdx] ?? 0;
 
   if (position <= 0) return null;
 
+  // Class position is derived from the SAME frozen order (count same-class cars
+  // ahead), so it updates continuously like the overall position instead of only
+  // at the start/finish line. Falls back to iRacing's official
+  // `PlayerCarClassPosition` when `CarIdxClass` isn't available to derive from.
+  const derivedClassPosition = classPositionFromOrder(positions, telemetry.CarIdxClass, playerCarIdx);
   const classPosition =
-    typeof telemetry.PlayerCarClassPosition === "number" && telemetry.PlayerCarClassPosition > 0
-      ? telemetry.PlayerCarClassPosition
-      : 0;
+    derivedClassPosition > 0
+      ? derivedClassPosition
+      : typeof telemetry.PlayerCarClassPosition === "number" && telemetry.PlayerCarClassPosition > 0
+        ? telemetry.PlayerCarClassPosition
+        : 0;
 
   return { position, classPosition, isMultiClass: resolveIsMultiClass(sessionInfo) === true };
 }

--- a/packages/website/src/content/docs/docs/actions/display-session/session-info.md
+++ b/packages/website/src/content/docs/docs/actions/display-session/session-info.md
@@ -63,7 +63,7 @@ Size of the rendered value, in PI units (5–36, doubled for SVG render). Defaul
 
 ### Position
 
-Display the current race position. Optionally shows total cars (e.g., `3/24`) by enabling the **Show Total** setting.
+Display your current race position — either within your own car class (the default) or overall across the whole field. Optionally shows the field size (e.g., `P3/24`) by enabling the **Show Total** setting.
 
 #### Details
 
@@ -71,10 +71,19 @@ Display the current race position. Optionally shows total cars (e.g., `3/24`) by
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the position updates live as drivers pass or are overtaken
 
+#### Setting: Position Type
+
+Which position to display. Defaults to **Class**.
+
+- **Class** (default) — Your position within your car class. In single-class races this matches your overall position.
+- **Overall** — Your position across the entire field, regardless of class.
+
 #### Setting: Show Total
 
-- **Off** (default) — Show just your position (e.g., `3`)
-- **On** — Show position out of field size (e.g., `3/24`)
+Whether to append the field size after your position. Defaults to **Off**.
+
+- **Off** (default) — Show just your position (e.g., `P3`)
+- **On** — Show your position out of the field size (e.g., `P3/24`). The total is scoped to match Position Type — cars in your class for **Class**, the whole field for **Overall**.
 
 #### Setting: Font Size
 


### PR DESCRIPTION
## Related Issue

Fixes #234

## What changed?

Adds a `positionType` setting (**Class** / Overall, default **Class**) to the Session Info action's **Position** mode, so multi-class drivers can see their in-class position rather than only overall race position.

- Both render with the `P` prefix; **Show Total Cars** scopes the count to the chosen type — `P2/8` (cars in your class) vs `P5/24` (full field).
- "Class" is explicit: always class position, even in single-class races (where it equals overall).
- **Live, internally-counted positions.** On track in a race the numbers come from `getLivePosition()` — the same class-aware resolver the Race Engineer uses: frozen overall position (#603) and a **class position derived from that same frozen order**. iRacing's official `PlayerCarClassPosition` only refreshes at the start/finish line, so it can't be used for a live display; instead the new `classPositionFromOrder()` helper in `@iracedeck/iracing-sdk` counts same-class cars (`CarIdxClass`) ranked ahead of you — the same counting `resolveStartingClassPosition` (#599) does for the grid. Pits / non-race fall back to official telemetry.
- This also upgrades the on-track **overall** number to the frozen calc, so the button matches the Race Engineer's voice. The Race Engineer's spoken class readout becomes live too; overtake **detection** (`diffOvertakes`) is unchanged.

## How to test

1. Join a **multi-class** race and add a Session Info key in **Position** mode (defaults to Class).
   - Confirm it shows your **in-class** position and that it updates **live** as you pass / are passed by cars in your class (not only at the start/finish line).
   - Enable **Show Total Cars** → shows `P{n}/{cars in your class}`.
   - Switch **Position Type** to **Overall** → shows overall position and the full field count `P{n}/{field}`.
2. In a **single-class** race, Class and Overall show the same number.
3. In **practice/qualifying** and while **in the pits**, position reads from official telemetry (standings) as before.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — shared action + shared PI; both plugins inherit automatically
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Position Type setting to Session Info to show position within your class (default) or overall, and a visibility toggle so it appears only in Position mode.
  * Show Total now reflects the selected Position Type.

* **Documentation**
  * Updated Session Info Position mode docs with Position Type details and examples.

* **Tests**
  * Expanded tests to cover class vs overall positioning and class-scoped active-car counting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->