### PR TITLE
feat(actions): surface each action's sim-communication method in PI + on icons (#612)

### DIFF
--- a/.claude/rules/action-documentation.md
+++ b/.claude/rules/action-documentation.md
@@ -26,7 +26,18 @@ Action documentation follows this section order:
 | Type | Button / Toggle / +/- / Multi-toggle |
 | SDK Support | Yes / No |
 | Encoder Support | Yes / No |
+| Communication Method | iRacing API / Key binding / Chat command |
 ```
+
+## Communication Method (issue #612)
+
+Every mode talks to iRacing through exactly one of three mechanisms — state it explicitly:
+
+- **iRacing API** — sends an iRacing SDK/broadcast command (`getCommands().*`). Most reliable, needs no binding.
+- **Key binding** — triggers a configurable key binding (keyboard OR SimHub role) via `tapBinding`/`holdBinding`. Requires a binding to be set.
+- **Chat command** — types an iRacing chat/text command, e.g. a `#…` pit macro, via `getCommands().chat.sendMessage(...)`.
+
+The value is sourced from the generated `packages/iracing-actions/src/actions/data/action-comms.json` (authored in `comms-catalog.ts`): `"api"` → iRacing API, `"keybind"` → Key binding, `"chat"` → Chat command. For a single-behavior doc page use the **Communication Method** row above. For a multi-mode action, state the method **per mode** (a row in the modes table or a line in each mode's section) — an action can mix all three (e.g. Fuel Service: API for fill/clear, Chat for `#fuel` add/reduce/set, Key binding for autofuel/lap-margin).
 
 ## Settings Section
 

--- a/.claude/rules/global-settings.md
+++ b/.claude/rules/global-settings.md
@@ -200,3 +200,9 @@ clearWarning("elevation-mismatch");                         // remove by id
 Records are keyed by `id` so independent producers coexist. `setWarning` skips the write when an identical record already exists; `clearWarning` is a no-op when the id is absent. The `ird-warnings` PI web component (auto-injected by `head-common.ejs`) renders the array and prepends a per-level icon — so warning **messages must not start with their own emoji**. Banners are state-driven and not dismissible: a warning persists until its condition clears.
 
 Reference producer: the elevation-mismatch detector wired in both plugins' `plugin.ts` using `evaluateElevationWarning()` + `getElevationStatus()`.
+
+## Binding-configured detection — `isConfigured` / `isBindingMissing` (#612)
+
+A binding key counts as "configured" when **either** a keyboard binding **or** a SimHub role is set — independent of iRacing connection or SimHub reachability. `BindingDispatcher.isConfigured(settingKey)` is the source of truth (it parses the global setting via `parseBinding` + `isSimHubBinding`). `ConnectionStateAwareAction.isBindingMissing(keys: string | string[] | null | undefined)` builds on it: returns true when any required key is unconfigured, false for `null`/empty (api/chat/fixed-key modes). Use `isBindingMissing(<per-context key(s)>)` to drive the per-button missing-binding icon warning — never the shared `isActiveBindingMissing()`/`activeBindingKeys`, which is one value per action-class instance and bleeds across the action's buttons.
+
+The PI `ird-binding-status` line shows the same configured/unconfigured state per mode (reading bindings from the *Related Key Bindings* `ird-key-binding` inputs). A mode bound to a SimHub role is "configured" even when SimHub isn't running — SimHub-not-running is surfaced separately as a live "SimHub not connected" caveat, not as a missing binding.

--- a/.claude/rules/key-icon-types.md
+++ b/.claude/rules/key-icon-types.md
@@ -114,3 +114,7 @@ Optimized for showing live telemetry values. Small title at top, large centered 
 - **Background**: Dynamic — can change color for alert effects (e.g., flash red on incident), defaults to `{{backgroundColor}}`
 - **Placeholders**: `{{backgroundColor}}`, `{{textColor}}`, `{{titleLabel}}`, `{{value}}`, `{{valueFontSize}}`
 - Reference: `packages/iracing-plugin-stream-deck/icons/session-info.svg`
+
+## Missing-binding warning overlay (#612)
+
+Independent of the icon type, a key whose current mode requires a binding (keyboard or SimHub role) but has **neither** set draws a centered ⚠️ warning triangle over the dimmed artwork. This is applied centrally in the icon-assembly layer — `assembleIcon({ bindingMissing })`, or `applyBindingWarning(content)` / `bindingWarningSvg()` for dynamic-template actions — not in individual icon SVGs. Actions compute the flag per button context via `this.isBindingMissing(<key(s)>)` (see `.claude/rules/stream-deck-actions.md`). The glyph is cross-platform-safe (see `svg-platform-compatibility.md`) and clears as soon as either binding type is configured. It is distinct from the inactive/disconnected overlay — it signals a configuration error, not a connection state.

--- a/.claude/rules/pi-templates.md
+++ b/.claude/rules/pi-templates.md
@@ -314,6 +314,21 @@ Templates not in the map (e.g., `settings`, hidden sub-actions) will not show a 
 
 **Maintenance:** When adding a new action, add its entry to `docs-urls.json` with the correct category and action name.
 
+## Binding-status line — `ird-binding-status` (#612)
+
+Each action's PI shows a per-mode communication/binding status line directly under the Mode selector, via the shared `ird-binding-status` web component (in `@iracedeck/pi-components`). Place it immediately after the mode `<sdpi-item>`:
+
+```ejs
+<% var __comms = require('./data/action-comms.json')['<action-name>']; %>
+<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
+```
+
+- `comms` — the action's entry from the generated `data/action-comms.json` (mode → `{ method, binding? }`). **Always `<%=` (HTML-escaped), never `<%-`** — the browser decodes the escaped attribute back to valid JSON on read, and `<%-` would break the attribute or allow injection.
+- `mode-setting` — the action setting whose value is the current mode (read from `_meta.modeSetting`).
+- The component reads the live mode, any `keyBy` secondary setting, and the binding values **directly from the PI DOM** (the `sdpi-select`s and the `ird-key-binding` inputs in the *Related Key Bindings* accordion) with change/input events + a polling fallback — the same approach as the conditional-visibility pattern, because the sdpi settings-subscription hooks only deliver the initial value to a read-only observer. It falls back to a control's `default` attribute when its value is empty (untouched controls report `""`).
+- For keybind modes it shows the keyboard/SimHub/none state, polls SimHub reachability for a live "SimHub not connected" line, and the "set it here" link opens + scrolls the *Related Key Bindings* accordion (located by `data-accordion-id="Related Key Bindings"`).
+- Source of the per-mode catalog: `comms-catalog.ts` → `pnpm generate:action-comms` → `data/action-comms.json` (guarded by a freshness test + a key cross-check against `key-bindings.json`). See `.claude/rules/stream-deck-actions.md` for the full per-action wiring (catalog + status line + icon overlay).
+
 ## Build Output
 
 - Templates in `packages/iracing-actions/src/actions/<name>/<name>.ejs` compile to each plugin's `com.iracedeck.sd.{name}.sdPlugin/ui/<name>.html` (output paths are flat — nesting in the source tree doesn't affect the output filename)

--- a/.claude/rules/stream-deck-actions.md
+++ b/.claude/rules/stream-deck-actions.md
@@ -402,3 +402,19 @@ override async onDialRotate(ev: IDeckDialRotateEvent<Settings>): Promise<void> {
   }
 }
 ```
+
+## Per-Mode Communication Method & Binding Status (#612)
+
+Every action mode talks to iRacing through exactly one of three methods — **API** (`getCommands().*`), **key binding** (`tapBinding`/`holdBinding`), or **chat** (`getCommands().chat.sendMessage("#…")`). This is formalized in a per-`(action, mode)` catalog and surfaced in the PI (a status line under the Mode selector) and on the key icon (a centered ⚠️ when a required binding is unset).
+
+When adding or modifying an action, keep these in sync:
+
+1. **Catalog** — add/update the action's entry in `packages/iracing-actions/src/actions/comms-catalog.ts` (one `CommDescriptor` per mode: `api` / `chat`, or a keybind with a constant key, a `keyBy` a secondary setting, multiple keys, or no binding for a fixed key). Use the `keybind` / `keybindBy` / `keybindKeys` / `keybindFixed` helpers. Run `pnpm generate:action-comms` to regenerate `data/action-comms.json`. A freshness test + a cross-check (every keybind key must exist in `key-bindings.json`) guard correctness.
+2. **PI status line** — add the shared component under the Mode `<sdpi-item>` in the action's `.ejs`:
+   ```ejs
+   <% var __comms = require('./data/action-comms.json')['<action-name>']; %>
+   <ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
+   ```
+   Use `<%=` (HTML-escaped) for the `comms` attribute, never `<%-`. Display-only / internal actions (session-info, telemetry-display, pit-crew) get no line and no catalog entry.
+3. **Icon overlay** — for keybind modes, compute the missing-binding flag **per button context** with the base-class `this.isBindingMissing(<key(s) for this mode's settings>)` — NOT the shared `isActiveBindingMissing()`, which bleeds one button's state onto every button of the action. Reuse the same key expression the action passes to `setActiveBinding`. Pass `bindingMissing` into the icon generator: `assembleIcon({ …, bindingMissing })` for static icons, or `applyBindingWarning(content)` for dynamic-template icons. Compute it fresh inside regenerate-callback closures so a live binding change updates the icon.
+4. **Docs** — state the per-mode method in the action docs and on the website action page (see `action-documentation.md` and `website-action-docs.md`).

--- a/.claude/rules/svg-platform-compatibility.md
+++ b/.claude/rules/svg-platform-compatibility.md
@@ -91,6 +91,10 @@ This minimal approach is correct — it ensures cross-platform consistency.
 4. **Do not use `<style>` elements** — use inline `style` attributes or direct SVG presentation attributes instead.
 5. **Test cross-platform** when introducing any SVG feature not already in use. If in doubt, check this table.
 
+## Binding-missing warning glyph (#612)
+
+The centered ⚠️ overlay drawn on a key when a required binding is unset (`assembleIcon({ bindingMissing })` / `bindingWarningSvg()` in `@iracedeck/icon-composer`) is built **only** from `polygon`, `rect` (with `rx`), `circle`, and a `<g opacity="…">` dim wrapper — all in the safe SVG Tiny 1.2 set — so it renders identically on Mirabox's QT5 engine. It uses no filters, masks, `clipPath`, or `<style>`/class-based styling. Keep it that way: the overlay must render on the lowest common denominator since a missing binding is essential information.
+
 ## Reference Documentation
 
 - QT5 SVG rendering: https://doc.qt.io/qt-5/svgrendering.html

--- a/.claude/rules/website-action-docs.md
+++ b/.claude/rules/website-action-docs.md
@@ -32,6 +32,7 @@ Description of what this mode does.
 
 #### Details
 
+- **Method:** `iRacing API`, `Key binding`, or `Chat command`
 - **Dial:** Describe rotation behavior, or `No rotation support`
 - **Default binding:** `` `Key` ``, or `No default key binding`, or `No keyboard binding`
 - **Telemetry-aware icon:** `Yes` (with a brief note on what updates), or `No`
@@ -48,6 +49,7 @@ Description of what this mode does.
 
 #### Details
 
+- **Method:** `iRacing API`, `Key binding`, or `Chat command`
 - **Dial:** Describe rotation behavior, or `No rotation support`
 - **Default binding:** `` `Key` ``, or `No default key binding`, or `No keyboard binding`
 - **Telemetry-aware icon:** `Yes` (with a brief note on what updates), or `No`
@@ -74,16 +76,20 @@ Description including default value.
 
 Each mode section must include a `#### Details` subheader containing a bullet list with the following items, in order:
 
-1. **Dial:** rotation behavior, or `No rotation support`
-2. **Default binding:** one of:
+1. **Method:** how the mode talks to iRacing — one of (issue #612):
+   - `iRacing API` — sends an iRacing SDK/broadcast command (`getCommands().*`). Most reliable, no binding needed.
+   - `Key binding` — triggers a configurable key binding (keyboard OR SimHub role) via `tapBinding`/`holdBinding`. Requires the binding to be set.
+   - `Chat command` — types an iRacing chat/text command, e.g. a `#…` pit macro, via `getCommands().chat.sendMessage(...)`.
+2. **Dial:** rotation behavior, or `No rotation support`
+3. **Default binding:** one of:
    - `` `Key` `` — action ships with a default keyboard binding (e.g., `` `F1` ``, `` `Ctrl+Shift+R` ``)
    - `No default key binding` — action uses a configurable keyboard shortcut but ships without a default; user must set both the iRacing binding and the action binding
-   - `No keyboard binding` — mode does not use the keyboard at all (typically SDK-only)
-3. **Telemetry-aware icon:** `Yes` (followed by a short note on what the icon reflects — e.g., "shows the currently selected pit service compound") or `No`. A mode is telemetry-aware when its icon re-renders in response to live `TelemetryData` updates; a mode that only renders a static icon on settings change is `No`.
+   - `No keyboard binding` — mode does not use the keyboard at all (typically SDK or chat). Use this for `iRacing API` and `Chat command` modes.
+4. **Telemetry-aware icon:** `Yes` (followed by a short note on what the icon reflects — e.g., "shows the currently selected pit service compound") or `No`. A mode is telemetry-aware when its icon re-renders in response to live `TelemetryData` updates; a mode that only renders a static icon on settings change is `No`.
 
 Trailing periods are omitted from each Details bullet value (the bullet list is terse metadata, not prose).
 
-The Details block is mode-specific: within a single action, different modes may use SDK for some behaviors and keyboard for others, and different modes may or may not react to telemetry. Document each mode as it actually behaves in code — `packages/iracing-actions/src/actions/<action>/<action>.ts` (look for `getCommands()` vs `tapBinding`/`holdBinding`, and whether the mode's icon-generation path subscribes to `sdkController` / reads `TelemetryData`) is the source of truth for how a mode is triggered and whether it is telemetry-aware; `packages/iracing-actions/src/actions/<action>/<action>.ejs` (the `default` attribute on `ird-key-binding`) and `packages/iracing-actions/src/actions/data/key-bindings.json` are the source of truth for default keys.
+The Details block is mode-specific: within a single action, different modes may use SDK for some behaviors, key bindings for others, and chat for others. Document each mode as it actually behaves in code. **The per-mode `Method` is sourced from the generated `packages/iracing-actions/src/actions/data/action-comms.json`** (authored in `comms-catalog.ts`): `"api"` → `iRacing API`, `"keybind"` → `Key binding`, `"chat"` → `Chat command`. The dispatch in `packages/iracing-actions/src/actions/<action>/<action>.ts` (`getCommands().*` vs `tapBinding`/`holdBinding` vs `chat.sendMessage("#…")`, and whether the icon path reads `TelemetryData`) is the underlying source of truth; `packages/iracing-actions/src/actions/<action>/<action>.ejs` (the `default` attribute on `ird-key-binding`) and `packages/iracing-actions/src/actions/data/key-bindings.json` are the source of truth for default keys.
 
 ### Settings block
 

--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -25,10 +25,20 @@ Each action entry:
 }
 ```
 
+## Communication method (per mode) — `action-comms.json` (#612)
+
+Every action mode talks to iRacing through one of three methods, formalized per-`(action, mode)` in `packages/iracing-actions/src/actions/data/action-comms.json` (generated from `comms-catalog.ts`):
+
+- **`api`** — iRacing API / SDK command (`getCommands().*`); most reliable, no binding needed.
+- **`keybind`** — a configurable key binding (keyboard OR SimHub role); requires the binding to be set. The descriptor's `binding` carries a constant `key`, a `keyBy` a secondary setting, multiple `keys`, or is absent for a fixed key (no user binding).
+- **`chat`** — an iRacing chat/text command, e.g. a `#…` pit macro.
+
+This is the **authoritative source for a mode's communication method** when answering "how does action X mode Y talk to iRacing?" or labeling docs. An action can mix all three across its modes (e.g. Fuel Service). Display-only / internal actions (session-info, telemetry-display, pit-crew) and the PI-less camera-controls are absent from the catalog. The method surfaces in the PI (an `ird-binding-status` line under the Mode selector) and on the key icon (a centered ⚠️ when a required binding is unset).
+
 ## How to Use
 
 When asked about actions or controls:
-1. Read `docs/reference/actions.json` and search by action name, mode value, or category
+1. Read `docs/reference/actions.json` and search by action name, mode value, or category (and `data/action-comms.json` for each mode's communication method)
 2. Report: action name, ID, file, modes with labels
 3. For implementation details, check the source at `packages/iracing-actions/src/actions/{action-name}/{action-name}.ts`
 4. For PI templates, check `packages/iracing-actions/src/actions/{action-name}/{action-name}.ejs`

--- a/docs/plugins/core/actions/adjust-master-volume.md
+++ b/docs/plugins/core/actions/adjust-master-volume.md
@@ -9,6 +9,7 @@ Adjusts the iRacing master audio volume.
 | Action ID | `com.iracedeck.sd.core.adjust-master-volume` |
 | Type | +/- |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | Yes |
 
 ## Behavior

--- a/docs/plugins/core/actions/autofuel-lap-margin.md
+++ b/docs/plugins/core/actions/autofuel-lap-margin.md
@@ -9,6 +9,7 @@ Adjusts the lap margin for automatic fuel calculation.
 | Action ID | `com.iracedeck.sd.core.autofuel-lap-margin` |
 | Type | +/- |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | Yes |
 
 ## Behavior

--- a/docs/plugins/core/actions/autofuel-toggle.md
+++ b/docs/plugins/core/actions/autofuel-toggle.md
@@ -9,6 +9,7 @@ Toggles the automatic fuel calculation feature.
 | Action ID | `com.iracedeck.sd.core.autofuel-toggle` |
 | Type | Toggle |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | No |
 
 ## Behavior

--- a/docs/plugins/core/actions/black-box-selector.md
+++ b/docs/plugins/core/actions/black-box-selector.md
@@ -9,6 +9,7 @@ Cycles through or directly selects iRacing black box screens.
 | Action ID | `com.iracedeck.sd.core.black-box-selector` |
 | Type | Multi-toggle |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | Yes |
 
 ## Behavior

--- a/docs/plugins/core/actions/driver-height-adjust.md
+++ b/docs/plugins/core/actions/driver-height-adjust.md
@@ -9,6 +9,7 @@ Adjusts the virtual driver's seating height.
 | Action ID | `com.iracedeck.sd.core.driver-height-adjust` |
 | Type | +/- |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | Yes |
 
 ## Behavior

--- a/docs/plugins/core/actions/enter-exit-tow-car.md
+++ b/docs/plugins/core/actions/enter-exit-tow-car.md
@@ -9,6 +9,7 @@ Enters, exits, or requests a tow for the car.
 | Action ID | `com.iracedeck.sd.core.enter-exit-tow-car` |
 | Type | Button |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | No |
 
 ## Behavior

--- a/docs/plugins/core/actions/escape.md
+++ b/docs/plugins/core/actions/escape.md
@@ -9,6 +9,7 @@ Sends the ESC key to iRacing. Used to exit the car or dismiss dialogs.
 | Action ID | `com.iracedeck.sd.core.car-control` |
 | Type | Car Control sub-action |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | Yes |
 
 ## Settings

--- a/docs/plugins/core/actions/fov-adjust.md
+++ b/docs/plugins/core/actions/fov-adjust.md
@@ -9,6 +9,7 @@ Adjusts the driver's field of view.
 | Action ID | `com.iracedeck.sd.core.fov-adjust` |
 | Type | +/- |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | Yes |
 
 ## Behavior

--- a/docs/plugins/core/actions/fps-network-display.md
+++ b/docs/plugins/core/actions/fps-network-display.md
@@ -9,6 +9,7 @@ Toggles the FPS and network statistics overlay.
 | Action ID | `com.iracedeck.sd.core.fps-network-display` |
 | Type | Toggle |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | No |
 
 ## Behavior

--- a/docs/plugins/core/actions/fuel-service.md
+++ b/docs/plugins/core/actions/fuel-service.md
@@ -9,7 +9,10 @@ Manages fuel pit stop settings: toggle fueling, add/reduce/set fuel amounts, cle
 | Action ID | `com.iracedeck.sd.core.fuel-service` |
 | Type | Multi-toggle |
 | SDK Support | Yes (toggle, clear) / No (macros, keyboard modes) |
+| Communication Method | iRacing API (varies by mode — see note) |
 | Encoder Support | Yes |
+
+> **Communication method by mode:** Toggle Fuel Fill and Clear Fuel Checkbox use the **iRacing API**; Add Fuel, Reduce Fuel, and Set Fuel Amount use **Chat command** (`#fuel` macros); Toggle Autofuel and Lap Margin Increase/Decrease use **Key binding**.
 
 ## Behavior
 

--- a/docs/plugins/core/actions/horizon-adjust.md
+++ b/docs/plugins/core/actions/horizon-adjust.md
@@ -9,6 +9,7 @@ Adjusts the vertical horizon position in the driver's view.
 | Action ID | `com.iracedeck.sd.core.horizon-adjust` |
 | Type | +/- |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | Yes |
 
 ## Behavior

--- a/docs/plugins/core/actions/ignition.md
+++ b/docs/plugins/core/actions/ignition.md
@@ -9,6 +9,7 @@ Toggles the car's ignition.
 | Action ID | `com.iracedeck.sd.core.ignition` |
 | Type | Button |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | No |
 
 ## Behavior

--- a/docs/plugins/core/actions/look-direction.md
+++ b/docs/plugins/core/actions/look-direction.md
@@ -9,6 +9,7 @@ Changes the driver's view direction.
 | Action ID | `com.iracedeck.sd.core.look-direction` |
 | Type | Multi-toggle |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | No |
 
 ## Behavior

--- a/docs/plugins/core/actions/pause-sim.md
+++ b/docs/plugins/core/actions/pause-sim.md
@@ -9,6 +9,7 @@ Pauses the simulation (single-player/replay only).
 | Action ID | `com.iracedeck.sd.core.pause-sim` |
 | Type | Toggle |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | No |
 
 ## Behavior

--- a/docs/plugins/core/actions/pit-speed-limiter.md
+++ b/docs/plugins/core/actions/pit-speed-limiter.md
@@ -9,6 +9,7 @@ Toggles the pit lane speed limiter.
 | Action ID | `com.iracedeck.sd.core.pit-speed-limiter` |
 | Type | Toggle |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | No |
 
 ## Behavior

--- a/docs/plugins/core/actions/radio-display.md
+++ b/docs/plugins/core/actions/radio-display.md
@@ -9,6 +9,7 @@ Toggles the radio/communications overlay display.
 | Action ID | `com.iracedeck.sd.core.radio-display` |
 | Type | Toggle |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | No |
 
 ## Behavior

--- a/docs/plugins/core/actions/recenter-vr-view.md
+++ b/docs/plugins/core/actions/recenter-vr-view.md
@@ -9,6 +9,7 @@ Recenters the virtual reality headset view.
 | Action ID | `com.iracedeck.sd.core.recenter-vr-view` |
 | Type | Button |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | No |
 
 ## Behavior

--- a/docs/plugins/core/actions/report-latency.md
+++ b/docs/plugins/core/actions/report-latency.md
@@ -9,6 +9,7 @@ Reports current network latency to the chat.
 | Action ID | `com.iracedeck.sd.core.report-latency` |
 | Type | Button |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | No |
 
 ## Behavior

--- a/docs/plugins/core/actions/speed-gear-pedals-display.md
+++ b/docs/plugins/core/actions/speed-gear-pedals-display.md
@@ -9,6 +9,7 @@ Toggles the speed, gear, and pedals overlay display.
 | Action ID | `com.iracedeck.sd.core.speed-gear-pedals-display` |
 | Type | Toggle |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | No |
 
 ## Behavior

--- a/docs/plugins/core/actions/splits-delta-cycle.md
+++ b/docs/plugins/core/actions/splits-delta-cycle.md
@@ -9,6 +9,7 @@ Manages splits delta display cycling, reference car toggling, custom sector mark
 | Action ID | `com.iracedeck.sd.core.splits-delta-cycle` |
 | Type | Multi-toggle |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | Yes |
 
 ## Behavior

--- a/docs/plugins/core/actions/starter.md
+++ b/docs/plugins/core/actions/starter.md
@@ -9,6 +9,7 @@ Engages the car's starter motor.
 | Action ID | `com.iracedeck.sd.core.starter` |
 | Type | Button |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | No |
 
 ## Behavior

--- a/docs/plugins/core/actions/toggle-dash-box.md
+++ b/docs/plugins/core/actions/toggle-dash-box.md
@@ -9,6 +9,7 @@ Toggles the in-car dash information box display.
 | Action ID | `com.iracedeck.sd.core.toggle-dash-box` |
 | Type | Toggle |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | No |
 
 ## Behavior

--- a/docs/plugins/core/actions/toggle-display-reference-car.md
+++ b/docs/plugins/core/actions/toggle-display-reference-car.md
@@ -11,6 +11,7 @@ Toggles the reference car display for split-time comparison.
 | Action ID | `com.iracedeck.sd.core.splits-delta-cycle` (toggle-ref-car mode) |
 | Type | Multi-toggle |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | Yes |
 
 ## Migration

--- a/docs/plugins/core/actions/toggle-ui-edit.md
+++ b/docs/plugins/core/actions/toggle-ui-edit.md
@@ -9,6 +9,7 @@ Toggles UI edit mode for repositioning on-screen elements.
 | Action ID | `com.iracedeck.sd.core.toggle-ui-edit` |
 | Type | Toggle |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | No |
 
 ## Behavior

--- a/docs/plugins/core/actions/toggle-virtual-mirror.md
+++ b/docs/plugins/core/actions/toggle-virtual-mirror.md
@@ -9,6 +9,7 @@ Toggles the virtual rear-view mirror display.
 | Action ID | `com.iracedeck.sd.core.toggle-virtual-mirror` |
 | Type | Toggle |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | No |
 
 ## Behavior

--- a/docs/plugins/core/actions/toggle-weather-radar.md
+++ b/docs/plugins/core/actions/toggle-weather-radar.md
@@ -9,6 +9,7 @@ Toggles the weather radar overlay display.
 | Action ID | `com.iracedeck.sd.core.toggle-weather-radar` |
 | Type | Toggle |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | No |
 
 ## Behavior

--- a/docs/plugins/core/actions/trigger-windshield-wipers.md
+++ b/docs/plugins/core/actions/trigger-windshield-wipers.md
@@ -9,6 +9,7 @@ Triggers a single wipe of the windshield wipers.
 | Action ID | `com.iracedeck.sd.core.trigger-windshield-wipers` |
 | Type | Button |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | No |
 
 ## Behavior

--- a/docs/plugins/core/actions/ui-size-adjust.md
+++ b/docs/plugins/core/actions/ui-size-adjust.md
@@ -9,6 +9,7 @@ Adjusts the overall UI scale.
 | Action ID | `com.iracedeck.sd.core.ui-size-adjust` |
 | Type | +/- |
 | SDK Support | No |
+| Communication Method | Key binding |
 | Encoder Support | Yes |
 
 ## Behavior

--- a/docs/superpowers/specs/2026-05-31-comms-method-audit.md
+++ b/docs/superpowers/specs/2026-05-31-comms-method-audit.md
@@ -1,0 +1,65 @@
+# Per-mode communication-method audit (#612) — for maintainer verification
+
+Code-verified classification of every action/mode's iRacing communication method, plus the binding key (or key-resolution rule) for keybind modes. This is the source the descriptor catalog will be built from. **Please verify before it's frozen.**
+
+Method legend: **api** = iRacing SDK/broadcast (`getCommands().*`); **keybind** = simulated key binding (keyboard OR SimHub), requires a binding; **chat** = iRacing chat/text command (`#…` macros via `chat.sendMessage`).
+
+## Pure API (no binding needed)
+
+| Action | Modes |
+|--------|-------|
+| camera-controls | all 12 (change/cycle/focus/switch/set-camera-state) |
+| media-capture | start-stop-video, show-timer, take-screenshot |
+| pit-quick-actions | clear-all-checkboxes, windshield-tearoff, request-fast-repair |
+| replay-control / replay-navigation / replay-speed / replay-transport | all modes |
+| telemetry-control | toggle/start/stop/restart-logging |
+
+## Pure CHAT (no binding needed)
+
+| Action | Modes |
+|--------|-------|
+| race-admin | all 27 modes (yellow, black-flag, dq-driver, …) — `#…` admin commands |
+
+## Pure KEYBIND (binding required)
+
+| Action | Mode setting | Key model |
+|--------|--------------|-----------|
+| ai-spotter-controls | mode | constant per mode (`spotter*`) |
+| black-box-selector | mode | `direct` → keyBy **blackBox** (11 keys); `next`/`previous` → constant cycle keys |
+| camera-editor-adjustments | adjustment | keyBy **direction** (`CAMERA_EDITOR_GLOBAL_KEYS[adjustment][direction]`) |
+| camera-editor-controls | control | constant per control (`CAMERA_EDITOR_CONTROLS_GLOBAL_KEYS`) |
+| car-control | control | constant per mode; **`escape` = hardcoded ESC, no user binding** |
+| cockpit-misc | control | mix: constant + keyBy **direction** (ffb-max-force, dash-page-1/2) |
+| force-feedback | mode | constant (auto-compute) + keyBy **direction** (rest) |
+| look-direction | (no mode selector) | keyBy **direction** (look-left/right/up/down), hold-based |
+| setup-aero / brakes / chassis / engine / fuel / hybrid / traction | setting | adjust modes → keyBy **direction**; toggles → constant; **view-* modes → dual-press (see decision 2)** |
+| splits-delta-cycle | mode | `cycle` → keyBy **direction**; rest constant |
+| toggle-ui-elements | element | 9 keybind constant + `replay-ui` → **api** |
+| view-adjustment | adjustment | keyBy **direction**; `recenter-vr` constant |
+
+## Mixed-method actions
+
+| Action | Breakdown |
+|--------|-----------|
+| fuel-service | api: toggle-fuel-fill, clear-fuel · chat: add/reduce/set-fuel · keybind: toggle-autofuel, lap-margin-inc/dec |
+| tire-service | chat: change-all-tires (`#t`), toggle-tires · api: clear-tires, change-compound |
+| chat | api: open-chat, reply, cancel, send-message, macro · keybind: whisper, toggle |
+| audio-controls | keybind: push-to-talk, voice-chat (keyBy **action**), master (keyBy **action**) · internal (decision 4): race-engineer, radar |
+
+## Display-only / internal (no iRacing communication)
+
+session-info, telemetry-display (display only) · pit-crew (race-engineer / radar / radar-volume — plugin state, not iRacing) · camera-cycle, camera-focus (icon/template only, no action code).
+
+---
+
+## Decisions needed (maintainer)
+
+1. **Display-only / internal actions** — proposed: **no** status line and **no** icon overlay for session-info, telemetry-display, pit-crew, camera-cycle, camera-focus (they don't command iRacing via any of the three methods).
+
+2. **setup `view-*` modes (dual-press)** — these keybind modes nudge+read a value; the actual key is the adjustment's increase/decrease pair, selected at press time by the global `dualPressDirections` + press length. Proposed model: descriptor uses the **increase key** as the representative binding (status line shows that key; icon warns if it's unset). Simpler than reading the two global dual-press settings in the PI.
+
+3. **car-control `escape`** — hardcoded ESC, not user-configurable. Proposed: descriptor `{ method: "keybind" }` with **no binding** → status line shows "Key binding — no binding needed", icon never warns. (Adds a "keybind-without-binding = fixed key" case to the component.)
+
+4. **audio-controls `race-engineer` / `radar`** — adjust plugin audio, not iRacing. Proposed: **omit from the comms map** → status line renders nothing for those two modes.
+
+5. ~~camera-editor~~ — **resolved**: both are keybind (controls = constant per `control`; adjustments = keyBy `direction`).

--- a/docs/superpowers/specs/2026-05-31-surface-comms-method-design.md
+++ b/docs/superpowers/specs/2026-05-31-surface-comms-method-design.md
@@ -1,0 +1,156 @@
+# Surface each action/mode's sim-communication method (#612)
+
+Status: approved design, ready for implementation planning
+Date: 2026-05-31
+Issue: #612 (milestone v1.20.0)
+Scope decision: implement the **entire** feature in one PR (foundation + PI status line + icon overlay + docs/website explainer + per-action audit + labels).
+
+## Problem
+
+iRaceDeck actions talk to iRacing through three mechanisms — the **iRacing API/SDK**, simulated **key bindings**, and **chat/text commands** — and which one a given action *mode* uses is invisible to the user. A mode can silently do nothing because a required binding was never set, and users can't reason about reliability or troubleshoot without knowing the mechanism.
+
+A "binding" is a discriminated union: a keyboard combination **or** a SimHub Control Mapper role (`BindingValue = KeyBindingValue | SimHubBindingValue`). A mode bound to a SimHub role is fully configured and must never be flagged "no binding set" — but it only works while SimHub is running, which the UI must surface.
+
+The communication method is **per-mode, not per-action**: a single action routinely mixes all three methods. Fuel Service is the canonical example — `toggle-autofuel` / `lap-margin-*` are keybind, `add/reduce/set-fuel` are chat macros, `clear-fuel` / `toggle-fuel-fill` are SDK.
+
+## Goal
+
+Make each action/mode's communication method obvious, and make a missing-but-required binding impossible to miss — in the Property Inspector, on the key icon, and in the documentation. A SimHub-bound mode reads as configured; the "SimHub must be running" caveat is surfaced separately.
+
+## Architecture overview
+
+Four layers over one shared foundation:
+
+1. **Foundation** — a per-`(action, mode)` communication descriptor, authoritative in TS, generated to JSON for non-TS consumers.
+2. **PI status line** — a shared `ird-binding-status` web component placed under the Mode selector.
+3. **Icon overlay** — a centered ⚠️ over dimmed artwork, applied in the shared icon-assembly layer.
+4. **Docs/website** — an explainer page on the three methods plus per-mode method labels, backed by a full audit of every action/mode.
+
+## 1. Foundation — per-mode communication descriptor
+
+### Descriptor shape
+
+```ts
+export type CommMethod = "api" | "keybind" | "chat";
+
+export type CommDescriptor = {
+  method: CommMethod;
+  // Present only when method === "keybind". A keybind mode always requires a binding.
+  binding?: {
+    key: string; // global-settings key (e.g. "fuelServiceToggleAutofuel") or per-action settings key
+    scope: "global" | "action";
+  };
+};
+
+// One action's modes -> descriptor. Keyed by the mode string used in the action's `mode` setting.
+export type ActionCommMap = Record<string, CommDescriptor>;
+```
+
+`method: "keybind"` is the only method that requires a binding, so no separate `required` flag is needed. `api` and `chat` modes never warn and never overlay.
+
+### Source of truth (Approach A — approved)
+
+TS descriptors are **authoritative**; JSON is **generated**.
+
+- Each action exports a typed descriptor, e.g. `export const FUEL_SERVICE_COMMS: ActionCommMap = { ... }`, type-checked so every key corresponds to a real mode. Where the action already encodes the mapping (e.g. `FUEL_SERVICE_GLOBAL_KEYS`), that map is **derived from** the descriptor (single source — no duplicate mode→key tables).
+- A barrel (`packages/iracing-actions/src/actions/comms-catalog.ts`) aggregates every action's `ActionCommMap` keyed by action folder name into a single `COMMS_CATALOG: Record<string, ActionCommMap>`.
+- `scripts/generate-action-comms.mjs` emits `packages/iracing-actions/src/actions/data/action-comms.json` from the catalog. A Vitest freshness test asserts the committed JSON matches the catalog (mirrors the existing `generate-icon-defaults.mjs` + freshness-test convention).
+- Consumers: action TS imports the catalog directly (icon overlay); the PI EJS `require()`s `data/action-comms.json` at compile time (same mechanism as `data/key-bindings.json`); docs generation reads the same JSON.
+
+### Shared binding helpers
+
+`parseBinding`, `isSimHubBinding`, and `formatKeyBinding` are pure and currently live in `deck-core`. Extract them (and the `KeyBindingValue` / `SimHubBindingValue` / `BindingValue` types) into a pure module importable by **both** `deck-core` and the browser-bundled `pi-components`, so the PI status component and the icon layer share one definition of "is this binding configured?" Re-export from `deck-core` for backward compatibility (no churn at call sites).
+
+## 2. Property Inspector — `ird-binding-status` component
+
+A new `ird-*` web component in `packages/pi-components/src/components/` (no raw HTML controls, per the rules). Placed directly under the Mode selector in each action's `.ejs`:
+
+```html
+<sdpi-item label="Mode"> ... </sdpi-item>
+<ird-binding-status
+  mode-select="mode-select"
+  comms='<%- JSON.stringify(require("./data/action-comms.json")["fuel-service"]) %>'
+></ird-binding-status>
+```
+
+Behavior:
+
+- Reads the current mode from the referenced `<sdpi-select>` (live: `change` + `input` + polling fallback, per the project's documented sdpi-select quirk).
+- Looks up the descriptor for the current mode in its `comms` attribute and renders exactly one status line. Method is always named (approved):
+  - `api` → ✅ "iRacing API — no binding needed."
+  - `chat` → ✅ "Chat command — no binding needed."
+  - `keybind`, keyboard binding set → ✅ "Key binding — currently set: Ctrl + X." (via `formatKeyBinding`)
+  - `keybind`, SimHub role set → ✅ "Bound to SimHub role: «role»." **plus** caveat ⚠️ "Requires SimHub to be running." The caveat renders live-red when SimHub is not reachable and muted when reachable.
+  - `keybind`, neither keyboard nor SimHub set → ⚠️ "No binding set — **set it here**." ("set it here" is a link.)
+- Subscribes to global-settings changes so it updates live as the user sets/clears/switches a binding (including keyboard↔SimHub) without changing mode.
+- "Set it here" link: opens the global key-bindings accordion (located via its `data-accordion-id`, persisting open state through `_accordionState` exactly as the `accordion` partial already does) and `scrollIntoView`s it. The accordion-open + scroll logic lives **inside** the component so every action navigates identically. The link does not need to focus the exact field — getting the user to the open accordion is sufficient.
+
+SimHub reachability reaches the browser PI via a plugin-maintained `_simHubReachable` passthrough global setting (same pattern as `_audioDeviceList` / `_warnings`), written from the existing `onSimHubReachabilityChange` in both plugins. The component reads it for the live caveat state.
+
+## 3. Icon overlay — centered ⚠️ over dimmed art
+
+`assembleIcon` gains an option:
+
+```ts
+assembleIcon({ /* ... existing ... */ bindingMissing?: boolean })
+```
+
+When `bindingMissing` is true, the composed graphic content is wrapped in `<g opacity="0.25">…</g>` and a centered warning triangle is appended. The glyph is drawn with SVG Tiny 1.2-safe primitives only (a `polygon` triangle + an exclamation built from `rect`/`text` — no filters, masks, or clipPath), so it renders on Mirabox's QT5 engine. Approved treatment: **triangle over dimmed art** (art stays identifiable, warning unmistakable).
+
+A standalone exported helper `bindingWarningSvg()` (returns the triangle SVG snippet) plus a `dimWrap(content)` helper cover dynamic-template actions that bypass `assembleIcon` (e.g. fuel-service's telemetry-driven `toggle-autofuel`), so those actions can compose the same overlay into their `{{iconContent}}`.
+
+`ConnectionStateAwareAction` gains `protected isActiveBindingMissing(): boolean`, derived from the **same** source of truth as readiness (the binding dispatcher / global settings, keyboard-OR-SimHub aware) — it returns true only when the active binding key has neither a keyboard binding nor a SimHub role. Each action computes the flag from its current mode's descriptor and passes `bindingMissing` into its icon generator.
+
+Semantics:
+
+- The warning is **independent of connection state** — a missing binding is a configuration error, shown whether or not iRacing is connected.
+- A **SimHub-configured** mode never shows the overlay (SimHub-not-running is the separate inactive/reachability state, surfaced in the PI caveat, not a missing binding).
+- The overlay clears the instant a keyboard binding or a SimHub role is set.
+
+## 4. Documentation, website, and the per-action audit
+
+### Audit
+
+Classify every mode of all ~36 actions by reading each dispatch path (`executeMode`-style switches, `getCommands()` vs `tapBinding`/`holdBinding` vs `chat.sendMessage`). Produce a classification table (action → mode → method → binding key/scope). **The table is reviewed and verified by the maintainer before it is frozen** into the TS descriptors and docs — the audit's correctness is a hard gate.
+
+### Docs
+
+- New explainer page (`docs/` + website) covering the three methods, the reliability rationale (API → key binding → chat), and that a "key binding" is fulfilled by a keyboard combination **or** a SimHub Control Mapper role (which requires SimHub running).
+- Extend `.claude/rules/action-documentation.md`: the action-doc template gains a per-mode **Method** expression (e.g. a Method column in the mode/settings table, or a per-mode method line). Backfill every existing action doc under `docs/`.
+- Website (`@iracedeck/website`): per-action / per-mode method labels on action pages, plus the new explainer page in navigation. Update action counts / feature lists only if affected.
+
+## 5. Testing
+
+- **Descriptor freshness**: committed `action-comms.json` matches `COMMS_CATALOG`; every descriptor key is a real mode for its action (cross-checked against each action's mode enum where feasible).
+- **`ird-binding-status` states**: api, chat, keyboard-set, SimHub-set, neither-set; live keyboard↔SimHub switching; SimHub reachable vs unreachable caveat; mode-change re-render.
+- **Accordion navigation**: "set it here" opens the target accordion (sets `open` + persists `_accordionState`) and calls `scrollIntoView`.
+- **Icon overlay**: on when binding missing, off when keyboard or SimHub configured; SimHub-configured never overlays; cross-platform-safe SVG (no filter/mask/clipPath tokens in output); `bindingWarningSvg()` snippet shape.
+- **`isActiveBindingMissing`**: true only when neither keyboard nor SimHub set; false for api/chat modes and for configured bindings.
+- **Shared helper extraction**: existing `parseBinding`/`isSimHubBinding`/`formatKeyBinding` tests continue to pass against the relocated module and the `deck-core` re-export.
+
+## Affected artifacts (sync in the same PR)
+
+- **pi-components** — new `ird-binding-status` component (SimHub-aware, accordion-open + scroll-to nav); extracted shared binding helpers; build/register the component.
+- **iracing-actions** — per-mode `*_COMMS` descriptors per action, `comms-catalog.ts` barrel, generated `data/action-comms.json`, `generate-action-comms.mjs`, wire `<ird-binding-status>` into every action `.ejs` under the Mode selector; derive existing mode→key maps from descriptors.
+- **icon-composer / deck-core** — `assembleIcon` `bindingMissing` option, `bindingWarningSvg()` + `dimWrap()` helpers, `ConnectionStateAwareAction.isActiveBindingMissing()`.
+- **Both plugins (Elgato + Mirabox)** — maintain `_simHubReachable` global setting from `onSimHubReachabilityChange`; pick up the shared PI component and icon overlay; verify overlay renders on QT5.
+- **Website** (`@iracedeck/website`) — explainer page + per-action method labels.
+- **Docs** (`docs/`) — explainer page; per-mode method in action-doc template; backfill all action docs.
+- **Rules** — `action-documentation.md` (method field), `stream-deck-actions.md`, `pi-templates.md` (new partial/component + accordion navigation), `key-icon-types.md` (overlay), `global-settings.md` (binding-status / union usage, `_simHubReachable`), `svg-platform-compatibility.md` (confirm the glyph is safe).
+- **Skills** — `iracedeck-actions` (per-mode method listing).
+- **Tests** — all of section 5.
+
+## Acceptance criteria (from the issue)
+
+- For any action, the PI shows, under the Mode selector, whether the current mode needs a binding and — if so — whether one is set (keyboard **or** SimHub), with a link to set it, plus the communication method.
+- A SimHub-bound mode shows as configured (never the ⚠️ "no binding" state); status reflects switching between Keyboard and SimHub live; the SimHub-must-be-running caveat is surfaced.
+- The "set it here" link opens the correct key-binding accordion and scrolls it into view within the PI.
+- A mode requiring a binding with **neither** keyboard nor SimHub set shows a centered ⚠️ on the key icon, on both Elgato and Mirabox; it clears once either binding type is configured.
+- A docs/website page explains the three methods (and keyboard-vs-SimHub bindings), and every action/mode is labeled with its method.
+- No raw HTML controls in PI templates; icon overlay uses cross-platform-safe SVG only.
+- `pnpm build`, `pnpm test`, `pnpm lint:fix`, `pnpm format:fix` all pass.
+
+## Notes / non-goals
+
+- Auto-fuel dispatch-method verification (#611) is a separate, smaller issue and not in scope here.
+- Per-action vs global binding scope: the descriptor supports both via `binding.scope`; the audit determines which actions use per-action key bindings (most keybind modes use global keys today).

--- a/docs/superpowers/specs/2026-05-31-surface-comms-method-design.md
+++ b/docs/superpowers/specs/2026-05-31-surface-comms-method-design.md
@@ -87,12 +87,12 @@ Behavior:
   - `api` → ✅ "iRacing API — no binding needed."
   - `chat` → ✅ "Chat command — no binding needed."
   - `keybind`, keyboard binding set → ✅ "Key binding — currently set: Ctrl + X." (via `formatKeyBinding`)
-  - `keybind`, SimHub role set → ✅ "Bound to SimHub role: «role»." **plus** caveat ⚠️ "Requires SimHub to be running." The caveat renders live-red when SimHub is not reachable and muted when reachable.
+  - `keybind`, SimHub role set → ✅ "SimHub binding: «role»." **plus**, only when SimHub is not reachable, a live red ✗ "SimHub not connected." line (nothing extra when reachable).
   - `keybind`, neither keyboard nor SimHub set → ⚠️ "No binding set — **set it here**." ("set it here" is a link.)
 - Subscribes to global-settings changes so it updates live as the user sets/clears/switches a binding (including keyboard↔SimHub) without changing mode.
 - "Set it here" link: opens the global key-bindings accordion (located via its `data-accordion-id`, persisting open state through `_accordionState` exactly as the `accordion` partial already does) and `scrollIntoView`s it. The accordion-open + scroll logic lives **inside** the component so every action navigates identically. The link does not need to focus the exact field — getting the user to the open accordion is sufficient.
 
-SimHub reachability reaches the browser PI via a plugin-maintained `_simHubReachable` passthrough global setting (same pattern as `_audioDeviceList` / `_warnings`), written from the existing `onSimHubReachabilityChange` in both plugins. The component reads it for the live caveat state.
+SimHub reachability is **polled browser-side** by the component (a `fetchSimHubReachable` HTTP probe of SimHub's Control Mapper endpoint, host/port read from global settings) on an interval while a SimHub-bound mode is shown, so the warning clears as soon as SimHub comes up. No plugin-maintained `_simHubReachable` setting is required — the plugins are unaffected by this part.
 
 ## 3. Icon overlay — centered ⚠️ over dimmed art
 
@@ -140,10 +140,10 @@ Classify every mode of all ~36 actions by reading each dispatch path (`executeMo
 - **pi-components** — new `ird-binding-status` component (SimHub-aware, accordion-open + scroll-to nav); extracted shared binding helpers; build/register the component.
 - **iracing-actions** — per-mode `*_COMMS` descriptors per action, `comms-catalog.ts` barrel, generated `data/action-comms.json`, `generate-action-comms.mjs`, wire `<ird-binding-status>` into every action `.ejs` under the Mode selector; derive existing mode→key maps from descriptors.
 - **icon-composer / deck-core** — `assembleIcon` `bindingMissing` option, `bindingWarningSvg()` + `dimWrap()` helpers, `ConnectionStateAwareAction.isActiveBindingMissing()`.
-- **Both plugins (Elgato + Mirabox)** — maintain `_simHubReachable` global setting from `onSimHubReachabilityChange`; pick up the shared PI component and icon overlay; verify overlay renders on QT5.
+- **Both plugins (Elgato + Mirabox)** — pick up the shared PI component and icon overlay; verify overlay renders on QT5. (No `_simHubReachable` wiring needed — reachability is polled browser-side.)
 - **Website** (`@iracedeck/website`) — explainer page + per-action method labels.
 - **Docs** (`docs/`) — explainer page; per-mode method in action-doc template; backfill all action docs.
-- **Rules** — `action-documentation.md` (method field), `stream-deck-actions.md`, `pi-templates.md` (new partial/component + accordion navigation), `key-icon-types.md` (overlay), `global-settings.md` (binding-status / union usage, `_simHubReachable`), `svg-platform-compatibility.md` (confirm the glyph is safe).
+- **Rules** — `action-documentation.md` (method field), `stream-deck-actions.md`, `pi-templates.md` (new partial/component + accordion navigation), `key-icon-types.md` (overlay), `global-settings.md` (binding-status / union usage), `svg-platform-compatibility.md` (confirm the glyph is safe).
 - **Skills** — `iracedeck-actions` (per-mode method listing).
 - **Tests** — all of section 5.
 

--- a/docs/superpowers/specs/2026-05-31-surface-comms-method-design.md
+++ b/docs/superpowers/specs/2026-05-31-surface-comms-method-design.md
@@ -57,9 +57,16 @@ TS descriptors are **authoritative**; JSON is **generated**.
 - `scripts/generate-action-comms.mjs` emits `packages/iracing-actions/src/actions/data/action-comms.json` from the catalog. A Vitest freshness test asserts the committed JSON matches the catalog (mirrors the existing `generate-icon-defaults.mjs` + freshness-test convention).
 - Consumers: action TS imports the catalog directly (icon overlay); the PI EJS `require()`s `data/action-comms.json` at compile time (same mechanism as `data/key-bindings.json`); docs generation reads the same JSON.
 
-### Shared binding helpers
+### Binding helpers — use each side's existing helpers (no cross-package extraction)
 
-`parseBinding`, `isSimHubBinding`, and `formatKeyBinding` are pure and currently live in `deck-core`. Extract them (and the `KeyBindingValue` / `SimHubBindingValue` / `BindingValue` types) into a pure module importable by **both** `deck-core` and the browser-bundled `pi-components`, so the PI status component and the icon layer share one definition of "is this binding configured?" Re-export from `deck-core` for backward compatibility (no churn at call sites).
+**Correction after reading the code:** `pi-components` runs in a browser and *cannot* import from `deck-core` (Node.js). This is an established, deliberate split — `key-binding-input.ts` carries an explicit SYNC NOTE and `pi-components/src/components/key-binding-utils.ts` already holds browser-side `formatKeyBinding` / `parseKeyBinding` / `parseSimpleDefault`, with `isSimHubBinding` / `BindingValue` duplicated in `key-binding-input.ts`. Extracting a shared module would fight that split and risk breaking the PI bundle.
+
+So there is **no cross-package extraction**. Instead:
+
+- The **icon/action side** (TS, Node/bundler) uses `deck-core`'s existing `parseBinding` / `isSimHubBinding` / `formatKeyBinding`.
+- The **PI component** (browser) reuses `pi-components`' existing browser-side helpers. The new `ird-binding-status` imports `formatKeyBinding` and a binding-parse + `isSimHubBinding` from the same `pi-components` modules `ird-key-binding` already uses.
+
+"Single definition of configured" is preserved per-runtime by the established duplication+sync-note convention, not by a new shared module.
 
 ## 2. Property Inspector — `ird-binding-status` component
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:ts": "turbo run build --filter=!@iracedeck/iracing-native --filter=!@iracedeck/website",
     "build:force": "turbo run build --force",
     "build:native": "pnpm --filter @iracedeck/iracing-native build",
+    "generate:action-comms": "tsx scripts/generate-action-comms.mjs",
     "build:with-restart": "node scripts/build-with-restart.mjs",
     "build:stream-deck": "pnpm build:ts && pnpm restart:stream-deck",
     "restart:stream-deck": "streamdeck restart com.iracedeck.sd.core",

--- a/packages/deck-core/src/binding-dispatcher.test.ts
+++ b/packages/deck-core/src/binding-dispatcher.test.ts
@@ -542,4 +542,42 @@ describe("BindingDispatcher", () => {
       expect(getBindingDispatcher().isReady("myKey", true)).toBe(false);
     });
   });
+
+  // --- isConfigured (issue #612) ---
+
+  describe("isConfigured", () => {
+    beforeEach(() => {
+      initializeBindingDispatcher(mockLogger);
+    });
+
+    it("returns false when no binding is set", () => {
+      mockGetGlobalSettings.mockReturnValue({});
+
+      expect(getBindingDispatcher().isConfigured("nonExistentKey")).toBe(false);
+    });
+
+    it("returns true for a keyboard binding regardless of connection", () => {
+      mockGetGlobalSettings.mockReturnValue({
+        myKey: JSON.stringify({ key: "f1", modifiers: [], code: "F1" }),
+      });
+
+      expect(getBindingDispatcher().isConfigured("myKey")).toBe(true);
+    });
+
+    it("returns true for a SimHub role even when SimHub is not reachable", () => {
+      mockIsSimHubReachable.mockReturnValue(false);
+      mockGetGlobalSettings.mockReturnValue({
+        myKey: JSON.stringify({ type: "simhub", role: "MyRole" }),
+      });
+
+      // SimHub-not-running is a reachability concern, not "not configured".
+      expect(getBindingDispatcher().isConfigured("myKey")).toBe(true);
+    });
+
+    it("returns false for an empty/corrupt binding value", () => {
+      mockGetGlobalSettings.mockReturnValue({ myKey: "" });
+
+      expect(getBindingDispatcher().isConfigured("myKey")).toBe(false);
+    });
+  });
 });

--- a/packages/deck-core/src/binding-dispatcher.ts
+++ b/packages/deck-core/src/binding-dispatcher.ts
@@ -52,6 +52,12 @@ export interface IBindingDispatcher {
 
   /** Check if a binding at the given setting key is ready to execute. */
   isReady(settingKey: string, iRacingConnected: boolean): boolean;
+
+  /**
+   * Whether a binding (keyboard or SimHub role) is configured at the given
+   * setting key — independent of connection/reachability (issue #612).
+   */
+  isConfigured(settingKey: string): boolean;
 }
 
 /**
@@ -209,6 +215,23 @@ class BindingDispatcher implements IBindingDispatcher {
     }
 
     return iRacingConnected;
+  }
+
+  /**
+   * Whether a binding (keyboard OR SimHub role) is configured at the given
+   * setting key — independent of iRacing connection or SimHub reachability.
+   *
+   * This is the source of truth for the binding-missing icon warning (#612):
+   * a keybind mode warns only when NEITHER a keyboard binding nor a SimHub
+   * role is set. SimHub-not-running is a separate (reachability) concern and
+   * does not count as "not configured".
+   *
+   * @param settingKey - The global settings key
+   */
+  isConfigured(settingKey: string): boolean {
+    const globalSettings = getGlobalSettings() as Record<string, unknown>;
+
+    return parseBinding(globalSettings[settingKey]) !== undefined;
   }
 
   // --- Internal helpers ---

--- a/packages/deck-core/src/comm-descriptor.test.ts
+++ b/packages/deck-core/src/comm-descriptor.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { isConstantBindingKey, keybind, keybindBy, resolveBindingKey } from "./comm-descriptor.js";
+
+describe("comm-descriptor helpers", () => {
+  it("keybind() builds a constant-key keybind descriptor", () => {
+    const d = keybind("fuelServiceToggleAutofuel");
+    expect(d.method).toBe("keybind");
+    expect(d.binding).toEqual({ scope: "global", key: "fuelServiceToggleAutofuel" });
+    expect(isConstantBindingKey(d.binding!)).toBe(true);
+  });
+
+  it("keybindBy() builds a secondary-setting-resolved descriptor", () => {
+    const d = keybindBy("direction", { increase: "viewFovInc", decrease: "viewFovDec" });
+    expect(d.method).toBe("keybind");
+    expect(isConstantBindingKey(d.binding!)).toBe(false);
+  });
+
+  it("resolveBindingKey returns the constant key directly", () => {
+    expect(resolveBindingKey({ scope: "global", key: "blackBoxCycleNext" }, {})).toBe("blackBoxCycleNext");
+  });
+
+  it("resolveBindingKey resolves keyBy from the secondary setting", () => {
+    const ref = {
+      scope: "global" as const,
+      keyBy: { setting: "direction", map: { increase: "incKey", decrease: "decKey" } },
+    };
+    expect(resolveBindingKey(ref, { direction: "increase" })).toBe("incKey");
+    expect(resolveBindingKey(ref, { direction: "decrease" })).toBe("decKey");
+  });
+
+  it("resolveBindingKey returns undefined when the secondary value is absent or unmapped", () => {
+    const ref = { scope: "global" as const, keyBy: { setting: "direction", map: { increase: "incKey" } } };
+    expect(resolveBindingKey(ref, {})).toBeUndefined();
+    expect(resolveBindingKey(ref, { direction: "sideways" })).toBeUndefined();
+  });
+
+  it("resolveBindingKey returns undefined for an undefined ref (api/chat modes)", () => {
+    expect(resolveBindingKey(undefined, { direction: "increase" })).toBeUndefined();
+  });
+});

--- a/packages/deck-core/src/comm-descriptor.test.ts
+++ b/packages/deck-core/src/comm-descriptor.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
 
-import { isConstantBindingKey, keybind, keybindBy, resolveBindingKey } from "./comm-descriptor.js";
+import {
+  isConstantBindingKey,
+  isMultiBindingKey,
+  keybind,
+  keybindBy,
+  keybindFixed,
+  keybindKeys,
+  resolveBindingKey,
+  resolveBindingKeys,
+} from "./comm-descriptor.js";
 
 describe("comm-descriptor helpers", () => {
   it("keybind() builds a constant-key keybind descriptor", () => {
@@ -37,5 +46,36 @@ describe("comm-descriptor helpers", () => {
 
   it("resolveBindingKey returns undefined for an undefined ref (api/chat modes)", () => {
     expect(resolveBindingKey(undefined, { direction: "increase" })).toBeUndefined();
+  });
+
+  it("keybindKeys() builds a multi-key descriptor and is recognised by the guard", () => {
+    const d = keybindKeys(["incKey", "decKey"]);
+    expect(d.method).toBe("keybind");
+    expect(isMultiBindingKey(d.binding!)).toBe(true);
+    expect(isConstantBindingKey(d.binding!)).toBe(false);
+  });
+
+  it("keybindFixed() builds a keybind descriptor with no binding (fixed key)", () => {
+    const d = keybindFixed();
+    expect(d).toEqual({ method: "keybind" });
+    expect(d.binding).toBeUndefined();
+  });
+
+  it("resolveBindingKeys returns all required keys for a multi-key ref", () => {
+    expect(resolveBindingKeys({ scope: "global", keys: ["incKey", "decKey"] }, {})).toEqual(["incKey", "decKey"]);
+  });
+
+  it("resolveBindingKeys returns a single-element array for a constant ref", () => {
+    expect(resolveBindingKeys({ scope: "global", key: "k" }, {})).toEqual(["k"]);
+  });
+
+  it("resolveBindingKeys resolves keyBy to one key (or empty when unmapped)", () => {
+    const ref = { scope: "global" as const, keyBy: { setting: "direction", map: { increase: "incKey" } } };
+    expect(resolveBindingKeys(ref, { direction: "increase" })).toEqual(["incKey"]);
+    expect(resolveBindingKeys(ref, { direction: "down" })).toEqual([]);
+  });
+
+  it("resolveBindingKeys returns empty for an undefined ref (fixed/api/chat modes)", () => {
+    expect(resolveBindingKeys(undefined, {})).toEqual([]);
   });
 });

--- a/packages/deck-core/src/comm-descriptor.ts
+++ b/packages/deck-core/src/comm-descriptor.ts
@@ -23,6 +23,16 @@ export interface BindingKeyConstant {
   key: string;
 }
 
+/**
+ * Several constant keys, ALL required for the mode (warn if any is unset).
+ * Used by setup view-* modes, which nudge-and-read via the adjustment's
+ * increase AND decrease keys.
+ */
+export interface BindingKeyMulti {
+  scope: "global" | "action";
+  keys: string[];
+}
+
 /** A binding key resolved from a secondary setting's current value. */
 export interface BindingKeyResolved {
   scope: "global" | "action";
@@ -34,12 +44,18 @@ export interface BindingKeyResolved {
   };
 }
 
-export type BindingKeyRef = BindingKeyConstant | BindingKeyResolved;
+export type BindingKeyRef = BindingKeyConstant | BindingKeyMulti | BindingKeyResolved;
 
-/** Communication descriptor for a single mode. */
+/**
+ * Communication descriptor for a single mode.
+ *
+ * A `keybind` method with NO `binding` means a fixed key with no user-facing
+ * binding (e.g. car-control's hardcoded Escape, or audio modes that drive
+ * plugin audio) — it never warns and reads as "no binding needed".
+ */
 export interface CommDescriptor {
   method: CommMethod;
-  /** Present only when `method === "keybind"`. */
+  /** Present for configurable keybind modes; omitted for fixed/no-binding ones. */
   binding?: BindingKeyRef;
 }
 
@@ -49,27 +65,45 @@ export type ActionCommMap = Record<string, CommDescriptor>;
 /** Whole catalog, keyed by action folder name. */
 export type CommsCatalog = Record<string, ActionCommMap>;
 
-/** Type guard: a constant (non-`keyBy`) binding key reference. */
+/** Type guard: a single constant-key binding reference. */
 export function isConstantBindingKey(ref: BindingKeyRef): ref is BindingKeyConstant {
   return "key" in ref;
 }
 
+/** Type guard: a multi-key (all-required) binding reference. */
+export function isMultiBindingKey(ref: BindingKeyRef): ref is BindingKeyMulti {
+  return "keys" in ref;
+}
+
 /**
- * Resolve a binding key reference to its concrete setting key, given the
- * action's current settings (needed for `keyBy` references). Returns undefined
- * when a `keyBy` secondary value isn't present in the map.
+ * Resolve a binding key reference to ALL concrete setting keys it requires,
+ * given the action's current settings (needed for `keyBy` references). A
+ * `keyBy` reference whose secondary value isn't mapped resolves to an empty
+ * array.
+ */
+export function resolveBindingKeys(ref: BindingKeyRef | undefined, settings: Record<string, unknown>): string[] {
+  if (!ref) return [];
+
+  if (isConstantBindingKey(ref)) return [ref.key];
+
+  if (isMultiBindingKey(ref)) return ref.keys;
+
+  const secondary = settings[ref.keyBy.setting];
+  const key = typeof secondary === "string" ? ref.keyBy.map[secondary] : undefined;
+
+  return key ? [key] : [];
+}
+
+/**
+ * Resolve a binding key reference to a single concrete key (the first required
+ * key). Convenience for single-key consumers; multi-key modes should use
+ * {@link resolveBindingKeys}.
  */
 export function resolveBindingKey(
   ref: BindingKeyRef | undefined,
   settings: Record<string, unknown>,
 ): string | undefined {
-  if (!ref) return undefined;
-
-  if (isConstantBindingKey(ref)) return ref.key;
-
-  const secondary = settings[ref.keyBy.setting];
-
-  return typeof secondary === "string" ? ref.keyBy.map[secondary] : undefined;
+  return resolveBindingKeys(ref, settings)[0];
 }
 
 /**
@@ -89,4 +123,18 @@ export function keybindBy(
 /** Build a keybind descriptor with a constant key. */
 export function keybind(key: string, scope: "global" | "action" = "global"): CommDescriptor {
   return { method: "keybind", binding: { scope, key } };
+}
+
+/** Build a keybind descriptor requiring several constant keys (all required). */
+export function keybindKeys(keys: string[], scope: "global" | "action" = "global"): CommDescriptor {
+  return { method: "keybind", binding: { scope, keys } };
+}
+
+/**
+ * Build a keybind descriptor with no user-facing binding (a fixed key such as
+ * Escape, or a mode that drives plugin audio). Reads as "no binding needed"
+ * and never warns.
+ */
+export function keybindFixed(): CommDescriptor {
+  return { method: "keybind" };
 }

--- a/packages/deck-core/src/comm-descriptor.ts
+++ b/packages/deck-core/src/comm-descriptor.ts
@@ -1,0 +1,92 @@
+/**
+ * Per-mode sim-communication descriptors (issue #612).
+ *
+ * Every action mode talks to iRacing through exactly one of three mechanisms:
+ * the iRacing API/SDK, a simulated key binding (keyboard OR SimHub role), or a
+ * chat/text command. These descriptors formalize that per-`(action, mode)` so
+ * the Property Inspector status line, the key-icon warning overlay, and the
+ * docs can all read one source of truth.
+ *
+ * The descriptor is keyed by the value of an action's PRIMARY mode setting.
+ * Some keybind modes resolve their binding key from a SECONDARY setting (e.g.
+ * view-adjustment's `direction`, black-box's selected box) — `keyBy` expresses
+ * that declaratively so the resolution survives serialization to JSON for the
+ * browser PI and docs generation.
+ */
+
+/** How a mode communicates with iRacing. */
+export type CommMethod = "api" | "keybind" | "chat";
+
+/** A binding key that is constant for the mode. */
+export interface BindingKeyConstant {
+  scope: "global" | "action";
+  key: string;
+}
+
+/** A binding key resolved from a secondary setting's current value. */
+export interface BindingKeyResolved {
+  scope: "global" | "action";
+  keyBy: {
+    /** Name of the secondary setting whose value selects the key. */
+    setting: string;
+    /** Map from secondary-setting value → binding setting key. */
+    map: Record<string, string>;
+  };
+}
+
+export type BindingKeyRef = BindingKeyConstant | BindingKeyResolved;
+
+/** Communication descriptor for a single mode. */
+export interface CommDescriptor {
+  method: CommMethod;
+  /** Present only when `method === "keybind"`. */
+  binding?: BindingKeyRef;
+}
+
+/** One action's modes → descriptor, keyed by the primary mode setting value. */
+export type ActionCommMap = Record<string, CommDescriptor>;
+
+/** Whole catalog, keyed by action folder name. */
+export type CommsCatalog = Record<string, ActionCommMap>;
+
+/** Type guard: a constant (non-`keyBy`) binding key reference. */
+export function isConstantBindingKey(ref: BindingKeyRef): ref is BindingKeyConstant {
+  return "key" in ref;
+}
+
+/**
+ * Resolve a binding key reference to its concrete setting key, given the
+ * action's current settings (needed for `keyBy` references). Returns undefined
+ * when a `keyBy` secondary value isn't present in the map.
+ */
+export function resolveBindingKey(
+  ref: BindingKeyRef | undefined,
+  settings: Record<string, unknown>,
+): string | undefined {
+  if (!ref) return undefined;
+
+  if (isConstantBindingKey(ref)) return ref.key;
+
+  const secondary = settings[ref.keyBy.setting];
+
+  return typeof secondary === "string" ? ref.keyBy.map[secondary] : undefined;
+}
+
+/**
+ * Build a keybind descriptor whose key is resolved from a secondary setting.
+ * Convenience for deriving descriptors from an action's existing
+ * `Record<primary, Record<secondary, key>>` global-key map without restating
+ * the key strings (keeps the action's map the single source of those keys).
+ */
+export function keybindBy(
+  setting: string,
+  map: Record<string, string>,
+  scope: "global" | "action" = "global",
+): CommDescriptor {
+  return { method: "keybind", binding: { scope, keyBy: { setting, map } } };
+}
+
+/** Build a keybind descriptor with a constant key. */
+export function keybind(key: string, scope: "global" | "action" = "global"): CommDescriptor {
+  return { method: "keybind", binding: { scope, key } };
+}

--- a/packages/deck-core/src/connection-state-aware-action.test.ts
+++ b/packages/deck-core/src/connection-state-aware-action.test.ts
@@ -10,6 +10,7 @@ const {
   mockHold,
   mockRelease,
   mockIsReady,
+  mockIsConfigured,
   mockOnGlobalSettingsChange,
   mockOnSimHubReachabilityChange,
 } = vi.hoisted(() => ({
@@ -20,6 +21,7 @@ const {
   mockHold: vi.fn().mockResolvedValue(undefined),
   mockRelease: vi.fn().mockResolvedValue(undefined),
   mockIsReady: vi.fn(() => true),
+  mockIsConfigured: vi.fn(() => true),
   mockOnGlobalSettingsChange: vi.fn(() => vi.fn()),
   mockOnSimHubReachabilityChange: vi.fn(() => vi.fn()),
 }));
@@ -38,6 +40,7 @@ vi.mock("./binding-dispatcher.js", () => ({
     hold: mockHold,
     release: mockRelease,
     isReady: mockIsReady,
+    isConfigured: mockIsConfigured,
   }),
 }));
 
@@ -96,6 +99,10 @@ class TestAction extends ConnectionStateAwareAction {
 
   async callReleaseBinding(actionId: string): Promise<void> {
     return this.releaseBinding(actionId);
+  }
+
+  callIsActiveBindingMissing(): boolean {
+    return this.isActiveBindingMissing();
   }
 }
 
@@ -276,6 +283,30 @@ describe("ConnectionStateAwareAction", () => {
 
       mockGetConnectionStatus.mockReturnValue(false);
       expect(action.callGetConnectionStatus()).toBe(false);
+    });
+  });
+
+  describe("isActiveBindingMissing", () => {
+    it("returns false when no binding is active (api/chat modes)", () => {
+      action.callSetActiveBinding(null);
+      expect(action.callIsActiveBindingMissing()).toBe(false);
+      // Must not even consult the dispatcher when there is no active key.
+      mockIsConfigured.mockClear();
+      action.callIsActiveBindingMissing();
+      expect(mockIsConfigured).not.toHaveBeenCalled();
+    });
+
+    it("returns true when the active binding is not configured", () => {
+      action.callSetActiveBinding("myKey");
+      mockIsConfigured.mockReturnValue(false);
+      expect(action.callIsActiveBindingMissing()).toBe(true);
+      expect(mockIsConfigured).toHaveBeenCalledWith("myKey");
+    });
+
+    it("returns false when the active binding is configured (keyboard or SimHub)", () => {
+      action.callSetActiveBinding("myKey");
+      mockIsConfigured.mockReturnValue(true);
+      expect(action.callIsActiveBindingMissing()).toBe(false);
     });
   });
 

--- a/packages/deck-core/src/connection-state-aware-action.test.ts
+++ b/packages/deck-core/src/connection-state-aware-action.test.ts
@@ -104,6 +104,10 @@ class TestAction extends ConnectionStateAwareAction {
   callIsActiveBindingMissing(): boolean {
     return this.isActiveBindingMissing();
   }
+
+  callIsBindingMissing(keys: string | string[] | null | undefined): boolean {
+    return this.isBindingMissing(keys);
+  }
 }
 
 function getSetActive(action: TestAction) {
@@ -326,6 +330,32 @@ describe("ConnectionStateAwareAction", () => {
       mockIsConfigured.mockClear();
       expect(action.callIsActiveBindingMissing()).toBe(false);
       expect(mockIsConfigured).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("isBindingMissing (per-context, stateless)", () => {
+    it("returns false for null/empty keys (api/chat/fixed modes)", () => {
+      mockIsConfigured.mockClear();
+      expect(action.callIsBindingMissing(null)).toBe(false);
+      expect(action.callIsBindingMissing("")).toBe(false);
+      expect(action.callIsBindingMissing([])).toBe(false);
+      expect(mockIsConfigured).not.toHaveBeenCalled();
+    });
+
+    it("does not depend on setActiveBinding (no cross-context bleed)", () => {
+      // Another context declared a missing binding...
+      action.callSetActiveBinding("otherKey");
+      mockIsConfigured.mockReturnValue(false);
+      // ...but THIS context's own configured key must read as present.
+      mockIsConfigured.mockImplementation((k: string) => k === "myKey");
+      expect(action.callIsBindingMissing("myKey")).toBe(false);
+      expect(action.callIsBindingMissing("otherKey")).toBe(true);
+    });
+
+    it("warns when any of several keys is unconfigured", () => {
+      mockIsConfigured.mockImplementation((k: string) => k !== "decKey");
+      expect(action.callIsBindingMissing(["incKey", "decKey"])).toBe(true);
+      expect(action.callIsBindingMissing(["incKey"])).toBe(false);
     });
   });
 

--- a/packages/deck-core/src/connection-state-aware-action.test.ts
+++ b/packages/deck-core/src/connection-state-aware-action.test.ts
@@ -21,7 +21,7 @@ const {
   mockHold: vi.fn().mockResolvedValue(undefined),
   mockRelease: vi.fn().mockResolvedValue(undefined),
   mockIsReady: vi.fn(() => true),
-  mockIsConfigured: vi.fn(() => true),
+  mockIsConfigured: vi.fn((_key: string) => true),
   mockOnGlobalSettingsChange: vi.fn(() => vi.fn()),
   mockOnSimHubReachabilityChange: vi.fn(() => vi.fn()),
 }));
@@ -85,7 +85,7 @@ class TestAction extends ConnectionStateAwareAction {
     return this.getConnectionStatus();
   }
 
-  callSetActiveBinding(key: string | null): void {
+  callSetActiveBinding(key: string | string[] | null): void {
     this.setActiveBinding(key);
   }
 
@@ -307,6 +307,25 @@ describe("ConnectionStateAwareAction", () => {
       action.callSetActiveBinding("myKey");
       mockIsConfigured.mockReturnValue(true);
       expect(action.callIsActiveBindingMissing()).toBe(false);
+    });
+
+    it("warns for a multi-key mode when ANY key is unconfigured", () => {
+      action.callSetActiveBinding(["incKey", "decKey"]);
+      mockIsConfigured.mockImplementation((k: string) => k !== "decKey");
+      expect(action.callIsActiveBindingMissing()).toBe(true);
+    });
+
+    it("does not warn for a multi-key mode when all keys are configured", () => {
+      action.callSetActiveBinding(["incKey", "decKey"]);
+      mockIsConfigured.mockReturnValue(true);
+      expect(action.callIsActiveBindingMissing()).toBe(false);
+    });
+
+    it("ignores empty-string keys (fixed-key modes track nothing)", () => {
+      action.callSetActiveBinding("");
+      mockIsConfigured.mockClear();
+      expect(action.callIsActiveBindingMissing()).toBe(false);
+      expect(mockIsConfigured).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/deck-core/src/connection-state-aware-action.ts
+++ b/packages/deck-core/src/connection-state-aware-action.ts
@@ -52,9 +52,11 @@ export abstract class ConnectionStateAwareAction<T = Record<string, unknown>> ex
   private lastReadyStatus: boolean | null = null;
 
   /**
-   * The currently active binding setting key for readiness tracking.
+   * The currently active binding setting key(s) for readiness tracking.
+   * Most modes track a single key; some (e.g. setup view-* dual-press modes)
+   * track several, all of which must be configured/ready (issue #612).
    */
-  private activeBindingKey: string | null = null;
+  private activeBindingKeys: string[] = [];
 
   /**
    * Unsubscribe function for global settings change listener.
@@ -114,12 +116,17 @@ export abstract class ConnectionStateAwareAction<T = Record<string, unknown>> ex
    * (e.g., user switches mode or direction). Cleanup is automatic —
    * onWillDisappear unsubscribes all listeners.
    *
-   * @param settingKey - The global settings key (e.g., "blackBoxLapTiming"), or null to clear
+   * @param settingKey - The global settings key (e.g., "blackBoxLapTiming"), an
+   *   array of keys (all required), or null/empty to clear. Empty strings are
+   *   ignored, so a fixed-key mode can pass "" to track nothing.
    */
-  protected setActiveBinding(settingKey: string | null): void {
-    this.activeBindingKey = settingKey;
+  protected setActiveBinding(settingKey: string | string[] | null): void {
+    const keys = (Array.isArray(settingKey) ? settingKey : settingKey ? [settingKey] : []).filter(
+      (k): k is string => typeof k === "string" && k.length > 0,
+    );
+    this.activeBindingKeys = keys;
 
-    if (settingKey) {
+    if (keys.length > 0) {
       // Subscribe to global settings changes (once)
       if (!this.globalSettingsUnsubscribe) {
         this.globalSettingsUnsubscribe = onGlobalSettingsChange(() => {
@@ -170,8 +177,9 @@ export abstract class ConnectionStateAwareAction<T = Record<string, unknown>> ex
 
       let isReady: boolean;
 
-      if (this.activeBindingKey) {
-        isReady = getBindingDispatcher().isReady(this.activeBindingKey, iRacingConnected);
+      if (this.activeBindingKeys.length > 0) {
+        // All tracked keys must be ready (multi-key modes warn if any is missing).
+        isReady = this.activeBindingKeys.every((key) => getBindingDispatcher().isReady(key, iRacingConnected));
       } else {
         isReady = iRacingConnected;
       }
@@ -206,9 +214,10 @@ export abstract class ConnectionStateAwareAction<T = Record<string, unknown>> ex
    * icon overlay and readiness overlay never disagree about "configured".
    */
   protected isActiveBindingMissing(): boolean {
-    if (!this.activeBindingKey) return false;
+    if (this.activeBindingKeys.length === 0) return false;
 
-    return !getBindingDispatcher().isConfigured(this.activeBindingKey);
+    // Warn if ANY required key is unconfigured (multi-key modes need all set).
+    return this.activeBindingKeys.some((key) => !getBindingDispatcher().isConfigured(key));
   }
 
   // --- Binding dispatch delegates ---

--- a/packages/deck-core/src/connection-state-aware-action.ts
+++ b/packages/deck-core/src/connection-state-aware-action.ts
@@ -214,10 +214,31 @@ export abstract class ConnectionStateAwareAction<T = Record<string, unknown>> ex
    * icon overlay and readiness overlay never disagree about "configured".
    */
   protected isActiveBindingMissing(): boolean {
-    if (this.activeBindingKeys.length === 0) return false;
+    return this.isBindingMissing(this.activeBindingKeys);
+  }
 
-    // Warn if ANY required key is unconfigured (multi-key modes need all set).
-    return this.activeBindingKeys.some((key) => !getBindingDispatcher().isConfigured(key));
+  /**
+   * Stateless per-context variant of {@link isActiveBindingMissing}: returns
+   * true when the given binding key(s) require a binding but ANY is
+   * unconfigured (neither keyboard nor SimHub). Pass `null`/empty for
+   * api/chat/fixed modes (returns false).
+   *
+   * Use THIS — not {@link isActiveBindingMissing} — to drive a per-button icon
+   * warning. One action-class instance serves every button context, so the
+   * `activeBindingKeys` field that backs `isActiveBindingMissing` is shared and
+   * would bleed one button's missing-binding state onto all the others. This
+   * variant derives solely from its arguments + global settings (#612).
+   *
+   * @param keys - The binding setting key(s) for a specific button's mode.
+   */
+  protected isBindingMissing(keys: string | string[] | null | undefined): boolean {
+    const list = (Array.isArray(keys) ? keys : keys ? [keys] : []).filter(
+      (k): k is string => typeof k === "string" && k.length > 0,
+    );
+
+    if (list.length === 0) return false;
+
+    return list.some((key) => !getBindingDispatcher().isConfigured(key));
   }
 
   // --- Binding dispatch delegates ---

--- a/packages/deck-core/src/connection-state-aware-action.ts
+++ b/packages/deck-core/src/connection-state-aware-action.ts
@@ -193,6 +193,24 @@ export abstract class ConnectionStateAwareAction<T = Record<string, unknown>> ex
     return this.sdkController.getConnectionStatus();
   }
 
+  /**
+   * Whether the action's currently active binding requires a binding but has
+   * neither a keyboard binding nor a SimHub role configured (issue #612).
+   *
+   * Drives the centered binding-missing warning overlay on the key icon.
+   * Returns false when no binding is active (api/chat modes) or when a binding
+   * of either type is set — including a SimHub role whose SimHub server is not
+   * currently running (that is a reachability concern, not a missing binding).
+   *
+   * Derived from the same dispatcher source of truth as readiness, so the
+   * icon overlay and readiness overlay never disagree about "configured".
+   */
+  protected isActiveBindingMissing(): boolean {
+    if (!this.activeBindingKey) return false;
+
+    return !getBindingDispatcher().isConfigured(this.activeBindingKey);
+  }
+
   // --- Binding dispatch delegates ---
 
   /**

--- a/packages/deck-core/src/index.ts
+++ b/packages/deck-core/src/index.ts
@@ -143,11 +143,16 @@ export {
 // Per-mode sim-communication descriptors (issue #612)
 export {
   isConstantBindingKey,
+  isMultiBindingKey,
   keybind,
   keybindBy,
+  keybindFixed,
+  keybindKeys,
   resolveBindingKey,
+  resolveBindingKeys,
   type ActionCommMap,
   type BindingKeyConstant,
+  type BindingKeyMulti,
   type BindingKeyRef,
   type BindingKeyResolved,
   type CommDescriptor,

--- a/packages/deck-core/src/index.ts
+++ b/packages/deck-core/src/index.ts
@@ -140,6 +140,21 @@ export {
   _resetGlobalSettings,
 } from "./global-settings.js";
 
+// Per-mode sim-communication descriptors (issue #612)
+export {
+  isConstantBindingKey,
+  keybind,
+  keybindBy,
+  resolveBindingKey,
+  type ActionCommMap,
+  type BindingKeyConstant,
+  type BindingKeyRef,
+  type BindingKeyResolved,
+  type CommDescriptor,
+  type CommMethod,
+  type CommsCatalog,
+} from "./comm-descriptor.js";
+
 // Unit conversion utilities
 export {
   LITERS_TO_GALLONS,

--- a/packages/deck-core/src/index.ts
+++ b/packages/deck-core/src/index.ts
@@ -66,6 +66,15 @@ export {
   type TitleOverrides,
 } from "./title-settings.js";
 
+// Binding-missing warning overlay (issue #612, re-exports from icon-composer)
+export {
+  applyBindingWarning,
+  BINDING_WARNING_DIM_OPACITY,
+  BINDING_WARNING_GLYPH,
+  bindingWarningSvg,
+  dimForBindingWarning,
+} from "./title-settings.js";
+
 // Icon base template (re-exports from icon-composer)
 export { generateBorderParts, ICON_BASE_TEMPLATE, extractGraphicContent } from "./icon-base.js";
 

--- a/packages/deck-core/src/title-settings.ts
+++ b/packages/deck-core/src/title-settings.ts
@@ -36,6 +36,15 @@ export {
   type TitleOverrides,
 } from "@iracedeck/icon-composer";
 
+// Binding-missing warning overlay (issue #612)
+export {
+  applyBindingWarning,
+  BINDING_WARNING_DIM_OPACITY,
+  BINDING_WARNING_GLYPH,
+  bindingWarningSvg,
+  dimForBindingWarning,
+} from "@iracedeck/icon-composer";
+
 // ---------------------------------------------------------------------------
 // Global Title Settings Reader
 // ---------------------------------------------------------------------------

--- a/packages/icon-composer/src/binding-warning.test.ts
+++ b/packages/icon-composer/src/binding-warning.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyBindingWarning,
+  BINDING_WARNING_DIM_OPACITY,
+  BINDING_WARNING_GLYPH,
+  bindingWarningSvg,
+  dimForBindingWarning,
+} from "./binding-warning.js";
+import { assembleIcon, BORDER_DEFAULTS } from "./title-settings.js";
+
+function decodeDataUri(dataUri: string): string {
+  const base64Match = dataUri.match(/^data:image\/svg\+xml;base64,(.+)$/);
+
+  if (base64Match) {
+    return Buffer.from(base64Match[1], "base64").toString("utf-8");
+  }
+
+  return dataUri;
+}
+
+const MOCK_GRAPHIC = `<svg viewBox="0 0 100 80"><desc>{"colors":{"backgroundColor":"#2a3444","textColor":"#ffffff"},"title":{"text":"TEST"}}</desc><rect x="0" y="0" width="100" height="80" fill="{{graphic1Color}}"/></svg>`;
+
+const DEFAULT_TITLE = {
+  showTitle: true,
+  showGraphics: true,
+  titleText: "TEST",
+  bold: true,
+  fontSize: 9,
+  position: "bottom" as const,
+  customPosition: 0,
+};
+
+const COLORS = { backgroundColor: "#2a3444", textColor: "#ffffff", graphic1Color: "#ffffff" };
+
+// SVG features that QT5 (Mirabox) silently drops — the warning glyph must use none of them.
+const FORBIDDEN_SVG_TOKENS = ["<filter", "feGaussianBlur", "<mask", "clipPath", "<style", ' class="ird', "url("];
+
+describe("binding-warning glyph", () => {
+  it("draws a triangle and exclamation using cross-platform-safe primitives only", () => {
+    expect(BINDING_WARNING_GLYPH).toContain("<polygon");
+    expect(BINDING_WARNING_GLYPH).toContain("<rect");
+    expect(BINDING_WARNING_GLYPH).toContain("<circle");
+
+    // No QT5-incompatible features.
+    for (const token of ["<filter", "feGaussianBlur", "<mask", "clipPath", "<style", "url("]) {
+      expect(BINDING_WARNING_GLYPH).not.toContain(token);
+    }
+  });
+
+  it("bindingWarningSvg() returns the glyph constant", () => {
+    expect(bindingWarningSvg()).toBe(BINDING_WARNING_GLYPH);
+  });
+
+  it("centers the triangle around the 144x144 canvas center", () => {
+    // Apex at x=72 (horizontal center) keeps the glyph centered.
+    expect(BINDING_WARNING_GLYPH).toContain("72,42");
+  });
+});
+
+describe("dimForBindingWarning", () => {
+  it("wraps content in a dim group at the documented opacity", () => {
+    const out = dimForBindingWarning("<rect/>");
+    expect(out).toBe(`<g opacity="${BINDING_WARNING_DIM_OPACITY}"><rect/></g>`);
+    expect(BINDING_WARNING_DIM_OPACITY).toBeLessThan(1);
+  });
+
+  it("returns empty string for empty content (no stray dim group)", () => {
+    expect(dimForBindingWarning("")).toBe("");
+  });
+});
+
+describe("applyBindingWarning", () => {
+  it("dims the existing content and appends the warning glyph", () => {
+    const out = applyBindingWarning("<rect id='art'/>");
+    expect(out).toContain(`<g opacity="${BINDING_WARNING_DIM_OPACITY}"><rect id='art'/></g>`);
+    expect(out).toContain(BINDING_WARNING_GLYPH);
+    // Glyph comes after the dimmed art so it renders on top.
+    expect(out.indexOf(BINDING_WARNING_GLYPH)).toBeGreaterThan(out.indexOf("opacity="));
+  });
+
+  it("still draws the warning when there is no artwork", () => {
+    expect(applyBindingWarning("")).toBe(BINDING_WARNING_GLYPH);
+  });
+});
+
+describe("assembleIcon bindingMissing overlay", () => {
+  it("adds the warning triangle and dims artwork when bindingMissing is true", () => {
+    const svg = decodeDataUri(
+      assembleIcon({
+        graphicSvg: MOCK_GRAPHIC,
+        colors: COLORS,
+        title: DEFAULT_TITLE,
+        border: BORDER_DEFAULTS,
+        bindingMissing: true,
+      }),
+    );
+    expect(svg).toContain("<polygon");
+    expect(svg).toContain(`opacity="${BINDING_WARNING_DIM_OPACITY}"`);
+  });
+
+  it("does NOT add the warning when bindingMissing is false/omitted", () => {
+    const svg = decodeDataUri(
+      assembleIcon({ graphicSvg: MOCK_GRAPHIC, colors: COLORS, title: DEFAULT_TITLE, border: BORDER_DEFAULTS }),
+    );
+    expect(svg).not.toContain("<polygon");
+    expect(svg).not.toContain(`opacity="${BINDING_WARNING_DIM_OPACITY}"`);
+  });
+
+  it("shows the warning even when graphics are hidden (config error must be visible)", () => {
+    const svg = decodeDataUri(
+      assembleIcon({
+        graphicSvg: MOCK_GRAPHIC,
+        colors: COLORS,
+        title: { ...DEFAULT_TITLE, showGraphics: false },
+        border: BORDER_DEFAULTS,
+        bindingMissing: true,
+      }),
+    );
+    expect(svg).toContain("<polygon");
+  });
+
+  it("keeps the title visible alongside the warning", () => {
+    const svg = decodeDataUri(
+      assembleIcon({
+        graphicSvg: MOCK_GRAPHIC,
+        colors: COLORS,
+        title: DEFAULT_TITLE,
+        border: BORDER_DEFAULTS,
+        bindingMissing: true,
+      }),
+    );
+    expect(svg).toContain("TEST");
+  });
+
+  it("emits no QT5-incompatible SVG features in the overlay", () => {
+    const svg = decodeDataUri(
+      assembleIcon({
+        graphicSvg: MOCK_GRAPHIC,
+        colors: COLORS,
+        title: DEFAULT_TITLE,
+        border: BORDER_DEFAULTS,
+        bindingMissing: true,
+      }),
+    );
+
+    for (const token of FORBIDDEN_SVG_TOKENS) {
+      expect(svg).not.toContain(token);
+    }
+  });
+});

--- a/packages/icon-composer/src/binding-warning.ts
+++ b/packages/icon-composer/src/binding-warning.ts
@@ -1,0 +1,74 @@
+/**
+ * Binding-missing warning overlay.
+ *
+ * Drawn centered on a key icon when a mode requires a binding (keyboard or
+ * SimHub) and neither is configured, so the problem is visible at a glance on
+ * the deck without opening the Property Inspector (issue #612).
+ *
+ * Cross-platform constraint: the glyph must render on Mirabox's QT5 engine
+ * (SVG Tiny 1.2 static). It uses only `polygon`, `rect` (with `rx`), and
+ * `circle` — no filters, masks, clipPath, or CSS. See
+ * `.claude/rules/svg-platform-compatibility.md`.
+ */
+
+/** Opacity applied to the existing artwork beneath the warning triangle. */
+export const BINDING_WARNING_DIM_OPACITY = 0.25;
+
+/** Warning triangle fill (matches the project's semantic yellow). */
+const WARNING_FILL = "#f39c12";
+/** Dark outline + exclamation colour for contrast over any artwork. */
+const WARNING_INK = "#1a1a1a";
+
+/**
+ * Centered warning-triangle glyph (⚠) for the 144×144 icon canvas.
+ *
+ * A standalone SVG snippet — no wrapping `<svg>` — so it can be appended into
+ * the icon base template's graphic slot (via {@link assembleIcon}'s
+ * `bindingMissing` option) or composed by actions that render dynamic
+ * templates directly (e.g. fuel-service's telemetry modes).
+ */
+export const BINDING_WARNING_GLYPH = [
+  // Plain group, no class attribute — QT5 has no CSS/class-based styling and the
+  // overlay must not rely on it (see svg-platform-compatibility rule).
+  "<g>",
+  // Triangle body, centered around (72, 72).
+  `<polygon points="72,42 104,100 40,100" fill="${WARNING_FILL}" stroke="${WARNING_INK}" stroke-width="3" stroke-linejoin="round"/>`,
+  // Exclamation bar.
+  `<rect x="68.5" y="64" width="7" height="20" rx="2.5" fill="${WARNING_INK}"/>`,
+  // Exclamation dot.
+  `<circle cx="72" cy="92" r="4" fill="${WARNING_INK}"/>`,
+  "</g>",
+].join("");
+
+/**
+ * Return the centered binding-missing warning glyph snippet.
+ *
+ * Provided as a function (alongside the {@link BINDING_WARNING_GLYPH} constant)
+ * so dynamic-template actions can compose the same overlay their static
+ * counterparts get from {@link assembleIcon}.
+ */
+export function bindingWarningSvg(): string {
+  return BINDING_WARNING_GLYPH;
+}
+
+/**
+ * Wrap arbitrary icon content in a dim group, used to fade existing artwork
+ * beneath the warning triangle so the triangle reads clearly while the mode's
+ * artwork stays faintly identifiable.
+ */
+export function dimForBindingWarning(content: string): string {
+  if (!content) return "";
+
+  return `<g opacity="${BINDING_WARNING_DIM_OPACITY}">${content}</g>`;
+}
+
+/**
+ * Compose the full binding-missing overlay over existing graphic content:
+ * the content dimmed, with the warning triangle drawn on top.
+ *
+ * Shared by {@link assembleIcon} and dynamic-template actions so both produce
+ * an identical overlay.
+ */
+export function applyBindingWarning(graphicContent: string): string {
+  return dimForBindingWarning(graphicContent) + BINDING_WARNING_GLYPH;
+}

--- a/packages/icon-composer/src/index.ts
+++ b/packages/icon-composer/src/index.ts
@@ -8,6 +8,15 @@
 // SVG utilities
 export { dataUriToSvg, isDataUri, isRawSvg, svgToDataUri } from "./svg-utils.js";
 
+// Binding-missing warning overlay (issue #612)
+export {
+  applyBindingWarning,
+  BINDING_WARNING_DIM_OPACITY,
+  BINDING_WARNING_GLYPH,
+  bindingWarningSvg,
+  dimForBindingWarning,
+} from "./binding-warning.js";
+
 // Icon base template and border parts
 export { extractGraphicContent, generateBorderParts, ICON_BASE_TEMPLATE } from "./icon-base.js";
 

--- a/packages/icon-composer/src/title-settings.ts
+++ b/packages/icon-composer/src/title-settings.ts
@@ -4,6 +4,7 @@
  * Pure functions for resolving settings and assembling final icons.
  * No dependencies on global settings stores — all inputs are parameters.
  */
+import { applyBindingWarning } from "./binding-warning.js";
 import { extractGraphicContent, generateBorderParts, ICON_BASE_TEMPLATE } from "./icon-base.js";
 import {
   escapeXml,
@@ -514,6 +515,9 @@ export function applyGraphicTransform(
  * @param options.title - Fully resolved title settings
  * @param options.border - Fully resolved border settings
  * @param options.graphic - Fully resolved graphic settings (optional — omit for no scaling)
+ * @param options.bindingMissing - When true, draw the centered binding-missing
+ *   warning triangle over dimmed artwork (issue #612). Used for keybind modes
+ *   that have neither a keyboard binding nor a SimHub role configured.
  * @returns SVG data URI string
  */
 export function assembleIcon(options: {
@@ -522,8 +526,9 @@ export function assembleIcon(options: {
   title: ResolvedTitleSettings;
   border: ResolvedBorderSettings;
   graphic?: ResolvedGraphicSettings;
+  bindingMissing?: boolean;
 }): string {
-  const { graphicSvg, colors, title, border, graphic } = options;
+  const { graphicSvg, colors, title, border, graphic, bindingMissing } = options;
 
   const rawGraphic = extractGraphicContent(graphicSvg);
   let graphicContent = title.showGraphics ? renderIconTemplate(rawGraphic, colors) : "";
@@ -548,6 +553,14 @@ export function assembleIcon(options: {
       area,
       graphic.scale,
     );
+  }
+
+  // Binding-missing overlay: dim the artwork and draw the centered warning
+  // triangle on top. Applied after scaling and regardless of showGraphics —
+  // a missing required binding is a configuration error the user must see
+  // even when artwork is hidden.
+  if (bindingMissing) {
+    graphicContent = applyBindingWarning(graphicContent);
   }
 
   const titleContent = title.showTitle

--- a/packages/iracing-actions/icons/setup-view.svg
+++ b/packages/iracing-actions/icons/setup-view.svg
@@ -12,5 +12,8 @@
     <!-- Large centered value (live dc* telemetry readout) -->
     <text x="72" y="{{valueY}}" text-anchor="middle" dominant-baseline="central"
           fill="{{textColor}}" font-family="Arial, sans-serif" font-size="{{valueFontSize}}" font-weight="bold">{{value}}</text>
+
+    <!-- Centered missing-binding warning overlay (issue #612), empty unless bindingMissing -->
+    {{warningContent}}
   </g>
 </svg>

--- a/packages/iracing-actions/src/actions/ai-spotter-controls/ai-spotter-controls.ejs
+++ b/packages/iracing-actions/src/actions/ai-spotter-controls/ai-spotter-controls.ejs
@@ -19,7 +19,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['ai-spotter-controls']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<%- include('title-overrides') %>
 

--- a/packages/iracing-actions/src/actions/ai-spotter-controls/ai-spotter-controls.ejs
+++ b/packages/iracing-actions/src/actions/ai-spotter-controls/ai-spotter-controls.ejs
@@ -18,6 +18,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['ai-spotter-controls']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<%- include('title-overrides') %>
 
 		<%- include('color-overrides', { slots: ['backgroundColor', 'textColor', 'graphic1Color', 'graphic2Color'], defaults: require('./data/icon-defaults.json')['ai-spotter-controls'] }) %>

--- a/packages/iracing-actions/src/actions/ai-spotter-controls/ai-spotter-controls.test.ts
+++ b/packages/iracing-actions/src/actions/ai-spotter-controls/ai-spotter-controls.test.ts
@@ -58,6 +58,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     holdBinding = vi.fn().mockResolvedValue(undefined);
     releaseBinding = vi.fn().mockResolvedValue(undefined);
     setActiveBinding = vi.fn();
+    isBindingMissing = vi.fn(() => false);
     async onWillAppear() {}
     async onDidReceiveSettings() {}
     async onWillDisappear() {}

--- a/packages/iracing-actions/src/actions/ai-spotter-controls/ai-spotter-controls.ts
+++ b/packages/iracing-actions/src/actions/ai-spotter-controls/ai-spotter-controls.ts
@@ -98,7 +98,7 @@ type AiSpotterControlsSettings = z.infer<typeof AiSpotterControlsSettings>;
  *
  * Generates an SVG data URI icon for the AI spotter controls action.
  */
-export function generateAiSpotterControlsSvg(settings: AiSpotterControlsSettings): string {
+export function generateAiSpotterControlsSvg(settings: AiSpotterControlsSettings, bindingMissing = false): string {
   const { control } = settings;
   const iconSvg = SPOTTER_ICONS[control] || SPOTTER_ICONS["damage-report"];
   const defaultTitle = SPOTTER_TITLES[control] || SPOTTER_TITLES["damage-report"];
@@ -110,7 +110,7 @@ export function generateAiSpotterControlsSvg(settings: AiSpotterControlsSettings
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -160,9 +160,14 @@ export class AiSpotterControls extends ConnectionStateAwareAction<AiSpotterContr
     ev: IDeckWillAppearEvent<AiSpotterControlsSettings> | IDeckDidReceiveSettingsEvent<AiSpotterControlsSettings>,
     settings: AiSpotterControlsSettings,
   ): Promise<void> {
-    const svgDataUri = generateAiSpotterControlsSvg(settings);
+    const svgDataUri = generateAiSpotterControlsSvg(
+      settings,
+      this.isBindingMissing(SPOTTER_GLOBAL_KEYS[settings.control]),
+    );
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateAiSpotterControlsSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () =>
+      generateAiSpotterControlsSvg(settings, this.isBindingMissing(SPOTTER_GLOBAL_KEYS[settings.control])),
+    );
   }
 }

--- a/packages/iracing-actions/src/actions/audio-controls/audio-controls.ejs
+++ b/packages/iracing-actions/src/actions/audio-controls/audio-controls.ejs
@@ -21,7 +21,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['audio-controls']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<sdpi-item label="Action" id="action-item">
 			<sdpi-select id="action-select" setting="action" default="volume-up">

--- a/packages/iracing-actions/src/actions/audio-controls/audio-controls.ejs
+++ b/packages/iracing-actions/src/actions/audio-controls/audio-controls.ejs
@@ -20,6 +20,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['audio-controls']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<sdpi-item label="Action" id="action-item">
 			<sdpi-select id="action-select" setting="action" default="volume-up">
 				<option value="volume-up">Volume Up</option>

--- a/packages/iracing-actions/src/actions/audio-controls/audio-controls.test.ts
+++ b/packages/iracing-actions/src/actions/audio-controls/audio-controls.test.ts
@@ -75,6 +75,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     holdBinding = mockHoldBinding;
     releaseBinding = mockReleaseBinding;
     setActiveBinding = vi.fn();
+    isBindingMissing = vi.fn(() => false);
     async onWillAppear() {}
     async onDidReceiveSettings() {}
     async onWillDisappear() {}

--- a/packages/iracing-actions/src/actions/audio-controls/audio-controls.ts
+++ b/packages/iracing-actions/src/actions/audio-controls/audio-controls.ts
@@ -111,7 +111,7 @@ type AudioControlsSettings = z.infer<typeof AudioControlsSettings>;
  *
  * Generates an SVG data URI icon for the audio controls action.
  */
-export function generateAudioControlsSvg(settings: AudioControlsSettings): string {
+export function generateAudioControlsSvg(settings: AudioControlsSettings, bindingMissing = false): string {
   const { category, action: audioAction } = settings;
 
   let iconKey: string;
@@ -132,7 +132,7 @@ export function generateAudioControlsSvg(settings: AudioControlsSettings): strin
   const border = resolveBorderSettings(iconSvg, getGlobalBorderSettings(), settings.borderOverrides);
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -303,9 +303,15 @@ export class AudioControls extends ConnectionStateAwareAction<AudioControlsSetti
     ev: IDeckWillAppearEvent<AudioControlsSettings> | IDeckDidReceiveSettingsEvent<AudioControlsSettings>,
     settings: AudioControlsSettings,
   ): Promise<void> {
-    const svgDataUri = generateAudioControlsSvg(settings);
+    const activeKey = this.resolveGlobalKey(settings.category, settings.action);
+    const svgDataUri = generateAudioControlsSvg(settings, this.isBindingMissing(activeKey));
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateAudioControlsSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () =>
+      generateAudioControlsSvg(
+        settings,
+        this.isBindingMissing(this.resolveGlobalKey(settings.category, settings.action)),
+      ),
+    );
   }
 }

--- a/packages/iracing-actions/src/actions/black-box-selector/black-box-selector.ejs
+++ b/packages/iracing-actions/src/actions/black-box-selector/black-box-selector.ejs
@@ -15,7 +15,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['black-box-selector']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<!-- Direct mode: black box selector -->
 		<sdpi-item label="Black Box" id="blackbox-item">

--- a/packages/iracing-actions/src/actions/black-box-selector/black-box-selector.ejs
+++ b/packages/iracing-actions/src/actions/black-box-selector/black-box-selector.ejs
@@ -14,6 +14,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['black-box-selector']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<!-- Direct mode: black box selector -->
 		<sdpi-item label="Black Box" id="blackbox-item">
 			<sdpi-select id="blackbox-select" setting="blackBox" default="lap-timing">

--- a/packages/iracing-actions/src/actions/black-box-selector/black-box-selector.test.ts
+++ b/packages/iracing-actions/src/actions/black-box-selector/black-box-selector.test.ts
@@ -78,6 +78,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     holdBinding = vi.fn().mockResolvedValue(undefined);
     releaseBinding = vi.fn().mockResolvedValue(undefined);
     setActiveBinding = mockSetActiveBinding;
+    isBindingMissing = vi.fn(() => false);
     async onWillAppear() {}
     async onDidReceiveSettings() {}
     async onWillDisappear() {}

--- a/packages/iracing-actions/src/actions/black-box-selector/black-box-selector.ts
+++ b/packages/iracing-actions/src/actions/black-box-selector/black-box-selector.ts
@@ -121,7 +121,7 @@ const GLOBAL_KEYS = {
  *
  * Generates an SVG data URI icon for the black box selector action.
  */
-export function generateBlackBoxSelectorSvg(settings: BlackBoxSelectorSettings): string {
+export function generateBlackBoxSelectorSvg(settings: BlackBoxSelectorSettings, bindingMissing = false): string {
   const { mode, blackBox } = settings;
 
   let iconSvg: string;
@@ -145,7 +145,7 @@ export function generateBlackBoxSelectorSvg(settings: BlackBoxSelectorSettings):
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -195,10 +195,12 @@ export class BlackBoxSelector extends ConnectionStateAwareAction<BlackBoxSelecto
     ev: IDeckWillAppearEvent<BlackBoxSelectorSettings> | IDeckDidReceiveSettingsEvent<BlackBoxSelectorSettings>,
     settings: BlackBoxSelectorSettings,
   ): Promise<void> {
-    const svgDataUri = generateBlackBoxSelectorSvg(settings);
+    const svgDataUri = generateBlackBoxSelectorSvg(settings, this.isBindingMissing(this.resolveSettingKey(settings)));
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateBlackBoxSelectorSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () =>
+      generateBlackBoxSelectorSvg(settings, this.isBindingMissing(this.resolveSettingKey(settings))),
+    );
   }
 
   override async onDialRotate(ev: IDeckDialRotateEvent<BlackBoxSelectorSettings>): Promise<void> {

--- a/packages/iracing-actions/src/actions/camera-editor-adjustments/camera-editor-adjustments.ejs
+++ b/packages/iracing-actions/src/actions/camera-editor-adjustments/camera-editor-adjustments.ejs
@@ -27,7 +27,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['camera-editor-adjustments']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">

--- a/packages/iracing-actions/src/actions/camera-editor-adjustments/camera-editor-adjustments.ejs
+++ b/packages/iracing-actions/src/actions/camera-editor-adjustments/camera-editor-adjustments.ejs
@@ -26,6 +26,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['camera-editor-adjustments']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">
 				<option value="increase">Increase</option>

--- a/packages/iracing-actions/src/actions/camera-editor-adjustments/camera-editor-adjustments.test.ts
+++ b/packages/iracing-actions/src/actions/camera-editor-adjustments/camera-editor-adjustments.test.ts
@@ -113,6 +113,8 @@ vi.mock("@iracedeck/deck-core", () => ({
     updateConnectionState = vi.fn();
     setKeyImage = vi.fn();
     setRegenerateCallback = vi.fn();
+    setActiveBinding = vi.fn();
+    isBindingMissing = vi.fn(() => false);
   },
   formatKeyBinding: vi.fn((b: { key: string; modifiers: string[] }) => {
     if (b.modifiers?.length) {

--- a/packages/iracing-actions/src/actions/camera-editor-adjustments/camera-editor-adjustments.ts
+++ b/packages/iracing-actions/src/actions/camera-editor-adjustments/camera-editor-adjustments.ts
@@ -176,7 +176,10 @@ type CameraEditorAdjustmentsSettings = z.infer<typeof CameraEditorAdjustmentsSet
  *
  * Generates an SVG data URI icon for the camera editor adjustments action.
  */
-export function generateCameraEditorAdjustmentsSvg(settings: CameraEditorAdjustmentsSettings): string {
+export function generateCameraEditorAdjustmentsSvg(
+  settings: CameraEditorAdjustmentsSettings,
+  bindingMissing = false,
+): string {
   const { adjustment, direction } = settings;
 
   const iconKey = `${adjustment}-${direction}`;
@@ -190,7 +193,7 @@ export function generateCameraEditorAdjustmentsSvg(settings: CameraEditorAdjustm
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -268,9 +271,12 @@ export class CameraEditorAdjustments extends ConnectionStateAwareAction<CameraEd
       | IDeckDidReceiveSettingsEvent<CameraEditorAdjustmentsSettings>,
     settings: CameraEditorAdjustmentsSettings,
   ): Promise<void> {
-    const svgDataUri = generateCameraEditorAdjustmentsSvg(settings);
+    const activeKey = CAMERA_EDITOR_GLOBAL_KEYS[settings.adjustment]?.[settings.direction];
+    const svgDataUri = generateCameraEditorAdjustmentsSvg(settings, this.isBindingMissing(activeKey));
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateCameraEditorAdjustmentsSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () =>
+      generateCameraEditorAdjustmentsSvg(settings, this.isBindingMissing(activeKey)),
+    );
   }
 }

--- a/packages/iracing-actions/src/actions/camera-editor-controls/camera-editor-controls.ejs
+++ b/packages/iracing-actions/src/actions/camera-editor-controls/camera-editor-controls.ejs
@@ -41,6 +41,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['camera-editor-controls']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<%- include('title-overrides') %>
 
 		<%- include('color-overrides', { slots: ['backgroundColor', 'textColor', 'graphic1Color'], defaults: require('./data/icon-defaults.json')['camera-editor-controls'] }) %>

--- a/packages/iracing-actions/src/actions/camera-editor-controls/camera-editor-controls.ejs
+++ b/packages/iracing-actions/src/actions/camera-editor-controls/camera-editor-controls.ejs
@@ -42,7 +42,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['camera-editor-controls']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<%- include('title-overrides') %>
 

--- a/packages/iracing-actions/src/actions/camera-editor-controls/camera-editor-controls.test.ts
+++ b/packages/iracing-actions/src/actions/camera-editor-controls/camera-editor-controls.test.ts
@@ -113,6 +113,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     updateConnectionState = vi.fn();
     setKeyImage = vi.fn();
     setRegenerateCallback = vi.fn();
+    isBindingMissing = vi.fn(() => false);
   },
   formatKeyBinding: vi.fn((b: { key: string; modifiers: string[] }) => {
     if (b.modifiers?.length) {

--- a/packages/iracing-actions/src/actions/camera-editor-controls/camera-editor-controls.ts
+++ b/packages/iracing-actions/src/actions/camera-editor-controls/camera-editor-controls.ts
@@ -200,7 +200,10 @@ type CameraEditorControlsSettings = z.infer<typeof CameraEditorControlsSettings>
  *
  * Generates an SVG data URI icon for the camera editor controls action.
  */
-export function generateCameraEditorControlsSvg(settings: CameraEditorControlsSettings): string {
+export function generateCameraEditorControlsSvg(
+  settings: CameraEditorControlsSettings,
+  bindingMissing = false,
+): string {
   const { control } = settings;
 
   const iconSvg = CONTROL_ICONS[control] || CONTROL_ICONS["open-camera-tool"];
@@ -213,7 +216,7 @@ export function generateCameraEditorControlsSvg(settings: CameraEditorControlsSe
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -271,9 +274,17 @@ export class CameraEditorControls extends ConnectionStateAwareAction<CameraEdito
     ev: IDeckWillAppearEvent<CameraEditorControlsSettings> | IDeckDidReceiveSettingsEvent<CameraEditorControlsSettings>,
     settings: CameraEditorControlsSettings,
   ): Promise<void> {
-    const svgDataUri = generateCameraEditorControlsSvg(settings);
+    const svgDataUri = generateCameraEditorControlsSvg(
+      settings,
+      this.isBindingMissing(CAMERA_EDITOR_CONTROLS_GLOBAL_KEYS[settings.control]),
+    );
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateCameraEditorControlsSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () =>
+      generateCameraEditorControlsSvg(
+        settings,
+        this.isBindingMissing(CAMERA_EDITOR_CONTROLS_GLOBAL_KEYS[settings.control]),
+      ),
+    );
   }
 }

--- a/packages/iracing-actions/src/actions/car-control/car-control.ejs
+++ b/packages/iracing-actions/src/actions/car-control/car-control.ejs
@@ -21,6 +21,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['car-control']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<sdpi-item id="auto-hold-item" label="Auto Hold" class="hidden">
 			<sdpi-checkbox setting="autoHold"></sdpi-checkbox>
 		</sdpi-item>

--- a/packages/iracing-actions/src/actions/car-control/car-control.ejs
+++ b/packages/iracing-actions/src/actions/car-control/car-control.ejs
@@ -22,7 +22,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['car-control']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<sdpi-item id="auto-hold-item" label="Auto Hold" class="hidden">
 			<sdpi-checkbox setting="autoHold"></sdpi-checkbox>

--- a/packages/iracing-actions/src/actions/car-control/car-control.test.ts
+++ b/packages/iracing-actions/src/actions/car-control/car-control.test.ts
@@ -93,6 +93,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     holdBinding = mockHoldBinding;
     releaseBinding = mockReleaseBinding;
     setActiveBinding = vi.fn();
+    isBindingMissing = vi.fn(() => false);
     async onWillAppear() {}
     async onDidReceiveSettings() {}
     async onWillDisappear() {}
@@ -104,6 +105,7 @@ vi.mock("@iracedeck/deck-core", () => ({
 
     return b.key;
   }),
+  applyBindingWarning: vi.fn((content: string) => content),
   applyGraphicTransform: vi.fn((_content: string) => _content),
   computeGraphicArea: vi.fn(() => ({ x: 8, y: 8, width: 128, height: 128 })),
   generateBorderParts: vi.fn(() => ({ defs: "", rects: "" })),

--- a/packages/iracing-actions/src/actions/car-control/car-control.ts
+++ b/packages/iracing-actions/src/actions/car-control/car-control.ts
@@ -1,4 +1,5 @@
 import {
+  applyBindingWarning,
   applyGraphicTransform,
   assembleIcon,
   CommonSettings,
@@ -341,7 +342,11 @@ type CarControlSettings = z.infer<typeof CarControlSettings>;
  *
  * Generates an SVG data URI icon for the car control action.
  */
-export function generateCarControlSvg(settings: CarControlSettings, telemetryState?: CarControlTelemetryState): string {
+export function generateCarControlSvg(
+  settings: CarControlSettings,
+  telemetryState?: CarControlTelemetryState,
+  bindingMissing = false,
+): string {
   const { control } = settings;
 
   // Pit-speed-limiter uses the template approach (dynamic speed number)
@@ -357,7 +362,7 @@ export function generateCarControlSvg(settings: CarControlSettings, telemetrySta
     );
     const borderSvg = generateBorderParts(border);
 
-    return renderDynamicIcon(settings, iconContent, borderSvg);
+    return renderDynamicIcon(settings, iconContent, borderSvg, bindingMissing);
   }
 
   // Push To Pass and DRS use dedicated templates with their own <desc> defaults
@@ -365,7 +370,7 @@ export function generateCarControlSvg(settings: CarControlSettings, telemetrySta
     const template = control === "push-to-pass" ? pushToPassTemplate : drsTemplate;
     const colors = resolveIconColors(template, getGlobalColors(), settings.colorOverrides) as Record<string, string>;
     const activeValue = control === "push-to-pass" ? telemetryState?.pushToPassActive : telemetryState?.drsActive;
-    const iconContent = control === "push-to-pass" ? pushToPassIcon(activeValue) : drsIcon(activeValue);
+    const baseIconContent = control === "push-to-pass" ? pushToPassIcon(activeValue) : drsIcon(activeValue);
     const toggleState: "on" | "off" | "na" = activeValue === undefined ? "na" : activeValue ? "on" : "off";
 
     const resolvedTitle = resolveTitleSettings(template, getGlobalTitleSettings(), settings.titleOverrides);
@@ -389,7 +394,11 @@ export function generateCarControlSvg(settings: CarControlSettings, telemetrySta
     );
     const borderSvg = generateBorderParts(border);
 
-    // Status bar is always visible, even when Show Graphics is off
+    // Status bar is always visible, even when Show Graphics is off. When a
+    // required binding is missing, dim the content and draw the centered
+    // warning over it (#612).
+    const iconContent = bindingMissing ? applyBindingWarning(baseIconContent) : baseIconContent;
+
     const svg = renderIconTemplate(template, {
       iconContent,
       titleContent,
@@ -413,7 +422,7 @@ export function generateCarControlSvg(settings: CarControlSettings, telemetrySta
 
     const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-    return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+    return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
   }
 
   // Static modes use standalone SVGs from @iracedeck/icons
@@ -426,7 +435,7 @@ export function generateCarControlSvg(settings: CarControlSettings, telemetrySta
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /** Bounding box for pit-limiter dynamic content (derived from circle r=38 centered at 72,46) */
@@ -436,6 +445,7 @@ function renderDynamicIcon(
   settings: CarControlSettings,
   iconContent: string,
   border: { defs: string; rects: string },
+  bindingMissing = false,
 ): string {
   const labels = CAR_CONTROL_LABELS[settings.control] || CAR_CONTROL_LABELS["starter"];
   const defaultTitle = `${labels.line2}\n${labels.line1}`;
@@ -458,6 +468,12 @@ function renderDynamicIcon(
       computeGraphicArea(resolvedTitle),
       graphic.scale,
     );
+  }
+
+  // When a required binding is missing, dim the content and draw the
+  // centered warning over it (#612).
+  if (bindingMissing) {
+    scaledContent = applyBindingWarning(scaledContent);
   }
 
   const titleContent = resolvedTitle.showTitle
@@ -780,14 +796,22 @@ export class CarControl extends ConnectionStateAwareAction<CarControlSettings> {
     const telemetry = this.sdkController.getCurrentTelemetry();
     const telemetryState = this.getTelemetryState(telemetry, settings.control);
 
-    const svgDataUri = generateCarControlSvg(settings, telemetryState);
+    const svgDataUri = generateCarControlSvg(
+      settings,
+      telemetryState,
+      this.isBindingMissing(CAR_CONTROL_GLOBAL_KEYS[settings.control]),
+    );
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
     this.setRegenerateCallback(ev.action.id, () => {
       const currentTelemetry = this.sdkController.getCurrentTelemetry();
       const currentState = this.getTelemetryState(currentTelemetry, settings.control);
 
-      return generateCarControlSvg(settings, currentState);
+      return generateCarControlSvg(
+        settings,
+        currentState,
+        this.isBindingMissing(CAR_CONTROL_GLOBAL_KEYS[settings.control]),
+      );
     });
 
     // Initialize state cache
@@ -798,21 +822,24 @@ export class CarControl extends ConnectionStateAwareAction<CarControlSettings> {
   private buildStateKey(settings: CarControlSettings, telemetryState: CarControlTelemetryState): string {
     const bo = settings.borderOverrides;
     const borderKey = `${bo?.enabled ?? ""}|${bo?.borderWidth ?? ""}|${bo?.borderColor ?? ""}|${bo?.glowEnabled ?? ""}|${bo?.glowWidth ?? ""}`;
+    // Include the binding-missing flag so a telemetry tick re-renders the key
+    // when the user sets/clears the control's binding (#612).
+    const warn = this.isBindingMissing(CAR_CONTROL_GLOBAL_KEYS[settings.control]) ? "warn" : "";
 
     if (settings.control === "pit-speed-limiter") {
-      return `pit-speed-limiter|${telemetryState.pitLimiterActive ?? false}|${telemetryState.pitSpeedLimit ?? DEFAULT_PIT_SPEED}|${borderKey}`;
+      return `pit-speed-limiter|${telemetryState.pitLimiterActive ?? false}|${telemetryState.pitSpeedLimit ?? DEFAULT_PIT_SPEED}|${borderKey}|${warn}`;
     }
 
     if (settings.control === "push-to-pass") {
-      return `push-to-pass|${telemetryState.pushToPassActive ?? "na"}|${borderKey}`;
+      return `push-to-pass|${telemetryState.pushToPassActive ?? "na"}|${borderKey}|${warn}`;
     }
 
     if (settings.control === "drs") {
-      return `drs|${telemetryState.drsActive ?? "na"}|${borderKey}`;
+      return `drs|${telemetryState.drsActive ?? "na"}|${borderKey}|${warn}`;
     }
 
     if (settings.control === "enter-exit-tow") {
-      return `enter-exit-tow|${telemetryState.enterExitTowState ?? "enter-car"}|${borderKey}`;
+      return `enter-exit-tow|${telemetryState.enterExitTowState ?? "enter-car"}|${borderKey}|${warn}`;
     }
 
     return settings.control;
@@ -844,13 +871,21 @@ export class CarControl extends ConnectionStateAwareAction<CarControlSettings> {
 
       const currentTelemetry = this.sdkController.getCurrentTelemetry();
       const currentState = this.getTelemetryState(currentTelemetry, storedSettings.control);
-      const svgDataUri = generateCarControlSvg(storedSettings, currentState);
+      const svgDataUri = generateCarControlSvg(
+        storedSettings,
+        currentState,
+        this.isBindingMissing(CAR_CONTROL_GLOBAL_KEYS[storedSettings.control]),
+      );
       await this.updateKeyImage(contextId, svgDataUri);
       this.setRegenerateCallback(contextId, () => {
         const t = this.sdkController.getCurrentTelemetry();
         const s = this.getTelemetryState(t, storedSettings.control);
 
-        return generateCarControlSvg(storedSettings, s);
+        return generateCarControlSvg(
+          storedSettings,
+          s,
+          this.isBindingMissing(CAR_CONTROL_GLOBAL_KEYS[storedSettings.control]),
+        );
       });
     });
   }

--- a/packages/iracing-actions/src/actions/chat/chat.ejs
+++ b/packages/iracing-actions/src/actions/chat/chat.ejs
@@ -18,6 +18,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['chat']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<sdpi-item label="Message Text" id="message-item" class="hidden">
 			<sdpi-textarea setting="message" rows="3" placeholder="Enter message to send"></sdpi-textarea>
 		</sdpi-item>

--- a/packages/iracing-actions/src/actions/chat/chat.ejs
+++ b/packages/iracing-actions/src/actions/chat/chat.ejs
@@ -19,7 +19,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['chat']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<sdpi-item label="Message Text" id="message-item" class="hidden">
 			<sdpi-textarea setting="message" rows="3" placeholder="Enter message to send"></sdpi-textarea>

--- a/packages/iracing-actions/src/actions/chat/chat.test.ts
+++ b/packages/iracing-actions/src/actions/chat/chat.test.ts
@@ -89,6 +89,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     holdBinding = vi.fn().mockResolvedValue(undefined);
     releaseBinding = vi.fn().mockResolvedValue(undefined);
     setActiveBinding = vi.fn();
+    isBindingMissing = vi.fn(() => false);
     async onWillAppear() {}
     async onDidReceiveSettings() {}
     async onWillDisappear() {}

--- a/packages/iracing-actions/src/actions/chat/chat.ts
+++ b/packages/iracing-actions/src/actions/chat/chat.ts
@@ -125,7 +125,7 @@ export function hasTemplateVars(settings: { keyText: string; message: string }):
  * For "send-message" mode: renders a large chat bubble with message text inside.
  * For other modes: renders icon with accent color and labels below.
  */
-export function generateChatSvg(settings: ChatSettings): string {
+export function generateChatSvg(settings: ChatSettings, bindingMissing = false): string {
   const { mode, iconColor, keyText } = settings;
 
   // Special handling for send-message mode: render text inside the bubble
@@ -161,6 +161,7 @@ export function generateChatSvg(settings: ChatSettings): string {
     title,
     border,
     graphic,
+    bindingMissing,
   });
 }
 
@@ -478,12 +479,15 @@ export class Chat extends ConnectionStateAwareAction<ChatSettings> {
 
   private async updateIconFromTelemetry(contextId: string, settings: ChatSettings): Promise<void> {
     const resolved = this.resolveSettingsTemplates(settings);
-    const svgDataUri = generateChatSvg(resolved);
+    const bindingMissing = this.isBindingMissing(CHAT_GLOBAL_KEYS[resolved.mode]);
+    const svgDataUri = generateChatSvg(resolved, bindingMissing);
 
     if (this.lastRenderedIcon.get(contextId) !== svgDataUri) {
       this.lastRenderedIcon.set(contextId, svgDataUri);
       await this.updateKeyImage(contextId, svgDataUri);
-      this.setRegenerateCallback(contextId, () => generateChatSvg(resolved));
+      this.setRegenerateCallback(contextId, () =>
+        generateChatSvg(resolved, this.isBindingMissing(CHAT_GLOBAL_KEYS[resolved.mode])),
+      );
     }
   }
 
@@ -492,10 +496,13 @@ export class Chat extends ConnectionStateAwareAction<ChatSettings> {
     settings: ChatSettings,
   ): Promise<void> {
     const resolved = this.resolveSettingsTemplates(settings);
-    const svgDataUri = generateChatSvg(resolved);
+    const bindingMissing = this.isBindingMissing(CHAT_GLOBAL_KEYS[resolved.mode]);
+    const svgDataUri = generateChatSvg(resolved, bindingMissing);
     this.lastRenderedIcon.set(ev.action.id, svgDataUri);
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateChatSvg(resolved));
+    this.setRegenerateCallback(ev.action.id, () =>
+      generateChatSvg(resolved, this.isBindingMissing(CHAT_GLOBAL_KEYS[resolved.mode])),
+    );
   }
 }

--- a/packages/iracing-actions/src/actions/cockpit-misc/cockpit-misc.ejs
+++ b/packages/iracing-actions/src/actions/cockpit-misc/cockpit-misc.ejs
@@ -18,6 +18,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['cockpit-misc']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">
 				<option value="increase">Increase</option>

--- a/packages/iracing-actions/src/actions/cockpit-misc/cockpit-misc.ejs
+++ b/packages/iracing-actions/src/actions/cockpit-misc/cockpit-misc.ejs
@@ -19,7 +19,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['cockpit-misc']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">

--- a/packages/iracing-actions/src/actions/cockpit-misc/cockpit-misc.test.ts
+++ b/packages/iracing-actions/src/actions/cockpit-misc/cockpit-misc.test.ts
@@ -62,6 +62,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     holdBinding = vi.fn().mockResolvedValue(undefined);
     releaseBinding = vi.fn().mockResolvedValue(undefined);
     setActiveBinding = vi.fn();
+    isBindingMissing = vi.fn(() => false);
     async onWillAppear() {}
     async onDidReceiveSettings() {}
     async onWillDisappear() {}

--- a/packages/iracing-actions/src/actions/cockpit-misc/cockpit-misc.ts
+++ b/packages/iracing-actions/src/actions/cockpit-misc/cockpit-misc.ts
@@ -122,7 +122,7 @@ type CockpitMiscSettings = z.infer<typeof CockpitMiscSettings>;
  *
  * Generates an SVG data URI icon for the cockpit misc action.
  */
-export function generateCockpitMiscSvg(settings: CockpitMiscSettings): string {
+export function generateCockpitMiscSvg(settings: CockpitMiscSettings, bindingMissing = false): string {
   const { control, direction } = settings;
 
   const svgEntry = COCKPIT_MISC_SVGS[control];
@@ -144,7 +144,7 @@ export function generateCockpitMiscSvg(settings: CockpitMiscSettings): string {
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg as string, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg as string, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -239,9 +239,15 @@ export class CockpitMisc extends ConnectionStateAwareAction<CockpitMiscSettings>
     ev: IDeckWillAppearEvent<CockpitMiscSettings> | IDeckDidReceiveSettingsEvent<CockpitMiscSettings>,
     settings: CockpitMiscSettings,
   ): Promise<void> {
-    const svgDataUri = generateCockpitMiscSvg(settings);
+    const activeKey = this.resolveGlobalKey(settings.control, settings.direction);
+    const svgDataUri = generateCockpitMiscSvg(settings, this.isBindingMissing(activeKey));
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateCockpitMiscSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () =>
+      generateCockpitMiscSvg(
+        settings,
+        this.isBindingMissing(this.resolveGlobalKey(settings.control, settings.direction)),
+      ),
+    );
   }
 }

--- a/packages/iracing-actions/src/actions/comms-catalog.test.ts
+++ b/packages/iracing-actions/src/actions/comms-catalog.test.ts
@@ -4,6 +4,40 @@ import { describe, expect, it } from "vitest";
 import { COMMS_CATALOG } from "./comms-catalog.js";
 
 const JSON_PATH = new URL("./data/action-comms.json", import.meta.url);
+const KEY_BINDINGS_PATH = new URL("./data/key-bindings.json", import.meta.url);
+
+/** Every global binding key referenced anywhere in the catalog. */
+function catalogBindingKeys(): Set<string> {
+  const keys = new Set<string>();
+
+  for (const map of Object.values(COMMS_CATALOG)) {
+    for (const [mode, descriptor] of Object.entries(map)) {
+      if (mode === "_meta") continue;
+
+      const ref = (descriptor as { binding?: Record<string, unknown> }).binding;
+
+      if (!ref) continue;
+
+      if (typeof ref.key === "string") keys.add(ref.key);
+
+      if (Array.isArray(ref.keys)) for (const k of ref.keys as string[]) keys.add(k);
+
+      if (ref.keyBy) for (const k of Object.values((ref.keyBy as { map: Record<string, string> }).map)) keys.add(k);
+    }
+  }
+
+  return keys;
+}
+
+/** Every `setting` declared in the key-bindings accordions. */
+function keyBindingSettings(): Set<string> {
+  const data = JSON.parse(readFileSync(KEY_BINDINGS_PATH, "utf-8")) as Record<string, Array<{ setting: string }>>;
+  const settings = new Set<string>();
+
+  for (const list of Object.values(data)) for (const b of list) settings.add(b.setting);
+
+  return settings;
+}
 
 describe("action-comms catalog", () => {
   it("committed action-comms.json matches the TS catalog (run `pnpm generate:action-comms`)", () => {
@@ -44,5 +78,13 @@ describe("action-comms catalog", () => {
         if (hasMulti) expect((ref as { keys: string[] }).keys.length).toBeGreaterThan(0);
       }
     }
+  });
+
+  it("every catalog binding key exists in key-bindings.json (the accordion source)", () => {
+    const declared = keyBindingSettings();
+    const missing = [...catalogBindingKeys()].filter((k) => !declared.has(k)).sort();
+    // A catalog key absent from key-bindings.json means the status line can't
+    // find an ird-key-binding for it → wrong/empty state. Catches typos too.
+    expect(missing, `binding keys missing from key-bindings.json: ${missing.join(", ")}`).toEqual([]);
   });
 });

--- a/packages/iracing-actions/src/actions/comms-catalog.test.ts
+++ b/packages/iracing-actions/src/actions/comms-catalog.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import { COMMS_CATALOG } from "./comms-catalog.js";
+
+const JSON_PATH = new URL("./data/action-comms.json", import.meta.url);
+
+describe("action-comms catalog", () => {
+  it("committed action-comms.json matches the TS catalog (run `pnpm generate:action-comms`)", () => {
+    const committed = JSON.parse(readFileSync(JSON_PATH, "utf-8"));
+    // Round-trip the catalog so the comparison is over plain JSON values.
+    const generated = JSON.parse(JSON.stringify(COMMS_CATALOG));
+    expect(committed).toEqual(generated);
+  });
+
+  it("every entry has a string modeSetting in _meta", () => {
+    for (const [action, map] of Object.entries(COMMS_CATALOG)) {
+      expect(typeof map._meta?.modeSetting, `${action}._meta.modeSetting`).toBe("string");
+    }
+  });
+
+  it("every mode descriptor is well-formed", () => {
+    for (const [action, map] of Object.entries(COMMS_CATALOG)) {
+      for (const [mode, descriptor] of Object.entries(map)) {
+        if (mode === "_meta") continue;
+
+        expect(["api", "keybind", "chat"], `${action}.${mode}.method`).toContain(descriptor.method);
+
+        // Only keybind modes may carry a binding; api/chat must not.
+        if (descriptor.method !== "keybind") {
+          expect(descriptor.binding, `${action}.${mode} should have no binding`).toBeUndefined();
+        }
+
+        const ref = descriptor.binding;
+
+        if (!ref) continue;
+
+        const hasConstant = "key" in ref;
+        const hasMulti = "keys" in ref;
+        const hasKeyBy = "keyBy" in ref;
+        // Exactly one binding-key form.
+        expect([hasConstant, hasMulti, hasKeyBy].filter(Boolean).length, `${action}.${mode} binding form`).toBe(1);
+
+        if (hasMulti) expect((ref as { keys: string[] }).keys.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/packages/iracing-actions/src/actions/comms-catalog.ts
+++ b/packages/iracing-actions/src/actions/comms-catalog.ts
@@ -30,6 +30,14 @@ import {
 const api: CommDescriptor = { method: "api" };
 const chat: CommDescriptor = { method: "chat" };
 
+/** Build a `{ mode: <descriptor> }` map for a list of same-method modes. */
+function allApi(modes: string[]): ActionCommMap {
+  return Object.fromEntries(modes.map((m) => [m, api]));
+}
+function allChat(modes: string[]): ActionCommMap {
+  return Object.fromEntries(modes.map((m) => [m, chat]));
+}
+
 /** Per-action metadata carried alongside the mode map. */
 export interface ActionCommMeta {
   /** Name of the action setting whose value selects the mode. */
@@ -43,13 +51,17 @@ function entry(modeSetting: string, modes: ActionCommMap): ActionCommEntry {
   return { _meta: { modeSetting }, ...modes };
 }
 
+/** Directional keybind mode whose key is chosen by the `direction` secondary setting. */
+function dir(increase: string, decrease: string): CommDescriptor {
+  return keybindBy("direction", { increase, decrease });
+}
+
 /**
- * Build the increase/decrease pair descriptor for a setup `view-*` mode, which
- * nudges-and-reads via the adjustment's increase AND decrease keys (both
- * required — warn if either is unset).
+ * Setup `view-*` mode: nudges-and-reads via the adjustment's increase AND
+ * decrease keys (both required — warn if either is unset).
  */
-function viewPair(prefix: string, mode: string): CommDescriptor {
-  return keybindKeys([`${prefix}${mode}Increase`, `${prefix}${mode}Decrease`]);
+function pair(increase: string, decrease: string): CommDescriptor {
+  return keybindKeys([increase, decrease]);
 }
 
 export const COMMS_CATALOG: Record<string, ActionCommEntry> = {
@@ -131,20 +143,55 @@ export const COMMS_CATALOG: Record<string, ActionCommEntry> = {
   }),
 
   "camera-editor-adjustments": entry("adjustment", {
-    latitude: keybindBy("direction", {
-      increase: "cameraEditorLatitudeIncrease",
-      decrease: "cameraEditorLatitudeDecrease",
-    }),
-    roll: keybindBy("direction", { increase: "cameraEditorRollIncrease", decrease: "cameraEditorRollDecrease" }),
-    height: keybindBy("direction", { increase: "cameraEditorHeightIncrease", decrease: "cameraEditorHeightDecrease" }),
+    latitude: dir("camEditLatitudeIncrease", "camEditLatitudeDecrease"),
+    longitude: dir("camEditLongitudeIncrease", "camEditLongitudeDecrease"),
+    altitude: dir("camEditAltitudeIncrease", "camEditAltitudeDecrease"),
+    yaw: dir("camEditYawIncrease", "camEditYawDecrease"),
+    pitch: dir("camEditPitchIncrease", "camEditPitchDecrease"),
+    "fov-zoom": dir("camEditFovZoomIncrease", "camEditFovZoomDecrease"),
+    "key-step": dir("camEditKeyStepIncrease", "camEditKeyStepDecrease"),
+    "vanish-x": dir("camEditVanishXIncrease", "camEditVanishXDecrease"),
+    "vanish-y": dir("camEditVanishYIncrease", "camEditVanishYDecrease"),
+    "blimp-radius": dir("camEditBlimpRadiusIncrease", "camEditBlimpRadiusDecrease"),
+    "blimp-velocity": dir("camEditBlimpVelocityIncrease", "camEditBlimpVelocityDecrease"),
+    "mic-gain": dir("camEditMicGainIncrease", "camEditMicGainDecrease"),
+    // Both directions trigger the same key — a single fixed binding.
+    "auto-set-mic-gain": keybind("camEditAutoSetMicGain"),
+    "f-number": dir("camEditFNumberIncrease", "camEditFNumberDecrease"),
+    "focus-depth": dir("camEditFocusDepthIncrease", "camEditFocusDepthDecrease"),
   }),
 
   "camera-editor-controls": entry("control", {
-    "open-camera-tool": keybind("cameraEditorOpenCameraTool"),
-    "reset-camera": keybind("cameraEditorResetCamera"),
-    "exit-car": keybind("cameraEditorExitCar"),
-    "reset-to-pits": keybind("cameraEditorResetToPits"),
-    tow: keybind("cameraEditorTow"),
+    "open-camera-tool": keybind("camCtrlOpenCameraTool"),
+    "key-acceleration-toggle": keybind("camCtrlKeyAccelerationToggle"),
+    "key-10x-toggle": keybind("camCtrlKey10xToggle"),
+    "parabolic-mic-toggle": keybind("camCtrlParabolicMicToggle"),
+    "cycle-position-type": keybind("camCtrlCyclePositionType"),
+    "cycle-aim-type": keybind("camCtrlCycleAimType"),
+    "acquire-start": keybind("camCtrlAcquireStart"),
+    "acquire-end": keybind("camCtrlAcquireEnd"),
+    "temporary-edits-toggle": keybind("camCtrlTemporaryEditsToggle"),
+    "dampening-toggle": keybind("camCtrlDampeningToggle"),
+    "zoom-toggle": keybind("camCtrlZoomToggle"),
+    "beyond-fence-toggle": keybind("camCtrlBeyondFenceToggle"),
+    "in-cockpit-toggle": keybind("camCtrlInCockpitToggle"),
+    "mouse-navigation-toggle": keybind("camCtrlMouseNavigationToggle"),
+    "pitch-gyro-toggle": keybind("camCtrlPitchGyroToggle"),
+    "roll-gyro-toggle": keybind("camCtrlRollGyroToggle"),
+    "limit-shot-range-toggle": keybind("camCtrlLimitShotRangeToggle"),
+    "show-camera-toggle": keybind("camCtrlShowCameraToggle"),
+    "shot-selection-toggle": keybind("camCtrlShotSelectionToggle"),
+    "manual-focus-toggle": keybind("camCtrlManualFocusToggle"),
+    "insert-camera": keybind("camCtrlInsertCamera"),
+    "remove-camera": keybind("camCtrlRemoveCamera"),
+    "copy-camera": keybind("camCtrlCopyCamera"),
+    "paste-camera": keybind("camCtrlPasteCamera"),
+    "copy-group": keybind("camCtrlCopyGroup"),
+    "paste-group": keybind("camCtrlPasteGroup"),
+    "save-track-camera": keybind("camCtrlSaveTrackCamera"),
+    "load-track-camera": keybind("camCtrlLoadTrackCamera"),
+    "save-car-camera": keybind("camCtrlSaveCarCamera"),
+    "load-car-camera": keybind("camCtrlLoadCarCamera"),
   }),
 
   "cockpit-misc": entry("control", {
@@ -228,7 +275,222 @@ export const COMMS_CATALOG: Record<string, ActionCommEntry> = {
     "display-ref-car": keybind("toggleUiDisplayRefCar"),
     "replay-ui": api,
   }),
-};
 
-/** `viewPair` is exported for the setup-* catalog entries added in a follow-up. */
-export { viewPair };
+  "ai-spotter-controls": entry("control", {
+    "damage-report": keybind("spotterDamageReport"),
+    "weather-report": keybind("spotterWeatherReport"),
+    "toggle-report-laps": keybind("spotterToggleReportLaps"),
+    "announce-leader": keybind("spotterAnnounceLeader"),
+    louder: keybind("spotterLouder"),
+    quieter: keybind("spotterQuieter"),
+    silence: keybind("spotterSilence"),
+  }),
+
+  // --- Setup actions (mode setting "setting"): view-* modes nudge-and-read via
+  // both the increase AND decrease keys; adjust modes pick one by `direction`. ---
+
+  "setup-aero": entry("setting", {
+    "view-front-wing": pair("setupAeroFrontWingIncrease", "setupAeroFrontWingDecrease"),
+    "view-rear-wing": pair("setupAeroRearWingIncrease", "setupAeroRearWingDecrease"),
+    "front-wing": dir("setupAeroFrontWingIncrease", "setupAeroFrontWingDecrease"),
+    "rear-wing": dir("setupAeroRearWingIncrease", "setupAeroRearWingDecrease"),
+    "qualifying-tape": dir("setupAeroQualifyingTapeIncrease", "setupAeroQualifyingTapeDecrease"),
+    "rf-brake-attached": keybind("setupAeroRfBrakeAttached"),
+  }),
+
+  "setup-brakes": entry("setting", {
+    "view-brake-bias": pair("setupBrakesBrakeBiasIncrease", "setupBrakesBrakeBiasDecrease"),
+    "view-brake-bias-fine": pair("setupBrakesBrakeBiasFineIncrease", "setupBrakesBrakeBiasFineDecrease"),
+    "view-peak-brake-bias": pair("setupBrakesPeakBrakeBiasIncrease", "setupBrakesPeakBrakeBiasDecrease"),
+    "view-brake-misc": pair("setupBrakesBrakeMiscIncrease", "setupBrakesBrakeMiscDecrease"),
+    "view-engine-braking": pair("setupBrakesEngineBrakingIncrease", "setupBrakesEngineBrakingDecrease"),
+    "view-abs-adjust": pair("setupBrakesAbsAdjustIncrease", "setupBrakesAbsAdjustDecrease"),
+    "abs-toggle": keybind("setupBrakesAbsToggle"),
+    "abs-adjust": dir("setupBrakesAbsAdjustIncrease", "setupBrakesAbsAdjustDecrease"),
+    "brake-bias": dir("setupBrakesBrakeBiasIncrease", "setupBrakesBrakeBiasDecrease"),
+    "brake-bias-fine": dir("setupBrakesBrakeBiasFineIncrease", "setupBrakesBrakeBiasFineDecrease"),
+    "peak-brake-bias": dir("setupBrakesPeakBrakeBiasIncrease", "setupBrakesPeakBrakeBiasDecrease"),
+    "brake-misc": dir("setupBrakesBrakeMiscIncrease", "setupBrakesBrakeMiscDecrease"),
+    "engine-braking": dir("setupBrakesEngineBrakingIncrease", "setupBrakesEngineBrakingDecrease"),
+  }),
+
+  "setup-chassis": entry("setting", {
+    "view-diff-preload": pair("setupChassisDifferentialPreloadIncrease", "setupChassisDifferentialPreloadDecrease"),
+    "view-diff-entry": pair("setupChassisDifferentialEntryIncrease", "setupChassisDifferentialEntryDecrease"),
+    "view-diff-middle": pair("setupChassisDifferentialMiddleIncrease", "setupChassisDifferentialMiddleDecrease"),
+    "view-diff-exit": pair("setupChassisDifferentialExitIncrease", "setupChassisDifferentialExitDecrease"),
+    "view-anti-roll-front": pair("setupChassisFrontArbIncrease", "setupChassisFrontArbDecrease"),
+    "view-anti-roll-rear": pair("setupChassisRearArbIncrease", "setupChassisRearArbDecrease"),
+    "view-power-steering": pair("setupChassisPowerSteeringIncrease", "setupChassisPowerSteeringDecrease"),
+    "view-weight-jacker-left": pair("setupChassisWeightJackerLeftIncrease", "setupChassisWeightJackerLeftDecrease"),
+    "view-weight-jacker-right": pair("setupChassisWeightJackerRightIncrease", "setupChassisWeightJackerRightDecrease"),
+    "differential-preload": dir("setupChassisDifferentialPreloadIncrease", "setupChassisDifferentialPreloadDecrease"),
+    "differential-entry": dir("setupChassisDifferentialEntryIncrease", "setupChassisDifferentialEntryDecrease"),
+    "differential-middle": dir("setupChassisDifferentialMiddleIncrease", "setupChassisDifferentialMiddleDecrease"),
+    "differential-exit": dir("setupChassisDifferentialExitIncrease", "setupChassisDifferentialExitDecrease"),
+    "front-arb": dir("setupChassisFrontArbIncrease", "setupChassisFrontArbDecrease"),
+    "rear-arb": dir("setupChassisRearArbIncrease", "setupChassisRearArbDecrease"),
+    "left-spring": dir("setupChassisLeftSpringIncrease", "setupChassisLeftSpringDecrease"),
+    "right-spring": dir("setupChassisRightSpringIncrease", "setupChassisRightSpringDecrease"),
+    "lf-shock": dir("setupChassisLfShockIncrease", "setupChassisLfShockDecrease"),
+    "rf-shock": dir("setupChassisRfShockIncrease", "setupChassisRfShockDecrease"),
+    "lr-shock": dir("setupChassisLrShockIncrease", "setupChassisLrShockDecrease"),
+    "rr-shock": dir("setupChassisRrShockIncrease", "setupChassisRrShockDecrease"),
+    "power-steering": dir("setupChassisPowerSteeringIncrease", "setupChassisPowerSteeringDecrease"),
+  }),
+
+  "setup-engine": entry("setting", {
+    "view-engine-power": pair("setupEngineEnginePowerIncrease", "setupEngineEnginePowerDecrease"),
+    "view-throttle-shape": pair("setupEngineThrottleShapingIncrease", "setupEngineThrottleShapingDecrease"),
+    "view-launch-rpm": pair("setupEngineLaunchRpmIncrease", "setupEngineLaunchRpmDecrease"),
+    "engine-power": dir("setupEngineEnginePowerIncrease", "setupEngineEnginePowerDecrease"),
+    "throttle-shaping": dir("setupEngineThrottleShapingIncrease", "setupEngineThrottleShapingDecrease"),
+    "boost-level": dir("setupEngineBoostLevelIncrease", "setupEngineBoostLevelDecrease"),
+    "launch-rpm": dir("setupEngineLaunchRpmIncrease", "setupEngineLaunchRpmDecrease"),
+  }),
+
+  "setup-fuel": entry("setting", {
+    "view-fuel-mixture": pair("setupFuelFuelMixtureIncrease", "setupFuelFuelMixtureDecrease"),
+    "view-fuel-cut-position": pair("setupFuelFuelCutPositionIncrease", "setupFuelFuelCutPositionDecrease"),
+    "fuel-mixture": dir("setupFuelFuelMixtureIncrease", "setupFuelFuelMixtureDecrease"),
+    "fuel-cut-position": dir("setupFuelFuelCutPositionIncrease", "setupFuelFuelCutPositionDecrease"),
+    "disable-fuel-cut": keybind("setupFuelDisableFuelCut"),
+    "low-fuel-accept": keybind("setupFuelLowFuelAccept"),
+    "fcy-mode-toggle": keybind("setupFuelFcyModeToggle"),
+  }),
+
+  "setup-hybrid": entry("setting", {
+    "view-mguk-deploy-mode": pair("setupHybridMgukDeployModeIncrease", "setupHybridMgukDeployModeDecrease"),
+    "view-mguk-regen-gain": pair("setupHybridMgukRegenGainIncrease", "setupHybridMgukRegenGainDecrease"),
+    "view-mguk-deploy-fixed": pair("setupHybridMgukFixedDeployIncrease", "setupHybridMgukFixedDeployDecrease"),
+    "mguk-regen-gain": dir("setupHybridMgukRegenGainIncrease", "setupHybridMgukRegenGainDecrease"),
+    "mguk-deploy-mode": dir("setupHybridMgukDeployModeIncrease", "setupHybridMgukDeployModeDecrease"),
+    "mguk-fixed-deploy": dir("setupHybridMgukFixedDeployIncrease", "setupHybridMgukFixedDeployDecrease"),
+    "hys-boost": keybind("setupHybridHysBoost"),
+    "hys-regen": keybind("setupHybridHysRegen"),
+    "hys-no-boost": keybind("setupHybridHysNoBoost"),
+  }),
+
+  "setup-traction": entry("setting", {
+    "view-tc-slot-1": pair("setupTractionTcSlot1Increase", "setupTractionTcSlot1Decrease"),
+    "view-tc-slot-2": pair("setupTractionTcSlot2Increase", "setupTractionTcSlot2Decrease"),
+    "view-tc-slot-3": pair("setupTractionTcSlot3Increase", "setupTractionTcSlot3Decrease"),
+    "view-tc-slot-4": pair("setupTractionTcSlot4Increase", "setupTractionTcSlot4Decrease"),
+    "tc-toggle": keybind("setupTractionTcToggle"),
+    "tc-slot-1": dir("setupTractionTcSlot1Increase", "setupTractionTcSlot1Decrease"),
+    "tc-slot-2": dir("setupTractionTcSlot2Increase", "setupTractionTcSlot2Decrease"),
+    "tc-slot-3": dir("setupTractionTcSlot3Increase", "setupTractionTcSlot3Decrease"),
+    "tc-slot-4": dir("setupTractionTcSlot4Increase", "setupTractionTcSlot4Decrease"),
+  }),
+
+  // --- API / chat actions (no binding required) ---
+
+  "media-capture": entry("mode", {
+    ...allApi([
+      "start-stop-video",
+      "video-timer",
+      "toggle-video-capture",
+      "take-screenshot",
+      "reload-all-textures",
+      "reload-car-textures",
+    ]),
+    "take-giant-screenshot": keybind("mediaCaptureGiantScreenshot"),
+  }),
+
+  "pit-quick-actions": entry("mode", allApi(["clear-all-checkboxes", "windshield-tearoff", "request-fast-repair"])),
+
+  "replay-control": entry("mode", {
+    ...allApi([
+      "play-pause",
+      "play-backward",
+      "stop",
+      "fast-forward",
+      "rewind",
+      "slow-motion",
+      "slow-motion-rewind",
+      "frame-forward",
+      "frame-backward",
+      "speed-increase",
+      "speed-decrease",
+      "set-speed",
+      "speed-display",
+      "next-session",
+      "prev-session",
+      "next-lap",
+      "prev-lap",
+      "next-incident",
+      "prev-incident",
+      "jump-to-beginning",
+      "jump-to-live",
+      "jump-to-my-car",
+      "jump-to-fastest-lap",
+      "next-car-number",
+      "prev-car-number",
+    ]),
+    "next-car": keybind("replayControlNextCar"),
+    "prev-car": keybind("replayControlPrevCar"),
+  }),
+
+  "replay-navigation": entry(
+    "navigation",
+    allApi([
+      "next-session",
+      "prev-session",
+      "next-lap",
+      "prev-lap",
+      "next-incident",
+      "prev-incident",
+      "jump-to-start",
+      "jump-to-end",
+      "set-play-position",
+      "search-session-time",
+      "erase-tape",
+    ]),
+  ),
+
+  "replay-speed": entry("direction", allApi(["increase", "decrease"])),
+
+  "replay-transport": entry(
+    "transport",
+    allApi(["play", "pause", "stop", "fast-forward", "rewind", "slow-motion", "frame-forward", "frame-backward"]),
+  ),
+
+  "telemetry-control": entry("mode", {
+    "toggle-logging": keybind("telemetryControlToggleLogging"),
+    "mark-event": keybind("telemetryControlMarkEvent"),
+    ...allApi(["start-recording", "stop-recording", "restart-recording"]),
+  }),
+
+  "race-admin": entry(
+    "mode",
+    allChat([
+      "yellow",
+      "black-flag",
+      "dq-driver",
+      "show-dqs-field",
+      "show-dqs-driver",
+      "clear-penalties",
+      "clear-all",
+      "wave-around",
+      "eol",
+      "pit-close",
+      "pit-open",
+      "pace-laps",
+      "single-file-restart",
+      "double-file-restart",
+      "advance-session",
+      "grid-set",
+      "grid-start",
+      "track-state",
+      "grant-admin",
+      "revoke-admin",
+      "remove-driver",
+      "enable-chat-all",
+      "enable-chat-driver",
+      "disable-chat-all",
+      "disable-chat-driver",
+      "message-all",
+      "rc-message",
+    ]),
+  ),
+};

--- a/packages/iracing-actions/src/actions/comms-catalog.ts
+++ b/packages/iracing-actions/src/actions/comms-catalog.ts
@@ -1,0 +1,234 @@
+/**
+ * Per-mode sim-communication catalog (issue #612) — authoritative source.
+ *
+ * Maps every (action, mode) to how it talks to iRacing: the iRacing API, a key
+ * binding (keyboard OR SimHub, possibly resolved from a secondary setting), or
+ * a chat command. The PI binding-status line and the docs read the GENERATED
+ * `data/action-comms.json`; regenerate it with `pnpm generate:action-comms`
+ * after editing this file (a freshness test guards the two staying in sync).
+ *
+ * Classification is the code-verified audit in
+ * `docs/superpowers/specs/2026-05-31-comms-method-audit.md`.
+ *
+ * Each action entry also records `modeSetting` — the name of the action setting
+ * whose value selects the mode — so the PI knows which setting to watch. It is
+ * emitted under the reserved `_meta` key inside each action's map.
+ *
+ * Display-only / internal actions (session-info, telemetry-display, pit-crew,
+ * camera-cycle, camera-focus) are intentionally absent: they issue no iRacing
+ * command, so they get no status line and no icon warning.
+ */
+import {
+  type ActionCommMap,
+  type CommDescriptor,
+  keybind,
+  keybindBy,
+  keybindFixed,
+  keybindKeys,
+} from "@iracedeck/deck-core";
+
+const api: CommDescriptor = { method: "api" };
+const chat: CommDescriptor = { method: "chat" };
+
+/** Per-action metadata carried alongside the mode map. */
+export interface ActionCommMeta {
+  /** Name of the action setting whose value selects the mode. */
+  modeSetting: string;
+}
+
+/** An action's mode map plus its `_meta`. The PI reads both from the JSON. */
+export type ActionCommEntry = ActionCommMap & { _meta: ActionCommMeta };
+
+function entry(modeSetting: string, modes: ActionCommMap): ActionCommEntry {
+  return { _meta: { modeSetting }, ...modes };
+}
+
+/**
+ * Build the increase/decrease pair descriptor for a setup `view-*` mode, which
+ * nudges-and-reads via the adjustment's increase AND decrease keys (both
+ * required — warn if either is unset).
+ */
+function viewPair(prefix: string, mode: string): CommDescriptor {
+  return keybindKeys([`${prefix}${mode}Increase`, `${prefix}${mode}Decrease`]);
+}
+
+export const COMMS_CATALOG: Record<string, ActionCommEntry> = {
+  "fuel-service": entry("mode", {
+    "toggle-fuel-fill": api,
+    "add-fuel": chat,
+    "reduce-fuel": chat,
+    "set-fuel-amount": chat,
+    "clear-fuel": api,
+    "toggle-autofuel": keybind("fuelServiceToggleAutofuel"),
+    "lap-margin-increase": keybind("fuelServiceLapMarginIncrease"),
+    "lap-margin-decrease": keybind("fuelServiceLapMarginDecrease"),
+  }),
+
+  "tire-service": entry("mode", {
+    "change-all-tires": chat,
+    "clear-tires": api,
+    "change-compound": api,
+    "toggle-tires": chat,
+  }),
+
+  "black-box-selector": entry("mode", {
+    direct: keybindBy("blackBox", {
+      "lap-timing": "blackBoxLapTiming",
+      standings: "blackBoxStandings",
+      relative: "blackBoxRelative",
+      fuel: "blackBoxFuel",
+      tires: "blackBoxTires",
+      "tire-info": "blackBoxTireInfo",
+      "pit-stop": "blackBoxPitStop",
+      "in-car": "blackBoxInCar",
+      mirror: "blackBoxMirror",
+      radio: "blackBoxRadio",
+      weather: "blackBoxWeather",
+    }),
+    next: keybind("blackBoxCycleNext"),
+    previous: keybind("blackBoxCyclePrevious"),
+  }),
+
+  "splits-delta-cycle": entry("mode", {
+    cycle: keybindBy("direction", { next: "splitsDeltaNext", previous: "splitsDeltaPrevious" }),
+    "toggle-ref-car": keybind("toggleUiDisplayRefCar"),
+    "custom-sector-start": keybind("splitsDeltaCustomSectorStart"),
+    "custom-sector-end": keybind("splitsDeltaCustomSectorEnd"),
+    "active-reset-set": keybind("splitsDeltaActiveResetSet"),
+    "active-reset-run": keybind("splitsDeltaActiveResetRun"),
+  }),
+
+  "look-direction": entry("direction", {
+    "look-left": keybind("lookDirectionLeft"),
+    "look-right": keybind("lookDirectionRight"),
+    "look-up": keybind("lookDirectionUp"),
+    "look-down": keybind("lookDirectionDown"),
+  }),
+
+  "car-control": entry("control", {
+    "pit-speed-limiter": keybind("carControlPitSpeedLimiter"),
+    "push-to-pass": keybind("carControlPushToPass"),
+    drs: keybind("carControlDrs"),
+    "headlight-flash": keybind("carControlHeadlightFlash"),
+    "tear-off-visor": keybind("carControlTearOffVisor"),
+    ignition: keybind("carControlIgnition"),
+    starter: keybind("carControlStarter"),
+    "enter-exit-tow": keybind("carControlEnterExitTow"),
+    "pause-sim": keybind("carControlPauseSim"),
+    // Hardcoded Escape — no user binding.
+    escape: keybindFixed(),
+  }),
+
+  "view-adjustment": entry("adjustment", {
+    fov: keybindBy("direction", { increase: "viewAdjustFovIncrease", decrease: "viewAdjustFovDecrease" }),
+    horizon: keybindBy("direction", { increase: "viewAdjustHorizonUp", decrease: "viewAdjustHorizonDown" }),
+    "driver-height": keybindBy("direction", {
+      increase: "viewAdjustDriverHeightUp",
+      decrease: "viewAdjustDriverHeightDown",
+    }),
+    "recenter-vr": keybind("viewAdjustRecenterVr"),
+    "ui-size": keybindBy("direction", { increase: "viewAdjustUiSizeIncrease", decrease: "viewAdjustUiSizeDecrease" }),
+  }),
+
+  "camera-editor-adjustments": entry("adjustment", {
+    latitude: keybindBy("direction", {
+      increase: "cameraEditorLatitudeIncrease",
+      decrease: "cameraEditorLatitudeDecrease",
+    }),
+    roll: keybindBy("direction", { increase: "cameraEditorRollIncrease", decrease: "cameraEditorRollDecrease" }),
+    height: keybindBy("direction", { increase: "cameraEditorHeightIncrease", decrease: "cameraEditorHeightDecrease" }),
+  }),
+
+  "camera-editor-controls": entry("control", {
+    "open-camera-tool": keybind("cameraEditorOpenCameraTool"),
+    "reset-camera": keybind("cameraEditorResetCamera"),
+    "exit-car": keybind("cameraEditorExitCar"),
+    "reset-to-pits": keybind("cameraEditorResetToPits"),
+    tow: keybind("cameraEditorTow"),
+  }),
+
+  "cockpit-misc": entry("control", {
+    "toggle-wipers": keybind("cockpitMiscToggleWipers"),
+    "trigger-wipers": keybind("cockpitMiscTriggerWipers"),
+    "ffb-max-force": keybindBy("direction", {
+      increase: "cockpitMiscFfbForceIncrease",
+      decrease: "cockpitMiscFfbForceDecrease",
+    }),
+    "report-latency": keybind("cockpitMiscReportLatency"),
+    "dash-page-1": keybindBy("direction", {
+      increase: "cockpitMiscDashPage1Increase",
+      decrease: "cockpitMiscDashPage1Decrease",
+    }),
+    "dash-page-2": keybindBy("direction", {
+      increase: "cockpitMiscDashPage2Increase",
+      decrease: "cockpitMiscDashPage2Decrease",
+    }),
+    "in-lap-mode": keybind("cockpitMiscInLapMode"),
+  }),
+
+  "force-feedback": entry("mode", {
+    "auto-compute-ffb-force": keybind("forceFeedbackAutoCompute"),
+    "ffb-force": keybindBy("direction", {
+      increase: "cockpitMiscFfbForceIncrease",
+      decrease: "cockpitMiscFfbForceDecrease",
+    }),
+    "wheel-lfe": keybindBy("direction", {
+      increase: "forceFeedbackWheelLfeLouder",
+      decrease: "forceFeedbackWheelLfeQuieter",
+    }),
+    "bass-shaker-lfe": keybindBy("direction", {
+      increase: "forceFeedbackBassShakerLfeLouder",
+      decrease: "forceFeedbackBassShakerLfeQuieter",
+    }),
+    "wheel-lfe-intensity": keybindBy("direction", {
+      increase: "forceFeedbackWheelLfeIntensityIncrease",
+      decrease: "forceFeedbackWheelLfeIntensityDecrease",
+    }),
+    "haptic-lfe-intensity": keybindBy("direction", {
+      increase: "forceFeedbackHapticLfeIntensityIncrease",
+      decrease: "forceFeedbackHapticLfeIntensityDecrease",
+    }),
+  }),
+
+  chat: entry("mode", {
+    "open-chat": api,
+    reply: api,
+    cancel: api,
+    "send-message": api,
+    macro: api,
+    whisper: keybind("chatWhisper"),
+    toggle: keybind("chatToggle"),
+  }),
+
+  "audio-controls": entry("category", {
+    "push-to-talk": keybind("audioControlsPushToTalk"),
+    "voice-chat": keybindBy("action", {
+      "volume-up": "audioVoiceChatVolumeUp",
+      "volume-down": "audioVoiceChatVolumeDown",
+      mute: "audioVoiceChatMute",
+    }),
+    master: keybindBy("action", {
+      "volume-up": "audioMasterVolumeUp",
+      "volume-down": "audioMasterVolumeDown",
+    }),
+    // Plugin audio, not iRacing — no binding.
+    "race-engineer": keybindFixed(),
+    radar: keybindFixed(),
+  }),
+
+  "toggle-ui-elements": entry("element", {
+    "dash-box": keybind("toggleUiDashBox"),
+    "speed-gear-pedals": keybind("toggleUiSpeedGearPedals"),
+    "radio-display": keybind("toggleUiRadioDisplay"),
+    "fps-network-display": keybind("toggleUiFpsNetworkDisplay"),
+    "weather-radar": keybind("toggleUiWeatherRadar"),
+    "virtual-mirror": keybind("toggleUiVirtualMirror"),
+    "ui-edit-mode": keybind("toggleUiEditMode"),
+    "driving-line": keybind("toggleUiDrivingLine"),
+    "display-ref-car": keybind("toggleUiDisplayRefCar"),
+    "replay-ui": api,
+  }),
+};
+
+/** `viewPair` is exported for the setup-* catalog entries added in a follow-up. */
+export { viewPair };

--- a/packages/iracing-actions/src/actions/data/action-comms.json
+++ b/packages/iracing-actions/src/actions/data/action-comms.json
@@ -1,0 +1,705 @@
+{
+  "fuel-service": {
+    "_meta": {
+      "modeSetting": "mode"
+    },
+    "toggle-fuel-fill": {
+      "method": "api"
+    },
+    "add-fuel": {
+      "method": "chat"
+    },
+    "reduce-fuel": {
+      "method": "chat"
+    },
+    "set-fuel-amount": {
+      "method": "chat"
+    },
+    "clear-fuel": {
+      "method": "api"
+    },
+    "toggle-autofuel": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "fuelServiceToggleAutofuel"
+      }
+    },
+    "lap-margin-increase": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "fuelServiceLapMarginIncrease"
+      }
+    },
+    "lap-margin-decrease": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "fuelServiceLapMarginDecrease"
+      }
+    }
+  },
+  "tire-service": {
+    "_meta": {
+      "modeSetting": "mode"
+    },
+    "change-all-tires": {
+      "method": "chat"
+    },
+    "clear-tires": {
+      "method": "api"
+    },
+    "change-compound": {
+      "method": "api"
+    },
+    "toggle-tires": {
+      "method": "chat"
+    }
+  },
+  "black-box-selector": {
+    "_meta": {
+      "modeSetting": "mode"
+    },
+    "direct": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "blackBox",
+          "map": {
+            "lap-timing": "blackBoxLapTiming",
+            "standings": "blackBoxStandings",
+            "relative": "blackBoxRelative",
+            "fuel": "blackBoxFuel",
+            "tires": "blackBoxTires",
+            "tire-info": "blackBoxTireInfo",
+            "pit-stop": "blackBoxPitStop",
+            "in-car": "blackBoxInCar",
+            "mirror": "blackBoxMirror",
+            "radio": "blackBoxRadio",
+            "weather": "blackBoxWeather"
+          }
+        }
+      }
+    },
+    "next": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "blackBoxCycleNext"
+      }
+    },
+    "previous": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "blackBoxCyclePrevious"
+      }
+    }
+  },
+  "splits-delta-cycle": {
+    "_meta": {
+      "modeSetting": "mode"
+    },
+    "cycle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "next": "splitsDeltaNext",
+            "previous": "splitsDeltaPrevious"
+          }
+        }
+      }
+    },
+    "toggle-ref-car": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "toggleUiDisplayRefCar"
+      }
+    },
+    "custom-sector-start": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "splitsDeltaCustomSectorStart"
+      }
+    },
+    "custom-sector-end": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "splitsDeltaCustomSectorEnd"
+      }
+    },
+    "active-reset-set": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "splitsDeltaActiveResetSet"
+      }
+    },
+    "active-reset-run": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "splitsDeltaActiveResetRun"
+      }
+    }
+  },
+  "look-direction": {
+    "_meta": {
+      "modeSetting": "direction"
+    },
+    "look-left": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "lookDirectionLeft"
+      }
+    },
+    "look-right": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "lookDirectionRight"
+      }
+    },
+    "look-up": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "lookDirectionUp"
+      }
+    },
+    "look-down": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "lookDirectionDown"
+      }
+    }
+  },
+  "car-control": {
+    "_meta": {
+      "modeSetting": "control"
+    },
+    "pit-speed-limiter": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "carControlPitSpeedLimiter"
+      }
+    },
+    "push-to-pass": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "carControlPushToPass"
+      }
+    },
+    "drs": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "carControlDrs"
+      }
+    },
+    "headlight-flash": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "carControlHeadlightFlash"
+      }
+    },
+    "tear-off-visor": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "carControlTearOffVisor"
+      }
+    },
+    "ignition": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "carControlIgnition"
+      }
+    },
+    "starter": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "carControlStarter"
+      }
+    },
+    "enter-exit-tow": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "carControlEnterExitTow"
+      }
+    },
+    "pause-sim": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "carControlPauseSim"
+      }
+    },
+    "escape": {
+      "method": "keybind"
+    }
+  },
+  "view-adjustment": {
+    "_meta": {
+      "modeSetting": "adjustment"
+    },
+    "fov": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "viewAdjustFovIncrease",
+            "decrease": "viewAdjustFovDecrease"
+          }
+        }
+      }
+    },
+    "horizon": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "viewAdjustHorizonUp",
+            "decrease": "viewAdjustHorizonDown"
+          }
+        }
+      }
+    },
+    "driver-height": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "viewAdjustDriverHeightUp",
+            "decrease": "viewAdjustDriverHeightDown"
+          }
+        }
+      }
+    },
+    "recenter-vr": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "viewAdjustRecenterVr"
+      }
+    },
+    "ui-size": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "viewAdjustUiSizeIncrease",
+            "decrease": "viewAdjustUiSizeDecrease"
+          }
+        }
+      }
+    }
+  },
+  "camera-editor-adjustments": {
+    "_meta": {
+      "modeSetting": "adjustment"
+    },
+    "latitude": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "cameraEditorLatitudeIncrease",
+            "decrease": "cameraEditorLatitudeDecrease"
+          }
+        }
+      }
+    },
+    "roll": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "cameraEditorRollIncrease",
+            "decrease": "cameraEditorRollDecrease"
+          }
+        }
+      }
+    },
+    "height": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "cameraEditorHeightIncrease",
+            "decrease": "cameraEditorHeightDecrease"
+          }
+        }
+      }
+    }
+  },
+  "camera-editor-controls": {
+    "_meta": {
+      "modeSetting": "control"
+    },
+    "open-camera-tool": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "cameraEditorOpenCameraTool"
+      }
+    },
+    "reset-camera": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "cameraEditorResetCamera"
+      }
+    },
+    "exit-car": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "cameraEditorExitCar"
+      }
+    },
+    "reset-to-pits": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "cameraEditorResetToPits"
+      }
+    },
+    "tow": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "cameraEditorTow"
+      }
+    }
+  },
+  "cockpit-misc": {
+    "_meta": {
+      "modeSetting": "control"
+    },
+    "toggle-wipers": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "cockpitMiscToggleWipers"
+      }
+    },
+    "trigger-wipers": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "cockpitMiscTriggerWipers"
+      }
+    },
+    "ffb-max-force": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "cockpitMiscFfbForceIncrease",
+            "decrease": "cockpitMiscFfbForceDecrease"
+          }
+        }
+      }
+    },
+    "report-latency": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "cockpitMiscReportLatency"
+      }
+    },
+    "dash-page-1": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "cockpitMiscDashPage1Increase",
+            "decrease": "cockpitMiscDashPage1Decrease"
+          }
+        }
+      }
+    },
+    "dash-page-2": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "cockpitMiscDashPage2Increase",
+            "decrease": "cockpitMiscDashPage2Decrease"
+          }
+        }
+      }
+    },
+    "in-lap-mode": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "cockpitMiscInLapMode"
+      }
+    }
+  },
+  "force-feedback": {
+    "_meta": {
+      "modeSetting": "mode"
+    },
+    "auto-compute-ffb-force": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "forceFeedbackAutoCompute"
+      }
+    },
+    "ffb-force": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "cockpitMiscFfbForceIncrease",
+            "decrease": "cockpitMiscFfbForceDecrease"
+          }
+        }
+      }
+    },
+    "wheel-lfe": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "forceFeedbackWheelLfeLouder",
+            "decrease": "forceFeedbackWheelLfeQuieter"
+          }
+        }
+      }
+    },
+    "bass-shaker-lfe": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "forceFeedbackBassShakerLfeLouder",
+            "decrease": "forceFeedbackBassShakerLfeQuieter"
+          }
+        }
+      }
+    },
+    "wheel-lfe-intensity": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "forceFeedbackWheelLfeIntensityIncrease",
+            "decrease": "forceFeedbackWheelLfeIntensityDecrease"
+          }
+        }
+      }
+    },
+    "haptic-lfe-intensity": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "forceFeedbackHapticLfeIntensityIncrease",
+            "decrease": "forceFeedbackHapticLfeIntensityDecrease"
+          }
+        }
+      }
+    }
+  },
+  "chat": {
+    "_meta": {
+      "modeSetting": "mode"
+    },
+    "open-chat": {
+      "method": "api"
+    },
+    "reply": {
+      "method": "api"
+    },
+    "cancel": {
+      "method": "api"
+    },
+    "send-message": {
+      "method": "api"
+    },
+    "macro": {
+      "method": "api"
+    },
+    "whisper": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "chatWhisper"
+      }
+    },
+    "toggle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "chatToggle"
+      }
+    }
+  },
+  "audio-controls": {
+    "_meta": {
+      "modeSetting": "category"
+    },
+    "push-to-talk": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "audioControlsPushToTalk"
+      }
+    },
+    "voice-chat": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "action",
+          "map": {
+            "volume-up": "audioVoiceChatVolumeUp",
+            "volume-down": "audioVoiceChatVolumeDown",
+            "mute": "audioVoiceChatMute"
+          }
+        }
+      }
+    },
+    "master": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "action",
+          "map": {
+            "volume-up": "audioMasterVolumeUp",
+            "volume-down": "audioMasterVolumeDown"
+          }
+        }
+      }
+    },
+    "race-engineer": {
+      "method": "keybind"
+    },
+    "radar": {
+      "method": "keybind"
+    }
+  },
+  "toggle-ui-elements": {
+    "_meta": {
+      "modeSetting": "element"
+    },
+    "dash-box": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "toggleUiDashBox"
+      }
+    },
+    "speed-gear-pedals": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "toggleUiSpeedGearPedals"
+      }
+    },
+    "radio-display": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "toggleUiRadioDisplay"
+      }
+    },
+    "fps-network-display": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "toggleUiFpsNetworkDisplay"
+      }
+    },
+    "weather-radar": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "toggleUiWeatherRadar"
+      }
+    },
+    "virtual-mirror": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "toggleUiVirtualMirror"
+      }
+    },
+    "ui-edit-mode": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "toggleUiEditMode"
+      }
+    },
+    "driving-line": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "toggleUiDrivingLine"
+      }
+    },
+    "display-ref-car": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "toggleUiDisplayRefCar"
+      }
+    },
+    "replay-ui": {
+      "method": "api"
+    }
+  }
+}

--- a/packages/iracing-actions/src/actions/data/action-comms.json
+++ b/packages/iracing-actions/src/actions/data/action-comms.json
@@ -330,34 +330,184 @@
         "keyBy": {
           "setting": "direction",
           "map": {
-            "increase": "cameraEditorLatitudeIncrease",
-            "decrease": "cameraEditorLatitudeDecrease"
+            "increase": "camEditLatitudeIncrease",
+            "decrease": "camEditLatitudeDecrease"
           }
         }
       }
     },
-    "roll": {
+    "longitude": {
       "method": "keybind",
       "binding": {
         "scope": "global",
         "keyBy": {
           "setting": "direction",
           "map": {
-            "increase": "cameraEditorRollIncrease",
-            "decrease": "cameraEditorRollDecrease"
+            "increase": "camEditLongitudeIncrease",
+            "decrease": "camEditLongitudeDecrease"
           }
         }
       }
     },
-    "height": {
+    "altitude": {
       "method": "keybind",
       "binding": {
         "scope": "global",
         "keyBy": {
           "setting": "direction",
           "map": {
-            "increase": "cameraEditorHeightIncrease",
-            "decrease": "cameraEditorHeightDecrease"
+            "increase": "camEditAltitudeIncrease",
+            "decrease": "camEditAltitudeDecrease"
+          }
+        }
+      }
+    },
+    "yaw": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "camEditYawIncrease",
+            "decrease": "camEditYawDecrease"
+          }
+        }
+      }
+    },
+    "pitch": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "camEditPitchIncrease",
+            "decrease": "camEditPitchDecrease"
+          }
+        }
+      }
+    },
+    "fov-zoom": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "camEditFovZoomIncrease",
+            "decrease": "camEditFovZoomDecrease"
+          }
+        }
+      }
+    },
+    "key-step": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "camEditKeyStepIncrease",
+            "decrease": "camEditKeyStepDecrease"
+          }
+        }
+      }
+    },
+    "vanish-x": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "camEditVanishXIncrease",
+            "decrease": "camEditVanishXDecrease"
+          }
+        }
+      }
+    },
+    "vanish-y": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "camEditVanishYIncrease",
+            "decrease": "camEditVanishYDecrease"
+          }
+        }
+      }
+    },
+    "blimp-radius": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "camEditBlimpRadiusIncrease",
+            "decrease": "camEditBlimpRadiusDecrease"
+          }
+        }
+      }
+    },
+    "blimp-velocity": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "camEditBlimpVelocityIncrease",
+            "decrease": "camEditBlimpVelocityDecrease"
+          }
+        }
+      }
+    },
+    "mic-gain": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "camEditMicGainIncrease",
+            "decrease": "camEditMicGainDecrease"
+          }
+        }
+      }
+    },
+    "auto-set-mic-gain": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camEditAutoSetMicGain"
+      }
+    },
+    "f-number": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "camEditFNumberIncrease",
+            "decrease": "camEditFNumberDecrease"
+          }
+        }
+      }
+    },
+    "focus-depth": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "camEditFocusDepthIncrease",
+            "decrease": "camEditFocusDepthDecrease"
           }
         }
       }
@@ -371,35 +521,210 @@
       "method": "keybind",
       "binding": {
         "scope": "global",
-        "key": "cameraEditorOpenCameraTool"
+        "key": "camCtrlOpenCameraTool"
       }
     },
-    "reset-camera": {
+    "key-acceleration-toggle": {
       "method": "keybind",
       "binding": {
         "scope": "global",
-        "key": "cameraEditorResetCamera"
+        "key": "camCtrlKeyAccelerationToggle"
       }
     },
-    "exit-car": {
+    "key-10x-toggle": {
       "method": "keybind",
       "binding": {
         "scope": "global",
-        "key": "cameraEditorExitCar"
+        "key": "camCtrlKey10xToggle"
       }
     },
-    "reset-to-pits": {
+    "parabolic-mic-toggle": {
       "method": "keybind",
       "binding": {
         "scope": "global",
-        "key": "cameraEditorResetToPits"
+        "key": "camCtrlParabolicMicToggle"
       }
     },
-    "tow": {
+    "cycle-position-type": {
       "method": "keybind",
       "binding": {
         "scope": "global",
-        "key": "cameraEditorTow"
+        "key": "camCtrlCyclePositionType"
+      }
+    },
+    "cycle-aim-type": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlCycleAimType"
+      }
+    },
+    "acquire-start": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlAcquireStart"
+      }
+    },
+    "acquire-end": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlAcquireEnd"
+      }
+    },
+    "temporary-edits-toggle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlTemporaryEditsToggle"
+      }
+    },
+    "dampening-toggle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlDampeningToggle"
+      }
+    },
+    "zoom-toggle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlZoomToggle"
+      }
+    },
+    "beyond-fence-toggle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlBeyondFenceToggle"
+      }
+    },
+    "in-cockpit-toggle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlInCockpitToggle"
+      }
+    },
+    "mouse-navigation-toggle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlMouseNavigationToggle"
+      }
+    },
+    "pitch-gyro-toggle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlPitchGyroToggle"
+      }
+    },
+    "roll-gyro-toggle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlRollGyroToggle"
+      }
+    },
+    "limit-shot-range-toggle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlLimitShotRangeToggle"
+      }
+    },
+    "show-camera-toggle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlShowCameraToggle"
+      }
+    },
+    "shot-selection-toggle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlShotSelectionToggle"
+      }
+    },
+    "manual-focus-toggle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlManualFocusToggle"
+      }
+    },
+    "insert-camera": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlInsertCamera"
+      }
+    },
+    "remove-camera": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlRemoveCamera"
+      }
+    },
+    "copy-camera": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlCopyCamera"
+      }
+    },
+    "paste-camera": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlPasteCamera"
+      }
+    },
+    "copy-group": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlCopyGroup"
+      }
+    },
+    "paste-group": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlPasteGroup"
+      }
+    },
+    "save-track-camera": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlSaveTrackCamera"
+      }
+    },
+    "load-track-camera": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlLoadTrackCamera"
+      }
+    },
+    "save-car-camera": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlSaveCarCamera"
+      }
+    },
+    "load-car-camera": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "camCtrlLoadCarCamera"
       }
     }
   },
@@ -700,6 +1025,1233 @@
     },
     "replay-ui": {
       "method": "api"
+    }
+  },
+  "ai-spotter-controls": {
+    "_meta": {
+      "modeSetting": "control"
+    },
+    "damage-report": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "spotterDamageReport"
+      }
+    },
+    "weather-report": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "spotterWeatherReport"
+      }
+    },
+    "toggle-report-laps": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "spotterToggleReportLaps"
+      }
+    },
+    "announce-leader": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "spotterAnnounceLeader"
+      }
+    },
+    "louder": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "spotterLouder"
+      }
+    },
+    "quieter": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "spotterQuieter"
+      }
+    },
+    "silence": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "spotterSilence"
+      }
+    }
+  },
+  "setup-aero": {
+    "_meta": {
+      "modeSetting": "setting"
+    },
+    "view-front-wing": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupAeroFrontWingIncrease",
+          "setupAeroFrontWingDecrease"
+        ]
+      }
+    },
+    "view-rear-wing": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupAeroRearWingIncrease",
+          "setupAeroRearWingDecrease"
+        ]
+      }
+    },
+    "front-wing": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupAeroFrontWingIncrease",
+            "decrease": "setupAeroFrontWingDecrease"
+          }
+        }
+      }
+    },
+    "rear-wing": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupAeroRearWingIncrease",
+            "decrease": "setupAeroRearWingDecrease"
+          }
+        }
+      }
+    },
+    "qualifying-tape": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupAeroQualifyingTapeIncrease",
+            "decrease": "setupAeroQualifyingTapeDecrease"
+          }
+        }
+      }
+    },
+    "rf-brake-attached": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "setupAeroRfBrakeAttached"
+      }
+    }
+  },
+  "setup-brakes": {
+    "_meta": {
+      "modeSetting": "setting"
+    },
+    "view-brake-bias": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupBrakesBrakeBiasIncrease",
+          "setupBrakesBrakeBiasDecrease"
+        ]
+      }
+    },
+    "view-brake-bias-fine": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupBrakesBrakeBiasFineIncrease",
+          "setupBrakesBrakeBiasFineDecrease"
+        ]
+      }
+    },
+    "view-peak-brake-bias": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupBrakesPeakBrakeBiasIncrease",
+          "setupBrakesPeakBrakeBiasDecrease"
+        ]
+      }
+    },
+    "view-brake-misc": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupBrakesBrakeMiscIncrease",
+          "setupBrakesBrakeMiscDecrease"
+        ]
+      }
+    },
+    "view-engine-braking": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupBrakesEngineBrakingIncrease",
+          "setupBrakesEngineBrakingDecrease"
+        ]
+      }
+    },
+    "view-abs-adjust": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupBrakesAbsAdjustIncrease",
+          "setupBrakesAbsAdjustDecrease"
+        ]
+      }
+    },
+    "abs-toggle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "setupBrakesAbsToggle"
+      }
+    },
+    "abs-adjust": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupBrakesAbsAdjustIncrease",
+            "decrease": "setupBrakesAbsAdjustDecrease"
+          }
+        }
+      }
+    },
+    "brake-bias": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupBrakesBrakeBiasIncrease",
+            "decrease": "setupBrakesBrakeBiasDecrease"
+          }
+        }
+      }
+    },
+    "brake-bias-fine": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupBrakesBrakeBiasFineIncrease",
+            "decrease": "setupBrakesBrakeBiasFineDecrease"
+          }
+        }
+      }
+    },
+    "peak-brake-bias": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupBrakesPeakBrakeBiasIncrease",
+            "decrease": "setupBrakesPeakBrakeBiasDecrease"
+          }
+        }
+      }
+    },
+    "brake-misc": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupBrakesBrakeMiscIncrease",
+            "decrease": "setupBrakesBrakeMiscDecrease"
+          }
+        }
+      }
+    },
+    "engine-braking": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupBrakesEngineBrakingIncrease",
+            "decrease": "setupBrakesEngineBrakingDecrease"
+          }
+        }
+      }
+    }
+  },
+  "setup-chassis": {
+    "_meta": {
+      "modeSetting": "setting"
+    },
+    "view-diff-preload": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupChassisDifferentialPreloadIncrease",
+          "setupChassisDifferentialPreloadDecrease"
+        ]
+      }
+    },
+    "view-diff-entry": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupChassisDifferentialEntryIncrease",
+          "setupChassisDifferentialEntryDecrease"
+        ]
+      }
+    },
+    "view-diff-middle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupChassisDifferentialMiddleIncrease",
+          "setupChassisDifferentialMiddleDecrease"
+        ]
+      }
+    },
+    "view-diff-exit": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupChassisDifferentialExitIncrease",
+          "setupChassisDifferentialExitDecrease"
+        ]
+      }
+    },
+    "view-anti-roll-front": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupChassisFrontArbIncrease",
+          "setupChassisFrontArbDecrease"
+        ]
+      }
+    },
+    "view-anti-roll-rear": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupChassisRearArbIncrease",
+          "setupChassisRearArbDecrease"
+        ]
+      }
+    },
+    "view-power-steering": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupChassisPowerSteeringIncrease",
+          "setupChassisPowerSteeringDecrease"
+        ]
+      }
+    },
+    "view-weight-jacker-left": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupChassisWeightJackerLeftIncrease",
+          "setupChassisWeightJackerLeftDecrease"
+        ]
+      }
+    },
+    "view-weight-jacker-right": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupChassisWeightJackerRightIncrease",
+          "setupChassisWeightJackerRightDecrease"
+        ]
+      }
+    },
+    "differential-preload": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupChassisDifferentialPreloadIncrease",
+            "decrease": "setupChassisDifferentialPreloadDecrease"
+          }
+        }
+      }
+    },
+    "differential-entry": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupChassisDifferentialEntryIncrease",
+            "decrease": "setupChassisDifferentialEntryDecrease"
+          }
+        }
+      }
+    },
+    "differential-middle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupChassisDifferentialMiddleIncrease",
+            "decrease": "setupChassisDifferentialMiddleDecrease"
+          }
+        }
+      }
+    },
+    "differential-exit": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupChassisDifferentialExitIncrease",
+            "decrease": "setupChassisDifferentialExitDecrease"
+          }
+        }
+      }
+    },
+    "front-arb": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupChassisFrontArbIncrease",
+            "decrease": "setupChassisFrontArbDecrease"
+          }
+        }
+      }
+    },
+    "rear-arb": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupChassisRearArbIncrease",
+            "decrease": "setupChassisRearArbDecrease"
+          }
+        }
+      }
+    },
+    "left-spring": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupChassisLeftSpringIncrease",
+            "decrease": "setupChassisLeftSpringDecrease"
+          }
+        }
+      }
+    },
+    "right-spring": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupChassisRightSpringIncrease",
+            "decrease": "setupChassisRightSpringDecrease"
+          }
+        }
+      }
+    },
+    "lf-shock": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupChassisLfShockIncrease",
+            "decrease": "setupChassisLfShockDecrease"
+          }
+        }
+      }
+    },
+    "rf-shock": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupChassisRfShockIncrease",
+            "decrease": "setupChassisRfShockDecrease"
+          }
+        }
+      }
+    },
+    "lr-shock": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupChassisLrShockIncrease",
+            "decrease": "setupChassisLrShockDecrease"
+          }
+        }
+      }
+    },
+    "rr-shock": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupChassisRrShockIncrease",
+            "decrease": "setupChassisRrShockDecrease"
+          }
+        }
+      }
+    },
+    "power-steering": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupChassisPowerSteeringIncrease",
+            "decrease": "setupChassisPowerSteeringDecrease"
+          }
+        }
+      }
+    }
+  },
+  "setup-engine": {
+    "_meta": {
+      "modeSetting": "setting"
+    },
+    "view-engine-power": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupEngineEnginePowerIncrease",
+          "setupEngineEnginePowerDecrease"
+        ]
+      }
+    },
+    "view-throttle-shape": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupEngineThrottleShapingIncrease",
+          "setupEngineThrottleShapingDecrease"
+        ]
+      }
+    },
+    "view-launch-rpm": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupEngineLaunchRpmIncrease",
+          "setupEngineLaunchRpmDecrease"
+        ]
+      }
+    },
+    "engine-power": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupEngineEnginePowerIncrease",
+            "decrease": "setupEngineEnginePowerDecrease"
+          }
+        }
+      }
+    },
+    "throttle-shaping": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupEngineThrottleShapingIncrease",
+            "decrease": "setupEngineThrottleShapingDecrease"
+          }
+        }
+      }
+    },
+    "boost-level": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupEngineBoostLevelIncrease",
+            "decrease": "setupEngineBoostLevelDecrease"
+          }
+        }
+      }
+    },
+    "launch-rpm": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupEngineLaunchRpmIncrease",
+            "decrease": "setupEngineLaunchRpmDecrease"
+          }
+        }
+      }
+    }
+  },
+  "setup-fuel": {
+    "_meta": {
+      "modeSetting": "setting"
+    },
+    "view-fuel-mixture": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupFuelFuelMixtureIncrease",
+          "setupFuelFuelMixtureDecrease"
+        ]
+      }
+    },
+    "view-fuel-cut-position": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupFuelFuelCutPositionIncrease",
+          "setupFuelFuelCutPositionDecrease"
+        ]
+      }
+    },
+    "fuel-mixture": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupFuelFuelMixtureIncrease",
+            "decrease": "setupFuelFuelMixtureDecrease"
+          }
+        }
+      }
+    },
+    "fuel-cut-position": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupFuelFuelCutPositionIncrease",
+            "decrease": "setupFuelFuelCutPositionDecrease"
+          }
+        }
+      }
+    },
+    "disable-fuel-cut": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "setupFuelDisableFuelCut"
+      }
+    },
+    "low-fuel-accept": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "setupFuelLowFuelAccept"
+      }
+    },
+    "fcy-mode-toggle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "setupFuelFcyModeToggle"
+      }
+    }
+  },
+  "setup-hybrid": {
+    "_meta": {
+      "modeSetting": "setting"
+    },
+    "view-mguk-deploy-mode": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupHybridMgukDeployModeIncrease",
+          "setupHybridMgukDeployModeDecrease"
+        ]
+      }
+    },
+    "view-mguk-regen-gain": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupHybridMgukRegenGainIncrease",
+          "setupHybridMgukRegenGainDecrease"
+        ]
+      }
+    },
+    "view-mguk-deploy-fixed": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupHybridMgukFixedDeployIncrease",
+          "setupHybridMgukFixedDeployDecrease"
+        ]
+      }
+    },
+    "mguk-regen-gain": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupHybridMgukRegenGainIncrease",
+            "decrease": "setupHybridMgukRegenGainDecrease"
+          }
+        }
+      }
+    },
+    "mguk-deploy-mode": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupHybridMgukDeployModeIncrease",
+            "decrease": "setupHybridMgukDeployModeDecrease"
+          }
+        }
+      }
+    },
+    "mguk-fixed-deploy": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupHybridMgukFixedDeployIncrease",
+            "decrease": "setupHybridMgukFixedDeployDecrease"
+          }
+        }
+      }
+    },
+    "hys-boost": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "setupHybridHysBoost"
+      }
+    },
+    "hys-regen": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "setupHybridHysRegen"
+      }
+    },
+    "hys-no-boost": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "setupHybridHysNoBoost"
+      }
+    }
+  },
+  "setup-traction": {
+    "_meta": {
+      "modeSetting": "setting"
+    },
+    "view-tc-slot-1": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupTractionTcSlot1Increase",
+          "setupTractionTcSlot1Decrease"
+        ]
+      }
+    },
+    "view-tc-slot-2": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupTractionTcSlot2Increase",
+          "setupTractionTcSlot2Decrease"
+        ]
+      }
+    },
+    "view-tc-slot-3": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupTractionTcSlot3Increase",
+          "setupTractionTcSlot3Decrease"
+        ]
+      }
+    },
+    "view-tc-slot-4": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keys": [
+          "setupTractionTcSlot4Increase",
+          "setupTractionTcSlot4Decrease"
+        ]
+      }
+    },
+    "tc-toggle": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "setupTractionTcToggle"
+      }
+    },
+    "tc-slot-1": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupTractionTcSlot1Increase",
+            "decrease": "setupTractionTcSlot1Decrease"
+          }
+        }
+      }
+    },
+    "tc-slot-2": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupTractionTcSlot2Increase",
+            "decrease": "setupTractionTcSlot2Decrease"
+          }
+        }
+      }
+    },
+    "tc-slot-3": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupTractionTcSlot3Increase",
+            "decrease": "setupTractionTcSlot3Decrease"
+          }
+        }
+      }
+    },
+    "tc-slot-4": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "keyBy": {
+          "setting": "direction",
+          "map": {
+            "increase": "setupTractionTcSlot4Increase",
+            "decrease": "setupTractionTcSlot4Decrease"
+          }
+        }
+      }
+    }
+  },
+  "media-capture": {
+    "_meta": {
+      "modeSetting": "mode"
+    },
+    "start-stop-video": {
+      "method": "api"
+    },
+    "video-timer": {
+      "method": "api"
+    },
+    "toggle-video-capture": {
+      "method": "api"
+    },
+    "take-screenshot": {
+      "method": "api"
+    },
+    "reload-all-textures": {
+      "method": "api"
+    },
+    "reload-car-textures": {
+      "method": "api"
+    },
+    "take-giant-screenshot": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "mediaCaptureGiantScreenshot"
+      }
+    }
+  },
+  "pit-quick-actions": {
+    "_meta": {
+      "modeSetting": "mode"
+    },
+    "clear-all-checkboxes": {
+      "method": "api"
+    },
+    "windshield-tearoff": {
+      "method": "api"
+    },
+    "request-fast-repair": {
+      "method": "api"
+    }
+  },
+  "replay-control": {
+    "_meta": {
+      "modeSetting": "mode"
+    },
+    "play-pause": {
+      "method": "api"
+    },
+    "play-backward": {
+      "method": "api"
+    },
+    "stop": {
+      "method": "api"
+    },
+    "fast-forward": {
+      "method": "api"
+    },
+    "rewind": {
+      "method": "api"
+    },
+    "slow-motion": {
+      "method": "api"
+    },
+    "slow-motion-rewind": {
+      "method": "api"
+    },
+    "frame-forward": {
+      "method": "api"
+    },
+    "frame-backward": {
+      "method": "api"
+    },
+    "speed-increase": {
+      "method": "api"
+    },
+    "speed-decrease": {
+      "method": "api"
+    },
+    "set-speed": {
+      "method": "api"
+    },
+    "speed-display": {
+      "method": "api"
+    },
+    "next-session": {
+      "method": "api"
+    },
+    "prev-session": {
+      "method": "api"
+    },
+    "next-lap": {
+      "method": "api"
+    },
+    "prev-lap": {
+      "method": "api"
+    },
+    "next-incident": {
+      "method": "api"
+    },
+    "prev-incident": {
+      "method": "api"
+    },
+    "jump-to-beginning": {
+      "method": "api"
+    },
+    "jump-to-live": {
+      "method": "api"
+    },
+    "jump-to-my-car": {
+      "method": "api"
+    },
+    "jump-to-fastest-lap": {
+      "method": "api"
+    },
+    "next-car-number": {
+      "method": "api"
+    },
+    "prev-car-number": {
+      "method": "api"
+    },
+    "next-car": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "replayControlNextCar"
+      }
+    },
+    "prev-car": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "replayControlPrevCar"
+      }
+    }
+  },
+  "replay-navigation": {
+    "_meta": {
+      "modeSetting": "navigation"
+    },
+    "next-session": {
+      "method": "api"
+    },
+    "prev-session": {
+      "method": "api"
+    },
+    "next-lap": {
+      "method": "api"
+    },
+    "prev-lap": {
+      "method": "api"
+    },
+    "next-incident": {
+      "method": "api"
+    },
+    "prev-incident": {
+      "method": "api"
+    },
+    "jump-to-start": {
+      "method": "api"
+    },
+    "jump-to-end": {
+      "method": "api"
+    },
+    "set-play-position": {
+      "method": "api"
+    },
+    "search-session-time": {
+      "method": "api"
+    },
+    "erase-tape": {
+      "method": "api"
+    }
+  },
+  "replay-speed": {
+    "_meta": {
+      "modeSetting": "direction"
+    },
+    "increase": {
+      "method": "api"
+    },
+    "decrease": {
+      "method": "api"
+    }
+  },
+  "replay-transport": {
+    "_meta": {
+      "modeSetting": "transport"
+    },
+    "play": {
+      "method": "api"
+    },
+    "pause": {
+      "method": "api"
+    },
+    "stop": {
+      "method": "api"
+    },
+    "fast-forward": {
+      "method": "api"
+    },
+    "rewind": {
+      "method": "api"
+    },
+    "slow-motion": {
+      "method": "api"
+    },
+    "frame-forward": {
+      "method": "api"
+    },
+    "frame-backward": {
+      "method": "api"
+    }
+  },
+  "telemetry-control": {
+    "_meta": {
+      "modeSetting": "mode"
+    },
+    "toggle-logging": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "telemetryControlToggleLogging"
+      }
+    },
+    "mark-event": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "telemetryControlMarkEvent"
+      }
+    },
+    "start-recording": {
+      "method": "api"
+    },
+    "stop-recording": {
+      "method": "api"
+    },
+    "restart-recording": {
+      "method": "api"
+    }
+  },
+  "race-admin": {
+    "_meta": {
+      "modeSetting": "mode"
+    },
+    "yellow": {
+      "method": "chat"
+    },
+    "black-flag": {
+      "method": "chat"
+    },
+    "dq-driver": {
+      "method": "chat"
+    },
+    "show-dqs-field": {
+      "method": "chat"
+    },
+    "show-dqs-driver": {
+      "method": "chat"
+    },
+    "clear-penalties": {
+      "method": "chat"
+    },
+    "clear-all": {
+      "method": "chat"
+    },
+    "wave-around": {
+      "method": "chat"
+    },
+    "eol": {
+      "method": "chat"
+    },
+    "pit-close": {
+      "method": "chat"
+    },
+    "pit-open": {
+      "method": "chat"
+    },
+    "pace-laps": {
+      "method": "chat"
+    },
+    "single-file-restart": {
+      "method": "chat"
+    },
+    "double-file-restart": {
+      "method": "chat"
+    },
+    "advance-session": {
+      "method": "chat"
+    },
+    "grid-set": {
+      "method": "chat"
+    },
+    "grid-start": {
+      "method": "chat"
+    },
+    "track-state": {
+      "method": "chat"
+    },
+    "grant-admin": {
+      "method": "chat"
+    },
+    "revoke-admin": {
+      "method": "chat"
+    },
+    "remove-driver": {
+      "method": "chat"
+    },
+    "enable-chat-all": {
+      "method": "chat"
+    },
+    "enable-chat-driver": {
+      "method": "chat"
+    },
+    "disable-chat-all": {
+      "method": "chat"
+    },
+    "disable-chat-driver": {
+      "method": "chat"
+    },
+    "message-all": {
+      "method": "chat"
+    },
+    "rc-message": {
+      "method": "chat"
     }
   }
 }

--- a/packages/iracing-actions/src/actions/force-feedback/force-feedback.ejs
+++ b/packages/iracing-actions/src/actions/force-feedback/force-feedback.ejs
@@ -25,6 +25,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['force-feedback']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select id="direction-select" setting="direction" default="increase">
 				<option value="increase" id="increase-label">Increase</option>

--- a/packages/iracing-actions/src/actions/force-feedback/force-feedback.ejs
+++ b/packages/iracing-actions/src/actions/force-feedback/force-feedback.ejs
@@ -26,7 +26,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['force-feedback']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select id="direction-select" setting="direction" default="increase">

--- a/packages/iracing-actions/src/actions/force-feedback/force-feedback.test.ts
+++ b/packages/iracing-actions/src/actions/force-feedback/force-feedback.test.ts
@@ -64,6 +64,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     holdBinding = vi.fn().mockResolvedValue(undefined);
     releaseBinding = vi.fn().mockResolvedValue(undefined);
     setActiveBinding = vi.fn();
+    isBindingMissing = vi.fn(() => false);
     async onWillAppear() {}
     async onDidReceiveSettings() {}
     async onWillDisappear() {}

--- a/packages/iracing-actions/src/actions/force-feedback/force-feedback.ts
+++ b/packages/iracing-actions/src/actions/force-feedback/force-feedback.ts
@@ -135,7 +135,7 @@ type ForceFeedbackSettings = z.infer<typeof ForceFeedbackSettings>;
  *
  * Generates an SVG data URI icon for the force feedback action.
  */
-export function generateForceFeedbackSvg(settings: ForceFeedbackSettings): string {
+export function generateForceFeedbackSvg(settings: ForceFeedbackSettings, bindingMissing = false): string {
   const { mode, direction } = settings;
 
   const svgEntry = FORCE_FEEDBACK_SVGS[mode];
@@ -157,7 +157,7 @@ export function generateForceFeedbackSvg(settings: ForceFeedbackSettings): strin
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg as string, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg as string, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -260,9 +260,15 @@ export class ForceFeedback extends ConnectionStateAwareAction<ForceFeedbackSetti
     ev: IDeckWillAppearEvent<ForceFeedbackSettings> | IDeckDidReceiveSettingsEvent<ForceFeedbackSettings>,
     settings: ForceFeedbackSettings,
   ): Promise<void> {
-    const svgDataUri = generateForceFeedbackSvg(settings);
+    const activeKey = this.resolveGlobalKey(settings.mode, settings.direction);
+    const svgDataUri = generateForceFeedbackSvg(settings, this.isBindingMissing(activeKey));
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateForceFeedbackSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () =>
+      generateForceFeedbackSvg(
+        settings,
+        this.isBindingMissing(this.resolveGlobalKey(settings.mode, settings.direction)),
+      ),
+    );
   }
 }

--- a/packages/iracing-actions/src/actions/fuel-service/fuel-service.ejs
+++ b/packages/iracing-actions/src/actions/fuel-service/fuel-service.ejs
@@ -19,6 +19,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var fuelComms = require('./data/action-comms.json')['fuel-service']; %>
+		<ird-binding-status mode-setting="<%= fuelComms._meta.modeSetting %>" comms='<%- JSON.stringify(fuelComms) %>'></ird-binding-status>
+
 		<div id="fuel-settings" class="hidden">
 			<sdpi-item label="Amount">
 				<sdpi-textfield

--- a/packages/iracing-actions/src/actions/fuel-service/fuel-service.ejs
+++ b/packages/iracing-actions/src/actions/fuel-service/fuel-service.ejs
@@ -20,7 +20,7 @@
 		</sdpi-item>
 
 		<% var fuelComms = require('./data/action-comms.json')['fuel-service']; %>
-		<ird-binding-status mode-setting="<%= fuelComms._meta.modeSetting %>" comms='<%- JSON.stringify(fuelComms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= fuelComms._meta.modeSetting %>" comms='<%= JSON.stringify(fuelComms) %>'></ird-binding-status>
 
 		<div id="fuel-settings" class="hidden">
 			<sdpi-item label="Amount">

--- a/packages/iracing-actions/src/actions/fuel-service/fuel-service.test.ts
+++ b/packages/iracing-actions/src/actions/fuel-service/fuel-service.test.ts
@@ -104,6 +104,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     releaseBinding = vi.fn().mockResolvedValue(undefined);
     setActiveBinding = vi.fn();
     isActiveBindingMissing = vi.fn(() => false);
+    isBindingMissing = vi.fn(() => false);
     async onWillAppear() {}
     async onDidReceiveSettings() {}
     async onWillDisappear() {}

--- a/packages/iracing-actions/src/actions/fuel-service/fuel-service.test.ts
+++ b/packages/iracing-actions/src/actions/fuel-service/fuel-service.test.ts
@@ -103,6 +103,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     holdBinding = vi.fn().mockResolvedValue(undefined);
     releaseBinding = vi.fn().mockResolvedValue(undefined);
     setActiveBinding = vi.fn();
+    isActiveBindingMissing = vi.fn(() => false);
     async onWillAppear() {}
     async onDidReceiveSettings() {}
     async onWillDisappear() {}
@@ -160,9 +161,20 @@ vi.mock("@iracedeck/deck-core", () => ({
     position: "bottom" as const,
     customPosition: 0,
   })),
+  applyBindingWarning: vi.fn((content: string) => `${content}<warn/>`),
   assembleIcon: vi.fn(
-    ({ graphicSvg, title }: { graphicSvg: string; colors: unknown; title: { titleText: string } }) => {
-      const encoded = encodeURIComponent(`<svg>${graphicSvg}${title?.titleText ?? ""}</svg>`);
+    ({
+      graphicSvg,
+      title,
+      bindingMissing,
+    }: {
+      graphicSvg: string;
+      colors: unknown;
+      title: { titleText: string };
+      bindingMissing?: boolean;
+    }) => {
+      const warn = bindingMissing ? "<warn/>" : "";
+      const encoded = encodeURIComponent(`<svg>${graphicSvg}${title?.titleText ?? ""}${warn}</svg>`);
 
       return `data:image/svg+xml,${encoded}`;
     },

--- a/packages/iracing-actions/src/actions/fuel-service/fuel-service.ts
+++ b/packages/iracing-actions/src/actions/fuel-service/fuel-service.ts
@@ -1,4 +1,5 @@
 import {
+  applyBindingWarning,
   assembleIcon,
   CommonSettings,
   ConnectionStateAwareAction,
@@ -300,6 +301,7 @@ export function getFuelServiceLabels(settings: FuelServiceSettings): { line1: st
 export function generateFuelServiceSvg(
   settings: FuelServiceSettings,
   telemetryState?: FuelServiceTelemetryState,
+  bindingMissing = false,
 ): string {
   const { mode } = settings;
 
@@ -351,8 +353,11 @@ export function generateFuelServiceSvg(
         })
       : "";
 
-    // Status bar is always visible, even when graphics are off
-    const iconContent = (resolvedTitle.showGraphics ? graphicContent : "") + statusBar;
+    // Status bar is always visible, even when graphics are off. When a required
+    // binding is missing (toggle-autofuel with neither keyboard nor SimHub set),
+    // dim the content and draw the centered warning over it (#612).
+    const baseContent = (resolvedTitle.showGraphics ? graphicContent : "") + statusBar;
+    const iconContent = bindingMissing ? applyBindingWarning(baseContent) : baseContent;
 
     const border = resolveBorderSettings(
       metadataSvg,
@@ -385,7 +390,7 @@ export function generateFuelServiceSvg(
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -676,16 +681,19 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
   private buildStateKey(settings: FuelServiceSettings, telemetryState: FuelServiceTelemetryState): string {
     const bo = settings.borderOverrides;
     const borderKey = `${bo?.enabled ?? ""}|${bo?.borderWidth ?? ""}|${bo?.borderColor ?? ""}|${bo?.glowEnabled ?? ""}|${bo?.glowWidth ?? ""}`;
+    // Include the binding-missing flag so a telemetry tick re-renders the key
+    // when the user sets/clears the toggle-autofuel binding (#612).
+    const warn = this.isActiveBindingMissing() ? "warn" : "";
 
     if (settings.mode === "toggle-fuel-fill") {
       return `fuel-fill|${telemetryState.fuelFillOn ?? "na"}|${telemetryState.fuelAmount ?? "none"}|${telemetryState.displayUnits ?? 0}|${borderKey}`;
     }
 
     if (settings.mode === "toggle-autofuel") {
-      return `autofuel|${telemetryState.autofuelEnabled ?? true}|${telemetryState.autofuelActive ?? "na"}|${borderKey}`;
+      return `autofuel|${telemetryState.autofuelEnabled ?? true}|${telemetryState.autofuelActive ?? "na"}|${borderKey}|${warn}`;
     }
 
-    return settings.mode;
+    return `${settings.mode}|${warn}`;
   }
 
   private async updateDisplay(
@@ -694,14 +702,14 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
   ): Promise<void> {
     const telemetry = this.sdkController.getCurrentTelemetry();
     const telemetryState = this.getTelemetryState(telemetry);
-    const svgDataUri = generateFuelServiceSvg(settings, telemetryState);
+    const svgDataUri = generateFuelServiceSvg(settings, telemetryState, this.isActiveBindingMissing());
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
     this.setRegenerateCallback(ev.action.id, () => {
       const currentTelemetry = this.sdkController.getCurrentTelemetry();
       const currentState = this.getTelemetryState(currentTelemetry);
 
-      return generateFuelServiceSvg(settings, currentState);
+      return generateFuelServiceSvg(settings, currentState, this.isActiveBindingMissing());
     });
     const stateKey = this.buildStateKey(settings, telemetryState);
     this.lastState.set(ev.action.id, stateKey);
@@ -720,13 +728,13 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
 
     if (lastStateKey !== stateKey) {
       this.lastState.set(contextId, stateKey);
-      const svgDataUri = generateFuelServiceSvg(settings, telemetryState);
+      const svgDataUri = generateFuelServiceSvg(settings, telemetryState, this.isActiveBindingMissing());
       await this.updateKeyImage(contextId, svgDataUri);
       this.setRegenerateCallback(contextId, () => {
         const currentTelemetry = this.sdkController.getCurrentTelemetry();
         const currentState = this.getTelemetryState(currentTelemetry);
 
-        return generateFuelServiceSvg(settings, currentState);
+        return generateFuelServiceSvg(settings, currentState, this.isActiveBindingMissing());
       });
     }
   }

--- a/packages/iracing-actions/src/actions/fuel-service/fuel-service.ts
+++ b/packages/iracing-actions/src/actions/fuel-service/fuel-service.ts
@@ -683,7 +683,7 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
     const borderKey = `${bo?.enabled ?? ""}|${bo?.borderWidth ?? ""}|${bo?.borderColor ?? ""}|${bo?.glowEnabled ?? ""}|${bo?.glowWidth ?? ""}`;
     // Include the binding-missing flag so a telemetry tick re-renders the key
     // when the user sets/clears the toggle-autofuel binding (#612).
-    const warn = this.isActiveBindingMissing() ? "warn" : "";
+    const warn = this.isBindingMissing(FUEL_SERVICE_GLOBAL_KEYS[settings.mode]) ? "warn" : "";
 
     if (settings.mode === "toggle-fuel-fill") {
       return `fuel-fill|${telemetryState.fuelFillOn ?? "na"}|${telemetryState.fuelAmount ?? "none"}|${telemetryState.displayUnits ?? 0}|${borderKey}`;
@@ -702,14 +702,22 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
   ): Promise<void> {
     const telemetry = this.sdkController.getCurrentTelemetry();
     const telemetryState = this.getTelemetryState(telemetry);
-    const svgDataUri = generateFuelServiceSvg(settings, telemetryState, this.isActiveBindingMissing());
+    const svgDataUri = generateFuelServiceSvg(
+      settings,
+      telemetryState,
+      this.isBindingMissing(FUEL_SERVICE_GLOBAL_KEYS[settings.mode]),
+    );
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
     this.setRegenerateCallback(ev.action.id, () => {
       const currentTelemetry = this.sdkController.getCurrentTelemetry();
       const currentState = this.getTelemetryState(currentTelemetry);
 
-      return generateFuelServiceSvg(settings, currentState, this.isActiveBindingMissing());
+      return generateFuelServiceSvg(
+        settings,
+        currentState,
+        this.isBindingMissing(FUEL_SERVICE_GLOBAL_KEYS[settings.mode]),
+      );
     });
     const stateKey = this.buildStateKey(settings, telemetryState);
     this.lastState.set(ev.action.id, stateKey);
@@ -728,13 +736,21 @@ export class FuelService extends ConnectionStateAwareAction<FuelServiceSettings>
 
     if (lastStateKey !== stateKey) {
       this.lastState.set(contextId, stateKey);
-      const svgDataUri = generateFuelServiceSvg(settings, telemetryState, this.isActiveBindingMissing());
+      const svgDataUri = generateFuelServiceSvg(
+        settings,
+        telemetryState,
+        this.isBindingMissing(FUEL_SERVICE_GLOBAL_KEYS[settings.mode]),
+      );
       await this.updateKeyImage(contextId, svgDataUri);
       this.setRegenerateCallback(contextId, () => {
         const currentTelemetry = this.sdkController.getCurrentTelemetry();
         const currentState = this.getTelemetryState(currentTelemetry);
 
-        return generateFuelServiceSvg(settings, currentState, this.isActiveBindingMissing());
+        return generateFuelServiceSvg(
+          settings,
+          currentState,
+          this.isBindingMissing(FUEL_SERVICE_GLOBAL_KEYS[settings.mode]),
+        );
       });
     }
   }

--- a/packages/iracing-actions/src/actions/look-direction/look-direction.ejs
+++ b/packages/iracing-actions/src/actions/look-direction/look-direction.ejs
@@ -15,6 +15,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['look-direction']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<%- include('title-overrides') %>
 
 		<%- include('color-overrides', { slots: ['backgroundColor', 'textColor', 'graphic1Color'], defaults: require('./data/icon-defaults.json')['look-direction'] }) %>

--- a/packages/iracing-actions/src/actions/look-direction/look-direction.ejs
+++ b/packages/iracing-actions/src/actions/look-direction/look-direction.ejs
@@ -16,7 +16,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['look-direction']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<%- include('title-overrides') %>
 

--- a/packages/iracing-actions/src/actions/look-direction/look-direction.test.ts
+++ b/packages/iracing-actions/src/actions/look-direction/look-direction.test.ts
@@ -45,6 +45,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     holdBinding = mockHoldBinding;
     releaseBinding = mockReleaseBinding;
     setActiveBinding = vi.fn();
+    isBindingMissing = vi.fn(() => false);
     async onWillAppear() {}
     async onDidReceiveSettings() {}
     async onWillDisappear() {}

--- a/packages/iracing-actions/src/actions/look-direction/look-direction.ts
+++ b/packages/iracing-actions/src/actions/look-direction/look-direction.ts
@@ -66,7 +66,7 @@ type LookDirectionSettings = z.infer<typeof LookDirectionSettings>;
  *
  * Generates an SVG data URI icon for the look direction action.
  */
-export function generateLookDirectionSvg(settings: LookDirectionSettings): string {
+export function generateLookDirectionSvg(settings: LookDirectionSettings, bindingMissing = false): string {
   const { direction } = settings;
 
   const iconSvg = DIRECTION_ICONS[direction] || DIRECTION_ICONS["look-left"];
@@ -79,7 +79,7 @@ export function generateLookDirectionSvg(settings: LookDirectionSettings): strin
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -157,9 +157,14 @@ export class LookDirection extends ConnectionStateAwareAction<LookDirectionSetti
     ev: IDeckWillAppearEvent<LookDirectionSettings> | IDeckDidReceiveSettingsEvent<LookDirectionSettings>,
     settings: LookDirectionSettings,
   ): Promise<void> {
-    const svgDataUri = generateLookDirectionSvg(settings);
+    const svgDataUri = generateLookDirectionSvg(
+      settings,
+      this.isBindingMissing(LOOK_DIRECTION_GLOBAL_KEYS[settings.direction]),
+    );
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateLookDirectionSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () =>
+      generateLookDirectionSvg(settings, this.isBindingMissing(LOOK_DIRECTION_GLOBAL_KEYS[settings.direction])),
+    );
   }
 }

--- a/packages/iracing-actions/src/actions/media-capture/media-capture.ejs
+++ b/packages/iracing-actions/src/actions/media-capture/media-capture.ejs
@@ -19,7 +19,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['media-capture']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<%- include('title-overrides') %>
 

--- a/packages/iracing-actions/src/actions/media-capture/media-capture.ejs
+++ b/packages/iracing-actions/src/actions/media-capture/media-capture.ejs
@@ -18,6 +18,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['media-capture']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<%- include('title-overrides') %>
 
 		<%- include('color-overrides', { slots: ['backgroundColor', 'textColor', 'graphic1Color'], defaults: require('./data/icon-defaults.json')['media-capture'] }) %>

--- a/packages/iracing-actions/src/actions/media-capture/media-capture.test.ts
+++ b/packages/iracing-actions/src/actions/media-capture/media-capture.test.ts
@@ -44,6 +44,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     updateConnectionState = vi.fn();
     setKeyImage = vi.fn();
     setRegenerateCallback = vi.fn();
+    isBindingMissing = vi.fn(() => false);
   },
   formatKeyBinding: vi.fn((b: { key: string; modifiers: string[] }) => {
     if (b.modifiers?.length) {

--- a/packages/iracing-actions/src/actions/media-capture/media-capture.ts
+++ b/packages/iracing-actions/src/actions/media-capture/media-capture.ts
@@ -82,7 +82,7 @@ type MediaCaptureSettings = z.infer<typeof MediaCaptureSettings>;
  *
  * Generates an SVG data URI icon for the media capture action.
  */
-export function generateMediaCaptureSvg(settings: MediaCaptureSettings): string {
+export function generateMediaCaptureSvg(settings: MediaCaptureSettings, bindingMissing = false): string {
   const { mode: actionType } = settings;
 
   const iconSvg = ACTION_ICONS[actionType] || ACTION_ICONS["start-stop-video"];
@@ -95,7 +95,7 @@ export function generateMediaCaptureSvg(settings: MediaCaptureSettings): string 
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -201,9 +201,14 @@ export class MediaCapture extends ConnectionStateAwareAction<MediaCaptureSetting
     ev: IDeckWillAppearEvent<MediaCaptureSettings> | IDeckDidReceiveSettingsEvent<MediaCaptureSettings>,
     settings: MediaCaptureSettings,
   ): Promise<void> {
-    const svgDataUri = generateMediaCaptureSvg(settings);
+    const svgDataUri = generateMediaCaptureSvg(
+      settings,
+      this.isBindingMissing(MEDIA_CAPTURE_GLOBAL_KEYS[settings.mode]),
+    );
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateMediaCaptureSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () =>
+      generateMediaCaptureSvg(settings, this.isBindingMissing(MEDIA_CAPTURE_GLOBAL_KEYS[settings.mode])),
+    );
   }
 }

--- a/packages/iracing-actions/src/actions/pit-quick-actions/pit-quick-actions.ejs
+++ b/packages/iracing-actions/src/actions/pit-quick-actions/pit-quick-actions.ejs
@@ -15,7 +15,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['pit-quick-actions']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<%- include('title-overrides') %>
 

--- a/packages/iracing-actions/src/actions/pit-quick-actions/pit-quick-actions.ejs
+++ b/packages/iracing-actions/src/actions/pit-quick-actions/pit-quick-actions.ejs
@@ -14,6 +14,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['pit-quick-actions']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<%- include('title-overrides') %>
 
 		<%- include('color-overrides', { slots: ['backgroundColor', 'textColor', 'graphic1Color'], defaults: require('./data/icon-defaults.json')['pit-quick-actions'] }) %>

--- a/packages/iracing-actions/src/actions/race-admin/race-admin.ejs
+++ b/packages/iracing-actions/src/actions/race-admin/race-admin.ejs
@@ -44,6 +44,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['race-admin']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<!-- Driver targeting (shown for modes that accept a driver parameter) -->
 		<div id="driver-section" class="hidden">
 			<sdpi-item label="Driver Target">

--- a/packages/iracing-actions/src/actions/race-admin/race-admin.ejs
+++ b/packages/iracing-actions/src/actions/race-admin/race-admin.ejs
@@ -45,7 +45,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['race-admin']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<!-- Driver targeting (shown for modes that accept a driver parameter) -->
 		<div id="driver-section" class="hidden">

--- a/packages/iracing-actions/src/actions/replay-control/replay-control.ejs
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.ejs
@@ -46,6 +46,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['replay-control']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<sdpi-item id="step-rate-setting" label="Step Rate" class="hidden">
 			<ird-range-input setting="stepRate" min="1" max="15" step="1" default="1" showlabels></ird-range-input>
 		</sdpi-item>

--- a/packages/iracing-actions/src/actions/replay-control/replay-control.ejs
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.ejs
@@ -47,7 +47,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['replay-control']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<sdpi-item id="step-rate-setting" label="Step Rate" class="hidden">
 			<ird-range-input setting="stepRate" min="1" max="15" step="1" default="1" showlabels></ird-range-input>

--- a/packages/iracing-actions/src/actions/replay-control/replay-control.test.ts
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.test.ts
@@ -143,6 +143,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     setRegenerateCallback = vi.fn();
     updateKeyImage = vi.fn();
     setActiveBinding = vi.fn();
+    isBindingMissing = vi.fn(() => false);
     tapBinding = vi.fn().mockResolvedValue(undefined);
     async onWillAppear() {}
     async onDidReceiveSettings() {}

--- a/packages/iracing-actions/src/actions/replay-control/replay-control.ts
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.ts
@@ -488,6 +488,7 @@ export function generateReplayControlSvg(
   isPlaying?: boolean,
   replaySpeed?: number,
   replaySlowMotion?: boolean,
+  bindingMissing = false,
 ): string {
   const { mode } = settings;
 
@@ -608,7 +609,7 @@ export function generateReplayControlSvg(
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -1910,10 +1911,19 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
     const isPlaying = this.shouldShowPause(ev.action.id);
     const speed = this.replaySpeed.get(ev.action.id);
     const slowMo = this.replaySlowMotion.get(ev.action.id);
-    const svgDataUri = generateReplayControlSvg(settings, isPlaying, speed, slowMo);
+    const bindingMissing = this.isBindingMissing(KEYSTROKE_MODES[settings.mode]);
+    const svgDataUri = generateReplayControlSvg(settings, isPlaying, speed, slowMo, bindingMissing);
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateReplayControlSvg(settings, isPlaying, speed, slowMo));
+    this.setRegenerateCallback(ev.action.id, () =>
+      generateReplayControlSvg(
+        settings,
+        isPlaying,
+        speed,
+        slowMo,
+        this.isBindingMissing(KEYSTROKE_MODES[settings.mode]),
+      ),
+    );
   }
 
   private updateAllTelemetryDisplays(): void {
@@ -1938,8 +1948,17 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
 
     this.lastState.set(contextId, stateKey);
 
-    const svgDataUri = generateReplayControlSvg(settings, isPlaying, speed, slowMo);
+    const bindingMissing = this.isBindingMissing(KEYSTROKE_MODES[settings.mode]);
+    const svgDataUri = generateReplayControlSvg(settings, isPlaying, speed, slowMo, bindingMissing);
     await this.updateKeyImage(contextId, svgDataUri);
-    this.setRegenerateCallback(contextId, () => generateReplayControlSvg(settings, isPlaying, speed, slowMo));
+    this.setRegenerateCallback(contextId, () =>
+      generateReplayControlSvg(
+        settings,
+        isPlaying,
+        speed,
+        slowMo,
+        this.isBindingMissing(KEYSTROKE_MODES[settings.mode]),
+      ),
+    );
   }
 }

--- a/packages/iracing-actions/src/actions/replay-navigation/replay-navigation.ejs
+++ b/packages/iracing-actions/src/actions/replay-navigation/replay-navigation.ejs
@@ -22,6 +22,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['replay-navigation']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<sdpi-item label="Frame Number" id="frame-item" class="hidden">
 			<sdpi-textfield setting="frameNumber" placeholder="0" type="number"></sdpi-textfield>
 		</sdpi-item>

--- a/packages/iracing-actions/src/actions/replay-navigation/replay-navigation.ejs
+++ b/packages/iracing-actions/src/actions/replay-navigation/replay-navigation.ejs
@@ -23,7 +23,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['replay-navigation']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<sdpi-item label="Frame Number" id="frame-item" class="hidden">
 			<sdpi-textfield setting="frameNumber" placeholder="0" type="number"></sdpi-textfield>

--- a/packages/iracing-actions/src/actions/replay-speed/replay-speed.ejs
+++ b/packages/iracing-actions/src/actions/replay-speed/replay-speed.ejs
@@ -14,7 +14,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['replay-speed']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<%- include('title-overrides') %>
 

--- a/packages/iracing-actions/src/actions/replay-speed/replay-speed.ejs
+++ b/packages/iracing-actions/src/actions/replay-speed/replay-speed.ejs
@@ -13,6 +13,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['replay-speed']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<%- include('title-overrides') %>
 
 		<%- include('color-overrides', { slots: ['backgroundColor', 'textColor'], defaults: require('./data/icon-defaults.json')['replay-speed'] }) %>

--- a/packages/iracing-actions/src/actions/replay-transport/replay-transport.ejs
+++ b/packages/iracing-actions/src/actions/replay-transport/replay-transport.ejs
@@ -20,7 +20,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['replay-transport']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<%- include('title-overrides') %>
 

--- a/packages/iracing-actions/src/actions/replay-transport/replay-transport.ejs
+++ b/packages/iracing-actions/src/actions/replay-transport/replay-transport.ejs
@@ -19,6 +19,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['replay-transport']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<%- include('title-overrides') %>
 
 		<%- include('color-overrides', { slots: ['backgroundColor', 'textColor'], defaults: require('./data/icon-defaults.json')['replay-transport'] }) %>

--- a/packages/iracing-actions/src/actions/setup-aero/setup-aero.ejs
+++ b/packages/iracing-actions/src/actions/setup-aero/setup-aero.ejs
@@ -22,7 +22,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['setup-aero']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">

--- a/packages/iracing-actions/src/actions/setup-aero/setup-aero.ejs
+++ b/packages/iracing-actions/src/actions/setup-aero/setup-aero.ejs
@@ -21,6 +21,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['setup-aero']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">
 				<option value="increase">Increase</option>

--- a/packages/iracing-actions/src/actions/setup-aero/setup-aero.test.ts
+++ b/packages/iracing-actions/src/actions/setup-aero/setup-aero.test.ts
@@ -58,6 +58,8 @@ vi.mock("@iracedeck/deck-core", () => ({
     holdBinding = vi.fn().mockResolvedValue(undefined);
     releaseBinding = vi.fn().mockResolvedValue(undefined);
     setActiveBinding = vi.fn();
+    isActiveBindingMissing = vi.fn(() => false);
+    isBindingMissing = vi.fn(() => false);
     async onWillAppear() {}
     async onDidReceiveSettings() {}
     async onWillDisappear() {}
@@ -124,9 +126,20 @@ vi.mock("@iracedeck/deck-core", () => ({
     position: "bottom" as const,
     customPosition: 0,
   })),
+  applyBindingWarning: vi.fn((content: string) => `${content}<warn/>`),
   assembleIcon: vi.fn(
-    ({ graphicSvg, title }: { graphicSvg: string; colors: unknown; title: { titleText: string } }) => {
-      const encoded = encodeURIComponent(`<svg>${graphicSvg}${title?.titleText ?? ""}</svg>`);
+    ({
+      graphicSvg,
+      title,
+      bindingMissing,
+    }: {
+      graphicSvg: string;
+      colors: unknown;
+      title: { titleText: string };
+      bindingMissing?: boolean;
+    }) => {
+      const warn = bindingMissing ? "<warn/>" : "";
+      const encoded = encodeURIComponent(`<svg>${graphicSvg}${title?.titleText ?? ""}${warn}</svg>`);
 
       return `data:image/svg+xml,${encoded}`;
     },

--- a/packages/iracing-actions/src/actions/setup-aero/setup-aero.ts
+++ b/packages/iracing-actions/src/actions/setup-aero/setup-aero.ts
@@ -128,7 +128,7 @@ type SetupAeroSettings = z.infer<typeof SetupAeroSettings>;
  * Generates an SVG data URI icon for the setup aero action's adjustment sub-modes.
  * View sub-modes use the shared `generateSetupViewSvg` render path.
  */
-export function generateSetupAeroSvg(settings: SetupAeroSettings): string {
+export function generateSetupAeroSvg(settings: SetupAeroSettings, bindingMissing = false): string {
   if (isViewSetting(settings.setting)) {
     return generateSetupViewSvg({
       viewId: settings.setting,
@@ -137,6 +137,7 @@ export function generateSetupAeroSvg(settings: SetupAeroSettings): string {
       colorOverrides: settings.colorOverrides,
       titleOverrides: settings.titleOverrides,
       borderOverrides: settings.borderOverrides,
+      bindingMissing,
     });
   }
 
@@ -154,7 +155,7 @@ export function generateSetupAeroSvg(settings: SetupAeroSettings): string {
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -340,6 +341,31 @@ export class SetupAero extends ConnectionStateAwareAction<SetupAeroSettings> {
     return SETUP_AERO_GLOBAL_KEYS[setting] ?? null;
   }
 
+  /**
+   * Per-button missing-binding check for the icon warning overlay (#612).
+   * Computed from THIS button's settings (not the shared `activeBindingKeys`).
+   * - View sub-modes require both the adjustment's increase + decrease bindings,
+   *   but only while dual-press is enabled (read-only Views need no binding).
+   * - Directional adjust modes require the single setting+direction binding.
+   * - Non-directional constants require the single setting binding.
+   */
+  private computeBindingMissing(settings: SetupAeroSettings): boolean {
+    if (isViewSetting(settings.setting)) {
+      if (!settings.dualPressEnabled) return false;
+
+      const adjustMode = getAdjustmentModeForView(settings.setting);
+
+      if (!adjustMode) return false;
+
+      return this.isBindingMissing([
+        SETUP_AERO_GLOBAL_KEYS[`${adjustMode}-increase`],
+        SETUP_AERO_GLOBAL_KEYS[`${adjustMode}-decrease`],
+      ]);
+    }
+
+    return this.isBindingMissing(this.resolveGlobalKey(settings.setting as SetupAeroAdjustSetting, settings.direction));
+  }
+
   private async updateDisplay(
     ev: IDeckWillAppearEvent<SetupAeroSettings> | IDeckDidReceiveSettingsEvent<SetupAeroSettings>,
     settings: SetupAeroSettings,
@@ -357,6 +383,8 @@ export class SetupAero extends ConnectionStateAwareAction<SetupAeroSettings> {
   }
 
   private renderIcon(settings: SetupAeroSettings): string {
+    const bindingMissing = this.computeBindingMissing(settings);
+
     if (isViewSetting(settings.setting)) {
       return generateSetupViewSvg({
         viewId: settings.setting,
@@ -365,10 +393,11 @@ export class SetupAero extends ConnectionStateAwareAction<SetupAeroSettings> {
         colorOverrides: settings.colorOverrides,
         titleOverrides: settings.titleOverrides,
         borderOverrides: settings.borderOverrides,
+        bindingMissing,
       });
     }
 
-    return generateSetupAeroSvg(settings);
+    return generateSetupAeroSvg(settings, bindingMissing);
   }
 
   private async updateDisplayFromTelemetry(
@@ -390,6 +419,7 @@ export class SetupAero extends ConnectionStateAwareAction<SetupAeroSettings> {
       colorOverrides: settings.colorOverrides,
       titleOverrides: settings.titleOverrides,
       borderOverrides: settings.borderOverrides,
+      bindingMissing: this.computeBindingMissing(settings),
     });
     await this.updateKeyImage(contextId, svgDataUri);
   }

--- a/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.ejs
+++ b/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.ejs
@@ -29,7 +29,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['setup-brakes']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">

--- a/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.ejs
+++ b/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.ejs
@@ -28,6 +28,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['setup-brakes']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">
 				<option value="increase">Increase</option>

--- a/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.test.ts
+++ b/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.test.ts
@@ -77,6 +77,8 @@ vi.mock("@iracedeck/deck-core", () => ({
     holdBinding = vi.fn().mockResolvedValue(undefined);
     releaseBinding = vi.fn().mockResolvedValue(undefined);
     setActiveBinding = vi.fn();
+    isActiveBindingMissing = vi.fn(() => false);
+    isBindingMissing = vi.fn(() => false);
     async onWillAppear() {}
     async onDidReceiveSettings() {}
     async onWillDisappear() {}
@@ -143,9 +145,20 @@ vi.mock("@iracedeck/deck-core", () => ({
     position: "bottom" as const,
     customPosition: 0,
   })),
+  applyBindingWarning: vi.fn((content: string) => `${content}<warn/>`),
   assembleIcon: vi.fn(
-    ({ graphicSvg, title }: { graphicSvg: string; colors: unknown; title: { titleText: string } }) => {
-      const encoded = encodeURIComponent(`<svg>${graphicSvg}${title?.titleText ?? ""}</svg>`);
+    ({
+      graphicSvg,
+      title,
+      bindingMissing,
+    }: {
+      graphicSvg: string;
+      colors: unknown;
+      title: { titleText: string };
+      bindingMissing?: boolean;
+    }) => {
+      const warn = bindingMissing ? "<warn/>" : "";
+      const encoded = encodeURIComponent(`<svg>${graphicSvg}${title?.titleText ?? ""}${warn}</svg>`);
 
       return `data:image/svg+xml,${encoded}`;
     },

--- a/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.ts
+++ b/packages/iracing-actions/src/actions/setup-brakes/setup-brakes.ts
@@ -185,7 +185,7 @@ function resolveIconKey(setting: SetupBrakesAdjustSetting, direction: DirectionT
  * Generates an SVG data URI icon for the setup brakes action's adjustment sub-modes.
  * View sub-modes call `generateSetupViewSvg` via `renderSettingIcon` instead.
  */
-export function generateSetupBrakesSvg(settings: SetupBrakesSettings): string {
+export function generateSetupBrakesSvg(settings: SetupBrakesSettings, bindingMissing = false): string {
   if (isViewSetting(settings.setting)) {
     // View sub-modes have no static icon — they render telemetry through the shared template.
     // Return a placeholder so callers that ignore telemetry get a stable string.
@@ -196,6 +196,7 @@ export function generateSetupBrakesSvg(settings: SetupBrakesSettings): string {
       colorOverrides: settings.colorOverrides,
       titleOverrides: settings.titleOverrides,
       borderOverrides: settings.borderOverrides,
+      bindingMissing,
     });
   }
 
@@ -213,7 +214,7 @@ export function generateSetupBrakesSvg(settings: SetupBrakesSettings): string {
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -411,6 +412,33 @@ export class SetupBrakes extends ConnectionStateAwareAction<SetupBrakesSettings>
     return SETUP_BRAKES_GLOBAL_KEYS[setting] ?? null;
   }
 
+  /**
+   * Per-button missing-binding check for the icon warning overlay (#612).
+   * Computed from THIS button's settings (not the shared `activeBindingKeys`).
+   * - View sub-modes require both the adjustment's increase + decrease bindings,
+   *   but only while dual-press is enabled (read-only Views need no binding).
+   * - Directional adjust modes require the single setting+direction binding.
+   * - Non-directional constants require the single setting binding.
+   */
+  private computeBindingMissing(settings: SetupBrakesSettings): boolean {
+    if (isViewSetting(settings.setting)) {
+      if (!settings.dualPressEnabled) return false;
+
+      const adjustMode = getAdjustmentModeForView(settings.setting);
+
+      if (!adjustMode) return false;
+
+      return this.isBindingMissing([
+        SETUP_BRAKES_GLOBAL_KEYS[`${adjustMode}-increase`],
+        SETUP_BRAKES_GLOBAL_KEYS[`${adjustMode}-decrease`],
+      ]);
+    }
+
+    return this.isBindingMissing(
+      this.resolveGlobalKey(settings.setting as SetupBrakesAdjustSetting, settings.direction),
+    );
+  }
+
   private async updateDisplay(
     ev: IDeckWillAppearEvent<SetupBrakesSettings> | IDeckDidReceiveSettingsEvent<SetupBrakesSettings>,
     settings: SetupBrakesSettings,
@@ -428,6 +456,8 @@ export class SetupBrakes extends ConnectionStateAwareAction<SetupBrakesSettings>
   }
 
   private renderIcon(settings: SetupBrakesSettings): string {
+    const bindingMissing = this.computeBindingMissing(settings);
+
     if (isViewSetting(settings.setting)) {
       return generateSetupViewSvg({
         viewId: settings.setting,
@@ -436,10 +466,11 @@ export class SetupBrakes extends ConnectionStateAwareAction<SetupBrakesSettings>
         colorOverrides: settings.colorOverrides,
         titleOverrides: settings.titleOverrides,
         borderOverrides: settings.borderOverrides,
+        bindingMissing,
       });
     }
 
-    return generateSetupBrakesSvg(settings);
+    return generateSetupBrakesSvg(settings, bindingMissing);
   }
 
   private async updateDisplayFromTelemetry(
@@ -461,6 +492,7 @@ export class SetupBrakes extends ConnectionStateAwareAction<SetupBrakesSettings>
       colorOverrides: settings.colorOverrides,
       titleOverrides: settings.titleOverrides,
       borderOverrides: settings.borderOverrides,
+      bindingMissing: this.computeBindingMissing(settings),
     });
     await this.updateKeyImage(contextId, svgDataUri);
   }

--- a/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.ejs
+++ b/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.ejs
@@ -37,6 +37,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['setup-chassis']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">
 				<option value="increase">Increase</option>

--- a/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.ejs
+++ b/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.ejs
@@ -38,7 +38,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['setup-chassis']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">

--- a/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.test.ts
+++ b/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.test.ts
@@ -115,6 +115,8 @@ vi.mock("@iracedeck/deck-core", () => ({
     holdBinding = vi.fn().mockResolvedValue(undefined);
     releaseBinding = vi.fn().mockResolvedValue(undefined);
     setActiveBinding = vi.fn();
+    isActiveBindingMissing = vi.fn(() => false);
+    isBindingMissing = vi.fn(() => false);
     async onWillAppear() {}
     async onDidReceiveSettings() {}
     async onWillDisappear() {}
@@ -181,9 +183,20 @@ vi.mock("@iracedeck/deck-core", () => ({
     position: "bottom" as const,
     customPosition: 0,
   })),
+  applyBindingWarning: vi.fn((content: string) => `${content}<warn/>`),
   assembleIcon: vi.fn(
-    ({ graphicSvg, title }: { graphicSvg: string; colors: unknown; title: { titleText: string } }) => {
-      const encoded = encodeURIComponent(`<svg>${graphicSvg}${title?.titleText ?? ""}</svg>`);
+    ({
+      graphicSvg,
+      title,
+      bindingMissing,
+    }: {
+      graphicSvg: string;
+      colors: unknown;
+      title: { titleText: string };
+      bindingMissing?: boolean;
+    }) => {
+      const warn = bindingMissing ? "<warn/>" : "";
+      const encoded = encodeURIComponent(`<svg>${graphicSvg}${title?.titleText ?? ""}${warn}</svg>`);
 
       return `data:image/svg+xml,${encoded}`;
     },

--- a/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.ts
+++ b/packages/iracing-actions/src/actions/setup-chassis/setup-chassis.ts
@@ -217,7 +217,7 @@ type SetupChassisSettings = z.infer<typeof SetupChassisSettings>;
  * Generates an SVG data URI icon for the setup chassis action's adjustment sub-modes.
  * View sub-modes use the shared `generateSetupViewSvg` render path.
  */
-export function generateSetupChassisSvg(settings: SetupChassisSettings): string {
+export function generateSetupChassisSvg(settings: SetupChassisSettings, bindingMissing = false): string {
   if (isViewSetting(settings.setting)) {
     return generateSetupViewSvg({
       viewId: settings.setting,
@@ -226,6 +226,7 @@ export function generateSetupChassisSvg(settings: SetupChassisSettings): string 
       colorOverrides: settings.colorOverrides,
       titleOverrides: settings.titleOverrides,
       borderOverrides: settings.borderOverrides,
+      bindingMissing,
     });
   }
 
@@ -242,7 +243,7 @@ export function generateSetupChassisSvg(settings: SetupChassisSettings): string 
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -405,6 +406,31 @@ export class SetupChassis extends ConnectionStateAwareAction<SetupChassisSetting
     await this.tapBinding(settingKey);
   }
 
+  /**
+   * Per-button missing-binding check for the icon warning overlay (#612).
+   * Computed from THIS button's settings (not the shared `activeBindingKeys`).
+   * - View sub-modes require both the adjustment's increase + decrease bindings
+   *   (weight-jacker Views map to dispatch-only keys), but only while dual-press
+   *   is enabled (read-only Views need no binding).
+   * - Adjust modes (all directional here) require the single setting+direction binding.
+   */
+  private computeBindingMissing(settings: SetupChassisSettings): boolean {
+    if (isViewSetting(settings.setting)) {
+      if (!settings.dualPressEnabled) return false;
+
+      const adjustMode = getAdjustmentModeForView(settings.setting);
+
+      if (!adjustMode) return false;
+
+      return this.isBindingMissing([
+        SETUP_CHASSIS_GLOBAL_KEYS[`${adjustMode}-increase`],
+        SETUP_CHASSIS_GLOBAL_KEYS[`${adjustMode}-decrease`],
+      ]);
+    }
+
+    return this.isBindingMissing(SETUP_CHASSIS_GLOBAL_KEYS[`${settings.setting}-${settings.direction}`]);
+  }
+
   private async updateDisplay(
     ev: IDeckWillAppearEvent<SetupChassisSettings> | IDeckDidReceiveSettingsEvent<SetupChassisSettings>,
     settings: SetupChassisSettings,
@@ -422,6 +448,8 @@ export class SetupChassis extends ConnectionStateAwareAction<SetupChassisSetting
   }
 
   private renderIcon(settings: SetupChassisSettings): string {
+    const bindingMissing = this.computeBindingMissing(settings);
+
     if (isViewSetting(settings.setting)) {
       return generateSetupViewSvg({
         viewId: settings.setting,
@@ -430,10 +458,11 @@ export class SetupChassis extends ConnectionStateAwareAction<SetupChassisSetting
         colorOverrides: settings.colorOverrides,
         titleOverrides: settings.titleOverrides,
         borderOverrides: settings.borderOverrides,
+        bindingMissing,
       });
     }
 
-    return generateSetupChassisSvg(settings);
+    return generateSetupChassisSvg(settings, bindingMissing);
   }
 
   private async updateDisplayFromTelemetry(
@@ -455,6 +484,7 @@ export class SetupChassis extends ConnectionStateAwareAction<SetupChassisSetting
       colorOverrides: settings.colorOverrides,
       titleOverrides: settings.titleOverrides,
       borderOverrides: settings.borderOverrides,
+      bindingMissing: this.computeBindingMissing(settings),
     });
     await this.updateKeyImage(contextId, svgDataUri);
   }

--- a/packages/iracing-actions/src/actions/setup-engine/setup-engine.ejs
+++ b/packages/iracing-actions/src/actions/setup-engine/setup-engine.ejs
@@ -22,6 +22,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['setup-engine']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">
 				<option value="increase">Increase</option>

--- a/packages/iracing-actions/src/actions/setup-engine/setup-engine.ejs
+++ b/packages/iracing-actions/src/actions/setup-engine/setup-engine.ejs
@@ -23,7 +23,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['setup-engine']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">

--- a/packages/iracing-actions/src/actions/setup-engine/setup-engine.test.ts
+++ b/packages/iracing-actions/src/actions/setup-engine/setup-engine.test.ts
@@ -62,6 +62,8 @@ vi.mock("@iracedeck/deck-core", () => ({
     holdBinding = vi.fn().mockResolvedValue(undefined);
     releaseBinding = vi.fn().mockResolvedValue(undefined);
     setActiveBinding = vi.fn();
+    isActiveBindingMissing = vi.fn(() => false);
+    isBindingMissing = vi.fn(() => false);
     async onWillAppear() {}
     async onDidReceiveSettings() {}
     async onWillDisappear() {}
@@ -128,9 +130,20 @@ vi.mock("@iracedeck/deck-core", () => ({
     position: "bottom" as const,
     customPosition: 0,
   })),
+  applyBindingWarning: vi.fn((content: string) => `${content}<warn/>`),
   assembleIcon: vi.fn(
-    ({ graphicSvg, title }: { graphicSvg: string; colors: unknown; title: { titleText: string } }) => {
-      const encoded = encodeURIComponent(`<svg>${graphicSvg}${title?.titleText ?? ""}</svg>`);
+    ({
+      graphicSvg,
+      title,
+      bindingMissing,
+    }: {
+      graphicSvg: string;
+      colors: unknown;
+      title: { titleText: string };
+      bindingMissing?: boolean;
+    }) => {
+      const warn = bindingMissing ? "<warn/>" : "";
+      const encoded = encodeURIComponent(`<svg>${graphicSvg}${title?.titleText ?? ""}${warn}</svg>`);
 
       return `data:image/svg+xml,${encoded}`;
     },

--- a/packages/iracing-actions/src/actions/setup-engine/setup-engine.ts
+++ b/packages/iracing-actions/src/actions/setup-engine/setup-engine.ts
@@ -130,7 +130,7 @@ type SetupEngineSettings = z.infer<typeof SetupEngineSettings>;
  * Generates an SVG data URI icon for the setup engine action's adjustment sub-modes.
  * View sub-modes use the shared `generateSetupViewSvg` render path.
  */
-export function generateSetupEngineSvg(settings: SetupEngineSettings): string {
+export function generateSetupEngineSvg(settings: SetupEngineSettings, bindingMissing = false): string {
   if (isViewSetting(settings.setting)) {
     return generateSetupViewSvg({
       viewId: settings.setting,
@@ -139,6 +139,7 @@ export function generateSetupEngineSvg(settings: SetupEngineSettings): string {
       colorOverrides: settings.colorOverrides,
       titleOverrides: settings.titleOverrides,
       borderOverrides: settings.borderOverrides,
+      bindingMissing,
     });
   }
 
@@ -156,7 +157,7 @@ export function generateSetupEngineSvg(settings: SetupEngineSettings): string {
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -319,6 +320,30 @@ export class SetupEngine extends ConnectionStateAwareAction<SetupEngineSettings>
     await this.tapBinding(settingKey);
   }
 
+  /**
+   * Per-button missing-binding check for the icon warning overlay (#612).
+   * Computed from THIS button's settings (not the shared `activeBindingKeys`).
+   * - View sub-modes require both the adjustment's increase + decrease bindings,
+   *   but only while dual-press is enabled (read-only Views need no binding).
+   * - Adjust modes (all directional here) require the single setting+direction binding.
+   */
+  private computeBindingMissing(settings: SetupEngineSettings): boolean {
+    if (isViewSetting(settings.setting)) {
+      if (!settings.dualPressEnabled) return false;
+
+      const adjustMode = getAdjustmentModeForView(settings.setting);
+
+      if (!adjustMode) return false;
+
+      return this.isBindingMissing([
+        SETUP_ENGINE_GLOBAL_KEYS[`${adjustMode}-increase`],
+        SETUP_ENGINE_GLOBAL_KEYS[`${adjustMode}-decrease`],
+      ]);
+    }
+
+    return this.isBindingMissing(SETUP_ENGINE_GLOBAL_KEYS[`${settings.setting}-${settings.direction}`]);
+  }
+
   private async updateDisplay(
     ev: IDeckWillAppearEvent<SetupEngineSettings> | IDeckDidReceiveSettingsEvent<SetupEngineSettings>,
     settings: SetupEngineSettings,
@@ -336,6 +361,8 @@ export class SetupEngine extends ConnectionStateAwareAction<SetupEngineSettings>
   }
 
   private renderIcon(settings: SetupEngineSettings): string {
+    const bindingMissing = this.computeBindingMissing(settings);
+
     if (isViewSetting(settings.setting)) {
       return generateSetupViewSvg({
         viewId: settings.setting,
@@ -344,10 +371,11 @@ export class SetupEngine extends ConnectionStateAwareAction<SetupEngineSettings>
         colorOverrides: settings.colorOverrides,
         titleOverrides: settings.titleOverrides,
         borderOverrides: settings.borderOverrides,
+        bindingMissing,
       });
     }
 
-    return generateSetupEngineSvg(settings);
+    return generateSetupEngineSvg(settings, bindingMissing);
   }
 
   private async updateDisplayFromTelemetry(
@@ -369,6 +397,7 @@ export class SetupEngine extends ConnectionStateAwareAction<SetupEngineSettings>
       colorOverrides: settings.colorOverrides,
       titleOverrides: settings.titleOverrides,
       borderOverrides: settings.borderOverrides,
+      bindingMissing: this.computeBindingMissing(settings),
     });
     await this.updateKeyImage(contextId, svgDataUri);
   }

--- a/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.ejs
+++ b/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.ejs
@@ -23,7 +23,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['setup-fuel']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">

--- a/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.ejs
+++ b/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.ejs
@@ -22,6 +22,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['setup-fuel']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">
 				<option value="increase">Increase</option>

--- a/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.test.ts
+++ b/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.test.ts
@@ -58,6 +58,8 @@ vi.mock("@iracedeck/deck-core", () => ({
     holdBinding = vi.fn().mockResolvedValue(undefined);
     releaseBinding = vi.fn().mockResolvedValue(undefined);
     setActiveBinding = vi.fn();
+    isActiveBindingMissing = vi.fn(() => false);
+    isBindingMissing = vi.fn(() => false);
     async onWillAppear() {}
     async onDidReceiveSettings() {}
     async onWillDisappear() {}
@@ -124,9 +126,20 @@ vi.mock("@iracedeck/deck-core", () => ({
     position: "bottom" as const,
     customPosition: 0,
   })),
+  applyBindingWarning: vi.fn((content: string) => `${content}<warn/>`),
   assembleIcon: vi.fn(
-    ({ graphicSvg, title }: { graphicSvg: string; colors: unknown; title: { titleText: string } }) => {
-      const encoded = encodeURIComponent(`<svg>${graphicSvg}${title?.titleText ?? ""}</svg>`);
+    ({
+      graphicSvg,
+      title,
+      bindingMissing,
+    }: {
+      graphicSvg: string;
+      colors: unknown;
+      title: { titleText: string };
+      bindingMissing?: boolean;
+    }) => {
+      const warn = bindingMissing ? "<warn/>" : "";
+      const encoded = encodeURIComponent(`<svg>${graphicSvg}${title?.titleText ?? ""}${warn}</svg>`);
 
       return `data:image/svg+xml,${encoded}`;
     },

--- a/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.ts
+++ b/packages/iracing-actions/src/actions/setup-fuel/setup-fuel.ts
@@ -134,7 +134,7 @@ type SetupFuelSettings = z.infer<typeof SetupFuelSettings>;
  * Generates an SVG data URI icon for the setup fuel action's adjustment sub-modes.
  * View sub-modes use the shared `generateSetupViewSvg` render path.
  */
-export function generateSetupFuelSvg(settings: SetupFuelSettings): string {
+export function generateSetupFuelSvg(settings: SetupFuelSettings, bindingMissing = false): string {
   if (isViewSetting(settings.setting)) {
     return generateSetupViewSvg({
       viewId: settings.setting,
@@ -143,6 +143,7 @@ export function generateSetupFuelSvg(settings: SetupFuelSettings): string {
       colorOverrides: settings.colorOverrides,
       titleOverrides: settings.titleOverrides,
       borderOverrides: settings.borderOverrides,
+      bindingMissing,
     });
   }
 
@@ -160,7 +161,7 @@ export function generateSetupFuelSvg(settings: SetupFuelSettings): string {
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -346,6 +347,31 @@ export class SetupFuel extends ConnectionStateAwareAction<SetupFuelSettings> {
     return SETUP_FUEL_GLOBAL_KEYS[setting] ?? null;
   }
 
+  /**
+   * Per-button missing-binding check for the icon warning overlay (#612).
+   * Computed from THIS button's settings (not the shared `activeBindingKeys`).
+   * - View sub-modes require both the adjustment's increase + decrease bindings,
+   *   but only while dual-press is enabled (read-only Views need no binding).
+   * - Directional adjust modes require the single setting+direction binding.
+   * - Non-directional constants require the single setting binding.
+   */
+  private computeBindingMissing(settings: SetupFuelSettings): boolean {
+    if (isViewSetting(settings.setting)) {
+      if (!settings.dualPressEnabled) return false;
+
+      const adjustMode = getAdjustmentModeForView(settings.setting);
+
+      if (!adjustMode) return false;
+
+      return this.isBindingMissing([
+        SETUP_FUEL_GLOBAL_KEYS[`${adjustMode}-increase`],
+        SETUP_FUEL_GLOBAL_KEYS[`${adjustMode}-decrease`],
+      ]);
+    }
+
+    return this.isBindingMissing(this.resolveGlobalKey(settings.setting as SetupFuelAdjustSetting, settings.direction));
+  }
+
   private async updateDisplay(
     ev: IDeckWillAppearEvent<SetupFuelSettings> | IDeckDidReceiveSettingsEvent<SetupFuelSettings>,
     settings: SetupFuelSettings,
@@ -363,6 +389,8 @@ export class SetupFuel extends ConnectionStateAwareAction<SetupFuelSettings> {
   }
 
   private renderIcon(settings: SetupFuelSettings): string {
+    const bindingMissing = this.computeBindingMissing(settings);
+
     if (isViewSetting(settings.setting)) {
       return generateSetupViewSvg({
         viewId: settings.setting,
@@ -371,10 +399,11 @@ export class SetupFuel extends ConnectionStateAwareAction<SetupFuelSettings> {
         colorOverrides: settings.colorOverrides,
         titleOverrides: settings.titleOverrides,
         borderOverrides: settings.borderOverrides,
+        bindingMissing,
       });
     }
 
-    return generateSetupFuelSvg(settings);
+    return generateSetupFuelSvg(settings, bindingMissing);
   }
 
   private async updateDisplayFromTelemetry(
@@ -396,6 +425,7 @@ export class SetupFuel extends ConnectionStateAwareAction<SetupFuelSettings> {
       colorOverrides: settings.colorOverrides,
       titleOverrides: settings.titleOverrides,
       borderOverrides: settings.borderOverrides,
+      bindingMissing: this.computeBindingMissing(settings),
     });
     await this.updateKeyImage(contextId, svgDataUri);
   }

--- a/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.ejs
+++ b/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.ejs
@@ -24,6 +24,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['setup-hybrid']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">
 				<option value="increase">Increase</option>

--- a/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.ejs
+++ b/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.ejs
@@ -25,7 +25,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['setup-hybrid']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">

--- a/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.test.ts
+++ b/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.test.ts
@@ -66,6 +66,8 @@ vi.mock("@iracedeck/deck-core", () => ({
     holdBinding = mockHoldBinding;
     releaseBinding = mockReleaseBinding;
     setActiveBinding = vi.fn();
+    isActiveBindingMissing = vi.fn(() => false);
+    isBindingMissing = vi.fn(() => false);
     async onWillAppear() {}
     async onDidReceiveSettings() {}
     async onWillDisappear() {}
@@ -134,9 +136,20 @@ vi.mock("@iracedeck/deck-core", () => ({
     position: "bottom" as const,
     customPosition: 0,
   })),
+  applyBindingWarning: vi.fn((content: string) => `${content}<warn/>`),
   assembleIcon: vi.fn(
-    ({ graphicSvg, title }: { graphicSvg: string; colors: unknown; title: { titleText: string } }) => {
-      const encoded = encodeURIComponent(`<svg>${graphicSvg}${title?.titleText ?? ""}</svg>`);
+    ({
+      graphicSvg,
+      title,
+      bindingMissing,
+    }: {
+      graphicSvg: string;
+      colors: unknown;
+      title: { titleText: string };
+      bindingMissing?: boolean;
+    }) => {
+      const warn = bindingMissing ? "<warn/>" : "";
+      const encoded = encodeURIComponent(`<svg>${graphicSvg}${title?.titleText ?? ""}${warn}</svg>`);
 
       return `data:image/svg+xml,${encoded}`;
     },

--- a/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.ts
+++ b/packages/iracing-actions/src/actions/setup-hybrid/setup-hybrid.ts
@@ -165,7 +165,7 @@ function resolveIconKey(setting: SetupHybridAdjustSetting, direction: DirectionT
  * Generates an SVG data URI icon for the setup hybrid action's adjustment sub-modes.
  * View sub-modes use the shared `generateSetupViewSvg` render path.
  */
-export function generateSetupHybridSvg(settings: SetupHybridSettings): string {
+export function generateSetupHybridSvg(settings: SetupHybridSettings, bindingMissing = false): string {
   if (isViewSetting(settings.setting)) {
     return generateSetupViewSvg({
       viewId: settings.setting,
@@ -174,6 +174,7 @@ export function generateSetupHybridSvg(settings: SetupHybridSettings): string {
       colorOverrides: settings.colorOverrides,
       titleOverrides: settings.titleOverrides,
       borderOverrides: settings.borderOverrides,
+      bindingMissing,
     });
   }
 
@@ -190,7 +191,7 @@ export function generateSetupHybridSvg(settings: SetupHybridSettings): string {
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -408,6 +409,34 @@ export class SetupHybrid extends ConnectionStateAwareAction<SetupHybridSettings>
     await this.tapBinding(settingKey);
   }
 
+  /**
+   * Per-button missing-binding check for the icon warning overlay (#612).
+   * Computed from THIS button's settings (not the shared `activeBindingKeys`).
+   * - View sub-modes require both the adjustment's increase + decrease bindings,
+   *   but only while dual-press is enabled (read-only Views need no binding).
+   * - Directional adjust modes require the single setting+direction binding.
+   * - Hold/constant modes require the single setting binding (direction ignored
+   *   by `resolveGlobalKey` for non-directional controls).
+   */
+  private computeBindingMissing(settings: SetupHybridSettings): boolean {
+    if (isViewSetting(settings.setting)) {
+      if (!settings.dualPressEnabled) return false;
+
+      const adjustMode = getAdjustmentModeForView(settings.setting);
+
+      if (!adjustMode) return false;
+
+      return this.isBindingMissing([
+        SETUP_HYBRID_GLOBAL_KEYS[`${adjustMode}-increase`],
+        SETUP_HYBRID_GLOBAL_KEYS[`${adjustMode}-decrease`],
+      ]);
+    }
+
+    return this.isBindingMissing(
+      this.resolveGlobalKey(settings.setting as SetupHybridAdjustSetting, settings.direction),
+    );
+  }
+
   private async updateDisplay(
     ev: IDeckWillAppearEvent<SetupHybridSettings> | IDeckDidReceiveSettingsEvent<SetupHybridSettings>,
     settings: SetupHybridSettings,
@@ -425,6 +454,8 @@ export class SetupHybrid extends ConnectionStateAwareAction<SetupHybridSettings>
   }
 
   private renderIcon(settings: SetupHybridSettings): string {
+    const bindingMissing = this.computeBindingMissing(settings);
+
     if (isViewSetting(settings.setting)) {
       return generateSetupViewSvg({
         viewId: settings.setting,
@@ -433,10 +464,11 @@ export class SetupHybrid extends ConnectionStateAwareAction<SetupHybridSettings>
         colorOverrides: settings.colorOverrides,
         titleOverrides: settings.titleOverrides,
         borderOverrides: settings.borderOverrides,
+        bindingMissing,
       });
     }
 
-    return generateSetupHybridSvg(settings);
+    return generateSetupHybridSvg(settings, bindingMissing);
   }
 
   private async updateDisplayFromTelemetry(
@@ -458,6 +490,7 @@ export class SetupHybrid extends ConnectionStateAwareAction<SetupHybridSettings>
       colorOverrides: settings.colorOverrides,
       titleOverrides: settings.titleOverrides,
       borderOverrides: settings.borderOverrides,
+      bindingMissing: this.computeBindingMissing(settings),
     });
     await this.updateKeyImage(contextId, svgDataUri);
   }

--- a/packages/iracing-actions/src/actions/setup-traction/setup-traction.ejs
+++ b/packages/iracing-actions/src/actions/setup-traction/setup-traction.ejs
@@ -24,6 +24,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['setup-traction']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">
 				<option value="increase">Increase</option>

--- a/packages/iracing-actions/src/actions/setup-traction/setup-traction.ejs
+++ b/packages/iracing-actions/src/actions/setup-traction/setup-traction.ejs
@@ -25,7 +25,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['setup-traction']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">

--- a/packages/iracing-actions/src/actions/setup-traction/setup-traction.test.ts
+++ b/packages/iracing-actions/src/actions/setup-traction/setup-traction.test.ts
@@ -64,6 +64,8 @@ vi.mock("@iracedeck/deck-core", () => ({
     holdBinding = vi.fn().mockResolvedValue(undefined);
     releaseBinding = vi.fn().mockResolvedValue(undefined);
     setActiveBinding = vi.fn();
+    isActiveBindingMissing = vi.fn(() => false);
+    isBindingMissing = vi.fn(() => false);
     async onWillAppear() {}
     async onDidReceiveSettings() {}
     async onWillDisappear() {}
@@ -130,9 +132,20 @@ vi.mock("@iracedeck/deck-core", () => ({
     position: "bottom" as const,
     customPosition: 0,
   })),
+  applyBindingWarning: vi.fn((content: string) => `${content}<warn/>`),
   assembleIcon: vi.fn(
-    ({ graphicSvg, title }: { graphicSvg: string; colors: unknown; title: { titleText: string } }) => {
-      const encoded = encodeURIComponent(`<svg>${graphicSvg}${title?.titleText ?? ""}</svg>`);
+    ({
+      graphicSvg,
+      title,
+      bindingMissing,
+    }: {
+      graphicSvg: string;
+      colors: unknown;
+      title: { titleText: string };
+      bindingMissing?: boolean;
+    }) => {
+      const warn = bindingMissing ? "<warn/>" : "";
+      const encoded = encodeURIComponent(`<svg>${graphicSvg}${title?.titleText ?? ""}${warn}</svg>`);
 
       return `data:image/svg+xml,${encoded}`;
     },

--- a/packages/iracing-actions/src/actions/setup-traction/setup-traction.ts
+++ b/packages/iracing-actions/src/actions/setup-traction/setup-traction.ts
@@ -156,7 +156,7 @@ function resolveIconKey(setting: SetupTractionAdjustSetting, direction: Directio
  * Generates an SVG data URI icon for the setup traction action's adjustment sub-modes.
  * View sub-modes use the shared `generateSetupViewSvg` render path.
  */
-export function generateSetupTractionSvg(settings: SetupTractionSettings): string {
+export function generateSetupTractionSvg(settings: SetupTractionSettings, bindingMissing = false): string {
   if (isViewSetting(settings.setting)) {
     return generateSetupViewSvg({
       viewId: settings.setting,
@@ -165,6 +165,7 @@ export function generateSetupTractionSvg(settings: SetupTractionSettings): strin
       colorOverrides: settings.colorOverrides,
       titleOverrides: settings.titleOverrides,
       borderOverrides: settings.borderOverrides,
+      bindingMissing,
     });
   }
 
@@ -181,7 +182,7 @@ export function generateSetupTractionSvg(settings: SetupTractionSettings): strin
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -367,6 +368,33 @@ export class SetupTraction extends ConnectionStateAwareAction<SetupTractionSetti
     return SETUP_TRACTION_GLOBAL_KEYS[setting] ?? null;
   }
 
+  /**
+   * Per-button missing-binding check for the icon warning overlay (#612).
+   * Computed from THIS button's settings (not the shared `activeBindingKeys`).
+   * - View sub-modes require both the adjustment's increase + decrease bindings,
+   *   but only while dual-press is enabled (read-only Views need no binding).
+   * - Directional adjust modes require the single setting+direction binding.
+   * - Non-directional constants require the single setting binding.
+   */
+  private computeBindingMissing(settings: SetupTractionSettings): boolean {
+    if (isViewSetting(settings.setting)) {
+      if (!settings.dualPressEnabled) return false;
+
+      const adjustMode = getAdjustmentModeForView(settings.setting);
+
+      if (!adjustMode) return false;
+
+      return this.isBindingMissing([
+        SETUP_TRACTION_GLOBAL_KEYS[`${adjustMode}-increase`],
+        SETUP_TRACTION_GLOBAL_KEYS[`${adjustMode}-decrease`],
+      ]);
+    }
+
+    return this.isBindingMissing(
+      this.resolveGlobalKey(settings.setting as SetupTractionAdjustSetting, settings.direction),
+    );
+  }
+
   private async updateDisplay(
     ev: IDeckWillAppearEvent<SetupTractionSettings> | IDeckDidReceiveSettingsEvent<SetupTractionSettings>,
     settings: SetupTractionSettings,
@@ -384,6 +412,8 @@ export class SetupTraction extends ConnectionStateAwareAction<SetupTractionSetti
   }
 
   private renderIcon(settings: SetupTractionSettings): string {
+    const bindingMissing = this.computeBindingMissing(settings);
+
     if (isViewSetting(settings.setting)) {
       return generateSetupViewSvg({
         viewId: settings.setting,
@@ -392,10 +422,11 @@ export class SetupTraction extends ConnectionStateAwareAction<SetupTractionSetti
         colorOverrides: settings.colorOverrides,
         titleOverrides: settings.titleOverrides,
         borderOverrides: settings.borderOverrides,
+        bindingMissing,
       });
     }
 
-    return generateSetupTractionSvg(settings);
+    return generateSetupTractionSvg(settings, bindingMissing);
   }
 
   private async updateDisplayFromTelemetry(
@@ -417,6 +448,7 @@ export class SetupTraction extends ConnectionStateAwareAction<SetupTractionSetti
       colorOverrides: settings.colorOverrides,
       titleOverrides: settings.titleOverrides,
       borderOverrides: settings.borderOverrides,
+      bindingMissing: this.computeBindingMissing(settings),
     });
     await this.updateKeyImage(contextId, svgDataUri);
   }

--- a/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ejs
+++ b/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ejs
@@ -17,6 +17,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['splits-delta-cycle']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<sdpi-item id="direction-item" label="Direction">
 			<sdpi-select setting="direction" default="next">
 				<option value="next">Next</option>

--- a/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ejs
+++ b/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ejs
@@ -18,7 +18,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['splits-delta-cycle']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<sdpi-item id="direction-item" label="Direction">
 			<sdpi-select setting="direction" default="next">

--- a/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.test.ts
+++ b/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.test.ts
@@ -44,6 +44,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     updateConnectionState = vi.fn();
     setKeyImage = vi.fn();
     setRegenerateCallback = vi.fn();
+    isBindingMissing = vi.fn(() => false);
   },
   formatKeyBinding: vi.fn((b: { key: string; modifiers: string[] }) => {
     if (b.modifiers?.length) {

--- a/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ts
+++ b/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ts
@@ -84,7 +84,7 @@ const MODE_KEY_MAP: Record<string, string> = {
 /**
  * @internal Exported for testing
  */
-export function generateSplitsDeltaCycleSvg(settings: SplitsDeltaCycleSettings): string {
+export function generateSplitsDeltaCycleSvg(settings: SplitsDeltaCycleSettings, bindingMissing = false): string {
   const { mode, direction } = settings;
 
   // toggle-ref-car uses a dedicated icon from splits-delta-cycle
@@ -101,7 +101,7 @@ export function generateSplitsDeltaCycleSvg(settings: SplitsDeltaCycleSettings):
 
     const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-    return assembleIcon({ graphicSvg: displayRefCarIconSvg, colors, title, border, graphic });
+    return assembleIcon({ graphicSvg: displayRefCarIconSvg, colors, title, border, graphic, bindingMissing });
   }
 
   const modeIconSvg = MODE_ICONS[mode];
@@ -119,7 +119,7 @@ export function generateSplitsDeltaCycleSvg(settings: SplitsDeltaCycleSettings):
 
     const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-    return assembleIcon({ graphicSvg: modeIconSvg, colors, title, border, graphic });
+    return assembleIcon({ graphicSvg: modeIconSvg, colors, title, border, graphic, bindingMissing });
   }
 
   const iconSvg = DIRECTION_ICONS[direction] || DIRECTION_ICONS.next;
@@ -131,7 +131,7 @@ export function generateSplitsDeltaCycleSvg(settings: SplitsDeltaCycleSettings):
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -198,9 +198,11 @@ export class SplitsDeltaCycle extends ConnectionStateAwareAction<SplitsDeltaCycl
     ev: IDeckWillAppearEvent<SplitsDeltaCycleSettings> | IDeckDidReceiveSettingsEvent<SplitsDeltaCycleSettings>,
     settings: SplitsDeltaCycleSettings,
   ): Promise<void> {
-    const svgDataUri = generateSplitsDeltaCycleSvg(settings);
+    const svgDataUri = generateSplitsDeltaCycleSvg(settings, this.isBindingMissing(this.resolveSettingKey(settings)));
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateSplitsDeltaCycleSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () =>
+      generateSplitsDeltaCycleSvg(settings, this.isBindingMissing(this.resolveSettingKey(settings))),
+    );
   }
 }

--- a/packages/iracing-actions/src/actions/telemetry-control/telemetry-control.ejs
+++ b/packages/iracing-actions/src/actions/telemetry-control/telemetry-control.ejs
@@ -16,6 +16,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['telemetry-control']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<%- include('title-overrides') %>
 
 		<%- include('color-overrides', { slots: ['backgroundColor', 'textColor', 'graphic1Color'], defaults: require('./data/icon-defaults.json')['telemetry-control'] }) %>

--- a/packages/iracing-actions/src/actions/telemetry-control/telemetry-control.ejs
+++ b/packages/iracing-actions/src/actions/telemetry-control/telemetry-control.ejs
@@ -17,7 +17,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['telemetry-control']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<%- include('title-overrides') %>
 

--- a/packages/iracing-actions/src/actions/telemetry-control/telemetry-control.test.ts
+++ b/packages/iracing-actions/src/actions/telemetry-control/telemetry-control.test.ts
@@ -38,6 +38,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     updateConnectionState = vi.fn();
     setKeyImage = vi.fn();
     setRegenerateCallback = vi.fn();
+    isBindingMissing = vi.fn(() => false);
   },
   formatKeyBinding: vi.fn((b: { key: string; modifiers: string[] }) => {
     if (b.modifiers?.length) {

--- a/packages/iracing-actions/src/actions/telemetry-control/telemetry-control.ts
+++ b/packages/iracing-actions/src/actions/telemetry-control/telemetry-control.ts
@@ -75,7 +75,7 @@ type TelemetryControlSettings = z.infer<typeof TelemetryControlSettings>;
  *
  * Generates an SVG data URI icon for the telemetry control action.
  */
-export function generateTelemetryControlSvg(settings: TelemetryControlSettings): string {
+export function generateTelemetryControlSvg(settings: TelemetryControlSettings, bindingMissing = false): string {
   const { mode: actionType } = settings;
 
   const iconSvg = ACTION_ICONS[actionType] || ACTION_ICONS["toggle-logging"];
@@ -88,7 +88,7 @@ export function generateTelemetryControlSvg(settings: TelemetryControlSettings):
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -187,9 +187,14 @@ export class TelemetryControl extends ConnectionStateAwareAction<TelemetryContro
     ev: IDeckWillAppearEvent<TelemetryControlSettings> | IDeckDidReceiveSettingsEvent<TelemetryControlSettings>,
     settings: TelemetryControlSettings,
   ): Promise<void> {
-    const svgDataUri = generateTelemetryControlSvg(settings);
+    const svgDataUri = generateTelemetryControlSvg(
+      settings,
+      this.isBindingMissing(TELEMETRY_CONTROL_GLOBAL_KEYS[settings.mode]),
+    );
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateTelemetryControlSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () =>
+      generateTelemetryControlSvg(settings, this.isBindingMissing(TELEMETRY_CONTROL_GLOBAL_KEYS[settings.mode])),
+    );
   }
 }

--- a/packages/iracing-actions/src/actions/tire-service/tire-service.ejs
+++ b/packages/iracing-actions/src/actions/tire-service/tire-service.ejs
@@ -15,6 +15,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['tire-service']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<div id="toggle-settings" class="hidden">
 			<sdpi-item label="Operation">
 				<sdpi-radio setting="toggleMode" columns="1">

--- a/packages/iracing-actions/src/actions/tire-service/tire-service.ejs
+++ b/packages/iracing-actions/src/actions/tire-service/tire-service.ejs
@@ -16,7 +16,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['tire-service']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<div id="toggle-settings" class="hidden">
 			<sdpi-item label="Operation">

--- a/packages/iracing-actions/src/actions/toggle-ui-elements/toggle-ui-elements.ejs
+++ b/packages/iracing-actions/src/actions/toggle-ui-elements/toggle-ui-elements.ejs
@@ -20,6 +20,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['toggle-ui-elements']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<%- include('title-overrides') %>
 
 		<%- include('color-overrides', { slots: ['backgroundColor', 'textColor', 'graphic1Color'], defaults: require('./data/icon-defaults.json')['toggle-ui-elements'] }) %>

--- a/packages/iracing-actions/src/actions/toggle-ui-elements/toggle-ui-elements.ejs
+++ b/packages/iracing-actions/src/actions/toggle-ui-elements/toggle-ui-elements.ejs
@@ -21,7 +21,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['toggle-ui-elements']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<%- include('title-overrides') %>
 

--- a/packages/iracing-actions/src/actions/toggle-ui-elements/toggle-ui-elements.test.ts
+++ b/packages/iracing-actions/src/actions/toggle-ui-elements/toggle-ui-elements.test.ts
@@ -53,6 +53,7 @@ vi.mock("@iracedeck/deck-core", () => ({
     updateConnectionState = vi.fn();
     setKeyImage = vi.fn();
     setRegenerateCallback = vi.fn();
+    isBindingMissing = vi.fn(() => false);
   },
   formatKeyBinding: vi.fn((b: { key: string; modifiers: string[] }) => {
     if (b.modifiers?.length) {

--- a/packages/iracing-actions/src/actions/toggle-ui-elements/toggle-ui-elements.ts
+++ b/packages/iracing-actions/src/actions/toggle-ui-elements/toggle-ui-elements.ts
@@ -112,7 +112,7 @@ type ToggleUiElementsSettings = z.infer<typeof ToggleUiElementsSettings>;
  *
  * Generates an SVG data URI icon for the toggle UI elements action.
  */
-export function generateToggleUiElementsSvg(settings: ToggleUiElementsSettings): string {
+export function generateToggleUiElementsSvg(settings: ToggleUiElementsSettings, bindingMissing = false): string {
   const { element } = settings;
 
   const iconSvg = ELEMENT_ICONS[element] || ELEMENT_ICONS["dash-box"];
@@ -125,7 +125,7 @@ export function generateToggleUiElementsSvg(settings: ToggleUiElementsSettings):
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -224,9 +224,14 @@ export class ToggleUiElements extends ConnectionStateAwareAction<ToggleUiElement
     ev: IDeckWillAppearEvent<ToggleUiElementsSettings> | IDeckDidReceiveSettingsEvent<ToggleUiElementsSettings>,
     settings: ToggleUiElementsSettings,
   ): Promise<void> {
-    const svgDataUri = generateToggleUiElementsSvg(settings);
+    const svgDataUri = generateToggleUiElementsSvg(
+      settings,
+      this.isBindingMissing(UI_ELEMENT_GLOBAL_KEYS[settings.element]),
+    );
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateToggleUiElementsSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () =>
+      generateToggleUiElementsSvg(settings, this.isBindingMissing(UI_ELEMENT_GLOBAL_KEYS[settings.element])),
+    );
   }
 }

--- a/packages/iracing-actions/src/actions/view-adjustment/view-adjustment.ejs
+++ b/packages/iracing-actions/src/actions/view-adjustment/view-adjustment.ejs
@@ -17,7 +17,7 @@
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['view-adjustment']; %>
-		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
 
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">

--- a/packages/iracing-actions/src/actions/view-adjustment/view-adjustment.ejs
+++ b/packages/iracing-actions/src/actions/view-adjustment/view-adjustment.ejs
@@ -16,6 +16,9 @@
 			</sdpi-select>
 		</sdpi-item>
 
+		<% var __comms = require('./data/action-comms.json')['view-adjustment']; %>
+		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%- JSON.stringify(__comms) %>'></ird-binding-status>
+
 		<sdpi-item label="Direction" id="direction-item">
 			<sdpi-select setting="direction" default="increase">
 				<option value="increase">Increase</option>

--- a/packages/iracing-actions/src/actions/view-adjustment/view-adjustment.test.ts
+++ b/packages/iracing-actions/src/actions/view-adjustment/view-adjustment.test.ts
@@ -50,6 +50,8 @@ vi.mock("@iracedeck/deck-core", () => ({
     updateConnectionState = vi.fn();
     setKeyImage = vi.fn();
     setRegenerateCallback = vi.fn();
+    setActiveBinding = vi.fn();
+    isBindingMissing = vi.fn(() => false);
   },
   formatKeyBinding: vi.fn((b: { key: string; modifiers: string[] }) => {
     if (b.modifiers?.length) {

--- a/packages/iracing-actions/src/actions/view-adjustment/view-adjustment.ts
+++ b/packages/iracing-actions/src/actions/view-adjustment/view-adjustment.ts
@@ -112,7 +112,7 @@ type ViewAdjustmentSettings = z.infer<typeof ViewAdjustmentSettings>;
  *
  * Generates an SVG data URI icon for the view adjustment action.
  */
-export function generateViewAdjustmentSvg(settings: ViewAdjustmentSettings): string {
+export function generateViewAdjustmentSvg(settings: ViewAdjustmentSettings, bindingMissing = false): string {
   const { adjustment, direction } = settings;
 
   const iconKey = `${adjustment}-${direction}`;
@@ -126,7 +126,7 @@ export function generateViewAdjustmentSvg(settings: ViewAdjustmentSettings): str
 
   const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
-  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic });
+  return assembleIcon({ graphicSvg: iconSvg, colors, title, border, graphic, bindingMissing });
 }
 
 /**
@@ -200,9 +200,12 @@ export class ViewAdjustment extends ConnectionStateAwareAction<ViewAdjustmentSet
     ev: IDeckWillAppearEvent<ViewAdjustmentSettings> | IDeckDidReceiveSettingsEvent<ViewAdjustmentSettings>,
     settings: ViewAdjustmentSettings,
   ): Promise<void> {
-    const svgDataUri = generateViewAdjustmentSvg(settings);
+    const activeKey = VIEW_ADJUSTMENT_GLOBAL_KEYS[settings.adjustment]?.[settings.direction];
+    const svgDataUri = generateViewAdjustmentSvg(settings, this.isBindingMissing(activeKey));
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () => generateViewAdjustmentSvg(settings));
+    this.setRegenerateCallback(ev.action.id, () =>
+      generateViewAdjustmentSvg(settings, this.isBindingMissing(activeKey)),
+    );
   }
 }

--- a/packages/iracing-actions/src/shared/setup-view.ts
+++ b/packages/iracing-actions/src/shared/setup-view.ts
@@ -10,6 +10,7 @@
  * exposes more dc* fields.
  */
 import {
+  applyBindingWarning,
   type BorderOverrides,
   type ColorSlots,
   generateBorderParts,
@@ -418,6 +419,13 @@ export interface SetupViewRenderInputs {
   readonly colorOverrides?: ColorSlots;
   readonly titleOverrides?: TitleOverrides;
   readonly borderOverrides?: BorderOverrides;
+  /**
+   * When true, draw the centered binding-missing warning triangle over the
+   * dimmed value readout (issue #612). A View sub-mode requires a binding only
+   * when its dual-press opt-in is on AND the adjustment binding(s) it would
+   * dispatch are unconfigured; the caller computes this per-button.
+   */
+  readonly bindingMissing?: boolean;
 }
 
 /**
@@ -456,15 +464,22 @@ export function generateSetupViewSvg(inputs: SetupViewRenderInputs): string {
   // below center so it's well-separated from the title without hugging the top.
   const valueY = "79";
 
+  // When a required binding is missing (#612), draw the value via the warning
+  // overlay slot — dimmed beneath the centered warning triangle — and blank the
+  // template's own value slot so it isn't rendered twice at full opacity.
+  const valueText = `<text x="72" y="${valueY}" text-anchor="middle" dominant-baseline="central" fill="${colors.textColor}" font-family="Arial, sans-serif" font-size="${valueFontSize}" font-weight="bold">${value}</text>`;
+  const warningContent = inputs.bindingMissing ? applyBindingWarning(valueText) : "";
+
   const svg = renderIconTemplate(setupViewTemplate, {
     backgroundColor: colors.backgroundColor,
     textColor: colors.textColor,
     titleContent,
     borderDefs: borderSvg.defs,
     borderContent: borderSvg.rects,
-    value,
+    value: inputs.bindingMissing ? "" : value,
     valueFontSize,
     valueY,
+    warningContent,
   });
 
   return svgToDataUri(svg);

--- a/packages/pi-components/src/components/binding-status.test.ts
+++ b/packages/pi-components/src/components/binding-status.test.ts
@@ -190,6 +190,21 @@ describe("ird-binding-status", () => {
     expect(text()).toContain("No binding set");
   });
 
+  it("falls back to a secondary select's default when its value is empty (untouched control)", () => {
+    el = mount(VIEW_COMMS);
+    setBinding("viewFovInc", keyboardBinding("a"));
+    // Direction select left at its default: empty value but default="increase".
+    const dirSel = document.createElement("sdpi-select");
+    dirSel.setAttribute("setting", "direction");
+    dirSel.setAttribute("default", "increase");
+    (dirSel as unknown as { value: string }).value = "";
+    document.body.appendChild(dirSel);
+    setMode("fov");
+    // Must resolve via the default → viewFovInc, not go blank / "No binding set".
+    expect(text()).toContain("Ctrl+A");
+    expect(text()).not.toContain("No binding set");
+  });
+
   it("opens the key-bindings accordion and scrolls when 'set it here' is clicked", () => {
     const details = document.createElement("details");
     details.setAttribute("data-accordion-id", "Related Key Bindings");

--- a/packages/pi-components/src/components/binding-status.test.ts
+++ b/packages/pi-components/src/components/binding-status.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import "./binding-status.js";
 
@@ -8,58 +8,9 @@ const { mockFetchReachable } = vi.hoisted(() => ({ mockFetchReachable: vi.fn() }
 vi.mock("./simhub-probe.js", () => ({
   fetchSimHubReachable: mockFetchReachable,
   // Large so the poll interval never fires during a test; the immediate probe
-  // on render is what we assert.
+  // on a SimHub-bound render / host change is what we assert.
   SIMHUB_POLL_INTERVAL_MS: 1_000_000,
 }));
-
-type SettingsEvent = { payload: { settings: Record<string, unknown> } };
-type Listener = (ev: SettingsEvent) => void;
-
-interface MockSDPIState {
-  /** Merge a partial into the current action settings and notify the component. */
-  emitAction: (partial: Record<string, unknown>) => void;
-  /** Merge a partial into global settings and notify the component (any source). */
-  emitGlobal: (partial: Record<string, unknown>) => void;
-}
-
-function installMockSDPI(): MockSDPIState {
-  const action: Record<string, unknown> = {};
-  const global: Record<string, unknown> = {};
-  const actionListeners: Listener[] = [];
-  const globalListeners: Listener[] = [];
-
-  const emitAction = (partial: Record<string, unknown>) => {
-    Object.assign(action, partial);
-
-    for (const cb of actionListeners) cb({ payload: { settings: action } });
-  };
-  const emitGlobal = (partial: Record<string, unknown>) => {
-    Object.assign(global, partial);
-
-    for (const cb of globalListeners) cb({ payload: { settings: global } });
-  };
-
-  const subscribe = (list: Listener[]) => (cb: Listener) => {
-    list.push(cb);
-
-    return () => {
-      const i = list.indexOf(cb);
-
-      if (i >= 0) list.splice(i, 1);
-    };
-  };
-
-  const streamDeckClient = {
-    getSettings: () => Promise.resolve({ settings: action }),
-    getGlobalSettings: () => Promise.resolve(global),
-    didReceiveSettings: { subscribe: subscribe(actionListeners) },
-    didReceiveGlobalSettings: { subscribe: subscribe(globalListeners) },
-  };
-
-  (window as unknown as Record<string, unknown>).SDPIComponents = { streamDeckClient };
-
-  return { emitAction, emitGlobal };
-}
 
 const keyboardBinding = (key: string) => JSON.stringify({ type: "keyboard", key, modifiers: ["ctrl"], code: key });
 const simhubBinding = (role: string) => JSON.stringify({ type: "simhub", role });
@@ -82,20 +33,37 @@ const VIEW_COMMS = {
   },
 };
 
+/** Notify the component (it listens for input/change on the document). */
+function tick(): void {
+  document.dispatchEvent(new Event("input"));
+}
+
+/** Set (creating if needed) a generic sdpi-style control's value, then notify. */
+function setControl(tag: string, setting: string, value: string): void {
+  let el = document.querySelector(`${tag}[setting="${setting}"]`) as (Element & { value?: unknown }) | null;
+
+  if (!el) {
+    el = document.createElement(tag);
+    el.setAttribute("setting", setting);
+    document.body.appendChild(el);
+  }
+
+  (el as { value?: unknown }).value = value;
+  tick();
+}
+
+const setMode = (m: string) => setControl("sdpi-select", "mode", m);
+const setSecondary = (name: string, v: string) => setControl("sdpi-select", name, v);
+const setBinding = (key: string, v: string) => setControl("ird-key-binding", key, v);
+
 describe("ird-binding-status", () => {
   let el: HTMLElement;
-  let mock: MockSDPIState;
 
   beforeEach(() => {
     while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
 
-    mock = installMockSDPI();
     mockFetchReachable.mockReset();
     mockFetchReachable.mockResolvedValue(true); // SimHub connected by default
-  });
-
-  afterEach(() => {
-    (window as unknown as Record<string, unknown>).SDPIComponents = undefined;
   });
 
   function mount(comms: object): HTMLElement {
@@ -107,7 +75,6 @@ describe("ird-binding-status", () => {
     return node;
   }
 
-  const setMode = (m: string) => mock.emitAction({ mode: m });
   const text = () => el.textContent ?? "";
 
   it("shows the API method", () => {
@@ -134,7 +101,7 @@ describe("ird-binding-status", () => {
   it("shows the keyboard binding value when configured", () => {
     el = mount(FUEL_COMMS);
     setMode("toggle-autofuel");
-    mock.emitGlobal({ fuelServiceToggleAutofuel: keyboardBinding("f1") });
+    setBinding("fuelServiceToggleAutofuel", keyboardBinding("f1"));
     expect(text()).toContain("Key binding:");
     expect(text()).toContain("Ctrl+F1");
   });
@@ -142,30 +109,28 @@ describe("ird-binding-status", () => {
   it("updates the text live when the binding is changed", () => {
     el = mount(FUEL_COMMS);
     setMode("toggle-autofuel");
-    mock.emitGlobal({ fuelServiceToggleAutofuel: keyboardBinding("f1") });
+    setBinding("fuelServiceToggleAutofuel", keyboardBinding("f1"));
     expect(text()).toContain("Ctrl+F1");
-    mock.emitGlobal({ fuelServiceToggleAutofuel: keyboardBinding("f2") });
+    setBinding("fuelServiceToggleAutofuel", keyboardBinding("f2"));
     expect(text()).toContain("Ctrl+F2");
     expect(text()).not.toContain("Ctrl+F1");
-    mock.emitGlobal({ fuelServiceToggleAutofuel: "" });
+    setBinding("fuelServiceToggleAutofuel", "");
     expect(text()).toContain("No binding set");
   });
 
-  it("shows nothing until settings have loaded", () => {
+  it("shows nothing until the binding input exists (no premature warning)", () => {
     el = mount(FUEL_COMMS);
-    // No settings yet → nothing.
-    expect(text()).toBe("");
     setMode("toggle-autofuel");
-    // Mode known but binding value not loaded → still nothing (no premature warning).
+    // No ird-key-binding for the key yet → render nothing, not "No binding set".
     expect(text()).toBe("");
-    mock.emitGlobal({ fuelServiceToggleAutofuel: "" });
+    setBinding("fuelServiceToggleAutofuel", "");
     expect(text()).toContain("No binding set");
   });
 
   it("warns with a 'set it here' link when no binding is set", () => {
     el = mount(FUEL_COMMS);
     setMode("toggle-autofuel");
-    mock.emitGlobal({ fuelServiceToggleAutofuel: "" });
+    setBinding("fuelServiceToggleAutofuel", "");
     expect(text()).toContain("No binding set");
     expect(el.querySelector("a.ird-binding-status-link")).not.toBeNull();
   });
@@ -174,7 +139,7 @@ describe("ird-binding-status", () => {
     mockFetchReachable.mockResolvedValue(true);
     el = mount(FUEL_COMMS);
     setMode("toggle-autofuel");
-    mock.emitGlobal({ fuelServiceToggleAutofuel: simhubBinding("My Role") });
+    setBinding("fuelServiceToggleAutofuel", simhubBinding("My Role"));
     expect(text()).toContain("SimHub binding: My Role");
     expect(text()).not.toContain("No binding set");
     await vi.waitFor(() => expect(mockFetchReachable).toHaveBeenCalled());
@@ -185,7 +150,7 @@ describe("ird-binding-status", () => {
     mockFetchReachable.mockResolvedValue(false);
     el = mount(FUEL_COMMS);
     setMode("toggle-autofuel");
-    mock.emitGlobal({ fuelServiceToggleAutofuel: simhubBinding("My Role") });
+    setBinding("fuelServiceToggleAutofuel", simhubBinding("My Role"));
     await vi.waitFor(() => expect(text()).toContain("SimHub not connected"));
     expect(el.querySelector(".ird-binding-status-danger")).not.toBeNull();
   });
@@ -194,10 +159,10 @@ describe("ird-binding-status", () => {
     mockFetchReachable.mockResolvedValue(false);
     el = mount(FUEL_COMMS);
     setMode("toggle-autofuel");
-    mock.emitGlobal({ fuelServiceToggleAutofuel: simhubBinding("My Role") });
+    setBinding("fuelServiceToggleAutofuel", simhubBinding("My Role"));
     await vi.waitFor(() => expect(text()).toContain("SimHub not connected"));
     mockFetchReachable.mockResolvedValue(true);
-    mock.emitGlobal({ simHubHost: "localhost" }); // host change forces a re-probe
+    setControl("sdpi-textfield", "simHubHost", "localhost"); // host change forces a re-probe
     await vi.waitFor(() => expect(text()).not.toContain("SimHub not connected"));
     expect(text()).toContain("SimHub binding: My Role");
   });
@@ -205,21 +170,23 @@ describe("ird-binding-status", () => {
   it("updates live when switching keyboard ↔ SimHub without changing mode", () => {
     el = mount(FUEL_COMMS);
     setMode("toggle-autofuel");
-    mock.emitGlobal({ fuelServiceToggleAutofuel: keyboardBinding("f1") });
+    setBinding("fuelServiceToggleAutofuel", keyboardBinding("f1"));
     expect(text()).toContain("Ctrl+F1");
-    mock.emitGlobal({ fuelServiceToggleAutofuel: simhubBinding("Role X") });
+    setBinding("fuelServiceToggleAutofuel", simhubBinding("Role X"));
     expect(text()).toContain("SimHub binding: Role X");
     expect(text()).not.toContain("Ctrl+F1");
   });
 
   it("resolves a dynamic key from the secondary setting (full resolution)", () => {
     el = mount(VIEW_COMMS);
-    mock.emitGlobal({ viewFovInc: keyboardBinding("a") });
-    mock.emitAction({ mode: "fov", direction: "increase" });
+    setBinding("viewFovInc", keyboardBinding("a"));
+    setBinding("viewFovDec", "");
+    setSecondary("direction", "increase");
+    setMode("fov");
     expect(text()).toContain("Key binding:");
     expect(text()).toContain("Ctrl+A");
     // Switching the secondary setting re-resolves to the other (unset) key.
-    mock.emitAction({ mode: "fov", direction: "decrease" });
+    setSecondary("direction", "decrease");
     expect(text()).toContain("No binding set");
   });
 
@@ -232,7 +199,7 @@ describe("ird-binding-status", () => {
 
     el = mount(FUEL_COMMS);
     setMode("toggle-autofuel");
-    mock.emitGlobal({ fuelServiceToggleAutofuel: "" });
+    setBinding("fuelServiceToggleAutofuel", "");
     (el.querySelector("a.ird-binding-status-link") as HTMLAnchorElement).click();
 
     expect(details.open).toBe(true);
@@ -254,8 +221,9 @@ describe("ird-binding-status", () => {
 
   it("lists all keys when a multi-key mode has them all set", () => {
     el = mount({ "view-fov": { method: "keybind", binding: { scope: "global", keys: ["incKey", "decKey"] } } });
+    setBinding("incKey", keyboardBinding("a"));
+    setBinding("decKey", keyboardBinding("b"));
     setMode("view-fov");
-    mock.emitGlobal({ incKey: keyboardBinding("a"), decKey: keyboardBinding("b") });
     expect(text()).toContain("Ctrl+A");
     expect(text()).toContain("Ctrl+B");
     expect(text()).not.toContain("No binding set");
@@ -263,8 +231,9 @@ describe("ird-binding-status", () => {
 
   it("warns when a multi-key mode has any key unset", () => {
     el = mount({ "view-fov": { method: "keybind", binding: { scope: "global", keys: ["incKey", "decKey"] } } });
+    setBinding("incKey", keyboardBinding("a"));
+    setBinding("decKey", "");
     setMode("view-fov");
-    mock.emitGlobal({ incKey: keyboardBinding("a"), decKey: "" });
     expect(text()).toContain("No binding set");
   });
 });

--- a/packages/pi-components/src/components/binding-status.test.ts
+++ b/packages/pi-components/src/components/binding-status.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import "./binding-status.js";
+
+type SettingsCallback = (value: string) => void;
+
+interface MockSDPIState {
+  settings: Map<string, SettingsCallback>;
+  global: Map<string, SettingsCallback>;
+}
+
+function installMockSDPI(): MockSDPIState {
+  const state: MockSDPIState = { settings: new Map(), global: new Map() };
+  const useSettings = (key: string, cb: SettingsCallback) => {
+    state.settings.set(key, cb);
+
+    return [async () => "", vi.fn()] as [() => Promise<string>, (v: string) => void];
+  };
+  const useGlobalSettings = (key: string, cb: SettingsCallback) => {
+    state.global.set(key, cb);
+
+    return [async () => "", vi.fn()] as [() => Promise<string>, (v: string) => void];
+  };
+  (window as unknown as Record<string, unknown>).SDPIComponents = { useSettings, useGlobalSettings };
+
+  return state;
+}
+
+const keyboardBinding = (key: string) => JSON.stringify({ type: "keyboard", key, modifiers: ["ctrl"], code: key });
+const simhubBinding = (role: string) => JSON.stringify({ type: "simhub", role });
+
+// fuel-service: api + chat + keybind in one action.
+const FUEL_COMMS = {
+  "toggle-fuel-fill": { method: "api" },
+  "add-fuel": { method: "chat" },
+  "toggle-autofuel": { method: "keybind", binding: { scope: "global", key: "fuelServiceToggleAutofuel" } },
+};
+
+// view-adjustment: dynamic key resolved from the `direction` secondary setting.
+const VIEW_COMMS = {
+  fov: {
+    method: "keybind",
+    binding: {
+      scope: "global",
+      keyBy: { setting: "direction", map: { increase: "viewFovInc", decrease: "viewFovDec" } },
+    },
+  },
+};
+
+describe("ird-binding-status", () => {
+  let el: HTMLElement;
+  let mock: MockSDPIState;
+
+  beforeEach(() => {
+    while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+
+    mock = installMockSDPI();
+  });
+
+  afterEach(() => {
+    (window as unknown as Record<string, unknown>).SDPIComponents = undefined;
+  });
+
+  function mount(comms: object, attrs: Record<string, string> = {}): HTMLElement {
+    const node = document.createElement("ird-binding-status");
+    node.setAttribute("comms", JSON.stringify(comms));
+    node.setAttribute("mode-setting", "mode");
+
+    for (const [k, v] of Object.entries(attrs)) node.setAttribute(k, v);
+
+    document.body.appendChild(node);
+
+    return node;
+  }
+
+  const text = () => el.textContent ?? "";
+
+  it("shows the API method with no binding needed", () => {
+    el = mount(FUEL_COMMS);
+    mock.settings.get("mode")!("toggle-fuel-fill");
+    expect(text()).toContain("iRacing API");
+    expect(text()).toContain("no binding needed");
+  });
+
+  it("shows the chat method with no binding needed", () => {
+    el = mount(FUEL_COMMS);
+    mock.settings.get("mode")!("add-fuel");
+    expect(text()).toContain("Chat command");
+  });
+
+  it("shows the keyboard binding value when configured", () => {
+    el = mount(FUEL_COMMS);
+    mock.settings.get("mode")!("toggle-autofuel");
+    mock.global.get("fuelServiceToggleAutofuel")!(keyboardBinding("f1"));
+    expect(text()).toContain("currently set");
+    expect(text()).toContain("Ctrl + F1");
+  });
+
+  it("warns with a 'set it here' link when no binding is set", () => {
+    el = mount(FUEL_COMMS);
+    mock.settings.get("mode")!("toggle-autofuel");
+    mock.global.get("fuelServiceToggleAutofuel")!("");
+    expect(text()).toContain("No binding set");
+    expect(el.querySelector("a.ird-binding-status-link")).not.toBeNull();
+  });
+
+  it("treats a SimHub role as configured (never the missing state) with a running caveat", () => {
+    el = mount(FUEL_COMMS);
+    mock.settings.get("mode")!("toggle-autofuel");
+    mock.global.get("fuelServiceToggleAutofuel")!(simhubBinding("My Role"));
+    expect(text()).toContain("SimHub role: My Role");
+    expect(text()).not.toContain("No binding set");
+    expect(text()).toContain("Requires SimHub to be running");
+  });
+
+  it("escalates the SimHub caveat when SimHub is not reachable", () => {
+    el = mount(FUEL_COMMS);
+    mock.settings.get("mode")!("toggle-autofuel");
+    mock.global.get("fuelServiceToggleAutofuel")!(simhubBinding("My Role"));
+    mock.global.get("_simHubReachable")!("false");
+    expect(text()).toContain("SimHub isn't running");
+  });
+
+  it("updates live when switching keyboard ↔ SimHub without changing mode", () => {
+    el = mount(FUEL_COMMS);
+    mock.settings.get("mode")!("toggle-autofuel");
+    mock.global.get("fuelServiceToggleAutofuel")!(keyboardBinding("f1"));
+    expect(text()).toContain("Ctrl + F1");
+    mock.global.get("fuelServiceToggleAutofuel")!(simhubBinding("Role X"));
+    expect(text()).toContain("SimHub role: Role X");
+    expect(text()).not.toContain("Ctrl + F1");
+  });
+
+  it("resolves a dynamic key from the secondary setting (full resolution)", () => {
+    el = mount(VIEW_COMMS);
+    mock.settings.get("mode")!("fov");
+    mock.settings.get("direction")!("increase");
+    mock.global.get("viewFovInc")!(keyboardBinding("a"));
+    expect(text()).toContain("currently set");
+    expect(text()).toContain("Ctrl + A");
+    // Switching the secondary setting re-resolves to the other key.
+    mock.settings.get("direction")!("decrease");
+    mock.global.get("viewFovDec")!("");
+    expect(text()).toContain("No binding set");
+  });
+
+  it("opens the key-bindings accordion and scrolls when 'set it here' is clicked", () => {
+    const details = document.createElement("details");
+    details.setAttribute("data-accordion-id", "Related Key Bindings");
+    const scrollSpy = vi.fn();
+    (details as unknown as { scrollIntoView: () => void }).scrollIntoView = scrollSpy;
+    document.body.appendChild(details);
+
+    el = mount(FUEL_COMMS);
+    mock.settings.get("mode")!("toggle-autofuel");
+    mock.global.get("fuelServiceToggleAutofuel")!("");
+    (el.querySelector("a.ird-binding-status-link") as HTMLAnchorElement).click();
+
+    expect(details.open).toBe(true);
+    expect(scrollSpy).toHaveBeenCalled();
+  });
+
+  it("renders nothing for an unknown mode", () => {
+    el = mount(FUEL_COMMS);
+    mock.settings.get("mode")!("does-not-exist");
+    expect(text()).toBe("");
+  });
+});

--- a/packages/pi-components/src/components/binding-status.test.ts
+++ b/packages/pi-components/src/components/binding-status.test.ts
@@ -94,7 +94,24 @@ describe("ird-binding-status", () => {
     mock.settings.get("mode")!("toggle-autofuel");
     mock.global.get("fuelServiceToggleAutofuel")!(keyboardBinding("f1"));
     expect(text()).toContain("currently set");
-    expect(text()).toContain("Ctrl + F1");
+    expect(text()).toContain("Ctrl+F1");
+  });
+
+  it("shows nothing (no 'No binding set' flash) until the binding value has loaded", () => {
+    el = mount(FUEL_COMMS);
+    mock.settings.get("mode")!("toggle-autofuel");
+    // Binding value has NOT arrived yet → render nothing, not "No binding set".
+    expect(text()).toBe("");
+    // Once it loads as empty, the missing state shows.
+    mock.global.get("fuelServiceToggleAutofuel")!("");
+    expect(text()).toContain("No binding set");
+  });
+
+  it("waits for the secondary setting before judging a dynamic-key mode", () => {
+    el = mount(VIEW_COMMS);
+    mock.settings.get("mode")!("fov");
+    // direction not loaded yet → nothing.
+    expect(text()).toBe("");
   });
 
   it("warns with a 'set it here' link when no binding is set", () => {
@@ -126,10 +143,10 @@ describe("ird-binding-status", () => {
     el = mount(FUEL_COMMS);
     mock.settings.get("mode")!("toggle-autofuel");
     mock.global.get("fuelServiceToggleAutofuel")!(keyboardBinding("f1"));
-    expect(text()).toContain("Ctrl + F1");
+    expect(text()).toContain("Ctrl+F1");
     mock.global.get("fuelServiceToggleAutofuel")!(simhubBinding("Role X"));
     expect(text()).toContain("SimHub role: Role X");
-    expect(text()).not.toContain("Ctrl + F1");
+    expect(text()).not.toContain("Ctrl+F1");
   });
 
   it("resolves a dynamic key from the secondary setting (full resolution)", () => {
@@ -138,7 +155,7 @@ describe("ird-binding-status", () => {
     mock.settings.get("direction")!("increase");
     mock.global.get("viewFovInc")!(keyboardBinding("a"));
     expect(text()).toContain("currently set");
-    expect(text()).toContain("Ctrl + A");
+    expect(text()).toContain("Ctrl+A");
     // Switching the secondary setting re-resolves to the other key.
     mock.settings.get("direction")!("decrease");
     mock.global.get("viewFovDec")!("");
@@ -179,8 +196,8 @@ describe("ird-binding-status", () => {
     mock.settings.get("mode")!("view-fov");
     mock.global.get("incKey")!(keyboardBinding("a"));
     mock.global.get("decKey")!(keyboardBinding("b"));
-    expect(text()).toContain("Ctrl + A");
-    expect(text()).toContain("Ctrl + B");
+    expect(text()).toContain("Ctrl+A");
+    expect(text()).toContain("Ctrl+B");
     expect(text()).not.toContain("No binding set");
   });
 

--- a/packages/pi-components/src/components/binding-status.test.ts
+++ b/packages/pi-components/src/components/binding-status.test.ts
@@ -3,6 +3,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import "./binding-status.js";
 
+const { mockFetchReachable } = vi.hoisted(() => ({ mockFetchReachable: vi.fn() }));
+
+vi.mock("./simhub-probe.js", () => ({
+  fetchSimHubReachable: mockFetchReachable,
+  // Large so the poll interval never fires during a test; the immediate probe
+  // on render is what we assert.
+  SIMHUB_POLL_INTERVAL_MS: 1_000_000,
+}));
+
 type SettingsCallback = (value: string) => void;
 
 interface MockSDPIState {
@@ -56,6 +65,8 @@ describe("ird-binding-status", () => {
     while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
 
     mock = installMockSDPI();
+    mockFetchReachable.mockReset();
+    mockFetchReachable.mockResolvedValue(true); // SimHub connected by default
   });
 
   afterEach(() => {
@@ -76,14 +87,13 @@ describe("ird-binding-status", () => {
 
   const text = () => el.textContent ?? "";
 
-  it("shows the API method with no binding needed", () => {
+  it("shows the API method", () => {
     el = mount(FUEL_COMMS);
     mock.settings.get("mode")!("toggle-fuel-fill");
     expect(text()).toContain("iRacing API");
-    expect(text()).toContain("no binding needed");
   });
 
-  it("shows the chat method with no binding needed", () => {
+  it("shows the chat method", () => {
     el = mount(FUEL_COMMS);
     mock.settings.get("mode")!("add-fuel");
     expect(text()).toContain("Chat command");
@@ -93,7 +103,7 @@ describe("ird-binding-status", () => {
     el = mount(FUEL_COMMS);
     mock.settings.get("mode")!("toggle-autofuel");
     mock.global.get("fuelServiceToggleAutofuel")!(keyboardBinding("f1"));
-    expect(text()).toContain("currently set");
+    expect(text()).toContain("Key binding:");
     expect(text()).toContain("Ctrl+F1");
   });
 
@@ -122,21 +132,38 @@ describe("ird-binding-status", () => {
     expect(el.querySelector("a.ird-binding-status-link")).not.toBeNull();
   });
 
-  it("treats a SimHub role as configured (never the missing state) with a running caveat", () => {
+  it("treats a SimHub role as configured (never the missing state); no warning when connected", async () => {
+    mockFetchReachable.mockResolvedValue(true);
     el = mount(FUEL_COMMS);
     mock.settings.get("mode")!("toggle-autofuel");
     mock.global.get("fuelServiceToggleAutofuel")!(simhubBinding("My Role"));
-    expect(text()).toContain("SimHub role: My Role");
+    expect(text()).toContain("SimHub binding: My Role");
     expect(text()).not.toContain("No binding set");
-    expect(text()).toContain("Requires SimHub to be running");
+    // After the probe confirms SimHub is up, no warning line.
+    await vi.waitFor(() => expect(mockFetchReachable).toHaveBeenCalled());
+    expect(text()).not.toContain("SimHub not connected");
   });
 
-  it("escalates the SimHub caveat when SimHub is not reachable", () => {
+  it("shows a red 'SimHub not connected' line when the probe finds SimHub down", async () => {
+    mockFetchReachable.mockResolvedValue(false);
     el = mount(FUEL_COMMS);
     mock.settings.get("mode")!("toggle-autofuel");
     mock.global.get("fuelServiceToggleAutofuel")!(simhubBinding("My Role"));
-    mock.global.get("_simHubReachable")!("false");
-    expect(text()).toContain("SimHub isn't running");
+    await vi.waitFor(() => expect(text()).toContain("SimHub not connected"));
+    expect(el.querySelector(".ird-binding-status-danger")).not.toBeNull();
+  });
+
+  it("clears the not-connected warning live once SimHub becomes reachable", async () => {
+    mockFetchReachable.mockResolvedValue(false);
+    el = mount(FUEL_COMMS);
+    mock.settings.get("mode")!("toggle-autofuel");
+    mock.global.get("fuelServiceToggleAutofuel")!(simhubBinding("My Role"));
+    await vi.waitFor(() => expect(text()).toContain("SimHub not connected"));
+    // SimHub comes up; the next probe (here forced via a host change) clears it.
+    mockFetchReachable.mockResolvedValue(true);
+    mock.global.get("simHubHost")!("127.0.0.1");
+    await vi.waitFor(() => expect(text()).not.toContain("SimHub not connected"));
+    expect(text()).toContain("SimHub binding: My Role");
   });
 
   it("updates live when switching keyboard ↔ SimHub without changing mode", () => {
@@ -145,7 +172,7 @@ describe("ird-binding-status", () => {
     mock.global.get("fuelServiceToggleAutofuel")!(keyboardBinding("f1"));
     expect(text()).toContain("Ctrl+F1");
     mock.global.get("fuelServiceToggleAutofuel")!(simhubBinding("Role X"));
-    expect(text()).toContain("SimHub role: Role X");
+    expect(text()).toContain("SimHub binding: Role X");
     expect(text()).not.toContain("Ctrl+F1");
   });
 
@@ -154,7 +181,7 @@ describe("ird-binding-status", () => {
     mock.settings.get("mode")!("fov");
     mock.settings.get("direction")!("increase");
     mock.global.get("viewFovInc")!(keyboardBinding("a"));
-    expect(text()).toContain("currently set");
+    expect(text()).toContain("Key binding:");
     expect(text()).toContain("Ctrl+A");
     // Switching the secondary setting re-resolves to the other key.
     mock.settings.get("direction")!("decrease");

--- a/packages/pi-components/src/components/binding-status.test.ts
+++ b/packages/pi-components/src/components/binding-status.test.ts
@@ -15,25 +15,49 @@ vi.mock("./simhub-probe.js", () => ({
 type SettingsCallback = (value: string) => void;
 
 interface MockSDPIState {
+  /** Action-settings subscriptions (mode + secondary keyBy settings). */
   settings: Map<string, SettingsCallback>;
-  global: Map<string, SettingsCallback>;
+  /** The live global-settings object the component reads. */
+  global: Record<string, unknown>;
+  /** Merge a partial into global settings and notify the component (any source). */
+  emitGlobal: (partial: Record<string, unknown>) => void;
 }
 
 function installMockSDPI(): MockSDPIState {
-  const state: MockSDPIState = { settings: new Map(), global: new Map() };
+  const settings = new Map<string, SettingsCallback>();
+  const global: Record<string, unknown> = {};
+  const listeners: Array<(ev: { payload: { settings: Record<string, unknown> } }) => void> = [];
+
+  const emitGlobal = (partial: Record<string, unknown>) => {
+    Object.assign(global, partial);
+
+    for (const cb of listeners) cb({ payload: { settings: global } });
+  };
+
   const useSettings = (key: string, cb: SettingsCallback) => {
-    state.settings.set(key, cb);
+    settings.set(key, cb);
 
     return [async () => "", vi.fn()] as [() => Promise<string>, (v: string) => void];
   };
-  const useGlobalSettings = (key: string, cb: SettingsCallback) => {
-    state.global.set(key, cb);
 
-    return [async () => "", vi.fn()] as [() => Promise<string>, (v: string) => void];
+  const streamDeckClient = {
+    getGlobalSettings: () => Promise.resolve(global),
+    didReceiveGlobalSettings: {
+      subscribe: (cb: (ev: { payload: { settings: Record<string, unknown> } }) => void) => {
+        listeners.push(cb);
+
+        return () => {
+          const i = listeners.indexOf(cb);
+
+          if (i >= 0) listeners.splice(i, 1);
+        };
+      },
+    },
   };
-  (window as unknown as Record<string, unknown>).SDPIComponents = { useSettings, useGlobalSettings };
 
-  return state;
+  (window as unknown as Record<string, unknown>).SDPIComponents = { useSettings, streamDeckClient };
+
+  return { settings, global, emitGlobal };
 }
 
 const keyboardBinding = (key: string) => JSON.stringify({ type: "keyboard", key, modifiers: ["ctrl"], code: key });
@@ -73,61 +97,73 @@ describe("ird-binding-status", () => {
     (window as unknown as Record<string, unknown>).SDPIComponents = undefined;
   });
 
-  function mount(comms: object, attrs: Record<string, string> = {}): HTMLElement {
+  function mount(comms: object): HTMLElement {
     const node = document.createElement("ird-binding-status");
     node.setAttribute("comms", JSON.stringify(comms));
     node.setAttribute("mode-setting", "mode");
-
-    for (const [k, v] of Object.entries(attrs)) node.setAttribute(k, v);
-
     document.body.appendChild(node);
 
     return node;
   }
 
+  const setMode = (m: string) => mock.settings.get("mode")!(m);
   const text = () => el.textContent ?? "";
 
   it("shows the API method", () => {
     el = mount(FUEL_COMMS);
-    mock.settings.get("mode")!("toggle-fuel-fill");
+    setMode("toggle-fuel-fill");
     expect(text()).toContain("iRacing API");
   });
 
   it("shows the chat method", () => {
     el = mount(FUEL_COMMS);
-    mock.settings.get("mode")!("add-fuel");
+    setMode("add-fuel");
     expect(text()).toContain("Chat command");
   });
 
   it("shows the keyboard binding value when configured", () => {
     el = mount(FUEL_COMMS);
-    mock.settings.get("mode")!("toggle-autofuel");
-    mock.global.get("fuelServiceToggleAutofuel")!(keyboardBinding("f1"));
+    setMode("toggle-autofuel");
+    mock.emitGlobal({ fuelServiceToggleAutofuel: keyboardBinding("f1") });
     expect(text()).toContain("Key binding:");
     expect(text()).toContain("Ctrl+F1");
   });
 
+  it("updates the text live when the binding is changed", () => {
+    el = mount(FUEL_COMMS);
+    setMode("toggle-autofuel");
+    mock.emitGlobal({ fuelServiceToggleAutofuel: keyboardBinding("f1") });
+    expect(text()).toContain("Ctrl+F1");
+    // A sibling ird-key-binding rebinds it → component reflects the new value.
+    mock.emitGlobal({ fuelServiceToggleAutofuel: keyboardBinding("f2") });
+    expect(text()).toContain("Ctrl+F2");
+    expect(text()).not.toContain("Ctrl+F1");
+    // ...and clearing it shows the missing state live.
+    mock.emitGlobal({ fuelServiceToggleAutofuel: "" });
+    expect(text()).toContain("No binding set");
+  });
+
   it("shows nothing (no 'No binding set' flash) until the binding value has loaded", () => {
     el = mount(FUEL_COMMS);
-    mock.settings.get("mode")!("toggle-autofuel");
-    // Binding value has NOT arrived yet → render nothing, not "No binding set".
+    setMode("toggle-autofuel");
+    // Global settings have NOT arrived yet → render nothing, not "No binding set".
     expect(text()).toBe("");
-    // Once it loads as empty, the missing state shows.
-    mock.global.get("fuelServiceToggleAutofuel")!("");
+    mock.emitGlobal({ fuelServiceToggleAutofuel: "" });
     expect(text()).toContain("No binding set");
   });
 
   it("waits for the secondary setting before judging a dynamic-key mode", () => {
     el = mount(VIEW_COMMS);
-    mock.settings.get("mode")!("fov");
+    setMode("fov");
+    mock.emitGlobal({ viewFovInc: keyboardBinding("a") });
     // direction not loaded yet → nothing.
     expect(text()).toBe("");
   });
 
   it("warns with a 'set it here' link when no binding is set", () => {
     el = mount(FUEL_COMMS);
-    mock.settings.get("mode")!("toggle-autofuel");
-    mock.global.get("fuelServiceToggleAutofuel")!("");
+    setMode("toggle-autofuel");
+    mock.emitGlobal({ fuelServiceToggleAutofuel: "" });
     expect(text()).toContain("No binding set");
     expect(el.querySelector("a.ird-binding-status-link")).not.toBeNull();
   });
@@ -135,11 +171,10 @@ describe("ird-binding-status", () => {
   it("treats a SimHub role as configured (never the missing state); no warning when connected", async () => {
     mockFetchReachable.mockResolvedValue(true);
     el = mount(FUEL_COMMS);
-    mock.settings.get("mode")!("toggle-autofuel");
-    mock.global.get("fuelServiceToggleAutofuel")!(simhubBinding("My Role"));
+    setMode("toggle-autofuel");
+    mock.emitGlobal({ fuelServiceToggleAutofuel: simhubBinding("My Role") });
     expect(text()).toContain("SimHub binding: My Role");
     expect(text()).not.toContain("No binding set");
-    // After the probe confirms SimHub is up, no warning line.
     await vi.waitFor(() => expect(mockFetchReachable).toHaveBeenCalled());
     expect(text()).not.toContain("SimHub not connected");
   });
@@ -147,8 +182,8 @@ describe("ird-binding-status", () => {
   it("shows a red 'SimHub not connected' line when the probe finds SimHub down", async () => {
     mockFetchReachable.mockResolvedValue(false);
     el = mount(FUEL_COMMS);
-    mock.settings.get("mode")!("toggle-autofuel");
-    mock.global.get("fuelServiceToggleAutofuel")!(simhubBinding("My Role"));
+    setMode("toggle-autofuel");
+    mock.emitGlobal({ fuelServiceToggleAutofuel: simhubBinding("My Role") });
     await vi.waitFor(() => expect(text()).toContain("SimHub not connected"));
     expect(el.querySelector(".ird-binding-status-danger")).not.toBeNull();
   });
@@ -156,36 +191,35 @@ describe("ird-binding-status", () => {
   it("clears the not-connected warning live once SimHub becomes reachable", async () => {
     mockFetchReachable.mockResolvedValue(false);
     el = mount(FUEL_COMMS);
-    mock.settings.get("mode")!("toggle-autofuel");
-    mock.global.get("fuelServiceToggleAutofuel")!(simhubBinding("My Role"));
+    setMode("toggle-autofuel");
+    mock.emitGlobal({ fuelServiceToggleAutofuel: simhubBinding("My Role") });
     await vi.waitFor(() => expect(text()).toContain("SimHub not connected"));
-    // SimHub comes up; the next probe (here forced via a host change) clears it.
+    // SimHub comes up; a host change forces a re-probe (stands in for the poll).
     mockFetchReachable.mockResolvedValue(true);
-    mock.global.get("simHubHost")!("127.0.0.1");
+    mock.emitGlobal({ simHubHost: "localhost" });
     await vi.waitFor(() => expect(text()).not.toContain("SimHub not connected"));
     expect(text()).toContain("SimHub binding: My Role");
   });
 
   it("updates live when switching keyboard ↔ SimHub without changing mode", () => {
     el = mount(FUEL_COMMS);
-    mock.settings.get("mode")!("toggle-autofuel");
-    mock.global.get("fuelServiceToggleAutofuel")!(keyboardBinding("f1"));
+    setMode("toggle-autofuel");
+    mock.emitGlobal({ fuelServiceToggleAutofuel: keyboardBinding("f1") });
     expect(text()).toContain("Ctrl+F1");
-    mock.global.get("fuelServiceToggleAutofuel")!(simhubBinding("Role X"));
+    mock.emitGlobal({ fuelServiceToggleAutofuel: simhubBinding("Role X") });
     expect(text()).toContain("SimHub binding: Role X");
     expect(text()).not.toContain("Ctrl+F1");
   });
 
   it("resolves a dynamic key from the secondary setting (full resolution)", () => {
     el = mount(VIEW_COMMS);
-    mock.settings.get("mode")!("fov");
+    setMode("fov");
     mock.settings.get("direction")!("increase");
-    mock.global.get("viewFovInc")!(keyboardBinding("a"));
+    mock.emitGlobal({ viewFovInc: keyboardBinding("a") });
     expect(text()).toContain("Key binding:");
     expect(text()).toContain("Ctrl+A");
-    // Switching the secondary setting re-resolves to the other key.
+    // Switching the secondary setting re-resolves to the other (unset) key.
     mock.settings.get("direction")!("decrease");
-    mock.global.get("viewFovDec")!("");
     expect(text()).toContain("No binding set");
   });
 
@@ -197,8 +231,8 @@ describe("ird-binding-status", () => {
     document.body.appendChild(details);
 
     el = mount(FUEL_COMMS);
-    mock.settings.get("mode")!("toggle-autofuel");
-    mock.global.get("fuelServiceToggleAutofuel")!("");
+    setMode("toggle-autofuel");
+    mock.emitGlobal({ fuelServiceToggleAutofuel: "" });
     (el.querySelector("a.ird-binding-status-link") as HTMLAnchorElement).click();
 
     expect(details.open).toBe(true);
@@ -207,22 +241,21 @@ describe("ird-binding-status", () => {
 
   it("renders nothing for an unknown mode", () => {
     el = mount(FUEL_COMMS);
-    mock.settings.get("mode")!("does-not-exist");
+    setMode("does-not-exist");
     expect(text()).toBe("");
   });
 
   it("shows 'no binding needed' for a fixed keybind (no binding ref) and never warns", () => {
     el = mount({ escape: { method: "keybind" } });
-    mock.settings.get("mode")!("escape");
+    setMode("escape");
     expect(text()).toContain("No binding needed");
     expect(el.querySelector("a.ird-binding-status-link")).toBeNull();
   });
 
   it("lists all keys when a multi-key mode has them all set", () => {
     el = mount({ "view-fov": { method: "keybind", binding: { scope: "global", keys: ["incKey", "decKey"] } } });
-    mock.settings.get("mode")!("view-fov");
-    mock.global.get("incKey")!(keyboardBinding("a"));
-    mock.global.get("decKey")!(keyboardBinding("b"));
+    setMode("view-fov");
+    mock.emitGlobal({ incKey: keyboardBinding("a"), decKey: keyboardBinding("b") });
     expect(text()).toContain("Ctrl+A");
     expect(text()).toContain("Ctrl+B");
     expect(text()).not.toContain("No binding set");
@@ -230,9 +263,8 @@ describe("ird-binding-status", () => {
 
   it("warns when a multi-key mode has any key unset", () => {
     el = mount({ "view-fov": { method: "keybind", binding: { scope: "global", keys: ["incKey", "decKey"] } } });
-    mock.settings.get("mode")!("view-fov");
-    mock.global.get("incKey")!(keyboardBinding("a"));
-    mock.global.get("decKey")!("");
+    setMode("view-fov");
+    mock.emitGlobal({ incKey: keyboardBinding("a"), decKey: "" });
     expect(text()).toContain("No binding set");
   });
 });

--- a/packages/pi-components/src/components/binding-status.test.ts
+++ b/packages/pi-components/src/components/binding-status.test.ts
@@ -12,52 +12,53 @@ vi.mock("./simhub-probe.js", () => ({
   SIMHUB_POLL_INTERVAL_MS: 1_000_000,
 }));
 
-type SettingsCallback = (value: string) => void;
+type SettingsEvent = { payload: { settings: Record<string, unknown> } };
+type Listener = (ev: SettingsEvent) => void;
 
 interface MockSDPIState {
-  /** Action-settings subscriptions (mode + secondary keyBy settings). */
-  settings: Map<string, SettingsCallback>;
-  /** The live global-settings object the component reads. */
-  global: Record<string, unknown>;
+  /** Merge a partial into the current action settings and notify the component. */
+  emitAction: (partial: Record<string, unknown>) => void;
   /** Merge a partial into global settings and notify the component (any source). */
   emitGlobal: (partial: Record<string, unknown>) => void;
 }
 
 function installMockSDPI(): MockSDPIState {
-  const settings = new Map<string, SettingsCallback>();
+  const action: Record<string, unknown> = {};
   const global: Record<string, unknown> = {};
-  const listeners: Array<(ev: { payload: { settings: Record<string, unknown> } }) => void> = [];
+  const actionListeners: Listener[] = [];
+  const globalListeners: Listener[] = [];
 
+  const emitAction = (partial: Record<string, unknown>) => {
+    Object.assign(action, partial);
+
+    for (const cb of actionListeners) cb({ payload: { settings: action } });
+  };
   const emitGlobal = (partial: Record<string, unknown>) => {
     Object.assign(global, partial);
 
-    for (const cb of listeners) cb({ payload: { settings: global } });
+    for (const cb of globalListeners) cb({ payload: { settings: global } });
   };
 
-  const useSettings = (key: string, cb: SettingsCallback) => {
-    settings.set(key, cb);
+  const subscribe = (list: Listener[]) => (cb: Listener) => {
+    list.push(cb);
 
-    return [async () => "", vi.fn()] as [() => Promise<string>, (v: string) => void];
+    return () => {
+      const i = list.indexOf(cb);
+
+      if (i >= 0) list.splice(i, 1);
+    };
   };
 
   const streamDeckClient = {
+    getSettings: () => Promise.resolve({ settings: action }),
     getGlobalSettings: () => Promise.resolve(global),
-    didReceiveGlobalSettings: {
-      subscribe: (cb: (ev: { payload: { settings: Record<string, unknown> } }) => void) => {
-        listeners.push(cb);
-
-        return () => {
-          const i = listeners.indexOf(cb);
-
-          if (i >= 0) listeners.splice(i, 1);
-        };
-      },
-    },
+    didReceiveSettings: { subscribe: subscribe(actionListeners) },
+    didReceiveGlobalSettings: { subscribe: subscribe(globalListeners) },
   };
 
-  (window as unknown as Record<string, unknown>).SDPIComponents = { useSettings, streamDeckClient };
+  (window as unknown as Record<string, unknown>).SDPIComponents = { streamDeckClient };
 
-  return { settings, global, emitGlobal };
+  return { emitAction, emitGlobal };
 }
 
 const keyboardBinding = (key: string) => JSON.stringify({ type: "keyboard", key, modifiers: ["ctrl"], code: key });
@@ -106,7 +107,7 @@ describe("ird-binding-status", () => {
     return node;
   }
 
-  const setMode = (m: string) => mock.settings.get("mode")!(m);
+  const setMode = (m: string) => mock.emitAction({ mode: m });
   const text = () => el.textContent ?? "";
 
   it("shows the API method", () => {
@@ -119,6 +120,15 @@ describe("ird-binding-status", () => {
     el = mount(FUEL_COMMS);
     setMode("add-fuel");
     expect(text()).toContain("Chat command");
+  });
+
+  it("updates live when the Mode changes", () => {
+    el = mount(FUEL_COMMS);
+    setMode("toggle-fuel-fill");
+    expect(text()).toContain("iRacing API");
+    setMode("add-fuel");
+    expect(text()).toContain("Chat command");
+    expect(text()).not.toContain("iRacing API");
   });
 
   it("shows the keyboard binding value when configured", () => {
@@ -134,30 +144,22 @@ describe("ird-binding-status", () => {
     setMode("toggle-autofuel");
     mock.emitGlobal({ fuelServiceToggleAutofuel: keyboardBinding("f1") });
     expect(text()).toContain("Ctrl+F1");
-    // A sibling ird-key-binding rebinds it → component reflects the new value.
     mock.emitGlobal({ fuelServiceToggleAutofuel: keyboardBinding("f2") });
     expect(text()).toContain("Ctrl+F2");
     expect(text()).not.toContain("Ctrl+F1");
-    // ...and clearing it shows the missing state live.
     mock.emitGlobal({ fuelServiceToggleAutofuel: "" });
     expect(text()).toContain("No binding set");
   });
 
-  it("shows nothing (no 'No binding set' flash) until the binding value has loaded", () => {
+  it("shows nothing until settings have loaded", () => {
     el = mount(FUEL_COMMS);
+    // No settings yet → nothing.
+    expect(text()).toBe("");
     setMode("toggle-autofuel");
-    // Global settings have NOT arrived yet → render nothing, not "No binding set".
+    // Mode known but binding value not loaded → still nothing (no premature warning).
     expect(text()).toBe("");
     mock.emitGlobal({ fuelServiceToggleAutofuel: "" });
     expect(text()).toContain("No binding set");
-  });
-
-  it("waits for the secondary setting before judging a dynamic-key mode", () => {
-    el = mount(VIEW_COMMS);
-    setMode("fov");
-    mock.emitGlobal({ viewFovInc: keyboardBinding("a") });
-    // direction not loaded yet → nothing.
-    expect(text()).toBe("");
   });
 
   it("warns with a 'set it here' link when no binding is set", () => {
@@ -168,7 +170,7 @@ describe("ird-binding-status", () => {
     expect(el.querySelector("a.ird-binding-status-link")).not.toBeNull();
   });
 
-  it("treats a SimHub role as configured (never the missing state); no warning when connected", async () => {
+  it("treats a SimHub role as configured; no warning when connected", async () => {
     mockFetchReachable.mockResolvedValue(true);
     el = mount(FUEL_COMMS);
     setMode("toggle-autofuel");
@@ -194,9 +196,8 @@ describe("ird-binding-status", () => {
     setMode("toggle-autofuel");
     mock.emitGlobal({ fuelServiceToggleAutofuel: simhubBinding("My Role") });
     await vi.waitFor(() => expect(text()).toContain("SimHub not connected"));
-    // SimHub comes up; a host change forces a re-probe (stands in for the poll).
     mockFetchReachable.mockResolvedValue(true);
-    mock.emitGlobal({ simHubHost: "localhost" });
+    mock.emitGlobal({ simHubHost: "localhost" }); // host change forces a re-probe
     await vi.waitFor(() => expect(text()).not.toContain("SimHub not connected"));
     expect(text()).toContain("SimHub binding: My Role");
   });
@@ -213,13 +214,12 @@ describe("ird-binding-status", () => {
 
   it("resolves a dynamic key from the secondary setting (full resolution)", () => {
     el = mount(VIEW_COMMS);
-    setMode("fov");
-    mock.settings.get("direction")!("increase");
     mock.emitGlobal({ viewFovInc: keyboardBinding("a") });
+    mock.emitAction({ mode: "fov", direction: "increase" });
     expect(text()).toContain("Key binding:");
     expect(text()).toContain("Ctrl+A");
     // Switching the secondary setting re-resolves to the other (unset) key.
-    mock.settings.get("direction")!("decrease");
+    mock.emitAction({ mode: "fov", direction: "decrease" });
     expect(text()).toContain("No binding set");
   });
 

--- a/packages/pi-components/src/components/binding-status.test.ts
+++ b/packages/pi-components/src/components/binding-status.test.ts
@@ -166,4 +166,29 @@ describe("ird-binding-status", () => {
     mock.settings.get("mode")!("does-not-exist");
     expect(text()).toBe("");
   });
+
+  it("shows 'no binding needed' for a fixed keybind (no binding ref) and never warns", () => {
+    el = mount({ escape: { method: "keybind" } });
+    mock.settings.get("mode")!("escape");
+    expect(text()).toContain("No binding needed");
+    expect(el.querySelector("a.ird-binding-status-link")).toBeNull();
+  });
+
+  it("lists all keys when a multi-key mode has them all set", () => {
+    el = mount({ "view-fov": { method: "keybind", binding: { scope: "global", keys: ["incKey", "decKey"] } } });
+    mock.settings.get("mode")!("view-fov");
+    mock.global.get("incKey")!(keyboardBinding("a"));
+    mock.global.get("decKey")!(keyboardBinding("b"));
+    expect(text()).toContain("Ctrl + A");
+    expect(text()).toContain("Ctrl + B");
+    expect(text()).not.toContain("No binding set");
+  });
+
+  it("warns when a multi-key mode has any key unset", () => {
+    el = mount({ "view-fov": { method: "keybind", binding: { scope: "global", keys: ["incKey", "decKey"] } } });
+    mock.settings.get("mode")!("view-fov");
+    mock.global.get("incKey")!(keyboardBinding("a"));
+    mock.global.get("decKey")!("");
+    expect(text()).toContain("No binding set");
+  });
 });

--- a/packages/pi-components/src/components/binding-status.ts
+++ b/packages/pi-components/src/components/binding-status.ts
@@ -1,0 +1,346 @@
+/// <reference lib="dom" />
+/**
+ * Binding / communication status line (issue #612).
+ *
+ * Rendered directly under an action's Mode selector. For the currently
+ * selected mode it states how that mode talks to iRacing (iRacing API, key
+ * binding, or chat command) and — for key-binding modes — whether a binding is
+ * configured (keyboard OR SimHub role), with a link that opens the global
+ * key-bindings accordion. Updates live as the mode changes and as bindings are
+ * set / cleared / switched between keyboard and SimHub.
+ *
+ * Usage in a PI template (the comms map is emitted from action-comms.json):
+ * ```html
+ * <ird-binding-status
+ *   mode-setting="mode"
+ *   comms='<%- JSON.stringify(require("./data/action-comms.json")["fuel-service"]) %>'
+ * ></ird-binding-status>
+ * ```
+ *
+ * Attributes:
+ * - comms        — JSON ActionCommMap: mode value → { method, binding? }
+ * - mode-setting — name of the primary mode setting (default "mode")
+ * - default-mode — mode value to use when there is no mode setting (single-mode actions)
+ *
+ * SYNC NOTE: CommDescriptor / BindingKeyRef below mirror their authoritative
+ * counterparts in @iracedeck/deck-core/comm-descriptor.ts. The PI runs in a
+ * browser and cannot import from deck-core (Node.js). When the descriptor
+ * shape changes, update BOTH locations.
+ */
+import { formatKeyBinding, parseKeyBinding } from "./key-binding-utils.js";
+
+type CommMethod = "api" | "keybind" | "chat";
+
+interface BindingKeyConstant {
+  scope: "global" | "action";
+  key: string;
+}
+interface BindingKeyResolved {
+  scope: "global" | "action";
+  keyBy: { setting: string; map: Record<string, string> };
+}
+type BindingKeyRef = BindingKeyConstant | BindingKeyResolved;
+
+interface CommDescriptor {
+  method: CommMethod;
+  binding?: BindingKeyRef;
+}
+type ActionCommMap = Record<string, CommDescriptor>;
+
+/** Accordion that holds the global key bindings (see global-key-bindings.ejs). */
+const KEY_BINDINGS_ACCORDION_ID = "Related Key Bindings";
+const SIMHUB_REACHABLE_SETTING = "_simHubReachable";
+
+type SettingsCallback = (value: string) => void;
+interface SDPILike {
+  useSettings: (key: string, cb: SettingsCallback, def: unknown) => [() => Promise<string>, (v: string) => void];
+  useGlobalSettings: (key: string, cb: SettingsCallback, def: unknown) => [() => Promise<string>, (v: string) => void];
+}
+
+function isConstantKey(ref: BindingKeyRef): ref is BindingKeyConstant {
+  return "key" in ref;
+}
+
+/** Parse a stored binding global-setting value into a display-ready shape. */
+function parseStoredBinding(
+  value: string,
+): { kind: "keyboard"; text: string } | { kind: "simhub"; role: string } | null {
+  if (!value) return null;
+
+  try {
+    const parsed = JSON.parse(value) as { type?: string; role?: string };
+
+    if (parsed.type === "simhub" && typeof parsed.role === "string" && parsed.role.length > 0) {
+      return { kind: "simhub", role: parsed.role };
+    }
+  } catch {
+    return null;
+  }
+
+  const kb = parseKeyBinding(value);
+  const text = formatKeyBinding(kb);
+
+  return text ? { kind: "keyboard", text } : null;
+}
+
+let styleInjected = false;
+
+export class BindingStatus extends HTMLElement {
+  private container: HTMLDivElement | null = null;
+  private comms: ActionCommMap = {};
+  private currentMode = "";
+  /** Live values of secondary (keyBy) settings, by setting name. */
+  private secondary = new Map<string, string>();
+  /** Live binding values, by global-settings key. */
+  private bindings = new Map<string, string>();
+  private simHubReachable = true;
+  private initialized = false;
+
+  connectedCallback(): void {
+    if (this.initialized) return;
+
+    this.initialized = true;
+    this.injectStyle();
+    this.container = document.createElement("div");
+    this.container.className = "ird-binding-status";
+    this.appendChild(this.container);
+
+    this.comms = this.parseComms(this.getAttribute("comms"));
+    this.currentMode = this.getAttribute("default-mode") ?? "";
+    this.hookSettings();
+    this.render();
+  }
+
+  private parseComms(raw: string | null): ActionCommMap {
+    if (!raw) return {};
+
+    try {
+      const parsed: unknown = JSON.parse(raw);
+
+      return parsed && typeof parsed === "object" ? (parsed as ActionCommMap) : {};
+    } catch {
+      return {};
+    }
+  }
+
+  private get sdpi(): SDPILike | undefined {
+    return (window as unknown as { SDPIComponents?: SDPILike }).SDPIComponents;
+  }
+
+  private hookSettings(): void {
+    const sdpi = this.sdpi;
+
+    if (!sdpi) return;
+
+    // Primary mode setting.
+    const modeSetting = this.getAttribute("mode-setting");
+
+    if (modeSetting) {
+      sdpi.useSettings(
+        modeSetting,
+        (value) => {
+          this.currentMode = value || (this.getAttribute("default-mode") ?? "");
+          this.render();
+        },
+        null,
+      );
+    }
+
+    // Secondary (keyBy) settings and the candidate binding keys.
+    const secondarySettings = new Set<string>();
+    const bindingKeys = new Set<string>();
+
+    for (const descriptor of Object.values(this.comms)) {
+      const ref = descriptor.binding;
+
+      if (!ref) continue;
+
+      if (isConstantKey(ref)) {
+        bindingKeys.add(ref.key);
+      } else {
+        secondarySettings.add(ref.keyBy.setting);
+
+        for (const key of Object.values(ref.keyBy.map)) bindingKeys.add(key);
+      }
+    }
+
+    for (const setting of secondarySettings) {
+      sdpi.useSettings(
+        setting,
+        (value) => {
+          this.secondary.set(setting, value);
+          this.render();
+        },
+        null,
+      );
+    }
+
+    for (const key of bindingKeys) {
+      sdpi.useGlobalSettings(
+        key,
+        (value) => {
+          this.bindings.set(key, value);
+          this.render();
+        },
+        null,
+      );
+    }
+
+    sdpi.useGlobalSettings(
+      SIMHUB_REACHABLE_SETTING,
+      (value) => {
+        // Default to reachable when unknown so we don't nag before the plugin reports.
+        this.simHubReachable = value !== "false" && value !== "0";
+        this.render();
+      },
+      null,
+    );
+  }
+
+  /** Resolve the active binding key for the current mode, if any. */
+  private resolveKey(descriptor: CommDescriptor): string | undefined {
+    const ref = descriptor.binding;
+
+    if (!ref) return undefined;
+
+    if (isConstantKey(ref)) return ref.key;
+
+    const secondaryValue = this.secondary.get(ref.keyBy.setting);
+
+    return secondaryValue ? ref.keyBy.map[secondaryValue] : undefined;
+  }
+
+  private render(): void {
+    if (!this.container) return;
+
+    const descriptor = this.comms[this.currentMode];
+
+    if (!descriptor) {
+      this.container.replaceChildren();
+
+      return;
+    }
+
+    if (descriptor.method === "api") {
+      this.renderOk("iRacing API — no binding needed.");
+
+      return;
+    }
+
+    if (descriptor.method === "chat") {
+      this.renderOk("Chat command — no binding needed.");
+
+      return;
+    }
+
+    // keybind
+    const key = this.resolveKey(descriptor);
+    const binding = key ? parseStoredBinding(this.bindings.get(key) ?? "") : null;
+
+    if (!binding) {
+      this.renderMissing();
+
+      return;
+    }
+
+    if (binding.kind === "keyboard") {
+      this.renderOk(`Key binding — currently set: ${binding.text}.`);
+
+      return;
+    }
+
+    // SimHub role — configured, but only works while SimHub runs.
+    this.renderSimHub(binding.role);
+  }
+
+  private renderOk(text: string): void {
+    this.container!.replaceChildren(this.line("ok", "✓", text));
+  }
+
+  private renderMissing(): void {
+    const row = this.line("warn", "⚠", "No binding set — ");
+    const link = document.createElement("a");
+    link.href = "#";
+    link.className = "ird-binding-status-link";
+    link.textContent = "set it here";
+    link.addEventListener("click", (e) => {
+      e.preventDefault();
+      this.openKeyBindings();
+    });
+    row.querySelector(".ird-binding-status-text")!.appendChild(link);
+    row.querySelector(".ird-binding-status-text")!.appendChild(document.createTextNode("."));
+    this.container!.replaceChildren(row);
+  }
+
+  private renderSimHub(role: string): void {
+    const main = this.line("ok", "✓", `Bound to SimHub role: ${role}.`);
+    const caveat = this.simHubReachable
+      ? this.line("muted", "", "Requires SimHub to be running.")
+      : this.line("warn", "⚠", "SimHub isn't running — this binding won't work until it is.");
+    this.container!.replaceChildren(main, caveat);
+  }
+
+  private line(level: "ok" | "warn" | "muted", symbol: string, text: string): HTMLDivElement {
+    const row = document.createElement("div");
+    row.className = `ird-binding-status-line ird-binding-status-${level}`;
+
+    if (symbol) {
+      const icon = document.createElement("span");
+      icon.className = "ird-binding-status-icon";
+      icon.textContent = symbol;
+      row.appendChild(icon);
+    }
+
+    const span = document.createElement("span");
+    span.className = "ird-binding-status-text";
+    span.textContent = text;
+    row.appendChild(span);
+
+    return row;
+  }
+
+  /** Open the global key-bindings accordion and scroll it into view. */
+  private openKeyBindings(): void {
+    const selector = `details[data-accordion-id="${KEY_BINDINGS_ACCORDION_ID}"]`;
+    const accordion = document.querySelector(selector) as HTMLDetailsElement | null;
+
+    if (!accordion) return;
+
+    // Setting `open` fires a toggle event, which the accordion persistence
+    // listener picks up — no need to write _accordionState here.
+    accordion.open = true;
+    accordion.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
+  private injectStyle(): void {
+    if (styleInjected || typeof document === "undefined") return;
+
+    const style = document.createElement("style");
+    style.textContent = `
+      ird-binding-status { display: block; }
+      ird-binding-status .ird-binding-status-line {
+        display: flex;
+        gap: 6px;
+        align-items: baseline;
+        margin: 4px 0 4px 95px;
+        font-family: "Segoe UI", Arial, Roboto, Helvetica, sans-serif,
+                     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-size: 8pt;
+        line-height: 1.3;
+      }
+      ird-binding-status .ird-binding-status-icon { flex-shrink: 0; }
+      ird-binding-status .ird-binding-status-ok { color: #5dd17a; }
+      ird-binding-status .ird-binding-status-warn { color: #ffc04d; }
+      ird-binding-status .ird-binding-status-muted { color: #9aa4ad; }
+      ird-binding-status .ird-binding-status-link { color: #4aa3ff; cursor: pointer; }
+    `;
+    document.head.appendChild(style);
+    styleInjected = true;
+  }
+}
+
+if (typeof customElements !== "undefined") {
+  if (!customElements.get("ird-binding-status")) {
+    customElements.define("ird-binding-status", BindingStatus);
+  }
+}

--- a/packages/pi-components/src/components/binding-status.ts
+++ b/packages/pi-components/src/components/binding-status.ts
@@ -28,6 +28,7 @@
  * shape changes, update BOTH locations.
  */
 import { formatKeyBinding, parseKeyBinding } from "./key-binding-utils.js";
+import { fetchSimHubReachable, SIMHUB_POLL_INTERVAL_MS } from "./simhub-probe.js";
 
 type CommMethod = "api" | "keybind" | "chat";
 
@@ -53,7 +54,6 @@ type ActionCommMap = Record<string, CommDescriptor>;
 
 /** Accordion that holds the global key bindings (see global-key-bindings.ejs). */
 const KEY_BINDINGS_ACCORDION_ID = "Related Key Bindings";
-const SIMHUB_REACHABLE_SETTING = "_simHubReachable";
 
 type SettingsCallback = (value: string) => void;
 interface SDPILike {
@@ -104,8 +104,18 @@ export class BindingStatus extends HTMLElement {
   private loadedBindings = new Set<string>();
   /** Secondary settings whose value has arrived at least once. */
   private loadedSecondary = new Set<string>();
-  private simHubReachable = true;
   private initialized = false;
+
+  // SimHub reachability is polled live (browser-side) while a SimHub-bound mode
+  // is shown, so the "SimHub not connected" warning clears as soon as SimHub
+  // comes up — no plugin-maintained setting needed (#612).
+  private simHubHost = "127.0.0.1";
+  private simHubPort = 8888;
+  private simHubProbed = false;
+  private simHubReachable = false;
+  private simHubPollTimer: number | null = null;
+  /** Recomputed each render: does the current display depend on SimHub being up? */
+  private pollSimHub = false;
 
   connectedCallback(): void {
     if (this.initialized) return;
@@ -201,15 +211,29 @@ export class BindingStatus extends HTMLElement {
       );
     }
 
+    // SimHub host/port — used to build the poll URL. Re-probe on change.
     sdpi.useGlobalSettings(
-      SIMHUB_REACHABLE_SETTING,
+      "simHubHost",
       (value) => {
-        // Default to reachable when unknown so we don't nag before the plugin reports.
-        this.simHubReachable = value !== "false" && value !== "0";
-        this.render();
+        this.simHubHost = value || "127.0.0.1";
+        this.onSimHubTargetChanged();
       },
       null,
     );
+    sdpi.useGlobalSettings(
+      "simHubPort",
+      (value) => {
+        this.simHubPort = parseInt(value, 10) || 8888;
+        this.onSimHubTargetChanged();
+      },
+      null,
+    );
+  }
+
+  private onSimHubTargetChanged(): void {
+    this.simHubProbed = false;
+
+    if (this.simHubPollTimer !== null) void this.probeSimHub();
   }
 
   /** Resolve ALL binding keys required by the current mode. */
@@ -227,99 +251,74 @@ export class BindingStatus extends HTMLElement {
   private render(): void {
     if (!this.container) return;
 
+    this.pollSimHub = false;
+    const rows = this.buildRows();
+    this.container.replaceChildren(...(rows === "pending" ? [] : rows));
+
+    // Poll SimHub only while a SimHub-bound mode is shown.
+    if (this.pollSimHub) this.ensureSimHubPolling();
+    else this.stopSimHubPolling();
+  }
+
+  /** Build the status rows for the current state, or "pending" to show nothing yet. */
+  private buildRows(): HTMLDivElement[] | "pending" {
     const descriptor = this.comms[this.currentMode];
 
-    if (!descriptor) {
-      this.container.replaceChildren();
+    if (!descriptor) return [];
 
-      return;
-    }
+    if (descriptor.method === "api") return [this.line("ok", "✓", "iRacing API")];
 
-    if (descriptor.method === "api") {
-      this.renderOk("iRacing API — no binding needed.");
-
-      return;
-    }
-
-    if (descriptor.method === "chat") {
-      this.renderOk("Chat command — no binding needed.");
-
-      return;
-    }
+    if (descriptor.method === "chat") return [this.line("ok", "✓", "Chat command")];
 
     // keybind with no binding ref → fixed key (e.g. Escape) or plugin-internal:
     // no user setup needed, never warns.
     const ref = descriptor.binding;
 
-    if (!ref) {
-      this.renderOk("No binding needed.");
-
-      return;
-    }
+    if (!ref) return [this.line("ok", "✓", "No binding needed.")];
 
     // A keyBy reference can't be resolved until its secondary setting has
     // loaded — render nothing rather than flash "No binding set" on PI open.
     if (!isConstantKey(ref) && !isMultiKey(ref) && !this.loadedSecondary.has(ref.keyBy.setting)) {
-      this.container.replaceChildren();
-
-      return;
+      return "pending";
     }
 
     const keys = this.resolveKeys(ref);
 
-    if (keys.length === 0) {
-      // Secondary value is loaded but unmapped → genuinely no binding.
-      this.renderMissing();
+    // Secondary value is loaded but unmapped → genuinely no binding.
+    if (keys.length === 0) return [this.missingRow()];
 
-      return;
-    }
-
-    // Wait for every required key's value to arrive before judging set/unset,
-    // so PI open doesn't briefly show "No binding set" before settings load.
-    if (keys.some((k) => !this.loadedBindings.has(k))) {
-      this.container.replaceChildren();
-
-      return;
-    }
+    // Wait for every required key's value to arrive before judging set/unset.
+    if (keys.some((k) => !this.loadedBindings.has(k))) return "pending";
 
     const parsed = keys.map((k) => parseStoredBinding(this.bindings.get(k) ?? ""));
 
     // Warn if ANY required key is unset (multi-key modes need all of them).
-    if (parsed.some((p) => p === null)) {
-      this.renderMissing();
-
-      return;
-    }
+    if (parsed.some((p) => p === null)) return [this.missingRow()];
 
     const set = parsed as Array<{ kind: "keyboard"; text: string } | { kind: "simhub"; role: string }>;
 
-    // Single SimHub role keeps the friendly "Bound to SimHub role" phrasing.
+    // Single SimHub role.
     if (set.length === 1 && set[0].kind === "simhub") {
-      this.renderSimHub(set[0].role);
+      this.pollSimHub = true;
 
-      return;
+      return this.simHubRows(set[0].role);
     }
 
     const labels = set.map((p) => (p.kind === "keyboard" ? p.text : `SimHub: ${p.role}`));
-    const lines = [this.line("ok", "✓", `Key binding — currently set: ${labels.join(", ")}.`)];
+    const rows = [this.line("ok", "✓", `Key binding: ${labels.join(", ")}`)];
 
-    // Any SimHub among the keys carries the "must be running" caveat.
+    // A SimHub key among several carries the not-connected warning too.
     if (set.some((p) => p.kind === "simhub")) {
-      lines.push(
-        this.simHubReachable
-          ? this.line("muted", "", "Requires SimHub to be running.")
-          : this.line("warn", "⚠", "SimHub isn't running — this binding won't work until it is."),
-      );
+      this.pollSimHub = true;
+      const warn = this.simHubNotConnectedRow();
+
+      if (warn) rows.push(warn);
     }
 
-    this.container.replaceChildren(...lines);
+    return rows;
   }
 
-  private renderOk(text: string): void {
-    this.container!.replaceChildren(this.line("ok", "✓", text));
-  }
-
-  private renderMissing(): void {
+  private missingRow(): HTMLDivElement {
     const row = this.line("warn", "⚠", "No binding set — ");
     const link = document.createElement("a");
     link.href = "#";
@@ -330,19 +329,57 @@ export class BindingStatus extends HTMLElement {
       this.openKeyBindings();
     });
     row.querySelector(".ird-binding-status-text")!.appendChild(link);
-    row.querySelector(".ird-binding-status-text")!.appendChild(document.createTextNode("."));
-    this.container!.replaceChildren(row);
+
+    return row;
   }
 
-  private renderSimHub(role: string): void {
-    const main = this.line("ok", "✓", `Bound to SimHub role: ${role}.`);
-    const caveat = this.simHubReachable
-      ? this.line("muted", "", "Requires SimHub to be running.")
-      : this.line("warn", "⚠", "SimHub isn't running — this binding won't work until it is.");
-    this.container!.replaceChildren(main, caveat);
+  private simHubRows(role: string): HTMLDivElement[] {
+    const rows = [this.line("ok", "✓", `SimHub binding: ${role}`)];
+    const warn = this.simHubNotConnectedRow();
+
+    if (warn) rows.push(warn);
+
+    return rows;
   }
 
-  private line(level: "ok" | "warn" | "muted", symbol: string, text: string): HTMLDivElement {
+  /** Red "SimHub not connected" line, only once a probe has confirmed it's down. */
+  private simHubNotConnectedRow(): HTMLDivElement | null {
+    return this.simHubProbed && !this.simHubReachable ? this.line("danger", "✗", "SimHub not connected") : null;
+  }
+
+  // --- SimHub reachability polling ---
+
+  private ensureSimHubPolling(): void {
+    if (this.simHubPollTimer !== null) return;
+
+    void this.probeSimHub();
+    this.simHubPollTimer = window.setInterval(() => void this.probeSimHub(), SIMHUB_POLL_INTERVAL_MS);
+  }
+
+  private stopSimHubPolling(): void {
+    if (this.simHubPollTimer !== null) {
+      window.clearInterval(this.simHubPollTimer);
+      this.simHubPollTimer = null;
+    }
+  }
+
+  private async probeSimHub(): Promise<void> {
+    const reachable = await fetchSimHubReachable(this.simHubHost, this.simHubPort);
+    this.simHubProbed = true;
+
+    if (reachable !== this.simHubReachable) {
+      this.simHubReachable = reachable;
+    }
+
+    // Re-render so the not-connected line appears/clears (also on first probe).
+    this.render();
+  }
+
+  disconnectedCallback(): void {
+    this.stopSimHubPolling();
+  }
+
+  private line(level: "ok" | "warn" | "muted" | "danger", symbol: string, text: string): HTMLDivElement {
     const row = document.createElement("div");
     row.className = `ird-binding-status-line ird-binding-status-${level}`;
 
@@ -393,6 +430,7 @@ export class BindingStatus extends HTMLElement {
       ird-binding-status .ird-binding-status-icon { flex-shrink: 0; }
       ird-binding-status .ird-binding-status-ok { color: #5dd17a; }
       ird-binding-status .ird-binding-status-warn { color: #ffc04d; }
+      ird-binding-status .ird-binding-status-danger { color: #ff5c5c; }
       ird-binding-status .ird-binding-status-muted { color: #9aa4ad; }
       ird-binding-status .ird-binding-status-link { color: #4aa3ff; cursor: pointer; }
     `;

--- a/packages/pi-components/src/components/binding-status.ts
+++ b/packages/pi-components/src/components/binding-status.ts
@@ -35,11 +35,15 @@ interface BindingKeyConstant {
   scope: "global" | "action";
   key: string;
 }
+interface BindingKeyMulti {
+  scope: "global" | "action";
+  keys: string[];
+}
 interface BindingKeyResolved {
   scope: "global" | "action";
   keyBy: { setting: string; map: Record<string, string> };
 }
-type BindingKeyRef = BindingKeyConstant | BindingKeyResolved;
+type BindingKeyRef = BindingKeyConstant | BindingKeyMulti | BindingKeyResolved;
 
 interface CommDescriptor {
   method: CommMethod;
@@ -59,6 +63,10 @@ interface SDPILike {
 
 function isConstantKey(ref: BindingKeyRef): ref is BindingKeyConstant {
   return "key" in ref;
+}
+
+function isMultiKey(ref: BindingKeyRef): ref is BindingKeyMulti {
+  return "keys" in ref;
 }
 
 /** Parse a stored binding global-setting value into a display-ready shape. */
@@ -157,6 +165,8 @@ export class BindingStatus extends HTMLElement {
 
       if (isConstantKey(ref)) {
         bindingKeys.add(ref.key);
+      } else if (isMultiKey(ref)) {
+        for (const key of ref.keys) bindingKeys.add(key);
       } else {
         secondarySettings.add(ref.keyBy.setting);
 
@@ -197,17 +207,16 @@ export class BindingStatus extends HTMLElement {
     );
   }
 
-  /** Resolve the active binding key for the current mode, if any. */
-  private resolveKey(descriptor: CommDescriptor): string | undefined {
-    const ref = descriptor.binding;
+  /** Resolve ALL binding keys required by the current mode. */
+  private resolveKeys(ref: BindingKeyRef): string[] {
+    if (isConstantKey(ref)) return [ref.key];
 
-    if (!ref) return undefined;
-
-    if (isConstantKey(ref)) return ref.key;
+    if (isMultiKey(ref)) return ref.keys;
 
     const secondaryValue = this.secondary.get(ref.keyBy.setting);
+    const key = secondaryValue ? ref.keyBy.map[secondaryValue] : undefined;
 
-    return secondaryValue ? ref.keyBy.map[secondaryValue] : undefined;
+    return key ? [key] : [];
   }
 
   private render(): void {
@@ -233,24 +242,56 @@ export class BindingStatus extends HTMLElement {
       return;
     }
 
-    // keybind
-    const key = this.resolveKey(descriptor);
-    const binding = key ? parseStoredBinding(this.bindings.get(key) ?? "") : null;
+    // keybind with no binding ref → fixed key (e.g. Escape) or plugin-internal:
+    // no user setup needed, never warns.
+    const ref = descriptor.binding;
 
-    if (!binding) {
+    if (!ref) {
+      this.renderOk("No binding needed.");
+
+      return;
+    }
+
+    const keys = this.resolveKeys(ref);
+
+    if (keys.length === 0) {
+      // keyBy secondary not yet resolvable — treat as not configured.
       this.renderMissing();
 
       return;
     }
 
-    if (binding.kind === "keyboard") {
-      this.renderOk(`Key binding — currently set: ${binding.text}.`);
+    const parsed = keys.map((k) => parseStoredBinding(this.bindings.get(k) ?? ""));
+
+    // Warn if ANY required key is unset (multi-key modes need all of them).
+    if (parsed.some((p) => p === null)) {
+      this.renderMissing();
 
       return;
     }
 
-    // SimHub role — configured, but only works while SimHub runs.
-    this.renderSimHub(binding.role);
+    const set = parsed as Array<{ kind: "keyboard"; text: string } | { kind: "simhub"; role: string }>;
+
+    // Single SimHub role keeps the friendly "Bound to SimHub role" phrasing.
+    if (set.length === 1 && set[0].kind === "simhub") {
+      this.renderSimHub(set[0].role);
+
+      return;
+    }
+
+    const labels = set.map((p) => (p.kind === "keyboard" ? p.text : `SimHub: ${p.role}`));
+    const lines = [this.line("ok", "✓", `Key binding — currently set: ${labels.join(", ")}.`)];
+
+    // Any SimHub among the keys carries the "must be running" caveat.
+    if (set.some((p) => p.kind === "simhub")) {
+      lines.push(
+        this.simHubReachable
+          ? this.line("muted", "", "Requires SimHub to be running.")
+          : this.line("warn", "⚠", "SimHub isn't running — this binding won't work until it is."),
+      );
+    }
+
+    this.container.replaceChildren(...lines);
   }
 
   private renderOk(text: string): void {

--- a/packages/pi-components/src/components/binding-status.ts
+++ b/packages/pi-components/src/components/binding-status.ts
@@ -55,22 +55,33 @@ type ActionCommMap = Record<string, CommDescriptor>;
 /** Accordion that holds the global key bindings (see global-key-bindings.ejs). */
 const KEY_BINDINGS_ACCORDION_ID = "Related Key Bindings";
 
-type Settings = Record<string, unknown>;
-interface SettingsEvent {
-  payload: { settings: Settings };
+/**
+ * Poll interval for reading current values off the PI's DOM controls. The
+ * Stream Deck settings-subscription APIs do not reliably re-deliver changes to
+ * a read-only observer like this; the proven approach in this codebase
+ * (conditional-visibility) reads the control's `.value` with change/input
+ * events plus a polling fallback, because sdpi-select events can be unreliable.
+ */
+const DOM_POLL_INTERVAL_MS = 250;
+
+/** An element that carries a current value (sdpi-select / ird-key-binding / inputs). */
+interface ValueElement extends Element {
+  value?: unknown;
 }
-type Disposable = { dispose?: () => void } | (() => void) | void;
-interface Subscribable {
-  subscribe: (cb: (ev: SettingsEvent) => void) => Disposable;
+
+/** Escape a value for safe use inside a `[attr="…"]` selector. */
+function cssAttr(value: string): string {
+  return value.replace(/["\\]/g, "\\$&");
 }
-interface StreamDeckClientLike {
-  getSettings: () => Promise<unknown>;
-  getGlobalSettings: () => Promise<Settings>;
-  didReceiveSettings: Subscribable;
-  didReceiveGlobalSettings: Subscribable;
-}
-interface SDPILike {
-  streamDeckClient: StreamDeckClientLike;
+
+function readValue(selector: string): string | null {
+  const el = document.querySelector(selector) as ValueElement | null;
+
+  if (!el) return null;
+
+  const v = el.value;
+
+  return typeof v === "string" ? v : v == null ? "" : String(v);
 }
 
 function isConstantKey(ref: BindingKeyRef): ref is BindingKeyConstant {
@@ -100,15 +111,6 @@ function parseStoredBinding(
   const kb = parseKeyBinding(value);
 
   return kb ? { kind: "keyboard", text: formatKeyBinding(kb) } : null;
-}
-
-/** `getSettings()` resolves to a payload wrapper; `didReceiveSettings` gives `.settings` directly. */
-function extractSettings(result: unknown): Settings {
-  if (result && typeof result === "object" && "settings" in result) {
-    return (result as { settings: Settings }).settings ?? {};
-  }
-
-  return (result as Settings) ?? {};
 }
 
 let styleInjected = false;
@@ -144,9 +146,9 @@ export class BindingStatus extends HTMLElement {
   private secondaryNames: string[] = [];
   /** Every global binding key referenced by this action's modes. */
   private candidateKeys: string[] = [];
-  /** Subscriptions to settings changes (from any source). */
-  private actionSub: Disposable = undefined;
-  private globalSub: Disposable = undefined;
+  /** DOM polling fallback + a bound change/input handler for snappy updates. */
+  private domPollTimer: number | null = null;
+  private readonly onDomChange = (): void => this.readDom();
 
   connectedCallback(): void {
     if (this.initialized) return;
@@ -175,15 +177,7 @@ export class BindingStatus extends HTMLElement {
     }
   }
 
-  private get sdpi(): SDPILike | undefined {
-    return (window as unknown as { SDPIComponents?: SDPILike }).SDPIComponents;
-  }
-
   private hookSettings(): void {
-    const sdpi = this.sdpi;
-
-    if (!sdpi) return;
-
     this.modeSetting = this.getAttribute("mode-setting") || "mode";
 
     // Collect the secondary (keyBy) setting names and the candidate binding keys.
@@ -209,60 +203,75 @@ export class BindingStatus extends HTMLElement {
     this.secondaryNames = [...secondaryNames];
     this.candidateKeys = [...bindingKeys];
 
-    // Drive EVERYTHING off the Stream Deck client event bus, which reports
-    // changes from ANY source — the Mode dropdown's own write, a sibling
-    // ird-key-binding write, the plugin, another PI. The sdpi `use*` hooks only
-    // delivered the initial value to a read-only observer like this, so the
-    // line went stale on mode/binding changes. Seed with current values, then
-    // keep in sync.
-    const client = sdpi.streamDeckClient;
+    // Read current values straight off the PI's DOM controls — the Mode
+    // <sdpi-select>, any secondary <sdpi-select>, and the <ird-key-binding>
+    // inputs in the key-bindings accordion (which hold the live binding value
+    // and update on edit). change/input events make it snappy; a polling
+    // fallback covers controls whose events are unreliable (and catches binding
+    // edits in the accordion). This is the proven pattern in this codebase.
+    document.addEventListener("input", this.onDomChange, true);
+    document.addEventListener("change", this.onDomChange, true);
+    this.domPollTimer = window.setInterval(this.onDomChange, DOM_POLL_INTERVAL_MS);
 
-    this.actionSub = client.didReceiveSettings.subscribe((ev) => this.applyActionSettings(ev.payload.settings));
-    this.globalSub = client.didReceiveGlobalSettings.subscribe((ev) => this.applyGlobalSettings(ev.payload.settings));
-
-    void client.getSettings().then((result) => this.applyActionSettings(extractSettings(result)));
-    void client.getGlobalSettings().then((settings) => this.applyGlobalSettings(settings));
+    this.readDom();
   }
 
-  /** Apply an action-settings snapshot: refresh the current mode + secondary values. */
-  private applyActionSettings(settings: Settings): void {
-    const rawMode = settings[this.modeSetting];
-    this.currentMode = typeof rawMode === "string" && rawMode ? rawMode : (this.getAttribute("default-mode") ?? "");
+  /** Read the current mode, secondary values, and binding values from the DOM. */
+  private readDom(): void {
+    let changed = false;
 
+    // Mode (sdpi-select) — fall back to the default-mode attribute when empty.
+    const rawMode = readValue(`[setting="${cssAttr(this.modeSetting)}"]`);
+    const mode = rawMode || (this.getAttribute("default-mode") ?? "");
+
+    if (mode !== this.currentMode) {
+      this.currentMode = mode;
+      changed = true;
+    }
+
+    // Secondary (keyBy) settings.
     for (const name of this.secondaryNames) {
-      const raw = settings[name];
-      this.secondary.set(name, typeof raw === "string" ? raw : "");
+      const value = readValue(`[setting="${cssAttr(name)}"]`);
+
+      if (value === null) continue; // control not present yet
+
       this.loadedSecondary.add(name);
+
+      if (this.secondary.get(name) !== value) {
+        this.secondary.set(name, value);
+        changed = true;
+      }
     }
 
-    this.render();
-  }
-
-  /** Apply a global-settings snapshot: refresh binding values + SimHub target. */
-  private applyGlobalSettings(settings: Settings): void {
+    // Binding values — read from the ird-key-binding inputs (live source).
     for (const key of this.candidateKeys) {
-      const raw = settings[key];
-      const value = typeof raw === "string" ? raw : raw == null ? "" : JSON.stringify(raw);
-      this.bindings.set(key, value);
-      this.loadedBindings.add(key); // present-or-absent now known
+      const value = readValue(`ird-key-binding[setting="${cssAttr(key)}"]`);
+
+      if (value === null) continue; // input not in this PI / not yet rendered
+
+      this.loadedBindings.add(key);
+
+      if (this.bindings.get(key) !== value) {
+        this.bindings.set(key, value);
+        changed = true;
+      }
     }
 
-    const host = typeof settings.simHubHost === "string" && settings.simHubHost ? settings.simHubHost : "127.0.0.1";
-    const port = parseInt(String(settings.simHubPort ?? ""), 10) || 8888;
+    // SimHub host/port (if those inputs exist on this PI) for the reachability probe.
+    const host = readValue(`[setting="simHubHost"]`) || "127.0.0.1";
+    const port = parseInt(readValue(`[setting="simHubPort"]`) ?? "", 10) || 8888;
 
     if (host !== this.simHubHost || port !== this.simHubPort) {
       this.simHubHost = host;
       this.simHubPort = port;
-      this.onSimHubTargetChanged();
+      this.simHubProbed = false;
+
+      if (this.simHubPollTimer !== null) void this.probeSimHub();
+
+      changed = true;
     }
 
-    this.render();
-  }
-
-  private onSimHubTargetChanged(): void {
-    this.simHubProbed = false;
-
-    if (this.simHubPollTimer !== null) void this.probeSimHub();
+    if (changed) this.render();
   }
 
   /** Resolve ALL binding keys required by the current mode. */
@@ -406,15 +415,13 @@ export class BindingStatus extends HTMLElement {
 
   disconnectedCallback(): void {
     this.stopSimHubPolling();
-    this.dispose(this.actionSub);
-    this.dispose(this.globalSub);
-    this.actionSub = undefined;
-    this.globalSub = undefined;
-  }
+    document.removeEventListener("input", this.onDomChange, true);
+    document.removeEventListener("change", this.onDomChange, true);
 
-  private dispose(sub: Disposable): void {
-    if (typeof sub === "function") sub();
-    else if (sub && typeof sub.dispose === "function") sub.dispose();
+    if (this.domPollTimer !== null) {
+      window.clearInterval(this.domPollTimer);
+      this.domPollTimer = null;
+    }
   }
 
   private line(level: "ok" | "warn" | "muted" | "danger", symbol: string, text: string): HTMLDivElement {

--- a/packages/pi-components/src/components/binding-status.ts
+++ b/packages/pi-components/src/components/binding-status.ts
@@ -84,6 +84,25 @@ function readValue(selector: string): string | null {
   return typeof v === "string" ? v : v == null ? "" : String(v);
 }
 
+/**
+ * Read an sdpi-select's current value, falling back to its `default` attribute
+ * when the value is empty. An sdpi-select left untouched at its default reports
+ * an empty `.value` until the setting is persisted, so the codebase's
+ * conditional-visibility pattern reads `value || default`. Without this, a
+ * `keyBy` secondary like Direction (default "next") resolves to "" and the
+ * status line goes blank (issue #612).
+ */
+function readSelectValue(setting: string): string | null {
+  const el = document.querySelector(`[setting="${cssAttr(setting)}"]`) as (ValueElement & Element) | null;
+
+  if (!el) return null;
+
+  const v = el.value;
+  const value = typeof v === "string" ? v : v == null ? "" : String(v);
+
+  return value || el.getAttribute("default") || "";
+}
+
 function isConstantKey(ref: BindingKeyRef): ref is BindingKeyConstant {
   return "key" in ref;
 }
@@ -220,8 +239,9 @@ export class BindingStatus extends HTMLElement {
   private readDom(): void {
     let changed = false;
 
-    // Mode (sdpi-select) — fall back to the default-mode attribute when empty.
-    const rawMode = readValue(`[setting="${cssAttr(this.modeSetting)}"]`);
+    // Mode (sdpi-select) — fall back to the select's own default, then to the
+    // component's default-mode attribute, when empty.
+    const rawMode = readSelectValue(this.modeSetting);
     const mode = rawMode || (this.getAttribute("default-mode") ?? "");
 
     if (mode !== this.currentMode) {
@@ -229,9 +249,10 @@ export class BindingStatus extends HTMLElement {
       changed = true;
     }
 
-    // Secondary (keyBy) settings.
+    // Secondary (keyBy) settings — also fall back to the select's default so an
+    // untouched control (e.g. Direction = "next") still resolves a key.
     for (const name of this.secondaryNames) {
-      const value = readValue(`[setting="${cssAttr(name)}"]`);
+      const value = readSelectValue(name);
 
       if (value === null) continue; // control not present yet
 

--- a/packages/pi-components/src/components/binding-status.ts
+++ b/packages/pi-components/src/components/binding-status.ts
@@ -86,9 +86,8 @@ function parseStoredBinding(
   }
 
   const kb = parseKeyBinding(value);
-  const text = formatKeyBinding(kb);
 
-  return text ? { kind: "keyboard", text } : null;
+  return kb ? { kind: "keyboard", text: formatKeyBinding(kb) } : null;
 }
 
 let styleInjected = false;
@@ -101,6 +100,10 @@ export class BindingStatus extends HTMLElement {
   private secondary = new Map<string, string>();
   /** Live binding values, by global-settings key. */
   private bindings = new Map<string, string>();
+  /** Global keys whose value has arrived at least once (distinguishes "loading" from "unset"). */
+  private loadedBindings = new Set<string>();
+  /** Secondary settings whose value has arrived at least once. */
+  private loadedSecondary = new Set<string>();
   private simHubReachable = true;
   private initialized = false;
 
@@ -179,6 +182,7 @@ export class BindingStatus extends HTMLElement {
         setting,
         (value) => {
           this.secondary.set(setting, value);
+          this.loadedSecondary.add(setting);
           this.render();
         },
         null,
@@ -190,6 +194,7 @@ export class BindingStatus extends HTMLElement {
         key,
         (value) => {
           this.bindings.set(key, value);
+          this.loadedBindings.add(key);
           this.render();
         },
         null,
@@ -252,11 +257,27 @@ export class BindingStatus extends HTMLElement {
       return;
     }
 
+    // A keyBy reference can't be resolved until its secondary setting has
+    // loaded — render nothing rather than flash "No binding set" on PI open.
+    if (!isConstantKey(ref) && !isMultiKey(ref) && !this.loadedSecondary.has(ref.keyBy.setting)) {
+      this.container.replaceChildren();
+
+      return;
+    }
+
     const keys = this.resolveKeys(ref);
 
     if (keys.length === 0) {
-      // keyBy secondary not yet resolvable — treat as not configured.
+      // Secondary value is loaded but unmapped → genuinely no binding.
       this.renderMissing();
+
+      return;
+    }
+
+    // Wait for every required key's value to arrive before judging set/unset,
+    // so PI open doesn't briefly show "No binding set" before settings load.
+    if (keys.some((k) => !this.loadedBindings.has(k))) {
+      this.container.replaceChildren();
 
       return;
     }

--- a/packages/pi-components/src/components/binding-status.ts
+++ b/packages/pi-components/src/components/binding-status.ts
@@ -55,18 +55,21 @@ type ActionCommMap = Record<string, CommDescriptor>;
 /** Accordion that holds the global key bindings (see global-key-bindings.ejs). */
 const KEY_BINDINGS_ACCORDION_ID = "Related Key Bindings";
 
-type SettingsCallback = (value: string) => void;
-type GlobalSettings = Record<string, unknown>;
-interface GlobalSettingsEvent {
-  payload: { settings: GlobalSettings };
+type Settings = Record<string, unknown>;
+interface SettingsEvent {
+  payload: { settings: Settings };
 }
 type Disposable = { dispose?: () => void } | (() => void) | void;
+interface Subscribable {
+  subscribe: (cb: (ev: SettingsEvent) => void) => Disposable;
+}
 interface StreamDeckClientLike {
-  getGlobalSettings: () => Promise<GlobalSettings>;
-  didReceiveGlobalSettings: { subscribe: (cb: (ev: GlobalSettingsEvent) => void) => Disposable };
+  getSettings: () => Promise<unknown>;
+  getGlobalSettings: () => Promise<Settings>;
+  didReceiveSettings: Subscribable;
+  didReceiveGlobalSettings: Subscribable;
 }
 interface SDPILike {
-  useSettings: (key: string, cb: SettingsCallback, def: unknown) => [() => Promise<string>, (v: string) => void];
   streamDeckClient: StreamDeckClientLike;
 }
 
@@ -99,6 +102,15 @@ function parseStoredBinding(
   return kb ? { kind: "keyboard", text: formatKeyBinding(kb) } : null;
 }
 
+/** `getSettings()` resolves to a payload wrapper; `didReceiveSettings` gives `.settings` directly. */
+function extractSettings(result: unknown): Settings {
+  if (result && typeof result === "object" && "settings" in result) {
+    return (result as { settings: Settings }).settings ?? {};
+  }
+
+  return (result as Settings) ?? {};
+}
+
 let styleInjected = false;
 
 export class BindingStatus extends HTMLElement {
@@ -126,9 +138,14 @@ export class BindingStatus extends HTMLElement {
   /** Recomputed each render: does the current display depend on SimHub being up? */
   private pollSimHub = false;
 
+  /** Name of the action setting whose value is the mode. */
+  private modeSetting = "mode";
+  /** Secondary (keyBy) action-setting names referenced by this action's modes. */
+  private secondaryNames: string[] = [];
   /** Every global binding key referenced by this action's modes. */
   private candidateKeys: string[] = [];
-  /** Subscription to global-settings changes (from any source). */
+  /** Subscriptions to settings changes (from any source). */
+  private actionSub: Disposable = undefined;
   private globalSub: Disposable = undefined;
 
   connectedCallback(): void {
@@ -167,22 +184,10 @@ export class BindingStatus extends HTMLElement {
 
     if (!sdpi) return;
 
-    // Primary mode setting.
-    const modeSetting = this.getAttribute("mode-setting");
+    this.modeSetting = this.getAttribute("mode-setting") || "mode";
 
-    if (modeSetting) {
-      sdpi.useSettings(
-        modeSetting,
-        (value) => {
-          this.currentMode = value || (this.getAttribute("default-mode") ?? "");
-          this.render();
-        },
-        null,
-      );
-    }
-
-    // Secondary (keyBy) settings and the candidate binding keys.
-    const secondarySettings = new Set<string>();
+    // Collect the secondary (keyBy) setting names and the candidate binding keys.
+    const secondaryNames = new Set<string>();
     const bindingKeys = new Set<string>();
 
     for (const descriptor of Object.values(this.comms)) {
@@ -195,40 +200,46 @@ export class BindingStatus extends HTMLElement {
       } else if (isMultiKey(ref)) {
         for (const key of ref.keys) bindingKeys.add(key);
       } else {
-        secondarySettings.add(ref.keyBy.setting);
+        secondaryNames.add(ref.keyBy.setting);
 
         for (const key of Object.values(ref.keyBy.map)) bindingKeys.add(key);
       }
     }
 
-    for (const setting of secondarySettings) {
-      sdpi.useSettings(
-        setting,
-        (value) => {
-          this.secondary.set(setting, value);
-          this.loadedSecondary.add(setting);
-          this.render();
-        },
-        null,
-      );
-    }
-
+    this.secondaryNames = [...secondaryNames];
     this.candidateKeys = [...bindingKeys];
 
-    // Read binding values + SimHub host/port from GLOBAL settings via the
-    // Stream Deck client, which reports changes from ANY source — including a
-    // sibling ird-key-binding write in this same PI (per-key useGlobalSettings
-    // subscriptions do not reliably re-fire for those). Seed with the current
-    // values, then keep in sync.
-    this.globalSub = sdpi.streamDeckClient.didReceiveGlobalSettings.subscribe((ev) => {
-      this.applyGlobalSettings(ev.payload.settings);
-    });
+    // Drive EVERYTHING off the Stream Deck client event bus, which reports
+    // changes from ANY source — the Mode dropdown's own write, a sibling
+    // ird-key-binding write, the plugin, another PI. The sdpi `use*` hooks only
+    // delivered the initial value to a read-only observer like this, so the
+    // line went stale on mode/binding changes. Seed with current values, then
+    // keep in sync.
+    const client = sdpi.streamDeckClient;
 
-    void sdpi.streamDeckClient.getGlobalSettings().then((settings) => this.applyGlobalSettings(settings));
+    this.actionSub = client.didReceiveSettings.subscribe((ev) => this.applyActionSettings(ev.payload.settings));
+    this.globalSub = client.didReceiveGlobalSettings.subscribe((ev) => this.applyGlobalSettings(ev.payload.settings));
+
+    void client.getSettings().then((result) => this.applyActionSettings(extractSettings(result)));
+    void client.getGlobalSettings().then((settings) => this.applyGlobalSettings(settings));
+  }
+
+  /** Apply an action-settings snapshot: refresh the current mode + secondary values. */
+  private applyActionSettings(settings: Settings): void {
+    const rawMode = settings[this.modeSetting];
+    this.currentMode = typeof rawMode === "string" && rawMode ? rawMode : (this.getAttribute("default-mode") ?? "");
+
+    for (const name of this.secondaryNames) {
+      const raw = settings[name];
+      this.secondary.set(name, typeof raw === "string" ? raw : "");
+      this.loadedSecondary.add(name);
+    }
+
+    this.render();
   }
 
   /** Apply a global-settings snapshot: refresh binding values + SimHub target. */
-  private applyGlobalSettings(settings: GlobalSettings): void {
+  private applyGlobalSettings(settings: Settings): void {
     for (const key of this.candidateKeys) {
       const raw = settings[key];
       const value = typeof raw === "string" ? raw : raw == null ? "" : JSON.stringify(raw);
@@ -395,11 +406,15 @@ export class BindingStatus extends HTMLElement {
 
   disconnectedCallback(): void {
     this.stopSimHubPolling();
-
-    if (typeof this.globalSub === "function") this.globalSub();
-    else if (this.globalSub && typeof this.globalSub.dispose === "function") this.globalSub.dispose();
-
+    this.dispose(this.actionSub);
+    this.dispose(this.globalSub);
+    this.actionSub = undefined;
     this.globalSub = undefined;
+  }
+
+  private dispose(sub: Disposable): void {
+    if (typeof sub === "function") sub();
+    else if (sub && typeof sub.dispose === "function") sub.dispose();
   }
 
   private line(level: "ok" | "warn" | "muted" | "danger", symbol: string, text: string): HTMLDivElement {

--- a/packages/pi-components/src/components/binding-status.ts
+++ b/packages/pi-components/src/components/binding-status.ts
@@ -56,9 +56,18 @@ type ActionCommMap = Record<string, CommDescriptor>;
 const KEY_BINDINGS_ACCORDION_ID = "Related Key Bindings";
 
 type SettingsCallback = (value: string) => void;
+type GlobalSettings = Record<string, unknown>;
+interface GlobalSettingsEvent {
+  payload: { settings: GlobalSettings };
+}
+type Disposable = { dispose?: () => void } | (() => void) | void;
+interface StreamDeckClientLike {
+  getGlobalSettings: () => Promise<GlobalSettings>;
+  didReceiveGlobalSettings: { subscribe: (cb: (ev: GlobalSettingsEvent) => void) => Disposable };
+}
 interface SDPILike {
   useSettings: (key: string, cb: SettingsCallback, def: unknown) => [() => Promise<string>, (v: string) => void];
-  useGlobalSettings: (key: string, cb: SettingsCallback, def: unknown) => [() => Promise<string>, (v: string) => void];
+  streamDeckClient: StreamDeckClientLike;
 }
 
 function isConstantKey(ref: BindingKeyRef): ref is BindingKeyConstant {
@@ -116,6 +125,11 @@ export class BindingStatus extends HTMLElement {
   private simHubPollTimer: number | null = null;
   /** Recomputed each render: does the current display depend on SimHub being up? */
   private pollSimHub = false;
+
+  /** Every global binding key referenced by this action's modes. */
+  private candidateKeys: string[] = [];
+  /** Subscription to global-settings changes (from any source). */
+  private globalSub: Disposable = undefined;
 
   connectedCallback(): void {
     if (this.initialized) return;
@@ -199,35 +213,39 @@ export class BindingStatus extends HTMLElement {
       );
     }
 
-    for (const key of bindingKeys) {
-      sdpi.useGlobalSettings(
-        key,
-        (value) => {
-          this.bindings.set(key, value);
-          this.loadedBindings.add(key);
-          this.render();
-        },
-        null,
-      );
+    this.candidateKeys = [...bindingKeys];
+
+    // Read binding values + SimHub host/port from GLOBAL settings via the
+    // Stream Deck client, which reports changes from ANY source — including a
+    // sibling ird-key-binding write in this same PI (per-key useGlobalSettings
+    // subscriptions do not reliably re-fire for those). Seed with the current
+    // values, then keep in sync.
+    this.globalSub = sdpi.streamDeckClient.didReceiveGlobalSettings.subscribe((ev) => {
+      this.applyGlobalSettings(ev.payload.settings);
+    });
+
+    void sdpi.streamDeckClient.getGlobalSettings().then((settings) => this.applyGlobalSettings(settings));
+  }
+
+  /** Apply a global-settings snapshot: refresh binding values + SimHub target. */
+  private applyGlobalSettings(settings: GlobalSettings): void {
+    for (const key of this.candidateKeys) {
+      const raw = settings[key];
+      const value = typeof raw === "string" ? raw : raw == null ? "" : JSON.stringify(raw);
+      this.bindings.set(key, value);
+      this.loadedBindings.add(key); // present-or-absent now known
     }
 
-    // SimHub host/port — used to build the poll URL. Re-probe on change.
-    sdpi.useGlobalSettings(
-      "simHubHost",
-      (value) => {
-        this.simHubHost = value || "127.0.0.1";
-        this.onSimHubTargetChanged();
-      },
-      null,
-    );
-    sdpi.useGlobalSettings(
-      "simHubPort",
-      (value) => {
-        this.simHubPort = parseInt(value, 10) || 8888;
-        this.onSimHubTargetChanged();
-      },
-      null,
-    );
+    const host = typeof settings.simHubHost === "string" && settings.simHubHost ? settings.simHubHost : "127.0.0.1";
+    const port = parseInt(String(settings.simHubPort ?? ""), 10) || 8888;
+
+    if (host !== this.simHubHost || port !== this.simHubPort) {
+      this.simHubHost = host;
+      this.simHubPort = port;
+      this.onSimHubTargetChanged();
+    }
+
+    this.render();
   }
 
   private onSimHubTargetChanged(): void {
@@ -377,6 +395,11 @@ export class BindingStatus extends HTMLElement {
 
   disconnectedCallback(): void {
     this.stopSimHubPolling();
+
+    if (typeof this.globalSub === "function") this.globalSub();
+    else if (this.globalSub && typeof this.globalSub.dispose === "function") this.globalSub.dispose();
+
+    this.globalSub = undefined;
   }
 
   private line(level: "ok" | "warn" | "muted" | "danger", symbol: string, text: string): HTMLDivElement {

--- a/packages/pi-components/src/components/index.ts
+++ b/packages/pi-components/src/components/index.ts
@@ -42,3 +42,6 @@ export {
 
 // Warnings Banner - global PI warning banner driven by the _warnings global setting
 export { WarningsBanner } from "./warnings.js";
+
+// Binding Status - per-mode communication / binding status line under the Mode selector
+export { BindingStatus } from "./binding-status.js";

--- a/packages/pi-components/src/components/key-binding-input.test.ts
+++ b/packages/pi-components/src/components/key-binding-input.test.ts
@@ -52,11 +52,11 @@ describe("key-binding-input", () => {
     });
 
     it("should format key with single modifier", () => {
-      expect(formatKeyBinding({ key: "a", modifiers: ["ctrl"] })).toBe("Ctrl + A");
+      expect(formatKeyBinding({ key: "a", modifiers: ["ctrl"] })).toBe("Ctrl+A");
     });
 
     it("should format key with multiple modifiers in correct order", () => {
-      expect(formatKeyBinding({ key: "a", modifiers: ["alt", "ctrl", "shift"] })).toBe("Ctrl + Shift + Alt + A");
+      expect(formatKeyBinding({ key: "a", modifiers: ["alt", "ctrl", "shift"] })).toBe("Ctrl+Shift+Alt+A");
     });
 
     it("should use display names for special keys", () => {
@@ -67,12 +67,12 @@ describe("key-binding-input", () => {
 
     it("should format function keys correctly", () => {
       expect(formatKeyBinding({ key: "f1", modifiers: [] })).toBe("F1");
-      expect(formatKeyBinding({ key: "f12", modifiers: ["ctrl"] })).toBe("Ctrl + F12");
+      expect(formatKeyBinding({ key: "f12", modifiers: ["ctrl"] })).toBe("Ctrl+F12");
     });
 
     it("should format arrow keys correctly", () => {
       expect(formatKeyBinding({ key: "up", modifiers: [] })).toBe("Up");
-      expect(formatKeyBinding({ key: "down", modifiers: ["shift"] })).toBe("Shift + Down");
+      expect(formatKeyBinding({ key: "down", modifiers: ["shift"] })).toBe("Shift+Down");
     });
 
     it("should format numpad keys correctly", () => {
@@ -91,7 +91,7 @@ describe("key-binding-input", () => {
     });
 
     it("should use displayKey with modifiers", () => {
-      expect(formatKeyBinding({ key: "'", modifiers: ["shift"], displayKey: "Ä" })).toBe("Shift + Ä");
+      expect(formatKeyBinding({ key: "'", modifiers: ["shift"], displayKey: "Ä" })).toBe("Shift+Ä");
     });
 
     it("should fall back to key when displayKey is absent", () => {

--- a/packages/pi-components/src/components/key-binding-utils.ts
+++ b/packages/pi-components/src/components/key-binding-utils.ts
@@ -54,7 +54,7 @@ export interface KeyBindingValue {
 
 /**
  * Format a key binding value for display.
- * Returns a human-readable string like "Ctrl + Shift + A".
+ * Returns a human-readable string like "Ctrl+Shift+A".
  */
 export function formatKeyBinding(value: KeyBindingValue | null): string {
   if (!value || !value.key) {
@@ -77,7 +77,7 @@ export function formatKeyBinding(value: KeyBindingValue | null): string {
     : KEY_DISPLAY_NAMES[value.key] || value.key.toUpperCase();
   parts.push(keyDisplay);
 
-  return parts.join(" + ");
+  return parts.join("+");
 }
 
 /**

--- a/packages/pi-components/src/components/simhub-probe.ts
+++ b/packages/pi-components/src/components/simhub-probe.ts
@@ -1,0 +1,26 @@
+/// <reference lib="dom" />
+/**
+ * SimHub Control Mapper reachability probe (issue #612).
+ *
+ * The binding-status component polls this to show/clear a "SimHub not
+ * connected" warning live. Mirrors the endpoint the ird-key-binding component
+ * already uses to fetch roles, but reduced to a boolean health check.
+ */
+
+/** Poll interval (ms) used by consumers that watch reachability over time. */
+export const SIMHUB_POLL_INTERVAL_MS = 3000;
+
+/**
+ * Returns true when SimHub's Control Mapper REST API answers at host:port.
+ * Never throws — a timeout, refused connection, or non-OK status is `false`.
+ */
+export async function fetchSimHubReachable(host: string, port: number): Promise<boolean> {
+  try {
+    const url = `http://${host}:${port}/api/ControlMapper/GetRoles/`;
+    const response = await fetch(url, { signal: AbortSignal.timeout(500) });
+
+    return response.ok;
+  } catch {
+    return false;
+  }
+}

--- a/packages/pi-components/src/components/simhub-probe.ts
+++ b/packages/pi-components/src/components/simhub-probe.ts
@@ -11,13 +11,35 @@
 export const SIMHUB_POLL_INTERVAL_MS = 3000;
 
 /**
+ * An abort signal that fires after `ms`. Prefers `AbortSignal.timeout` (the
+ * Stream Deck PI WebView supports it — ird-key-binding already relies on it),
+ * with an `AbortController` + `setTimeout` fallback for any older embedded
+ * WebView that lacks it. Returns undefined when neither exists (request simply
+ * runs without a client-side timeout rather than failing).
+ */
+function abortAfter(ms: number): AbortSignal | undefined {
+  if (typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function") {
+    return AbortSignal.timeout(ms);
+  }
+
+  if (typeof AbortController !== "undefined") {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), ms);
+
+    return controller.signal;
+  }
+
+  return undefined;
+}
+
+/**
  * Returns true when SimHub's Control Mapper REST API answers at host:port.
  * Never throws — a timeout, refused connection, or non-OK status is `false`.
  */
 export async function fetchSimHubReachable(host: string, port: number): Promise<boolean> {
   try {
     const url = `http://${host}:${port}/api/ControlMapper/GetRoles/`;
-    const response = await fetch(url, { signal: AbortSignal.timeout(500) });
+    const response = await fetch(url, { signal: abortAfter(500) });
 
     return response.ok;
   } catch {

--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -93,6 +93,7 @@ export default defineConfig({
         {
           label: "Features",
           items: [
+            { slug: "docs/features/communication-methods" },
             { slug: "docs/features/key-bindings" },
             { slug: "docs/features/flags-overlay" },
             { slug: "docs/features/focus-iracing-window" },

--- a/packages/website/src/content/docs/docs/actions/audio-voice/ai-spotter-controls.md
+++ b/packages/website/src/content/docs/docs/actions/audio-voice/ai-spotter-controls.md
@@ -19,6 +19,7 @@ Ask the spotter to read the current damage status.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -35,6 +36,7 @@ Ask the spotter to read the current weather conditions.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -51,6 +53,7 @@ Toggle whether the spotter reports lap information.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -67,6 +70,7 @@ Toggle the announcement of the leader crossing the start/finish line.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -83,6 +87,7 @@ Raise the spotter volume.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -99,6 +104,7 @@ Lower the spotter volume.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -115,6 +121,7 @@ Silence the spotter entirely.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/audio-voice/audio-controls.md
+++ b/packages/website/src/content/docs/docs/actions/audio-voice/audio-controls.md
@@ -24,6 +24,7 @@ Hold voice chat push-to-talk for as long as the button is pressed. Release the b
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support; press and hold the dial to transmit, release to stop
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -40,6 +41,7 @@ Control voice chat volume and mute.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts voice chat volume (clockwise = up, counter-clockwise = down) regardless of the Action setting; pressing the dial **always** toggles mute, even if the Action setting is Volume Up or Volume Down
 - **Default binding:** Depends on the selected action — see the **Action** setting below
 - **Telemetry-aware icon:** No
@@ -58,6 +60,7 @@ Control the iRacing master volume. The Master mode has no mute option — the Ac
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts master volume (clockwise = up, counter-clockwise = down) regardless of the Action setting; pressing the dial triggers the configured action
 - **Default binding:** Depends on the selected action — see the **Action** setting below
 - **Telemetry-aware icon:** No
@@ -75,6 +78,7 @@ Adjust iRaceDeck's own **Race Engineer voice** level — the same level as the R
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Not supported yet — only key presses adjust the volume
 - **Default binding:** None — controls iRaceDeck audio directly (no iRacing key binding)
 - **Telemetry-aware icon:** No
@@ -92,6 +96,7 @@ Adjust iRaceDeck's own proximity **Radar** tick level — the same level as the 
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Not supported yet — only key presses adjust the volume
 - **Default binding:** None — controls iRaceDeck audio directly (no iRacing key binding)
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/audio-voice/audio-controls.md
+++ b/packages/website/src/content/docs/docs/actions/audio-voice/audio-controls.md
@@ -78,7 +78,7 @@ Adjust iRaceDeck's own **Race Engineer voice** level — the same level as the R
 
 #### Details
 
-- **Method:** Key binding
+- **Method:** iRaceDeck audio (no iRacing command)
 - **Dial:** Not supported yet — only key presses adjust the volume
 - **Default binding:** None — controls iRaceDeck audio directly (no iRacing key binding)
 - **Telemetry-aware icon:** No
@@ -96,7 +96,7 @@ Adjust iRaceDeck's own proximity **Radar** tick level — the same level as the 
 
 #### Details
 
-- **Method:** Key binding
+- **Method:** iRaceDeck audio (no iRacing command)
 - **Dial:** Not supported yet — only key presses adjust the volume
 - **Default binding:** None — controls iRaceDeck audio directly (no iRacing key binding)
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-aero.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-aero.md
@@ -38,6 +38,7 @@ Adjust the front wing angle. The **Direction** setting picks whether pressing th
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts the front wing (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Front Wing + and Front Wing - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -55,6 +56,7 @@ Adjust the rear wing angle. The **Direction** setting picks whether pressing the
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts the rear wing (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Rear Wing + and Rear Wing - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -72,6 +74,7 @@ Adjust the amount of qualifying tape covering the radiators. The **Direction** s
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts qualifying tape (clockwise = more tape, counter-clockwise = less tape), regardless of the Direction setting
 - **Default binding:** No default key binding — both Qualifying Tape + and Qualifying Tape - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -89,6 +92,7 @@ Toggle the right-front brake attachment.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-brakes.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-brakes.md
@@ -40,6 +40,7 @@ Toggle ABS on or off.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -56,6 +57,7 @@ Step the ABS level up or down. The **Direction** setting picks whether pressing 
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts the ABS level (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both ABS Adjust + and ABS Adjust - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -73,6 +75,7 @@ Shift the brake bias forward or rearward. The **Direction** setting picks whethe
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts brake bias (clockwise = forward, counter-clockwise = rearward), regardless of the Direction setting
 - **Default binding:** `=` (increase) and `-` (decrease) — matches iRacing's default brake bias keys
 - **Telemetry-aware icon:** No
@@ -90,6 +93,7 @@ Fine-adjust the brake bias in smaller increments than the main Brake Bias mode.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts brake bias fine (clockwise = forward, counter-clockwise = rearward), regardless of the Direction setting
 - **Default binding:** No default key binding — both Brake Bias Fine + and Brake Bias Fine - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -107,6 +111,7 @@ Adjust the peak brake bias setting.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts peak brake bias (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Peak Brake Bias + and Peak Brake Bias - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -124,6 +129,7 @@ Adjust iRacing's "brake misc" catch-all setting. The exact effect depends on the
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts brake misc (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Brake Misc + and Brake Misc - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -141,6 +147,7 @@ Adjust the engine braking level.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts engine braking (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Engine Braking + and Engine Braking - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-chassis.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-chassis.md
@@ -43,6 +43,7 @@ Adjust the differential preload value.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts differential preload (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Diff Preload + and Diff Preload - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -60,6 +61,7 @@ Adjust the differential entry (on-throttle) setting.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts differential entry (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Diff Entry + and Diff Entry - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -77,6 +79,7 @@ Adjust the differential middle (coasting) setting.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts differential middle (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Diff Middle + and Diff Middle - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -94,6 +97,7 @@ Adjust the differential exit setting.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts differential exit (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Diff Exit + and Diff Exit - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -111,6 +115,7 @@ Adjust the front anti-roll bar stiffness.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts the front ARB (clockwise = stiffer, counter-clockwise = softer), regardless of the Direction setting
 - **Default binding:** No default key binding — both Front ARB + and Front ARB - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -128,6 +133,7 @@ Adjust the rear anti-roll bar stiffness.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts the rear ARB (clockwise = stiffer, counter-clockwise = softer), regardless of the Direction setting
 - **Default binding:** No default key binding — both Rear ARB + and Rear ARB - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -145,6 +151,7 @@ Adjust the left-side spring preload.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts the left spring (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Left Spring + and Left Spring - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -162,6 +169,7 @@ Adjust the right-side spring preload.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts the right spring (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Right Spring + and Right Spring - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -179,6 +187,7 @@ Adjust the left-front shock setting.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts the left-front shock (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both LF Shock + and LF Shock - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -196,6 +205,7 @@ Adjust the right-front shock setting.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts the right-front shock (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both RF Shock + and RF Shock - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -213,6 +223,7 @@ Adjust the left-rear shock setting.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts the left-rear shock (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both LR Shock + and LR Shock - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -230,6 +241,7 @@ Adjust the right-rear shock setting.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts the right-rear shock (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both RR Shock + and RR Shock - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -247,6 +259,7 @@ Adjust the power steering assist level.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts power steering (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Power Steering + and Power Steering - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-engine.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-engine.md
@@ -37,6 +37,7 @@ Adjust the engine power setting.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts engine power (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Engine Power + and Engine Power - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -54,6 +55,7 @@ Adjust the throttle shape (linear / progressive curve).
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts throttle shaping (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Throttle Shape + and Throttle Shape - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -71,6 +73,7 @@ Adjust the engine boost level.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts boost (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Boost + and Boost - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -88,6 +91,7 @@ Adjust the launch control RPM target.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts launch RPM (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Launch RPM + and Launch RPM - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-fuel.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-fuel.md
@@ -36,6 +36,7 @@ Adjust the fuel / air mixture setting.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts fuel mixture (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Fuel Mixture + and Fuel Mixture - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -53,6 +54,7 @@ Adjust the fuel cut position setting.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts fuel cut position (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both Fuel Cut Position + and Fuel Cut Position - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -70,6 +72,7 @@ Toggle the fuel cut disable setting.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -86,6 +89,7 @@ Accept the low fuel warning dialog that appears in some series.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -102,6 +106,7 @@ Toggle full-course yellow mode on or off.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-hybrid.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-hybrid.md
@@ -37,6 +37,7 @@ Adjust the MGU-K regeneration gain.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts MGU-K regen gain (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both MGU-K Re-Gen Gain + and MGU-K Re-Gen Gain - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -54,6 +55,7 @@ Step through the MGU-K deploy modes.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation steps through MGU-K deploy modes (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both MGU-K Deploy Mode + and MGU-K Deploy Mode - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -71,6 +73,7 @@ Adjust the fixed MGU-K deployment level.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts the fixed deploy level (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both MGU-K Fixed Deploy + and MGU-K Fixed Deploy - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -88,6 +91,7 @@ Hold the HYS boost key for as long as the button is pressed. Release the button 
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support; press and hold the dial to boost, release to stop
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -104,6 +108,7 @@ Hold the HYS regen key for as long as the button is pressed. Release the button 
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support; press and hold the dial to regenerate, release to stop
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -120,6 +125,7 @@ Toggle the "no boost" mode on or off.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-traction.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-traction.md
@@ -40,6 +40,7 @@ Toggle traction control on or off.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -56,6 +57,7 @@ Adjust TC slot 1.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts TC slot 1 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both TC1 + and TC1 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -73,6 +75,7 @@ Adjust TC slot 2.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts TC slot 2 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both TC2 + and TC2 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -90,6 +93,7 @@ Adjust TC slot 3.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts TC slot 3 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both TC3 + and TC3 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -107,6 +111,7 @@ Adjust TC slot 4.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts TC slot 4 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both TC4 + and TC4 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/cockpit/cockpit-misc.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/cockpit-misc.md
@@ -19,6 +19,7 @@ Toggle the windshield wipers on or off.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Shift+W`
 - **Telemetry-aware icon:** No
@@ -35,6 +36,7 @@ Trigger a single wiper sweep.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+Alt+W`
 - **Telemetry-aware icon:** No
@@ -51,6 +53,7 @@ Adjust the force feedback maximum force. The **Direction** setting picks whether
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts FFB max force (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both FFB Force Increase and FFB Force Decrease must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -68,6 +71,7 @@ Report the current network latency in chat.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `L`
 - **Telemetry-aware icon:** No
@@ -84,6 +88,7 @@ Cycle through the pages on dashboard display 1. The **Direction** setting picks 
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation cycles dash page 1 (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
 - **Default binding:** No default key binding — both Dash Page 1 + and Dash Page 1 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -101,6 +106,7 @@ Cycle through the pages on dashboard display 2. The **Direction** setting picks 
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation cycles dash page 2 (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
 - **Default binding:** No default key binding — both Dash Page 2 + and Dash Page 2 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -118,6 +124,7 @@ Toggle in-lap mode (used for practice and qualifying to mark the return to pit).
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Alt+L`
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/cockpit/force-feedback.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/force-feedback.md
@@ -19,6 +19,7 @@ Toggle iRacing's auto-compute FFB force calibration. This is a disruptive toggle
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support; dial press is also disabled to prevent accidental toggling
 - **Default binding:** `Ctrl+A`
 - **Telemetry-aware icon:** No
@@ -35,6 +36,7 @@ Adjust the overall force feedback force. Shares the same global key binding as C
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts FFB force (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** No default key binding — both FFB Force Increase and FFB Force Decrease must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -52,6 +54,7 @@ Adjust the wheel LFE (low-frequency effects) loudness.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts wheel LFE loudness (clockwise = louder, counter-clockwise = quieter), regardless of the Direction setting
 - **Default binding:** No default key binding — both Wheel LFE Louder and Wheel LFE Quieter must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -69,6 +72,7 @@ Adjust the bass shaker LFE loudness.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts bass shaker LFE loudness (clockwise = louder, counter-clockwise = quieter), regardless of the Direction setting
 - **Default binding:** No default key binding — both Bass Shaker LFE Louder and Bass Shaker LFE Quieter must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -86,6 +90,7 @@ Adjust the wheel LFE intensity curve.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts wheel LFE intensity (clockwise = more intense, counter-clockwise = less intense), regardless of the Direction setting
 - **Default binding:** No default key binding — both Wheel LFE More Intense and Wheel LFE Less Intense must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
@@ -103,6 +108,7 @@ Adjust the haptic LFE intensity curve.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts haptic LFE intensity (clockwise = more intense, counter-clockwise = less intense), regardless of the Direction setting
 - **Default binding:** No default key binding — both Haptic LFE More Intense and Haptic LFE Less Intense must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/cockpit/splits-delta-cycle.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/splits-delta-cycle.md
@@ -19,6 +19,7 @@ Cycle through iRacing's splits delta display modes. When placed on a key, pressi
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation cycles splits delta modes (clockwise = next, counter-clockwise = previous); pressing the dial does nothing in this mode
 - **Default binding:** Depends on the selected direction — see the **Direction** setting below
 - **Telemetry-aware icon:** No
@@ -38,6 +39,7 @@ Toggle the reference car overlay on or off. Replaces the old "Display Reference 
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+C`
 - **Telemetry-aware icon:** No
@@ -54,6 +56,7 @@ Mark the start point for a custom sector on the current lap.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -70,6 +73,7 @@ Mark the end point for a custom sector on the current lap. Together with **Custo
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -86,6 +90,7 @@ Save the current car state — position, speed, temperatures — as a reset snap
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -102,6 +107,7 @@ Teleport the car back to the saved active reset snapshot. Solo practice sessions
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/cockpit/telemetry-control.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/telemetry-control.md
@@ -19,6 +19,7 @@ Toggle iRacing's telemetry log file on or off.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Alt+L`
 - **Telemetry-aware icon:** No
@@ -35,6 +36,7 @@ Mark the current moment in the telemetry log for later review.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `M`
 - **Telemetry-aware icon:** No
@@ -51,6 +53,7 @@ Start a telemetry recording session via the iRacing SDK.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -67,6 +70,7 @@ Stop the current telemetry recording session via the iRacing SDK.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -83,6 +87,7 @@ Stop and immediately restart telemetry recording via the iRacing SDK.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/cockpit/toggle-ui-elements.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/toggle-ui-elements.md
@@ -19,6 +19,7 @@ Toggle the dashboard information box.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `D`
 - **Telemetry-aware icon:** No
@@ -35,6 +36,7 @@ Toggle the speed, gear, and pedal inputs display.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `P`
 - **Telemetry-aware icon:** No
@@ -51,6 +53,7 @@ Toggle the radio communication display.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `O`
 - **Telemetry-aware icon:** No
@@ -67,6 +70,7 @@ Toggle the FPS and network statistics display.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `F`
 - **Telemetry-aware icon:** No
@@ -83,6 +87,7 @@ Toggle the weather radar overlay.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Alt+R`
 - **Telemetry-aware icon:** No
@@ -99,6 +104,7 @@ Toggle the virtual mirror.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Alt+M`
 - **Telemetry-aware icon:** No
@@ -115,6 +121,7 @@ Enter or exit UI edit mode for repositioning overlays.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Alt+K`
 - **Telemetry-aware icon:** No
@@ -135,6 +142,7 @@ The driving line must first be enabled in iRacing's options (Settings → Drivin
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+Alt+L`
 - **Telemetry-aware icon:** No
@@ -155,6 +163,7 @@ Toggle the reference car display.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+C`
 - **Telemetry-aware icon:** No
@@ -171,6 +180,7 @@ Toggle the replay user interface controls. This mode uses the iRacing SDK camera
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/communication/chat.md
+++ b/packages/website/src/content/docs/docs/actions/communication/chat.md
@@ -23,6 +23,7 @@ Send a user-defined chat message. Supports [template variables](/docs/features/t
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — when the button text or message template references live variables (e.g., `{{Speed}}`), the button re-renders whenever those variables change
@@ -53,6 +54,7 @@ Send one of iRacing's 15 built-in chat macros.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -73,6 +75,7 @@ Reply to the most recent chat message using iRacing's reply command.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -89,6 +92,7 @@ Send a private whisper to a specific driver. Whisper has no SDK command in iRaci
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding — Whisper has no default iRacing hotkey, so you must configure it in both iRacing and the Property Inspector
 - **Telemetry-aware icon:** No
@@ -105,6 +109,7 @@ Show or hide the chat window. iRacing's `Text Chat Toggle` control has no SDK co
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding — `Text Chat Toggle` has no default iRacing hotkey, so you must bind a key in iRacing's *Options → Controls → Text Chat Toggle* and the matching key in the Property Inspector
 - **Telemetry-aware icon:** No — iRacing does not expose chat-window state via telemetry, so the button cannot reflect whether chat is currently visible
@@ -121,6 +126,7 @@ Open the chat input window without sending anything.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -137,6 +143,7 @@ Cancel or close the chat window.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/communication/race-admin.md
+++ b/packages/website/src/content/docs/docs/actions/communication/race-admin.md
@@ -25,6 +25,7 @@ Throw a caution flag — sends `!yellow [message]`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -41,6 +42,7 @@ Issue a penalty — sends `!black <driver> [time/laps/D]`. Black Flag supports t
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -63,6 +65,7 @@ Disqualify a driver without removing them — sends `!dq <driver> [message]`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -83,6 +86,7 @@ Display disqualifications for the entire field — sends `!showdqs`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -99,6 +103,7 @@ Display disqualifications for a specific driver — sends `!showdqs <driver>`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -115,6 +120,7 @@ Clear all penalties for a driver — sends `!clear <driver> [message]`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -135,6 +141,7 @@ Clear all penalties for the entire field — sends `!clearall`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -151,6 +158,7 @@ Wave a car to the next lap and the end of the pace line — sends `!waveby <driv
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -171,6 +179,7 @@ Move a driver to the end of the pace line — sends `!eol <driver> [message]`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -191,6 +200,7 @@ Close pit entrances during green flag running — sends `!pitclose`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -207,6 +217,7 @@ Open pit entrances during green flag running — sends `!pitopen`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -223,6 +234,7 @@ Add, subtract, or set pace laps until green — sends `!pacelaps <+n|-n|n>`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -245,6 +257,7 @@ Switch to single-file restart rules — sends `!restart single`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -261,6 +274,7 @@ Switch to double-file restart rules — sends `!restart double`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -277,6 +291,7 @@ Advance to the next session (e.g., qualify to grid) — sends `!advance [message
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -293,6 +308,7 @@ Disable auto-race start for a number of minutes — sends `!gridset [minutes]` (
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -309,6 +325,7 @@ Initiate the pace car or standing start sequence — sends `!gridstart`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -325,6 +342,7 @@ Set the track usage percentage for the next session — sends `!trackstate [perc
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -341,6 +359,7 @@ Grant admin privileges to a driver — sends `!admin <driver> [message]`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -361,6 +380,7 @@ Revoke admin privileges from a driver — sends `!nadmin <driver> [message]`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -381,6 +401,7 @@ Permanently remove a driver from the session — sends `!remove <driver> [messag
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -401,6 +422,7 @@ Re-enable chat for all drivers — sends `!chat`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -417,6 +439,7 @@ Re-enable chat for a specific driver — sends `!chat <driver>`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -433,6 +456,7 @@ Disable chat for all non-admin drivers — sends `!nchat`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -449,6 +473,7 @@ Mute a specific driver — sends `!nchat <driver>`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -465,6 +490,7 @@ Send a message to every participant, bypassing chat disables — sends `/all <me
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -481,6 +507,7 @@ Send a message visible only to administrators — sends `/rc <message>`.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/driving/black-box-selector.md
+++ b/packages/website/src/content/docs/docs/actions/driving/black-box-selector.md
@@ -19,6 +19,7 @@ Open a specific black box overlay. Pressing the button toggles the overlay — p
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation cycles through black boxes (clockwise = next, counter-clockwise = previous), using the **Cycle Next** / **Cycle Previous** bindings regardless of which black box is selected
 - **Default binding:** Depends on the selected black box — see the **Black Box** setting below
 - **Telemetry-aware icon:** No
@@ -47,6 +48,7 @@ Cycle to the next black box.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation cycles through black boxes (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -63,6 +65,7 @@ Cycle to the previous black box.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation cycles through black boxes (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/driving/car-control.md
+++ b/packages/website/src/content/docs/docs/actions/driving/car-control.md
@@ -19,6 +19,7 @@ Toggle the pit speed limiter.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `A`
 - **Telemetry-aware icon:** Yes — the icon reflects the current pit limiter state from iRacing telemetry in real time
@@ -35,6 +36,7 @@ Activate Push To Pass / Overtake for IndyCar, Super Formula, LMDh, and other car
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding — Push To Pass has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
 - **Telemetry-aware icon:** Yes — the icon reads `P2P_Status` (not the momentary button press) so it shows whether overtake power is currently active, not just whether you pressed the button
@@ -51,6 +53,7 @@ Toggle DRS on Formula cars.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding — DRS has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
 - **Telemetry-aware icon:** Yes — the icon reads `DRS_Status` to show whether DRS is currently open
@@ -67,6 +70,7 @@ Flash the headlights while the button is held. Useful for multi-class racing com
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support; press and hold the dial to flash, release to stop
 - **Default binding:** No default key binding — Headlight Flash has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
 - **Telemetry-aware icon:** No
@@ -83,6 +87,7 @@ Tear off a layer of visor film in open-wheel cars, clearing the view.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding — Tear Off Visor has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
 - **Telemetry-aware icon:** No
@@ -99,6 +104,7 @@ Toggle the ignition on or off.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `I`
 - **Telemetry-aware icon:** No
@@ -115,6 +121,7 @@ Engage the car starter. Hold the button to crank.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support; press and hold the dial to crank, release to stop
 - **Default binding:** `S`
 - **Telemetry-aware icon:** No
@@ -131,6 +138,7 @@ Context-aware car entry, exit, pit reset, or tow. The icon updates dynamically b
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support; manual hold holds `Shift+R` while the button is pressed. When auto-hold is on for the active state, a single tap holds it for 1.5 seconds or until you press again
 - **Default binding:** `Shift+R`
 - **Telemetry-aware icon:** Yes — the icon switches between Enter Car, Exit Car, Reset to Pits, and Tow based on whether you are out of the car, in the pits, on track in a non-race session, or on track in a race
@@ -159,6 +167,7 @@ Send the `Escape` key to exit the car or dismiss dialogs. The `Escape` key is ha
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support; manual hold holds `Escape` while the button is pressed, auto-hold releases after 1.5 seconds or when you press again
 - **Default binding:** `Escape` (hardcoded — iRacing always uses `Escape` for this action, so the binding is not user-configurable)
 - **Telemetry-aware icon:** No
@@ -176,6 +185,7 @@ Pause the simulation.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Shift+P`
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/driving/look-direction.md
+++ b/packages/website/src/content/docs/docs/actions/driving/look-direction.md
@@ -19,6 +19,7 @@ Hold the look-left key while the button is pressed.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Z`
 - **Telemetry-aware icon:** No
@@ -35,6 +36,7 @@ Hold the look-right key while the button is pressed.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `X`
 - **Telemetry-aware icon:** No
@@ -51,6 +53,7 @@ Hold the look-up key while the button is pressed.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -67,6 +70,7 @@ Hold the look-down key while the button is pressed.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/media/media-capture.md
+++ b/packages/website/src/content/docs/docs/actions/media/media-capture.md
@@ -19,6 +19,7 @@ Toggle video recording on or off via the iRacing SDK.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -35,6 +36,7 @@ Show the video recording timer overlay via the iRacing SDK.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -51,6 +53,7 @@ Enable or disable the video capture subsystem via the iRacing SDK.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -67,6 +70,7 @@ Capture a standard screenshot via the iRacing SDK.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -83,6 +87,7 @@ Capture a high-resolution giant screenshot. This mode uses a keyboard binding be
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+Shift+PrintScreen`
 - **Telemetry-aware icon:** No
@@ -99,6 +104,7 @@ Reload all in-sim textures via the iRacing SDK.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -115,6 +121,7 @@ Reload only the player's car textures via the iRacing SDK.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/pit-service/fuel-service.md
+++ b/packages/website/src/content/docs/docs/actions/pit-service/fuel-service.md
@@ -19,6 +19,7 @@ Toggle the fuel fill checkbox on or off via the iRacing SDK. The icon shows the 
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — shows the current refuel amount and an on/off indicator driven by `PitSvFlags.FuelFill`
@@ -35,6 +36,7 @@ Queue an "add fuel" chat macro. Pressing the button sends `#fuel +<amount><unit>
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** Rotation adjusts fuel (clockwise = add, counter-clockwise = reduce)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -57,6 +59,7 @@ Queue a "reduce fuel" chat macro. Pressing the button sends `#fuel -<amount><uni
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** Rotation adjusts fuel (clockwise = reduce, counter-clockwise = add)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -83,6 +86,7 @@ When iRacing's autofuel "enable fueling on change" setting is off and your fuel 
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -105,6 +109,7 @@ Clear the pending fuel request via the iRacing SDK. Removes the fuel line from t
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -121,6 +126,7 @@ Toggle iRacing's autofuel checkbox on or off. The icon shows a green ON / red OF
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** Yes — shows an on/off indicator driven by `dpFuelAutoFillActive`
@@ -137,6 +143,7 @@ Raise the autofuel lap margin by one. Pressing the button taps the iRacing "Lap 
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts lap margin (clockwise = increase, counter-clockwise = decrease)
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
@@ -153,6 +160,7 @@ Lower the autofuel lap margin by one. Pressing the button taps the iRacing "Lap 
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts lap margin (clockwise = decrease, counter-clockwise = increase)
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/pit-service/pit-quick-actions.md
+++ b/packages/website/src/content/docs/docs/actions/pit-service/pit-quick-actions.md
@@ -19,6 +19,7 @@ Clear every pit service checkbox in a single press — tires, fuel, windshield, 
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -35,6 +36,7 @@ Toggle the windshield tearoff request. Press once to queue a tearoff, press agai
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — status bar shows green when a tearoff is requested and red when it is not, and the border color tracks the same on / off state
@@ -51,6 +53,7 @@ Toggle a fast repair request. Press once to queue a fast repair, press again to 
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — status bar shows green when a fast repair is queued, red when it is not, and grey N/A when the session has no fast repairs left; the border color tracks the same on / off / n/a state

--- a/packages/website/src/content/docs/docs/actions/pit-service/tire-service.md
+++ b/packages/website/src/content/docs/docs/actions/pit-service/tire-service.md
@@ -19,6 +19,7 @@ Request new tires on all four corners. Uses iRacing's `#t` pit chat macro.
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -35,6 +36,7 @@ Clear all tire change requests — removes all tires from the pit service.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -51,6 +53,7 @@ Toggle tire changes per wheel. You choose which tires (LF, RF, LR, RR) the butto
 
 #### Details
 
+- **Method:** Chat command
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — tire colors reflect the current iRacing pit service state
@@ -86,6 +89,7 @@ The available compounds depend on the car — most cars have DRY and WET, while 
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — shows the currently selected pit service compound

--- a/packages/website/src/content/docs/docs/actions/view-camera/camera-editor-adjustments.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/camera-editor-adjustments.md
@@ -19,6 +19,7 @@ Move the camera along the latitude axis.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts latitude (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** `D` (increase) and `A` (decrease)
 - **Telemetry-aware icon:** No
@@ -36,6 +37,7 @@ Move the camera along the longitude axis.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts longitude (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** `S` (increase) and `W` (decrease)
 - **Telemetry-aware icon:** No
@@ -53,6 +55,7 @@ Move the camera along the altitude axis.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts altitude (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** `Alt+S` (increase) and `Alt+W` (decrease)
 - **Telemetry-aware icon:** No
@@ -70,6 +73,7 @@ Rotate the camera on the yaw axis.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts yaw (clockwise = positive, counter-clockwise = negative), regardless of the Direction setting
 - **Default binding:** `Ctrl+D` (increase) and `Ctrl+A` (decrease)
 - **Telemetry-aware icon:** No
@@ -87,6 +91,7 @@ Tilt the camera on the pitch axis.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts pitch (clockwise = up, counter-clockwise = down), regardless of the Direction setting
 - **Default binding:** `Ctrl+W` (increase) and `Ctrl+S` (decrease)
 - **Telemetry-aware icon:** No
@@ -104,6 +109,7 @@ Adjust the camera field of view.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts FOV zoom (clockwise = zoom in, counter-clockwise = zoom out), regardless of the Direction setting
 - **Default binding:** `[` (increase/zoom in) and `]` (decrease/zoom out)
 - **Telemetry-aware icon:** No
@@ -121,6 +127,7 @@ Adjust the camera editor key step size.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts key step size (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** `-` (increase) and `=` (decrease)
 - **Telemetry-aware icon:** No
@@ -138,6 +145,7 @@ Shift the vanishing point along the X axis.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts the vanishing point X (clockwise = right, counter-clockwise = left), regardless of the Direction setting
 - **Default binding:** `Alt+X` (increase/right) and `Ctrl+X` (decrease/left)
 - **Telemetry-aware icon:** No
@@ -155,6 +163,7 @@ Shift the vanishing point along the Y axis.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts the vanishing point Y (clockwise = up, counter-clockwise = down), regardless of the Direction setting
 - **Default binding:** `Alt+Y` (increase/up) and `Ctrl+Y` (decrease/down)
 - **Telemetry-aware icon:** No
@@ -172,6 +181,7 @@ Adjust the blimp camera orbit radius.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts blimp radius (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** `Ctrl+H` (increase) and `Ctrl+G` (decrease)
 - **Telemetry-aware icon:** No
@@ -189,6 +199,7 @@ Adjust the blimp camera orbit velocity.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts blimp velocity (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** `Alt+H` (increase) and `Alt+G` (decrease)
 - **Telemetry-aware icon:** No
@@ -206,6 +217,7 @@ Adjust the camera microphone gain.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts mic gain (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** `Alt+Up` (increase) and `Alt+Down` (decrease)
 - **Telemetry-aware icon:** No
@@ -223,6 +235,7 @@ Automatically set the microphone gain for the current camera. Non-directional to
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+Alt+Down`
 - **Telemetry-aware icon:** No
@@ -239,6 +252,7 @@ Adjust the camera aperture (depth of field strength).
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts the F-number (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** `Alt+U` (increase) and `Alt+I` (decrease)
 - **Telemetry-aware icon:** No
@@ -256,6 +270,7 @@ Adjust the focus depth.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts focus depth (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
 - **Default binding:** `Ctrl+U` (increase) and `Ctrl+I` (decrease)
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/view-camera/camera-editor-controls.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/camera-editor-controls.md
@@ -19,6 +19,7 @@ Open the iRacing camera editor tool.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+F12`
 - **Telemetry-aware icon:** No
@@ -35,6 +36,7 @@ Toggle the camera editor's key acceleration mode.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+P`
 - **Telemetry-aware icon:** No
@@ -51,6 +53,7 @@ Toggle the key 10x multiplier mode.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Alt+P`
 - **Telemetry-aware icon:** No
@@ -67,6 +70,7 @@ Toggle the parabolic microphone mode.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+O`
 - **Telemetry-aware icon:** No
@@ -83,6 +87,7 @@ Step through the available position types.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Alt+N`
 - **Telemetry-aware icon:** No
@@ -99,6 +104,7 @@ Step through the available aim types.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Alt+M`
 - **Telemetry-aware icon:** No
@@ -115,6 +121,7 @@ Mark the start of an acquire sequence.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+Q`
 - **Telemetry-aware icon:** No
@@ -131,6 +138,7 @@ Mark the end of an acquire sequence.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Q`
 - **Telemetry-aware icon:** No
@@ -147,6 +155,7 @@ Toggle temporary edits mode.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+L`
 - **Telemetry-aware icon:** No
@@ -163,6 +172,7 @@ Toggle the camera dampening setting.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+N`
 - **Telemetry-aware icon:** No
@@ -179,6 +189,7 @@ Toggle the zoom mode.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+M`
 - **Telemetry-aware icon:** No
@@ -195,6 +206,7 @@ Toggle the beyond-fence camera mode.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+B`
 - **Telemetry-aware icon:** No
@@ -211,6 +223,7 @@ Toggle the in-cockpit camera mode.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Alt+B`
 - **Telemetry-aware icon:** No
@@ -227,6 +240,7 @@ Toggle mouse navigation mode.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+Z`
 - **Telemetry-aware icon:** No
@@ -243,6 +257,7 @@ Toggle the pitch gyro mode.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+J`
 - **Telemetry-aware icon:** No
@@ -259,6 +274,7 @@ Toggle the roll gyro mode.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Alt+J`
 - **Telemetry-aware icon:** No
@@ -275,6 +291,7 @@ Toggle the limit-shot-range mode.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Alt+O`
 - **Telemetry-aware icon:** No
@@ -291,6 +308,7 @@ Toggle the show camera overlay.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Alt+Q`
 - **Telemetry-aware icon:** No
@@ -307,6 +325,7 @@ Toggle shot selection mode.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+T`
 - **Telemetry-aware icon:** No
@@ -323,6 +342,7 @@ Toggle manual focus mode.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+F`
 - **Telemetry-aware icon:** No
@@ -339,6 +359,7 @@ Insert a new camera at the current position.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Ctrl+Insert`
 - **Telemetry-aware icon:** No
@@ -355,6 +376,7 @@ Remove the current camera.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Ctrl+Delete`
 - **Telemetry-aware icon:** No
@@ -371,6 +393,7 @@ Copy the current camera to the clipboard.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Ctrl+C`
 - **Telemetry-aware icon:** No
@@ -387,6 +410,7 @@ Paste the clipboard camera over the current one.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Ctrl+V`
 - **Telemetry-aware icon:** No
@@ -403,6 +427,7 @@ Copy the current camera group to the clipboard.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+Alt+C`
 - **Telemetry-aware icon:** No
@@ -419,6 +444,7 @@ Paste the clipboard camera group.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+Alt+V`
 - **Telemetry-aware icon:** No
@@ -435,6 +461,7 @@ Save the current camera configuration to the track.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Ctrl+F11`
 - **Telemetry-aware icon:** No
@@ -451,6 +478,7 @@ Load a previously saved track camera.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Ctrl+F11`
 - **Telemetry-aware icon:** No
@@ -467,6 +495,7 @@ Save the current camera configuration to the car.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Alt+F11`
 - **Telemetry-aware icon:** No
@@ -483,6 +512,7 @@ Load a previously saved car camera.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Shift+Alt+F11`
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/view-camera/replay-control.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/replay-control.md
@@ -25,6 +25,7 @@ Toggle forward playback. Remembers your last slow-motion speed across pause / re
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the icon reflects whether the replay is currently playing or paused based on live replay state
@@ -41,6 +42,7 @@ Toggle reverse playback. Mirrors slow-motion speed when switching direction.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the icon reflects whether reverse playback is active based on live replay state
@@ -57,6 +59,7 @@ Pause playback and reset the remembered speed so the next Play / Pause starts at
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -73,6 +76,7 @@ Progressive fast-forward. The first press jumps to 2x; each subsequent press add
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -89,6 +93,7 @@ Progressive rewind. The first press jumps to −2x; each subsequent press adds *
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -105,6 +110,7 @@ Progressive slow-motion. The first press jumps to 1/2x; each subsequent press ma
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -121,6 +127,7 @@ Progressive slow-motion rewind. The first press jumps to −1/2x; each subsequen
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -137,6 +144,7 @@ Advance exactly one frame.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -153,6 +161,7 @@ Step back exactly one frame.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -169,6 +178,7 @@ Traverse the full speed range upward: 1/16x → ... → 1/2x → 1x → 2x → .
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation progressively adjusts replay speed (clockwise = increase, counter-clockwise = decrease)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -185,6 +195,7 @@ Traverse the full speed range downward. Direction-aware — works whether playba
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation progressively adjusts replay speed (clockwise = increase, counter-clockwise = decrease)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -201,6 +212,7 @@ Set replay playback to a specific speed selected in the Property Inspector.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation steps playback forward or backward by one frame
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -217,6 +229,7 @@ Read-only display of the current replay speed. Pressing the button does nothing 
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the icon shows the live replay speed pulled from telemetry
@@ -233,6 +246,7 @@ Jump to the next session in the replay.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation cycles sessions (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -249,6 +263,7 @@ Jump to the previous session in the replay.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation cycles sessions (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -265,6 +280,7 @@ Jump forward one lap.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation cycles laps (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -281,6 +297,7 @@ Jump backward one lap.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation cycles laps (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -297,6 +314,7 @@ Jump to the next incident.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation cycles incidents (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -313,6 +331,7 @@ Jump to the previous incident.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation cycles incidents (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -329,6 +348,7 @@ Jump to the start of the replay.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation cycles incidents (clockwise = next incident, counter-clockwise = previous incident)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -345,6 +365,7 @@ Jump to the live point in the session (end of the replay buffer).
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation cycles incidents (clockwise = next incident, counter-clockwise = previous incident)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -361,6 +382,7 @@ Jump the replay camera to your own car.
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation cycles to the next / previous car on track around your position (clockwise = ahead, counter-clockwise = behind)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -385,6 +407,7 @@ The button first pauses the replay, then jumps to the first and last frames of t
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -404,6 +427,7 @@ Switch the replay camera to the next car. Defers to iRacing's own car-ordering b
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Clockwise sends Next Car, counter-clockwise sends Previous Car
 - **Default binding:** `V`
 - **Telemetry-aware icon:** No
@@ -420,6 +444,7 @@ Switch the replay camera to the previous car. Defers to iRacing's own car-orderi
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Clockwise sends Next Car, counter-clockwise sends Previous Car
 - **Default binding:** `Shift+V`
 - **Telemetry-aware icon:** No
@@ -436,6 +461,7 @@ Switch the replay camera to the next car by car number order. Includes all cars 
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation cycles cars by number order (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
@@ -452,6 +478,7 @@ Switch the replay camera to the previous car by car number order. Includes all c
 
 #### Details
 
+- **Method:** iRacing API
 - **Dial:** Rotation cycles cars by number order (clockwise = next, counter-clockwise = previous)
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/actions/view-camera/view-adjustment.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/view-adjustment.md
@@ -19,6 +19,7 @@ Adjust the field of view.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts FOV (clockwise = wider, counter-clockwise = narrower), regardless of the Direction setting
 - **Default binding:** `]` (increase) and `[` (decrease)
 - **Telemetry-aware icon:** No
@@ -36,6 +37,7 @@ Adjust the horizon line position.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts horizon (clockwise = up, counter-clockwise = down), regardless of the Direction setting
 - **Default binding:** `Shift+]` (increase/up) and `Shift+[` (decrease/down)
 - **Telemetry-aware icon:** No
@@ -53,6 +55,7 @@ Adjust the driver eye position.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts driver height (clockwise = raise, counter-clockwise = lower), regardless of the Direction setting
 - **Default binding:** `Ctrl+]` (increase/up) and `Ctrl+[` (decrease/down)
 - **Telemetry-aware icon:** No
@@ -70,6 +73,7 @@ Re-center the VR headset view.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `;`
 - **Telemetry-aware icon:** No
@@ -86,6 +90,7 @@ Adjust the in-sim UI element size.
 
 #### Details
 
+- **Method:** Key binding
 - **Dial:** Rotation adjusts UI size (clockwise = larger, counter-clockwise = smaller), regardless of the Direction setting
 - **Default binding:** `Ctrl+PageUp` (increase) and `Ctrl+PageDown` (decrease)
 - **Telemetry-aware icon:** No

--- a/packages/website/src/content/docs/docs/features/communication-methods.md
+++ b/packages/website/src/content/docs/docs/features/communication-methods.md
@@ -1,0 +1,59 @@
+---
+title: How Actions Talk to iRacing
+description: The three ways iRaceDeck actions communicate with iRacing — API, key binding, and chat — and how to tell which one a mode uses.
+---
+
+Every iRaceDeck action mode controls iRacing through one of three mechanisms. Which one a mode uses affects how reliable it is and whether you need to configure anything — so iRaceDeck now shows the method, and the binding state, right in the Property Inspector and on the key icon.
+
+## The three methods
+
+### iRacing API
+
+The mode sends a command straight to iRacing through its SDK (the same broadcast channel iRacing's own UI uses). This is the most reliable method: it works regardless of your key bindings, needs no setup, and can't be intercepted by another window.
+
+Examples: pit service (fuel fill, clear tires, fast repair), camera switching and focus, replay transport, telemetry recording.
+
+### Key binding
+
+The mode simulates a control that you've bound — either a **keyboard shortcut** or a **SimHub Control Mapper role**. A key binding is needed when iRacing exposes no SDK command for the feature (camera editor, look-around, black-box pages, most car-setup adjustments, UI toggles).
+
+Key-binding modes only work once the binding is configured, and a keyboard binding must match your iRacing key configuration. See [Key Bindings](/docs/features/key-bindings/) for how to set keyboard shortcuts and SimHub roles.
+
+:::caution[SimHub must be running]
+A binding set to a **SimHub** role only fires while SimHub (with the Control Mapper plugin) is running. iRaceDeck polls SimHub and shows a red "SimHub not connected" line in the Property Inspector when it isn't reachable.
+:::
+
+### Chat command
+
+The mode types an iRacing chat/text command — typically a `#…` pit macro such as `#fuel`, `#t` (tires), or a race-control command. Chat commands cover features that have neither an SDK command nor a dedicated key binding.
+
+Chat is the least direct method: it opens iRacing's chat box, types the command, and submits it, so it depends on chat being available and can be affected by timing on a busy system.
+
+## Reliability, in short
+
+When iRaceDeck has a choice, it prefers methods in this order:
+
+1. **iRacing API** — direct and reliable, no setup
+2. **Key binding** — reliable once configured; depends on your key config (keyboard) or SimHub running (SimHub role)
+3. **Chat command** — works everywhere iRacing chat does, but the least direct
+
+A single action can mix all three across its modes. Fuel Service is the clearest example: *Toggle Fuel Fill* and *Clear Fuel* use the API, *Add/Reduce/Set Fuel* use `#fuel` chat macros, and *Toggle Autofuel* / *Lap Margin* use key bindings.
+
+## How to tell which method a mode uses
+
+### In the Property Inspector
+
+Directly under the **Mode** selector, iRaceDeck shows a status line for the current mode:
+
+- ✓ **iRacing API** / ✓ **Chat command** — no binding needed
+- ✓ **Key binding: Ctrl+Shift+A** — a keyboard binding is set
+- ✓ **SimHub binding: «role»** — a SimHub role is set (plus a red **SimHub not connected** line if SimHub is down)
+- ⚠ **No binding set — set it here** — the mode needs a binding and none is configured. The **set it here** link opens the *Related Key Bindings* section so you can set one.
+
+The line updates live as you change the mode or set, clear, or switch the binding.
+
+### On the key icon
+
+When a mode needs a binding and **neither** a keyboard shortcut **nor** a SimHub role is set, the key shows a centered ⚠ warning over its dimmed artwork — so a missing binding is obvious on the deck without opening the Property Inspector. It clears the moment you configure either binding type.
+
+Per-mode method labels also appear in each action's documentation, under the mode's **Details** list.

--- a/scripts/generate-action-comms.mjs
+++ b/scripts/generate-action-comms.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+/**
+ * Generates packages/iracing-actions/src/actions/data/action-comms.json from
+ * the authoritative TS catalog (comms-catalog.ts), for the PI templates and
+ * docs to consume (issue #612).
+ *
+ * Run with tsx so the TypeScript catalog imports resolve:
+ *   pnpm generate:action-comms
+ * A freshness test (comms-catalog.test.ts) fails if the committed JSON drifts
+ * from the catalog.
+ */
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import url from "node:url";
+
+import { COMMS_CATALOG } from "../packages/iracing-actions/src/actions/comms-catalog.ts";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const OUTPUT_FILE = path.resolve(__dirname, "../packages/iracing-actions/src/actions/data/action-comms.json");
+
+writeFileSync(OUTPUT_FILE, JSON.stringify(COMMS_CATALOG, null, 2) + "\n", "utf-8");
+
+console.log(`Generated ${OUTPUT_FILE}`);
+console.log(`Actions: ${Object.keys(COMMS_CATALOG).length}`);


### PR DESCRIPTION
## Related Issue

Fixes #612

## What changed?

Surfaces each action/mode's iRacing communication method (API / key binding / chat) and missing-binding state in the Property Inspector, on the key icon, and in the docs — backed by a code-verified per-mode catalog.

- **Foundation (deck-core / icon-composer):** a per-`(action, mode)` `CommDescriptor` (`method: api | keybind | chat` + optional `binding` ref — constant key, multi-key, or `keyBy` a secondary setting); a stateless `isBindingMissing(keys)` and `dispatcher.isConfigured()` (keyboard OR SimHub aware); and a centered ⚠️ `assembleIcon({ bindingMissing })` overlay (QT5-safe, also exposed as `bindingWarningSvg()`/`applyBindingWarning()` for dynamic-template actions).
- **PI component (`ird-binding-status`):** rendered under each Mode selector. Names the method and, for keybind modes, shows the live keyboard/SimHub/none state with a "set it here" link that opens + scrolls the key-bindings accordion. SimHub-bound modes show a red "SimHub not connected" line only while SimHub is down (browser-side polling, clears live). Reads mode/secondary/binding values from the PI DOM (events + polling, with `value || default` fallback) so it updates live on every change.
- **Catalog:** `comms-catalog.ts` (authoritative TS) → generated `action-comms.json` (`pnpm generate:action-comms`), with a freshness test and a cross-check that every binding key exists in `key-bindings.json`.
- **Wiring:** the status line is in all 30 actions' PIs; the per-context missing-binding icon overlay is in every keybind action. Pure API/chat actions get the line but never the overlay.
- **Documentation:** a new "How Actions Talk to iRacing" explainer page (website) covering the three methods + the API → key binding → chat reliability rationale + the keyboard-vs-SimHub distinction; per-mode **Method** labels on every website action page and a Communication Method row in the internal `docs/` action pages; `.claude/rules/` (action/website doc templates, stream-deck-actions, pi-templates, key-icon-types, global-settings, svg-platform-compatibility) and the `iracedeck-actions` skill updated.

## How to test

1. Build: `pnpm build:ts` (or reload the Stream Deck plugin).
2. On a **Fuel Service** key, switch Mode: API/chat modes read "no binding needed"; `Toggle Autofuel` shows the live keyboard/SimHub binding state, and the key icon shows a centered ⚠️ when no binding (keyboard or SimHub) is set, clearing once one is configured.
3. Set/clear/switch the binding in *Related Key Bindings* — the line and icon update live.
4. Check a `keyBy` mode (**Cycle Splits Delta → Next/Previous**, a **View Adjustment** direction, a **Setup** adjust mode) and a SimHub-bound mode (caveat shows only while SimHub is down).
5. Docs: `pnpm --filter @iracedeck/website build` and view `/docs/features/communication-methods/`.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — delivered via the shared `iracing-actions` / `pi-components` / `deck-core` packages both plugins consume; verified end-to-end on Stream Deck (Mirabox shares the same code paths)
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual "binding missing" overlay on action icons/titles when required controls are not configured
  * Per‑mode binding/status line in the Property Inspector showing method (API/keybind/chat), live binding values, and a "set it here" link
  * Live SimHub reachability indicator for SimHub-based bindings

* **Documentation**
  * Added audit/design specs and website/docs describing per‑mode communication methods, binding rules, and UI behavior

* **Chores**
  * Added authoritative per‑action communication metadata generation and supporting updates across actions and icons
<!-- end of auto-generated comment: release notes by coderabbit.ai -->