### PR TITLE
ci(release): opt Firebase deploy into Node 24 (#388)

### DIFF
--- a/.github/workflows/firebase-hosting-release.yml
+++ b/.github/workflows/firebase-hosting-release.yml
@@ -15,6 +15,14 @@ on:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    # Force GitHub's runner to execute JavaScript actions on Node 24. The Firebase
+    # deploy action below still declares `using: node20`, which GitHub has deprecated:
+    # Node 20 actions are forced to Node 24 from 2026-06-02 and Node 20 is removed
+    # from runners on 2026-09-16. Opting in early verifies the action runs under
+    # Node 24 before the forced cutover. Remove this once
+    # FirebaseExtended/action-hosting-deploy ships a Node 24 release (issue #388).
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
@
## Related Issue

Fixes #388

## What changed?

`FirebaseExtended/action-hosting-deploy@v0` still declares `using: node20` in its `action.yml`, which GitHub has deprecated. Node 20 JavaScript actions are forced to Node 24 starting 2026-06-02, and Node 20 is removed from runners on 2026-09-16.

This sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` on the `build_and_deploy` job in `.github/workflows/firebase-hosting-release.yml`, opting the deploy into Node 24 ahead of the forced cutover. It is the holding fix recommended in the issue (option 2). The third-party action stays in place; if upstream has not shipped a Node 24 release by ~August 2026, we can migrate to deploying via `firebase-tools` directly (option 3) — it is already a devDependency.

## How to test

This workflow only runs on `workflow_dispatch` or `workflow_call` (from `release.yml`) and deploys to the live channel, so it cannot be exercised from a PR without triggering a real production deploy. Verification happens at the next release: the "Node.js 20 actions are deprecated" annotation should no longer appear, and the deploy step should run under Node 24.

## Checklist

- [x] Linked to an approved issue
- [ ] New code has unit tests — n/a (CI workflow config only)
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — n/a (no plugin code; this is the only workflow using the action)
- [x] No unrelated changes included
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to ensure compatibility with Node 24 runtime environment in preparation for upcoming Node version transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->