### PR TITLE
feat(actions): add Telemetry Control "snapshot" mode to save telemetry to disk (#635)

### DIFF
--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -9,7 +9,7 @@ description: Use when looking up Stream Deck actions, sub-actions, modes, catego
 
 Complete action definitions: `docs/reference/actions.json`
 
-This skill file documents **31 actions with 290 modes** using a detailed per-mode count (the totals in the category table below). The user-facing website (`packages/website/src/content/docs/`) uses a coarser counting convention and shows a lower total (**260 modes**) — treat the website as the source of truth for user-facing copy and this skill file as the detailed inventory. `docs/reference/actions.json` has not yet been re-synced to the per-mode counting convention; treat it as a detailed inventory of individual mode values that is occasionally out of date.
+This skill file documents **31 actions with 291 modes** using a detailed per-mode count (the totals in the category table below). The user-facing website (`packages/website/src/content/docs/`) uses a coarser counting convention and shows a lower total (**260 modes**) — treat the website as the source of truth for user-facing copy and this skill file as the detailed inventory. `docs/reference/actions.json` has not yet been re-synced to the per-mode counting convention; treat it as a detailed inventory of individual mode values that is occasionally out of date.
 
 Each action entry:
 ```json
@@ -33,7 +33,7 @@ Every action mode talks to iRacing through one of three methods, formalized per-
 - **`keybind`** — a configurable key binding (keyboard OR SimHub role); requires the binding to be set. The descriptor's `binding` carries a constant `key`, a `keyBy` a secondary setting, multiple `keys`, or is absent for a fixed key (no user binding).
 - **`chat`** — an iRacing chat/text command, e.g. a `#…` pit macro.
 
-This is the **authoritative source for a mode's communication method** when answering "how does action X mode Y talk to iRacing?" or labeling docs. An action can mix all three across its modes (e.g. Fuel Service). Display-only / internal actions (session-info, telemetry-display, pit-crew) and the PI-less camera-controls are absent from the catalog. The method surfaces in the PI (an `ird-binding-status` line under the Mode selector) and on the key icon (a centered ⚠️ when a required binding is unset).
+This is the **authoritative source for a mode's communication method** when answering "how does action X mode Y talk to iRacing?" or labeling docs. An action can mix all three across its modes (e.g. Fuel Service). Display-only / internal actions (session-info, telemetry-display, pit-crew) and the PI-less camera-controls are absent from the catalog. The Telemetry Control **snapshot** mode is likewise absent (it writes telemetry to disk, issuing no iRacing command), so it shows no status line. The method surfaces in the PI (an `ird-binding-status` line under the Mode selector) and on the key icon (a centered ⚠️ when a required binding is unset).
 
 ## How to Use
 
@@ -49,13 +49,13 @@ When asked about actions or controls:
 |----------|---------|-------|-------------|
 | Display & Session | 2 | 8 | Live session data: incidents, laps, position, fuel, flags, track wetness |
 | Driving Controls | 6 | 31 | AI spotter, audio (incl. Race Engineer & Radar volume), black boxes, look direction, car control, pit crew (Race Engineer toggle + radar) |
-| Cockpit & Interface | 5 | 34 | Wipers, force feedback, splits & reference, telemetry, UI toggles |
+| Cockpit & Interface | 5 | 35 | Wipers, force feedback, splits & reference, telemetry, UI toggles |
 | View & Camera | 5 | 88 | FOV, replay, camera controls, broadcast tools |
 | Media | 1 | 7 | Video recording, screenshots, texture management |
 | Pit Service | 3 | 15 | Fuel, tires, compounds, tearoff, fast repair |
 | Car Setup | 7 | 73 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control — adjustment modes plus live-display "View …" sub-modes; each View sub-mode also supports dual-press (tap = configured direction, long-press = opposite) so one key both shows the value and adjusts it (#540) |
 | Communication | 2 | 34 | Chat, macros (15), whisper, toggle, reply, race admin commands |
-| **Total** | **31** | **290** | |
+| **Total** | **31** | **291** | |
 
 Mode counts reflect the PI Mode/Setting dropdown choices documented in each action page. Directional variants (Increase/Decrease) are treated as a single mode with a Direction sub-setting, matching the per-mode website format. Legacy replay actions (Replay Transport, Replay Speed, Replay Navigation) and Camera Cycle (Legacy) still exist in the plugin manifest for backward compatibility but are not counted as documented actions.
 
@@ -85,7 +85,7 @@ Mode counts reflect the PI Mode/Setting dropdown choices documented in each acti
 |--------|-------|-------------|
 | Cockpit Misc | 7 | toggle-wipers, trigger-wipers, ffb-max-force (+/-), report-latency, dash-page-1 (+/-), dash-page-2 (+/-), in-lap-mode |
 | Splits & Reference | 6 | cycle (+/- direction), toggle-ref-car, custom-sector-start, custom-sector-end, active-reset-set, active-reset-run |
-| Telemetry Control | 5 | toggle-logging, mark-event, start/stop/restart recording (SDK) |
+| Telemetry Control | 6 | toggle-logging, mark-event, start/stop/restart recording (SDK), snapshot (developer tool — saves current telemetry + session info to disk as timestamped JSON + Markdown; configurable Output Folder; no iRacing command) |
 | Force Feedback | 6 | auto-compute-ffb-force, ffb-force (+/-), wheel-lfe (+/-), bass-shaker-lfe (+/-), wheel-lfe-intensity (+/-), haptic-lfe-intensity (+/-) |
 | Toggle UI Elements | 10 | dash-box, speed/gear/pedals, radio, FPS/network, weather, virtual mirror, UI edit, driving-line, display-ref-car (deprecated), replay-ui (SDK) |
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@
 
 ## Features
 
-**31 actions** with **261+ modes** across 8 categories, with Stream Deck+ dial rotation support on most modes:
+**31 actions** with **262+ modes** across 8 categories, with Stream Deck+ dial rotation support on most modes:
 
 | Category                | Actions | Modes | Examples                                                              |
 | ----------------------- | ------- | ----- | --------------------------------------------------------------------- |
 | **Display & Session**   | 2       | 7     | Incidents, laps, position, fuel, flags                                |
 | **Driving Controls**    | 6       | 32    | AI spotter, audio (incl. Race Engineer & Radar volume), black box cycling, look direction, car control, pit crew |
-| **Cockpit & Interface** | 5       | 33    | Wipers, FFB, splits & reference, telemetry, UI toggles                |
+| **Cockpit & Interface** | 5       | 34    | Wipers, FFB, splits & reference, telemetry, UI toggles                |
 | **View & Camera**       | 5       | 89    | FOV, replay, camera controls, broadcast tools                         |
 | **Media**               | 1       | 7     | Video recording, screenshots                                          |
 | **Pit Service**         | 3       | 15    | Fuel, tires, compounds, tearoff, fast repair                          |

--- a/docs/reference/actions.json
+++ b/docs/reference/actions.json
@@ -259,7 +259,12 @@
             { "value": "mark-event", "label": "Mark Event" },
             { "value": "start-recording", "label": "Start Recording" },
             { "value": "stop-recording", "label": "Stop Recording" },
-            { "value": "restart-recording", "label": "Restart Recording" }
+            { "value": "restart-recording", "label": "Restart Recording" },
+            {
+              "value": "snapshot",
+              "label": "Take Snapshot",
+              "description": "Developer tool: saves the current telemetry + session info to disk as timestamped JSON and Markdown files"
+            }
           ]
         },
         {

--- a/packages/icons/preview/telemetry-control/snapshot.svg
+++ b/packages/icons/preview/telemetry-control/snapshot.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 62" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#3a2a3a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TAKE\nSNAPSHOT"},"border":{"color":"#6a5a6a"}}</desc>
+
+
+    <polyline points="2,10 12,16 22,4 32,12 42,6 50,10 58,7" fill="none" stroke="#ffffff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="30" y1="24" x2="30" y2="42" stroke="#2ecc71" stroke-width="4" stroke-linecap="round"/>
+    <polyline points="21,34 30,43 39,34" fill="none" stroke="#2ecc71" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    <polyline points="4,48 4,60 56,60 56,48" fill="none" stroke="#ffffff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+
+</svg>

--- a/packages/icons/telemetry-control/snapshot.svg
+++ b/packages/icons/telemetry-control/snapshot.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 62" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#3a2a3a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TAKE\nSNAPSHOT"},"border":{"color":"#6a5a6a"}}</desc>
+
+
+    <polyline points="2,10 12,16 22,4 32,12 42,6 50,10 58,7" fill="none" stroke="{{graphic1Color}}" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="30" y1="24" x2="30" y2="42" stroke="#2ecc71" stroke-width="4" stroke-linecap="round"/>
+    <polyline points="21,34 30,43 39,34" fill="none" stroke="#2ecc71" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    <polyline points="4,48 4,60 56,60 56,48" fill="none" stroke="{{graphic1Color}}" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+
+</svg>

--- a/packages/iracing-actions/src/actions/telemetry-control/telemetry-control.ejs
+++ b/packages/iracing-actions/src/actions/telemetry-control/telemetry-control.ejs
@@ -7,17 +7,63 @@
 		<%- include('section-header', { title: 'Action Settings' }) %>
 
 		<sdpi-item label="Mode">
-			<sdpi-select setting="mode" default="toggle-logging">
+			<sdpi-select id="mode-select" setting="mode" default="toggle-logging">
 				<option value="toggle-logging">Toggle Logging</option>
 				<option value="mark-event">Mark Event</option>
 				<option value="start-recording">Start Recording</option>
 				<option value="stop-recording">Stop Recording</option>
 				<option value="restart-recording">Restart Recording</option>
+				<option value="snapshot">Take Snapshot</option>
 			</sdpi-select>
 		</sdpi-item>
 
 		<% var __comms = require('./data/action-comms.json')['telemetry-control']; %>
 		<ird-binding-status mode-setting="<%= __comms._meta.modeSetting %>" comms='<%= JSON.stringify(__comms) %>'></ird-binding-status>
+
+		<sdpi-item id="snapshot-settings" label="Output Folder" class="hidden">
+			<sdpi-textfield setting="outputDir" placeholder="%USERPROFILE%\iRaceDeck\telemetry-snapshots"></sdpi-textfield>
+		</sdpi-item>
+		<div id="snapshot-help" class="ird-supporting-text hidden">
+			Folder where snapshots are written (timestamped JSON + Markdown). Leave blank to use the default
+			(an "iRaceDeck\telemetry-snapshots" folder in your user home folder). Environment variables such as
+			%USERPROFILE% and a leading ~ are expanded; a relative path is resolved against your home folder. The
+			folder is created if it does not exist.
+		</div>
+
+		<script>
+			async function initialize() {
+				await customElements.whenDefined("sdpi-select");
+
+				const modeSelect = document.getElementById("mode-select");
+				if (!modeSelect) return;
+
+				updateVisibility(modeSelect.value || "toggle-logging");
+
+				modeSelect.addEventListener("change", (ev) => updateVisibility(ev.target.value));
+				modeSelect.addEventListener("input", (ev) => updateVisibility(ev.target.value));
+
+				let lastMode = modeSelect.value || "toggle-logging";
+				setInterval(() => {
+					const current = modeSelect.value;
+					if (current && current !== lastMode) {
+						lastMode = current;
+						updateVisibility(current);
+					}
+				}, 100);
+			}
+
+			function updateVisibility(mode) {
+				const isSnapshot = mode === "snapshot";
+				document.getElementById("snapshot-settings")?.classList.toggle("hidden", !isSnapshot);
+				document.getElementById("snapshot-help")?.classList.toggle("hidden", !isSnapshot);
+			}
+
+			if (document.readyState === "loading") {
+				document.addEventListener("DOMContentLoaded", initialize);
+			} else {
+				initialize();
+			}
+		</script>
 
 		<%- include('title-overrides') %>
 

--- a/packages/iracing-actions/src/actions/telemetry-control/telemetry-control.test.ts
+++ b/packages/iracing-actions/src/actions/telemetry-control/telemetry-control.test.ts
@@ -1,6 +1,34 @@
+import { homedir as osHomedir } from "node:os";
+import { sep as pathSep } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { generateTelemetryControlSvg, TELEMETRY_CONTROL_GLOBAL_KEYS } from "./telemetry-control.js";
+import {
+  defaultSnapshotDir,
+  generateTelemetryControlSvg,
+  resolveSnapshotDir,
+  TELEMETRY_CONTROL_GLOBAL_KEYS,
+  TelemetryControl,
+} from "./telemetry-control.js";
+
+const { mockTapBinding, mockMkdirSync, mockWriteFileSync, mockGetCurrentTelemetry, mockGetSessionInfo } = vi.hoisted(
+  () => ({
+    mockTapBinding: vi.fn().mockResolvedValue(undefined),
+    mockMkdirSync: vi.fn(),
+    mockWriteFileSync: vi.fn(),
+    mockGetCurrentTelemetry: vi.fn(),
+    mockGetSessionInfo: vi.fn(),
+  }),
+);
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+
+  return {
+    ...actual,
+    mkdirSync: mockMkdirSync,
+    writeFileSync: mockWriteFileSync,
+  };
+});
 
 vi.mock("@iracedeck/icons/telemetry-control/toggle-logging.svg", () => ({
   default: '<svg xmlns="http://www.w3.org/2000/svg">{{mainLabel}} {{subLabel}}</svg>',
@@ -15,6 +43,9 @@ vi.mock("@iracedeck/icons/telemetry-control/stop-recording.svg", () => ({
   default: '<svg xmlns="http://www.w3.org/2000/svg">{{mainLabel}} {{subLabel}}</svg>',
 }));
 vi.mock("@iracedeck/icons/telemetry-control/restart-recording.svg", () => ({
+  default: '<svg xmlns="http://www.w3.org/2000/svg">{{mainLabel}} {{subLabel}}</svg>',
+}));
+vi.mock("@iracedeck/icons/telemetry-control/snapshot.svg", () => ({
   default: '<svg xmlns="http://www.w3.org/2000/svg">{{mainLabel}} {{subLabel}}</svg>',
 }));
 
@@ -34,11 +65,23 @@ vi.mock("@iracedeck/deck-core", () => ({
   },
   ConnectionStateAwareAction: class MockConnectionStateAwareAction {
     logger = { trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
-    sdkController = { subscribe: vi.fn(), unsubscribe: vi.fn(), getCurrentTelemetry: vi.fn() };
+    sdkController = {
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+      getCurrentTelemetry: mockGetCurrentTelemetry,
+      getSessionInfo: mockGetSessionInfo,
+    };
     updateConnectionState = vi.fn();
     setKeyImage = vi.fn();
     setRegenerateCallback = vi.fn();
     isBindingMissing = vi.fn(() => false);
+    setActiveBinding = vi.fn();
+    tapBinding = mockTapBinding;
+    holdBinding = vi.fn().mockResolvedValue(undefined);
+    releaseBinding = vi.fn().mockResolvedValue(undefined);
+    async onWillAppear() {}
+    async onDidReceiveSettings() {}
+    async onWillDisappear() {}
   },
   formatKeyBinding: vi.fn((b: { key: string; modifiers: string[] }) => {
     if (b.modifiers?.length) {
@@ -120,6 +163,7 @@ const ALL_ACTIONS = [
   "start-recording",
   "stop-recording",
   "restart-recording",
+  "snapshot",
 ] as const;
 
 describe("TelemetryControl", () => {
@@ -161,7 +205,7 @@ describe("TelemetryControl", () => {
       expect(result).toContain("data:image/svg+xml");
     });
 
-    it("should generate valid data URIs for all 5 actions", () => {
+    it("should generate valid data URIs for all actions", () => {
       for (const mode of ALL_ACTIONS) {
         const result = generateTelemetryControlSvg({ mode });
 
@@ -199,6 +243,7 @@ describe("TelemetryControl", () => {
         "start-recording": { mainLabel: "RECORDING", subLabel: "START" },
         "stop-recording": { mainLabel: "RECORDING", subLabel: "STOP" },
         "restart-recording": { mainLabel: "RECORDING", subLabel: "RESTART" },
+        snapshot: { mainLabel: "TAKE", subLabel: "SNAPSHOT" },
       };
 
       for (const [mode, labels] of Object.entries(expectedLabels)) {
@@ -210,6 +255,133 @@ describe("TelemetryControl", () => {
         expect(decoded).toContain(labels.mainLabel);
         expect(decoded).toContain(labels.subLabel);
       }
+    });
+  });
+
+  describe("snapshot mode", () => {
+    const sampleTelemetry = {
+      PlayerCarIdx: 1,
+      Speed: 50,
+      CarIdxPosition: [0, 1],
+      CarIdxLapDistPct: [0, 0.5],
+      CarIdxLap: [0, 3],
+      CarIdxTrackSurface: [-1, 3],
+    };
+    const sampleSessionInfo = {
+      WeekendInfo: { TrackDisplayName: "Test Track" },
+      DriverInfo: { Drivers: [{ CarIdx: 1, CarNumber: "42", UserName: "Test Driver" }] },
+    };
+
+    function fakeEvent(actionId: string, settings: Record<string, unknown>) {
+      return { action: { id: actionId, setTitle: vi.fn(), setImage: vi.fn() }, payload: { settings } };
+    }
+
+    // A platform-appropriate ABSOLUTE path (so resolveSnapshotDir returns it unchanged
+    // on both Windows and POSIX CI runners).
+    const absDir = process.platform === "win32" ? "C:\\snapshots" : "/tmp/snapshots";
+
+    it("defaultSnapshotDir ends with the telemetry-snapshots folder under home", () => {
+      expect(defaultSnapshotDir()).toMatch(/[\\/]iRaceDeck[\\/]telemetry-snapshots$/);
+      // Must NOT assume a "Documents" known folder (OneDrive / localization safe).
+      expect(defaultSnapshotDir()).not.toMatch(/Documents/i);
+    });
+
+    it("resolveSnapshotDir falls back to the default for blank input", () => {
+      expect(resolveSnapshotDir("")).toBe(defaultSnapshotDir());
+      expect(resolveSnapshotDir("   ")).toBe(defaultSnapshotDir());
+      expect(resolveSnapshotDir(undefined)).toBe(defaultSnapshotDir());
+    });
+
+    it("resolveSnapshotDir keeps an absolute configured directory as-is", () => {
+      const abs = process.platform === "win32" ? "C:\\snapshots" : "/tmp/snapshots";
+      expect(resolveSnapshotDir(abs)).toBe(abs);
+    });
+
+    it("resolveSnapshotDir expands %VAR% environment placeholders", () => {
+      process.env.IRD_TEST_SNAP = process.platform === "win32" ? "C:\\snap-env" : "/snap-env";
+
+      try {
+        expect(resolveSnapshotDir("%IRD_TEST_SNAP%")).toBe(process.env.IRD_TEST_SNAP);
+      } finally {
+        delete process.env.IRD_TEST_SNAP;
+      }
+    });
+
+    it("resolveSnapshotDir resolves a relative path against home, not the process cwd", () => {
+      const result = resolveSnapshotDir("snaps");
+      // Resolved to an absolute path, and NOT under the current working directory
+      // (which, in the running plugin, is the Stream Deck install folder).
+      expect(result.endsWith(`${pathSep}snaps`)).toBe(true);
+      expect(result).not.toBe("snaps");
+      expect(result.startsWith(osHomedir())).toBe(true);
+    });
+
+    it("writes json and md files when telemetry is available", async () => {
+      mockGetCurrentTelemetry.mockReturnValue(sampleTelemetry);
+      mockGetSessionInfo.mockReturnValue(sampleSessionInfo);
+
+      const action = new TelemetryControl();
+      await action.onKeyDown(fakeEvent("a1", { mode: "snapshot", outputDir: absDir }) as never);
+
+      expect(mockMkdirSync).toHaveBeenCalledWith(absDir, { recursive: true });
+      expect(mockWriteFileSync).toHaveBeenCalledTimes(2);
+
+      const [jsonCall, mdCall] = mockWriteFileSync.mock.calls;
+      expect(jsonCall[0]).toMatch(/telemetry-snapshot-\d{8}-\d{6}-\d{3}\.json$/);
+      expect(mdCall[0]).toMatch(/telemetry-snapshot-\d{8}-\d{6}-\d{3}\.md$/);
+
+      const jsonBody = JSON.parse(jsonCall[1] as string);
+      expect(jsonBody.telemetry).toEqual(sampleTelemetry);
+      expect(jsonBody.sessionInfo).toEqual(sampleSessionInfo);
+      expect(mdCall[1]).toContain("Test Driver");
+    });
+
+    it("uses the default output directory when outputDir is blank", async () => {
+      mockGetCurrentTelemetry.mockReturnValue(sampleTelemetry);
+      mockGetSessionInfo.mockReturnValue(sampleSessionInfo);
+
+      const action = new TelemetryControl();
+      await action.onKeyDown(fakeEvent("a1", { mode: "snapshot" }) as never);
+
+      expect(mockMkdirSync).toHaveBeenCalledWith(defaultSnapshotDir(), { recursive: true });
+    });
+
+    it("skips writing and warns when no telemetry is available", async () => {
+      mockGetCurrentTelemetry.mockReturnValue(null);
+
+      const action = new TelemetryControl();
+      await action.onKeyDown(fakeEvent("a1", { mode: "snapshot" }) as never);
+
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+      expect(mockMkdirSync).not.toHaveBeenCalled();
+      expect((action as never as { logger: { warn: ReturnType<typeof vi.fn> } }).logger.warn).toHaveBeenCalled();
+    });
+
+    it("logs an error when the file write fails", async () => {
+      mockGetCurrentTelemetry.mockReturnValue(sampleTelemetry);
+      mockGetSessionInfo.mockReturnValue(sampleSessionInfo);
+      // mockImplementationOnce (not mockImplementation): vi.clearAllMocks() in
+      // beforeEach clears call history but NOT implementations, so a persistent
+      // throw would leak into later tests. Scope it to this single call.
+      mockWriteFileSync.mockImplementationOnce(() => {
+        throw new Error("disk full");
+      });
+
+      const action = new TelemetryControl();
+      await action.onKeyDown(fakeEvent("a1", { mode: "snapshot", outputDir: absDir }) as never);
+
+      const logger = (action as never as { logger: { error: ReturnType<typeof vi.fn> } }).logger;
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("disk full"));
+    });
+
+    it("does not write files for non-snapshot modes", async () => {
+      mockGetCurrentTelemetry.mockReturnValue(sampleTelemetry);
+
+      const action = new TelemetryControl();
+      await action.onKeyDown(fakeEvent("a1", { mode: "toggle-logging" }) as never);
+
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+      expect(mockTapBinding).toHaveBeenCalledWith("telemetryControlToggleLogging");
     });
   });
 });

--- a/packages/iracing-actions/src/actions/telemetry-control/telemetry-control.ts
+++ b/packages/iracing-actions/src/actions/telemetry-control/telemetry-control.ts
@@ -19,9 +19,14 @@ import {
 } from "@iracedeck/deck-core";
 import markEventIconSvg from "@iracedeck/icons/telemetry-control/mark-event.svg";
 import restartRecordingIconSvg from "@iracedeck/icons/telemetry-control/restart-recording.svg";
+import snapshotIconSvg from "@iracedeck/icons/telemetry-control/snapshot.svg";
 import startRecordingIconSvg from "@iracedeck/icons/telemetry-control/start-recording.svg";
 import stopRecordingIconSvg from "@iracedeck/icons/telemetry-control/stop-recording.svg";
 import toggleLoggingIconSvg from "@iracedeck/icons/telemetry-control/toggle-logging.svg";
+import { buildSnapshotEnvelope, generateMarkdown, snapshotBaseName } from "@iracedeck/iracing-sdk";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
 import z from "zod";
 
 const ACTION_VALUES = [
@@ -30,6 +35,7 @@ const ACTION_VALUES = [
   "start-recording",
   "stop-recording",
   "restart-recording",
+  "snapshot",
 ] as const;
 
 type TelemetryControlAction = (typeof ACTION_VALUES)[number];
@@ -40,6 +46,7 @@ const ACTION_ICONS: Record<TelemetryControlAction, string> = {
   "start-recording": startRecordingIconSvg,
   "stop-recording": stopRecordingIconSvg,
   "restart-recording": restartRecordingIconSvg,
+  snapshot: snapshotIconSvg,
 };
 
 /**
@@ -51,7 +58,54 @@ const TELEMETRY_CONTROL_TITLES: Record<TelemetryControlAction, string> = {
   "start-recording": "RECORDING\nSTART",
   "stop-recording": "RECORDING\nSTOP",
   "restart-recording": "RECORDING\nRESTART",
+  snapshot: "TAKE\nSNAPSHOT",
 };
+
+/**
+ * @internal Exported for testing
+ *
+ * Default output directory for telemetry snapshots: <home>/iRaceDeck/telemetry-snapshots.
+ *
+ * Deliberately rooted at the home directory rather than the "Documents" known
+ * folder: on Windows, Documents is frequently redirected to OneDrive and/or
+ * localized (e.g. "Tiedostot"), so `homedir()/Documents` points at a stale or
+ * non-existent path. `homedir()/iRaceDeck` is predictable and always writable.
+ */
+export function defaultSnapshotDir(): string {
+  return join(homedir(), "iRaceDeck", "telemetry-snapshots");
+}
+
+/**
+ * Expands a leading `~` and Windows `%VAR%` environment placeholders in a path
+ * string. Unknown `%VAR%` tokens are left intact.
+ */
+function expandPath(input: string): string {
+  let expanded = input;
+
+  if (expanded === "~" || expanded.startsWith("~/") || expanded.startsWith("~\\")) {
+    expanded = join(homedir(), expanded.slice(1));
+  }
+
+  return expanded.replace(/%([^%]+)%/g, (match, name: string) => process.env[name] ?? match);
+}
+
+/**
+ * @internal Exported for testing
+ *
+ * Resolves the effective snapshot output directory. Blank/whitespace falls back
+ * to the default. The configured value has `~`/`%VAR%` expanded, and a relative
+ * path is resolved against the user's home directory — NOT the plugin process
+ * cwd, which is the Stream Deck plugin install folder.
+ */
+export function resolveSnapshotDir(outputDir: string | undefined): string {
+  const trimmed = outputDir?.trim();
+
+  if (!trimmed) return defaultSnapshotDir();
+
+  const expanded = expandPath(trimmed);
+
+  return isAbsolute(expanded) ? expanded : resolve(homedir(), expanded);
+}
 
 /**
  * @internal Exported for testing
@@ -66,6 +120,8 @@ export const TELEMETRY_CONTROL_GLOBAL_KEYS: Record<string, string> = {
 
 const TelemetryControlSettings = CommonSettings.extend({
   mode: z.enum(ACTION_VALUES).default("toggle-logging"),
+  // Output directory for the "snapshot" mode (blank = default folder).
+  outputDir: z.string().default(""),
 });
 
 type TelemetryControlSettings = z.infer<typeof TelemetryControlSettings>;
@@ -131,13 +187,13 @@ export class TelemetryControl extends ConnectionStateAwareAction<TelemetryContro
   override async onKeyDown(ev: IDeckKeyDownEvent<TelemetryControlSettings>): Promise<void> {
     this.logger.info("Key down received");
     const settings = this.parseSettings(ev.payload.settings);
-    await this.executeAction(settings.mode);
+    await this.executeAction(settings);
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<TelemetryControlSettings>): Promise<void> {
     this.logger.info("Dial down received");
     const settings = this.parseSettings(ev.payload.settings);
-    await this.executeAction(settings.mode);
+    await this.executeAction(settings);
   }
 
   private parseSettings(settings: unknown): TelemetryControlSettings {
@@ -147,7 +203,9 @@ export class TelemetryControl extends ConnectionStateAwareAction<TelemetryContro
     return parsed.success ? parsed.data : TelemetryControlSettings.parse({});
   }
 
-  private async executeAction(actionType: TelemetryControlAction): Promise<void> {
+  private async executeAction(settings: TelemetryControlSettings): Promise<void> {
+    const actionType = settings.mode;
+
     switch (actionType) {
       // Keyboard-based actions
       case "toggle-logging":
@@ -174,6 +232,11 @@ export class TelemetryControl extends ConnectionStateAwareAction<TelemetryContro
       case "restart-recording":
         this.executeSdkCommand(() => getCommands().telem.restart(), "Restart recording");
         break;
+
+      // Disk-write action (developer tool) — reads live telemetry, no iRacing command.
+      case "snapshot":
+        this.captureSnapshot(settings);
+        break;
     }
   }
 
@@ -181,6 +244,57 @@ export class TelemetryControl extends ConnectionStateAwareAction<TelemetryContro
     const success = command();
     this.logger.info(`${label} executed`);
     this.logger.debug(`Result: ${success}`);
+  }
+
+  /**
+   * Reads the current telemetry + session info and writes a timestamped JSON
+   * snapshot plus a Markdown companion report. Feedback is log-only: success at
+   * info level, failures at warn/error level.
+   */
+  private captureSnapshot(settings: TelemetryControlSettings): void {
+    const telemetry = this.sdkController.getCurrentTelemetry();
+
+    if (!telemetry) {
+      this.logger.warn("Telemetry snapshot skipped: no telemetry available (is iRacing running?)");
+
+      return;
+    }
+
+    const sessionInfo = this.sdkController.getSessionInfo() ?? null;
+
+    // Everything below — including the pure envelope/markdown builders — runs
+    // inside the try so a throw on malformed telemetry can never escape onto the
+    // Stream Deck event loop as an unhandled rejection.
+    try {
+      const now = new Date();
+      const envelope = buildSnapshotEnvelope(
+        telemetry as unknown as Record<string, unknown>,
+        sessionInfo as Record<string, unknown> | null,
+        true,
+        now,
+      );
+      const markdown = generateMarkdown(
+        telemetry as unknown as Record<string, unknown>,
+        sessionInfo as Record<string, unknown> | null,
+        now,
+      );
+
+      const dir = resolveSnapshotDir(settings.outputDir);
+      // Append milliseconds so two presses within the same second don't collide
+      // and silently overwrite each other (the shared snapshotBaseName has only
+      // 1-second resolution, which is fine for the one-shot CLI).
+      const baseName = `${snapshotBaseName(now)}-${String(now.getMilliseconds()).padStart(3, "0")}`;
+      const jsonPath = join(dir, `${baseName}.json`);
+      const mdPath = join(dir, `${baseName}.md`);
+
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(jsonPath, JSON.stringify(envelope, null, 2), "utf-8");
+      writeFileSync(mdPath, markdown, "utf-8");
+      this.logger.info("Telemetry snapshot saved");
+      this.logger.debug(`Snapshot written to ${jsonPath} and ${mdPath}`);
+    } catch (error) {
+      this.logger.error(`Failed to write telemetry snapshot: ${error instanceof Error ? error.message : error}`);
+    }
   }
 
   private async updateDisplay(

--- a/packages/iracing-actions/src/actions/telemetry-control/telemetry-control.ts
+++ b/packages/iracing-actions/src/actions/telemetry-control/telemetry-control.ts
@@ -280,10 +280,9 @@ export class TelemetryControl extends ConnectionStateAwareAction<TelemetryContro
       );
 
       const dir = resolveSnapshotDir(settings.outputDir);
-      // Append milliseconds so two presses within the same second don't collide
-      // and silently overwrite each other (the shared snapshotBaseName has only
-      // 1-second resolution, which is fine for the one-shot CLI).
-      const baseName = `${snapshotBaseName(now)}-${String(now.getMilliseconds()).padStart(3, "0")}`;
+      // snapshotBaseName includes milliseconds, so two presses within the same
+      // second don't collide and silently overwrite each other.
+      const baseName = snapshotBaseName(now);
       const jsonPath = join(dir, `${baseName}.json`);
       const mdPath = join(dir, `${baseName}.md`);
 

--- a/packages/iracing-sdk/src/cli/telemetry-snapshot.ts
+++ b/packages/iracing-sdk/src/cli/telemetry-snapshot.ts
@@ -18,7 +18,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 import { createSDK } from "../factory.js";
-import { TrkLoc } from "../types.js";
+import { buildSnapshotEnvelope, generateMarkdown, snapshotBaseName } from "../snapshot.js";
 
 interface CliOptions {
   format: "json" | "keyvalue";
@@ -155,401 +155,6 @@ function filterVars(data: Record<string, unknown>, vars: string[]): Record<strin
   return result;
 }
 
-interface DriverInfo {
-  carIdx: number;
-  carNumber: string;
-  driverName: string;
-  position: number;
-  lapsCompleted: number;
-  lapDistPct: number;
-  trackLocation: string;
-}
-
-function trkLocToString(loc: number): string {
-  switch (loc) {
-    case TrkLoc.OnTrack:
-      return "On Track";
-    case TrkLoc.OffTrack:
-      return "Off Track";
-    case TrkLoc.InPitStall:
-      return "In Pit Stall";
-    case TrkLoc.AproachingPits:
-      return "Pit Lane";
-    case TrkLoc.NotInWorld:
-      return "Not in World";
-    default:
-      return `Unknown (${loc})`;
-  }
-}
-
-function buildDriverList(
-  telemetry: Record<string, unknown>,
-  sessionInfo: Record<string, unknown> | null,
-): DriverInfo[] {
-  const positions = telemetry.CarIdxPosition as number[] | undefined;
-  const lapDistPcts = telemetry.CarIdxLapDistPct as number[] | undefined;
-  const laps = telemetry.CarIdxLap as number[] | undefined;
-  const trackSurfaces = telemetry.CarIdxTrackSurface as number[] | undefined;
-
-  if (!positions || !lapDistPcts || !laps || !trackSurfaces) return [];
-
-  const driverInfo = sessionInfo?.DriverInfo as Record<string, unknown> | undefined;
-  const drivers = (driverInfo?.Drivers as Array<Record<string, unknown>>) ?? [];
-
-  const driverMap = new Map<number, { carNumber: string; userName: string }>();
-
-  for (const d of drivers) {
-    driverMap.set(d.CarIdx as number, {
-      carNumber: String(d.CarNumber ?? ""),
-      userName: String(d.UserName ?? ""),
-    });
-  }
-
-  const result: DriverInfo[] = [];
-
-  for (let i = 0; i < positions.length; i++) {
-    if (positions[i] <= 0 && trackSurfaces[i] === TrkLoc.NotInWorld) continue;
-
-    const driver = driverMap.get(i);
-
-    if (!driver) continue;
-
-    result.push({
-      carIdx: i,
-      carNumber: driver.carNumber,
-      driverName: driver.userName,
-      position: positions[i],
-      lapsCompleted: Math.max(0, laps[i] - 1),
-      lapDistPct: lapDistPcts[i],
-      trackLocation: trkLocToString(trackSurfaces[i]),
-    });
-  }
-
-  return result;
-}
-
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str : str + " ".repeat(len - str.length);
-}
-
-function padLeft(str: string, len: number): string {
-  return str.length >= len ? str : " ".repeat(len - str.length) + str;
-}
-
-function buildMarkdownTable(headers: string[], rows: string[][], alignRight: boolean[]): string {
-  const colWidths = headers.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i].length)));
-
-  const headerLine =
-    "| " +
-    headers.map((h, i) => (alignRight[i] ? padLeft(h, colWidths[i]) : padRight(h, colWidths[i]))).join(" | ") +
-    " |";
-
-  const separatorLine =
-    "| " + colWidths.map((w, i) => (alignRight[i] ? "-".repeat(w - 1) + ":" : "-".repeat(w))).join(" | ") + " |";
-
-  const dataLines = rows.map(
-    (row) =>
-      "| " +
-      row.map((cell, i) => (alignRight[i] ? padLeft(cell, colWidths[i]) : padRight(cell, colWidths[i]))).join(" | ") +
-      " |",
-  );
-
-  return [headerLine, separatorLine, ...dataLines].join("\n");
-}
-
-function getSessionIdentification(sessionInfo: Record<string, unknown> | null): string | null {
-  if (!sessionInfo) return null;
-
-  const weekend = sessionInfo.WeekendInfo as Record<string, unknown> | undefined;
-  const sessionSection = sessionInfo.SessionInfo as Record<string, unknown> | undefined;
-  const sessions = sessionSection?.Sessions as Array<Record<string, unknown>> | undefined;
-
-  const rows: string[][] = [];
-
-  if (weekend) {
-    const trackName = weekend.TrackDisplayName ?? weekend.TrackName;
-    const config = weekend.TrackConfigName;
-    const trackLine = config ? `${trackName} — ${config}` : String(trackName ?? "Unknown Track");
-    rows.push(["Track", trackLine]);
-
-    if (weekend.TrackLength) rows.push(["Track Length", String(weekend.TrackLength)]);
-
-    if (weekend.TrackCity || weekend.TrackCountry) {
-      const location = [weekend.TrackCity, weekend.TrackCountry].filter(Boolean).join(", ");
-      rows.push(["Location", location]);
-    }
-
-    if (weekend.EventType) rows.push(["Event Type", String(weekend.EventType)]);
-
-    if (weekend.Category) rows.push(["Category", String(weekend.Category)]);
-
-    if (weekend.TrackType) rows.push(["Track Type", String(weekend.TrackType)]);
-
-    if (weekend.NumCarClasses) rows.push(["Car Classes", String(weekend.NumCarClasses)]);
-
-    if (weekend.TrackPitSpeedLimit) rows.push(["Pit Speed Limit", String(weekend.TrackPitSpeedLimit)]);
-  }
-
-  if (sessions && sessions.length > 0) {
-    const currentSession = sessions[sessions.length - 1];
-
-    if (currentSession.SessionType) rows.push(["Session Type", String(currentSession.SessionType)]);
-
-    if (currentSession.SessionLaps) rows.push(["Session Laps", String(currentSession.SessionLaps)]);
-
-    if (currentSession.SessionTime) rows.push(["Session Time", String(currentSession.SessionTime)]);
-  }
-
-  if (weekend) {
-    if (weekend.TrackSkies) rows.push(["Skies", String(weekend.TrackSkies)]);
-
-    if (weekend.TrackAirTemp) rows.push(["Air Temp", String(weekend.TrackAirTemp)]);
-
-    if (weekend.TrackSurfaceTemp) rows.push(["Surface Temp", String(weekend.TrackSurfaceTemp)]);
-  }
-
-  if (rows.length === 0) return null;
-
-  return buildMarkdownTable(["", ""], rows, [false, false]);
-}
-
-function buildDriverDetailsTable(sessionInfo: Record<string, unknown> | null): string | null {
-  if (!sessionInfo) return null;
-
-  const driverInfo = sessionInfo.DriverInfo as Record<string, unknown> | undefined;
-  const drivers = driverInfo?.Drivers as Array<Record<string, unknown>> | undefined;
-
-  if (!drivers || drivers.length === 0) return null;
-
-  const headers = ["Car Idx", "Car #", "Driver", "Car", "iRating", "License", "Team", "AI"];
-  const alignRight = [true, true, false, false, true, false, false, false];
-
-  const rows: string[][] = [];
-
-  for (const d of drivers) {
-    if (d.CarIsPaceCar === 1) continue;
-
-    rows.push([
-      String(d.CarIdx ?? ""),
-      String(d.CarNumber ?? ""),
-      String(d.UserName ?? ""),
-      String(d.CarScreenNameShort ?? d.CarScreenName ?? ""),
-      String(d.IRating ?? ""),
-      String(d.LicString ?? ""),
-      String(d.TeamName ?? ""),
-      d.CarIsAI === 1 ? "Yes" : "No",
-    ]);
-  }
-
-  if (rows.length === 0) return null;
-
-  return buildMarkdownTable(headers, rows, alignRight);
-}
-
-function formatTime(seconds: number): string {
-  if (seconds < 0) return "-";
-
-  const mins = Math.floor(seconds / 60);
-  const secs = seconds % 60;
-
-  return mins > 0 ? `${mins}:${secs.toFixed(3).padStart(7, "0")}` : `${secs.toFixed(3)}s`;
-}
-
-function buildPlayerTelemetry(
-  telemetry: Record<string, unknown>,
-  sessionInfo: Record<string, unknown> | null,
-): string | null {
-  const playerCarIdx = telemetry.PlayerCarIdx as number | undefined;
-
-  if (playerCarIdx === undefined) return null;
-
-  const driverInfo = sessionInfo?.DriverInfo as Record<string, unknown> | undefined;
-  const drivers = driverInfo?.Drivers as Array<Record<string, unknown>> | undefined;
-  const player = drivers?.find((d) => d.CarIdx === playerCarIdx);
-
-  const posRows: string[][] = [];
-
-  // Player identity
-  if (player) {
-    posRows.push(["Driver", String(player.UserName)]);
-    posRows.push(["Car", `${player.CarScreenName ?? player.CarScreenNameShort ?? "Unknown"} (#${player.CarNumber})`]);
-
-    if (player.TeamName) posRows.push(["Team", String(player.TeamName)]);
-
-    if (player.IRating) posRows.push(["iRating", String(player.IRating)]);
-
-    if (player.LicString) posRows.push(["License", String(player.LicString)]);
-  }
-
-  // Car info from DriverInfo section
-  if (driverInfo) {
-    if (driverInfo.DriverSetupName) posRows.push(["Setup", String(driverInfo.DriverSetupName)]);
-
-    if (driverInfo.DriverCarFuelMaxLtr) posRows.push(["Max Fuel", `${driverInfo.DriverCarFuelMaxLtr} L`]);
-
-    if (driverInfo.DriverCarEstLapTime)
-      posRows.push(["Est. Lap Time", formatTime(Number(driverInfo.DriverCarEstLapTime))]);
-  }
-
-  // Position
-  if (telemetry.PlayerCarPosition !== undefined)
-    posRows.push(["Position (Overall)", String(telemetry.PlayerCarPosition)]);
-
-  if (telemetry.PlayerCarClassPosition !== undefined)
-    posRows.push(["Position (Class)", String(telemetry.PlayerCarClassPosition)]);
-
-  posRows.push(["Track Surface", trkLocToString((telemetry.PlayerTrackSurface as number) ?? TrkLoc.NotInWorld)]);
-
-  if (telemetry.OnPitRoad !== undefined) posRows.push(["On Pit Road", telemetry.OnPitRoad ? "Yes" : "No"]);
-
-  if (telemetry.PlayerCarInPitStall !== undefined)
-    posRows.push(["In Pit Stall", telemetry.PlayerCarInPitStall ? "Yes" : "No"]);
-
-  if (telemetry.PlayerCarMyIncidentCount !== undefined)
-    posRows.push(["Incidents", String(telemetry.PlayerCarMyIncidentCount)]);
-
-  // Lap & timing
-  if (telemetry.Lap !== undefined) posRows.push(["Current Lap", String(telemetry.Lap)]);
-
-  if (telemetry.LapCompleted !== undefined) posRows.push(["Laps Completed", String(telemetry.LapCompleted)]);
-
-  if (telemetry.LapDistPct !== undefined)
-    posRows.push(["Lap Distance %", (Number(telemetry.LapDistPct) * 100).toFixed(4) + "%"]);
-
-  if (telemetry.LapCurrentLapTime !== undefined)
-    posRows.push(["Current Lap Time", formatTime(Number(telemetry.LapCurrentLapTime))]);
-
-  if (telemetry.LapBestLapTime !== undefined && Number(telemetry.LapBestLapTime) > 0)
-    posRows.push(["Best Lap Time", formatTime(Number(telemetry.LapBestLapTime))]);
-
-  if (telemetry.LapLastLapTime !== undefined && Number(telemetry.LapLastLapTime) > 0)
-    posRows.push(["Last Lap Time", formatTime(Number(telemetry.LapLastLapTime))]);
-
-  if (telemetry.LapDeltaToBestLap !== undefined && telemetry.LapDeltaToBestLap_OK)
-    posRows.push([
-      "Delta to Best",
-      `${Number(telemetry.LapDeltaToBestLap) >= 0 ? "+" : ""}${Number(telemetry.LapDeltaToBestLap).toFixed(3)}s`,
-    ]);
-
-  // Vehicle state
-  if (telemetry.Speed !== undefined) posRows.push(["Speed", `${(Number(telemetry.Speed) * 3.6).toFixed(1)} km/h`]);
-
-  if (telemetry.RPM !== undefined) posRows.push(["RPM", String(Math.round(Number(telemetry.RPM)))]);
-
-  if (telemetry.Gear !== undefined)
-    posRows.push([
-      "Gear",
-      Number(telemetry.Gear) === -1 ? "R" : Number(telemetry.Gear) === 0 ? "N" : String(telemetry.Gear),
-    ]);
-
-  if (telemetry.Throttle !== undefined) posRows.push(["Throttle", `${(Number(telemetry.Throttle) * 100).toFixed(0)}%`]);
-
-  if (telemetry.Brake !== undefined) posRows.push(["Brake", `${(Number(telemetry.Brake) * 100).toFixed(0)}%`]);
-
-  if (telemetry.SteeringWheelAngle !== undefined)
-    posRows.push(["Steering Angle", `${(Number(telemetry.SteeringWheelAngle) * (180 / Math.PI)).toFixed(1)}°`]);
-
-  // Fuel
-  if (telemetry.FuelLevel !== undefined) posRows.push(["Fuel Level", `${Number(telemetry.FuelLevel).toFixed(1)} L`]);
-
-  if (telemetry.FuelLevelPct !== undefined)
-    posRows.push(["Fuel %", `${(Number(telemetry.FuelLevelPct) * 100).toFixed(1)}%`]);
-
-  if (telemetry.FuelUsePerHour !== undefined)
-    posRows.push(["Fuel Use/Hour", `${Number(telemetry.FuelUsePerHour).toFixed(1)} L/h`]);
-
-  // Temperatures & electrical
-  if (telemetry.OilTemp !== undefined) posRows.push(["Oil Temp", `${Number(telemetry.OilTemp).toFixed(1)} °C`]);
-
-  if (telemetry.WaterTemp !== undefined) posRows.push(["Water Temp", `${Number(telemetry.WaterTemp).toFixed(1)} °C`]);
-
-  if (telemetry.Voltage !== undefined) posRows.push(["Voltage", `${Number(telemetry.Voltage).toFixed(1)} V`]);
-
-  if (posRows.length === 0) return null;
-
-  return buildMarkdownTable(["", ""], posRows, [false, false]);
-}
-
-function generateMarkdown(telemetry: Record<string, unknown>, sessionInfo: Record<string, unknown> | null): string {
-  const drivers = buildDriverList(telemetry, sessionInfo);
-  const lines: string[] = [];
-
-  lines.push("# Telemetry Snapshot");
-  lines.push("");
-  lines.push(`*${new Date().toISOString()}*`);
-  lines.push("");
-
-  const sessionTable = getSessionIdentification(sessionInfo);
-
-  if (sessionTable) {
-    lines.push("## Session Info");
-    lines.push("");
-    lines.push(sessionTable);
-    lines.push("");
-  }
-
-  if (drivers.length === 0) {
-    lines.push("No position data available.");
-    lines.push("");
-  } else {
-    const headers = ["Pos", "Car #", "Car Idx", "Driver", "Laps", "Lap Dist %", "Location"];
-    const alignRight = [true, true, true, false, true, true, false];
-
-    const toRow = (d: DriverInfo): string[] => [
-      String(d.position),
-      d.carNumber,
-      String(d.carIdx),
-      d.driverName,
-      String(d.lapsCompleted),
-      (d.lapDistPct * 100).toFixed(4) + "%",
-      d.trackLocation,
-    ];
-
-    // Table 1: sorted by position
-    const byPosition = [...drivers].sort((a, b) => {
-      if (a.position <= 0 && b.position <= 0) return 0;
-
-      if (a.position <= 0) return 1;
-
-      if (b.position <= 0) return -1;
-
-      return a.position - b.position;
-    });
-
-    // Table 2: sorted by lap distance percentage only (track position, not race position)
-    const byTrackProgress = [...drivers].sort((a, b) => b.lapDistPct - a.lapDistPct);
-
-    lines.push("## Race Position Order");
-    lines.push("");
-    lines.push(buildMarkdownTable(headers, byPosition.map(toRow), alignRight));
-    lines.push("");
-    lines.push("## Track Position Order (Car Ahead / Behind)");
-    lines.push("");
-    lines.push(buildMarkdownTable(headers, byTrackProgress.map(toRow), alignRight));
-    lines.push("");
-  }
-
-  const driverTable = buildDriverDetailsTable(sessionInfo);
-
-  if (driverTable) {
-    lines.push("## Driver Details");
-    lines.push("");
-    lines.push(driverTable);
-    lines.push("");
-  }
-
-  const playerTable = buildPlayerTelemetry(telemetry, sessionInfo);
-
-  if (playerTable) {
-    lines.push("## Player Telemetry");
-    lines.push("");
-    lines.push(playerTable);
-    lines.push("");
-  }
-
-  return lines.join("\n");
-}
-
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const options = parseArgs(args);
@@ -609,14 +214,11 @@ async function main(): Promise<void> {
   const sessionInfo = sdk.getSessionInfo() ?? null;
 
   // Build output object
-  const output: Record<string, unknown> = {
-    timestamp: new Date().toISOString(),
-    telemetry,
-  };
-
-  if (options.includeSession && sessionInfo) {
-    output.sessionInfo = sessionInfo;
-  }
+  const output = buildSnapshotEnvelope(
+    telemetry as unknown as Record<string, unknown>,
+    sessionInfo as Record<string, unknown> | null,
+    options.includeSession,
+  );
 
   // Disconnect
   sdk.disconnect();
@@ -627,7 +229,7 @@ async function main(): Promise<void> {
   if (options.format === "json") {
     result = JSON.stringify(output, null, 2);
   } else {
-    result = formatKeyValue(output);
+    result = formatKeyValue(output as unknown as Record<string, unknown>);
   }
 
   // Resolve output path
@@ -636,13 +238,10 @@ async function main(): Promise<void> {
   if (options.output) {
     outputPath = resolve(process.env.INIT_CWD || process.cwd(), options.output);
   } else if (options.outputDir) {
-    const now = new Date();
-    const pad = (n: number): string => String(n).padStart(2, "0");
-    const timestamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
     const ext = options.format === "json" ? "json" : "txt";
     const baseDir = resolve(process.env.INIT_CWD || process.cwd(), options.outputDir);
     mkdirSync(baseDir, { recursive: true });
-    outputPath = join(baseDir, `telemetry-snapshot-${timestamp}.${ext}`);
+    outputPath = join(baseDir, `${snapshotBaseName()}.${ext}`);
   }
 
   // Generate markdown

--- a/packages/iracing-sdk/src/cli/telemetry-snapshot.ts
+++ b/packages/iracing-sdk/src/cli/telemetry-snapshot.ts
@@ -213,11 +213,17 @@ async function main(): Promise<void> {
   // Always read session info (needed for markdown driver names)
   const sessionInfo = sdk.getSessionInfo() ?? null;
 
+  // Freeze a single timestamp so the JSON `timestamp`, the generated filename,
+  // and the Markdown header all describe the same instant (and don't drift
+  // across a second boundary between the three calls below).
+  const now = new Date();
+
   // Build output object
   const output = buildSnapshotEnvelope(
     telemetry as unknown as Record<string, unknown>,
     sessionInfo as Record<string, unknown> | null,
     options.includeSession,
+    now,
   );
 
   // Disconnect
@@ -241,13 +247,14 @@ async function main(): Promise<void> {
     const ext = options.format === "json" ? "json" : "txt";
     const baseDir = resolve(process.env.INIT_CWD || process.cwd(), options.outputDir);
     mkdirSync(baseDir, { recursive: true });
-    outputPath = join(baseDir, `${snapshotBaseName()}.${ext}`);
+    outputPath = join(baseDir, `${snapshotBaseName(now)}.${ext}`);
   }
 
   // Generate markdown
   const markdown = generateMarkdown(
     telemetry as unknown as Record<string, unknown>,
     sessionInfo as Record<string, unknown> | null,
+    now,
   );
 
   // Output

--- a/packages/iracing-sdk/src/index.ts
+++ b/packages/iracing-sdk/src/index.ts
@@ -130,3 +130,19 @@ export {
   getCarNumberRawFromSessionInfo,
   getAllCarNumbers,
 } from "./session-utils.js";
+
+// Telemetry snapshot formatting utilities
+export {
+  type DriverInfo,
+  type SnapshotEnvelope,
+  buildDriverDetailsTable,
+  buildDriverList,
+  buildMarkdownTable,
+  buildPlayerTelemetry,
+  buildSnapshotEnvelope,
+  generateMarkdown,
+  getSessionIdentification,
+  snapshotBaseName,
+  snapshotTimestamp,
+  trkLocToString,
+} from "./snapshot.js";

--- a/packages/iracing-sdk/src/snapshot.test.ts
+++ b/packages/iracing-sdk/src/snapshot.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDriverDetailsTable,
+  buildDriverList,
+  buildMarkdownTable,
+  buildPlayerTelemetry,
+  buildSnapshotEnvelope,
+  generateMarkdown,
+  getSessionIdentification,
+  snapshotBaseName,
+  snapshotTimestamp,
+  trkLocToString,
+} from "./snapshot.js";
+import { TrkLoc } from "./types.js";
+
+const sampleTelemetry: Record<string, unknown> = {
+  PlayerCarIdx: 1,
+  PlayerCarPosition: 2,
+  PlayerCarClassPosition: 1,
+  PlayerTrackSurface: TrkLoc.OnTrack,
+  OnPitRoad: false,
+  Lap: 5,
+  Speed: 50, // m/s
+  RPM: 6500.4,
+  Gear: 4,
+  FuelLevel: 32.567,
+  CarIdxPosition: [0, 2, 1],
+  CarIdxLapDistPct: [0, 0.25, 0.75],
+  CarIdxLap: [0, 5, 5],
+  CarIdxTrackSurface: [TrkLoc.NotInWorld, TrkLoc.OnTrack, TrkLoc.OnTrack],
+};
+
+const sampleSessionInfo: Record<string, unknown> = {
+  WeekendInfo: {
+    TrackDisplayName: "Silverstone Circuit",
+    TrackConfigName: "Grand Prix",
+    TrackLength: "5.81 km",
+    EventType: "Race",
+  },
+  SessionInfo: {
+    Sessions: [{ SessionType: "Race", SessionLaps: "20", SessionTime: "unlimited" }],
+  },
+  DriverInfo: {
+    DriverCarIdx: 1,
+    Drivers: [
+      { CarIdx: 1, CarNumber: "42", UserName: "Test Driver", CarScreenName: "Mazda MX-5", IRating: 2500 },
+      { CarIdx: 2, CarNumber: "7", UserName: "Other Driver", CarScreenName: "Mazda MX-5", IRating: 1900 },
+    ],
+  },
+};
+
+describe("trkLocToString", () => {
+  it("should map known track locations", () => {
+    expect(trkLocToString(TrkLoc.OnTrack)).toBe("On Track");
+    expect(trkLocToString(TrkLoc.OffTrack)).toBe("Off Track");
+    expect(trkLocToString(TrkLoc.InPitStall)).toBe("In Pit Stall");
+    expect(trkLocToString(TrkLoc.AproachingPits)).toBe("Pit Lane");
+    expect(trkLocToString(TrkLoc.NotInWorld)).toBe("Not in World");
+  });
+
+  it("should report unknown values", () => {
+    expect(trkLocToString(99)).toBe("Unknown (99)");
+  });
+});
+
+describe("buildDriverList", () => {
+  it("should return empty list when car index arrays are missing", () => {
+    expect(buildDriverList({}, sampleSessionInfo)).toEqual([]);
+  });
+
+  it("should skip cars that are not in the world with no position", () => {
+    const drivers = buildDriverList(sampleTelemetry, sampleSessionInfo);
+
+    expect(drivers.map((d) => d.carIdx)).toEqual([1, 2]);
+  });
+
+  it("should map driver names and numbers from session info", () => {
+    const drivers = buildDriverList(sampleTelemetry, sampleSessionInfo);
+
+    expect(drivers[0]).toMatchObject({ carIdx: 1, carNumber: "42", driverName: "Test Driver", position: 2 });
+  });
+
+  it("should compute laps completed as lap - 1 with a floor of 0", () => {
+    const drivers = buildDriverList(sampleTelemetry, sampleSessionInfo);
+
+    expect(drivers[0].lapsCompleted).toBe(4);
+
+    const lapZero = buildDriverList({ ...sampleTelemetry, CarIdxLap: [0, 0, 0] }, sampleSessionInfo);
+
+    expect(lapZero[0].lapsCompleted).toBe(0);
+  });
+});
+
+describe("buildMarkdownTable", () => {
+  it("should build an aligned markdown table", () => {
+    const table = buildMarkdownTable(["Name", "Value"], [["Speed", "100"]], [false, true]);
+    const lines = table.split("\n");
+
+    expect(lines[0]).toBe("| Name  | Value |");
+    expect(lines[1]).toBe("| ----- | ----: |");
+    expect(lines[2]).toBe("| Speed |   100 |");
+  });
+});
+
+describe("getSessionIdentification", () => {
+  it("should return null when session info is null", () => {
+    expect(getSessionIdentification(null)).toBeNull();
+  });
+
+  it("should return null when no identifying fields exist", () => {
+    expect(getSessionIdentification({})).toBeNull();
+  });
+
+  it("should include track and session details", () => {
+    const table = getSessionIdentification(sampleSessionInfo);
+
+    expect(table).toContain("Silverstone Circuit — Grand Prix");
+    expect(table).toContain("Session Type");
+    expect(table).toContain("Race");
+  });
+});
+
+describe("buildDriverDetailsTable", () => {
+  it("should return null when session info is null", () => {
+    expect(buildDriverDetailsTable(null)).toBeNull();
+  });
+
+  it("should return null when there are no drivers", () => {
+    expect(buildDriverDetailsTable({ DriverInfo: { Drivers: [] } })).toBeNull();
+  });
+
+  it("should list drivers and skip the pace car", () => {
+    const withPaceCar = {
+      DriverInfo: {
+        Drivers: [
+          { CarIdx: 0, CarNumber: "0", UserName: "Pace Car", CarIsPaceCar: 1 },
+          { CarIdx: 1, CarNumber: "42", UserName: "Test Driver" },
+        ],
+      },
+    };
+    const table = buildDriverDetailsTable(withPaceCar);
+
+    expect(table).toContain("Test Driver");
+    expect(table).not.toContain("Pace Car");
+  });
+});
+
+describe("buildPlayerTelemetry", () => {
+  it("should return null when player car index is missing", () => {
+    expect(buildPlayerTelemetry({}, sampleSessionInfo)).toBeNull();
+  });
+
+  it("should include player identity and vehicle state", () => {
+    const table = buildPlayerTelemetry(sampleTelemetry, sampleSessionInfo);
+
+    expect(table).toContain("Test Driver");
+    expect(table).toContain("Mazda MX-5 (#42)");
+    expect(table).toContain("180.0 km/h"); // 50 m/s * 3.6
+    expect(table).toContain("32.6 L");
+  });
+});
+
+describe("generateMarkdown", () => {
+  it("should include all report sections for full data", () => {
+    const markdown = generateMarkdown(sampleTelemetry, sampleSessionInfo);
+
+    expect(markdown).toContain("# Telemetry Snapshot");
+    expect(markdown).toContain("## Session Info");
+    expect(markdown).toContain("## Race Position Order");
+    expect(markdown).toContain("## Track Position Order (Car Ahead / Behind)");
+    expect(markdown).toContain("## Driver Details");
+    expect(markdown).toContain("## Player Telemetry");
+  });
+
+  it("should note missing position data when telemetry has no car arrays", () => {
+    const markdown = generateMarkdown({}, null);
+
+    expect(markdown).toContain("No position data available.");
+  });
+
+  it("should stamp the report with the provided time", () => {
+    const now = new Date("2026-06-02T15:04:05.000Z");
+    const markdown = generateMarkdown(sampleTelemetry, sampleSessionInfo, now);
+
+    expect(markdown).toContain("*2026-06-02T15:04:05.000Z*");
+  });
+});
+
+describe("snapshotTimestamp", () => {
+  it("should format the timestamp as YYYYMMDD-HHMMSS in local time", () => {
+    const now = new Date(2026, 5, 2, 15, 4, 5);
+
+    expect(snapshotTimestamp(now)).toBe("20260602-150405");
+  });
+
+  it("should zero-pad single digit components", () => {
+    const now = new Date(2026, 0, 1, 1, 2, 3);
+
+    expect(snapshotTimestamp(now)).toBe("20260101-010203");
+  });
+});
+
+describe("snapshotBaseName", () => {
+  it("should prefix the timestamp with telemetry-snapshot-", () => {
+    const now = new Date(2026, 5, 2, 15, 4, 5);
+
+    expect(snapshotBaseName(now)).toBe("telemetry-snapshot-20260602-150405");
+  });
+});
+
+describe("buildSnapshotEnvelope", () => {
+  const now = new Date("2026-06-02T15:04:05.000Z");
+
+  it("should include telemetry and an ISO timestamp", () => {
+    const envelope = buildSnapshotEnvelope(sampleTelemetry, sampleSessionInfo, false, now);
+
+    expect(envelope.timestamp).toBe("2026-06-02T15:04:05.000Z");
+    expect(envelope.telemetry).toBe(sampleTelemetry);
+    expect(envelope.sessionInfo).toBeUndefined();
+  });
+
+  it("should include session info when requested", () => {
+    const envelope = buildSnapshotEnvelope(sampleTelemetry, sampleSessionInfo, true, now);
+
+    expect(envelope.sessionInfo).toBe(sampleSessionInfo);
+  });
+
+  it("should omit session info when requested but unavailable", () => {
+    const envelope = buildSnapshotEnvelope(sampleTelemetry, null, true, now);
+
+    expect(envelope.sessionInfo).toBeUndefined();
+  });
+});

--- a/packages/iracing-sdk/src/snapshot.test.ts
+++ b/packages/iracing-sdk/src/snapshot.test.ts
@@ -202,10 +202,16 @@ describe("snapshotTimestamp", () => {
 });
 
 describe("snapshotBaseName", () => {
-  it("should prefix the timestamp with telemetry-snapshot-", () => {
-    const now = new Date(2026, 5, 2, 15, 4, 5);
+  it("should prefix the timestamp with telemetry-snapshot- and include milliseconds", () => {
+    const now = new Date(2026, 5, 2, 15, 4, 5, 0);
 
-    expect(snapshotBaseName(now)).toBe("telemetry-snapshot-20260602-150405");
+    expect(snapshotBaseName(now)).toBe("telemetry-snapshot-20260602-150405-000");
+  });
+
+  it("should zero-pad the millisecond component", () => {
+    const now = new Date(2026, 5, 2, 15, 4, 5, 7);
+
+    expect(snapshotBaseName(now)).toBe("telemetry-snapshot-20260602-150405-007");
   });
 });
 

--- a/packages/iracing-sdk/src/snapshot.ts
+++ b/packages/iracing-sdk/src/snapshot.ts
@@ -1,0 +1,484 @@
+/**
+ * Telemetry snapshot formatting utilities
+ *
+ * Pure helpers shared by the telemetry-snapshot CLI and the Telemetry Snapshot
+ * Stream Deck action. They format a telemetry + session info reading into a
+ * JSON envelope and a human-readable Markdown report. No filesystem access —
+ * callers decide where the output goes.
+ */
+import { TrkLoc } from "./types.js";
+
+/**
+ * Driver summary row extracted from telemetry + session info.
+ */
+export interface DriverInfo {
+  carIdx: number;
+  carNumber: string;
+  driverName: string;
+  position: number;
+  lapsCompleted: number;
+  lapDistPct: number;
+  trackLocation: string;
+}
+
+/**
+ * The JSON output shape of a telemetry snapshot.
+ */
+export interface SnapshotEnvelope {
+  timestamp: string;
+  telemetry: Record<string, unknown>;
+  sessionInfo?: Record<string, unknown>;
+}
+
+/**
+ * Converts a TrkLoc enum value to a human-readable string.
+ */
+export function trkLocToString(loc: number): string {
+  switch (loc) {
+    case TrkLoc.OnTrack:
+      return "On Track";
+    case TrkLoc.OffTrack:
+      return "Off Track";
+    case TrkLoc.InPitStall:
+      return "In Pit Stall";
+    case TrkLoc.AproachingPits:
+      return "Pit Lane";
+    case TrkLoc.NotInWorld:
+      return "Not in World";
+    default:
+      return `Unknown (${loc})`;
+  }
+}
+
+/**
+ * Builds a list of drivers currently in the session from telemetry car-index
+ * arrays and session info driver records.
+ */
+export function buildDriverList(
+  telemetry: Record<string, unknown>,
+  sessionInfo: Record<string, unknown> | null,
+): DriverInfo[] {
+  const positions = telemetry.CarIdxPosition as number[] | undefined;
+  const lapDistPcts = telemetry.CarIdxLapDistPct as number[] | undefined;
+  const laps = telemetry.CarIdxLap as number[] | undefined;
+  const trackSurfaces = telemetry.CarIdxTrackSurface as number[] | undefined;
+
+  if (!positions || !lapDistPcts || !laps || !trackSurfaces) return [];
+
+  const driverInfo = sessionInfo?.DriverInfo as Record<string, unknown> | undefined;
+  const drivers = (driverInfo?.Drivers as Array<Record<string, unknown>>) ?? [];
+
+  const driverMap = new Map<number, { carNumber: string; userName: string }>();
+
+  for (const d of drivers) {
+    driverMap.set(d.CarIdx as number, {
+      carNumber: String(d.CarNumber ?? ""),
+      userName: String(d.UserName ?? ""),
+    });
+  }
+
+  const result: DriverInfo[] = [];
+
+  for (let i = 0; i < positions.length; i++) {
+    if (positions[i] <= 0 && trackSurfaces[i] === TrkLoc.NotInWorld) continue;
+
+    const driver = driverMap.get(i);
+
+    if (!driver) continue;
+
+    result.push({
+      carIdx: i,
+      carNumber: driver.carNumber,
+      driverName: driver.userName,
+      position: positions[i],
+      lapsCompleted: Math.max(0, laps[i] - 1),
+      lapDistPct: lapDistPcts[i],
+      trackLocation: trkLocToString(trackSurfaces[i]),
+    });
+  }
+
+  return result;
+}
+
+function padRight(str: string, len: number): string {
+  return str.length >= len ? str : str + " ".repeat(len - str.length);
+}
+
+function padLeft(str: string, len: number): string {
+  return str.length >= len ? str : " ".repeat(len - str.length) + str;
+}
+
+/**
+ * Builds a Markdown table from headers and rows with per-column alignment.
+ */
+export function buildMarkdownTable(headers: string[], rows: string[][], alignRight: boolean[]): string {
+  const colWidths = headers.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i].length)));
+
+  const headerLine =
+    "| " +
+    headers.map((h, i) => (alignRight[i] ? padLeft(h, colWidths[i]) : padRight(h, colWidths[i]))).join(" | ") +
+    " |";
+
+  const separatorLine =
+    "| " + colWidths.map((w, i) => (alignRight[i] ? "-".repeat(w - 1) + ":" : "-".repeat(w))).join(" | ") + " |";
+
+  const dataLines = rows.map(
+    (row) =>
+      "| " +
+      row.map((cell, i) => (alignRight[i] ? padLeft(cell, colWidths[i]) : padRight(cell, colWidths[i]))).join(" | ") +
+      " |",
+  );
+
+  return [headerLine, separatorLine, ...dataLines].join("\n");
+}
+
+/**
+ * Builds a Markdown table identifying the session (track, event type, weather, …).
+ * Returns null when no identifying information is available.
+ */
+export function getSessionIdentification(sessionInfo: Record<string, unknown> | null): string | null {
+  if (!sessionInfo) return null;
+
+  const weekend = sessionInfo.WeekendInfo as Record<string, unknown> | undefined;
+  const sessionSection = sessionInfo.SessionInfo as Record<string, unknown> | undefined;
+  const sessions = sessionSection?.Sessions as Array<Record<string, unknown>> | undefined;
+
+  const rows: string[][] = [];
+
+  if (weekend) {
+    const trackName = weekend.TrackDisplayName ?? weekend.TrackName;
+    const config = weekend.TrackConfigName;
+    const trackLine = config ? `${trackName} — ${config}` : String(trackName ?? "Unknown Track");
+    rows.push(["Track", trackLine]);
+
+    if (weekend.TrackLength) rows.push(["Track Length", String(weekend.TrackLength)]);
+
+    if (weekend.TrackCity || weekend.TrackCountry) {
+      const location = [weekend.TrackCity, weekend.TrackCountry].filter(Boolean).join(", ");
+      rows.push(["Location", location]);
+    }
+
+    if (weekend.EventType) rows.push(["Event Type", String(weekend.EventType)]);
+
+    if (weekend.Category) rows.push(["Category", String(weekend.Category)]);
+
+    if (weekend.TrackType) rows.push(["Track Type", String(weekend.TrackType)]);
+
+    if (weekend.NumCarClasses) rows.push(["Car Classes", String(weekend.NumCarClasses)]);
+
+    if (weekend.TrackPitSpeedLimit) rows.push(["Pit Speed Limit", String(weekend.TrackPitSpeedLimit)]);
+  }
+
+  if (sessions && sessions.length > 0) {
+    const currentSession = sessions[sessions.length - 1];
+
+    if (currentSession.SessionType) rows.push(["Session Type", String(currentSession.SessionType)]);
+
+    if (currentSession.SessionLaps) rows.push(["Session Laps", String(currentSession.SessionLaps)]);
+
+    if (currentSession.SessionTime) rows.push(["Session Time", String(currentSession.SessionTime)]);
+  }
+
+  if (weekend) {
+    if (weekend.TrackSkies) rows.push(["Skies", String(weekend.TrackSkies)]);
+
+    if (weekend.TrackAirTemp) rows.push(["Air Temp", String(weekend.TrackAirTemp)]);
+
+    if (weekend.TrackSurfaceTemp) rows.push(["Surface Temp", String(weekend.TrackSurfaceTemp)]);
+  }
+
+  if (rows.length === 0) return null;
+
+  return buildMarkdownTable(["", ""], rows, [false, false]);
+}
+
+/**
+ * Builds a Markdown table of all driver details from session info.
+ * Returns null when no drivers are present.
+ */
+export function buildDriverDetailsTable(sessionInfo: Record<string, unknown> | null): string | null {
+  if (!sessionInfo) return null;
+
+  const driverInfo = sessionInfo.DriverInfo as Record<string, unknown> | undefined;
+  const drivers = driverInfo?.Drivers as Array<Record<string, unknown>> | undefined;
+
+  if (!drivers || drivers.length === 0) return null;
+
+  const headers = ["Car Idx", "Car #", "Driver", "Car", "iRating", "License", "Team", "AI"];
+  const alignRight = [true, true, false, false, true, false, false, false];
+
+  const rows: string[][] = [];
+
+  for (const d of drivers) {
+    if (d.CarIsPaceCar === 1) continue;
+
+    rows.push([
+      String(d.CarIdx ?? ""),
+      String(d.CarNumber ?? ""),
+      String(d.UserName ?? ""),
+      String(d.CarScreenNameShort ?? d.CarScreenName ?? ""),
+      String(d.IRating ?? ""),
+      String(d.LicString ?? ""),
+      String(d.TeamName ?? ""),
+      d.CarIsAI === 1 ? "Yes" : "No",
+    ]);
+  }
+
+  if (rows.length === 0) return null;
+
+  return buildMarkdownTable(headers, rows, alignRight);
+}
+
+function formatTime(seconds: number): string {
+  if (seconds < 0) return "-";
+
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+
+  return mins > 0 ? `${mins}:${secs.toFixed(3).padStart(7, "0")}` : `${secs.toFixed(3)}s`;
+}
+
+/**
+ * Builds a Markdown table of the player's car telemetry (identity, position,
+ * lap timing, vehicle state, fuel, temperatures).
+ * Returns null when the player car index is unavailable.
+ */
+export function buildPlayerTelemetry(
+  telemetry: Record<string, unknown>,
+  sessionInfo: Record<string, unknown> | null,
+): string | null {
+  const playerCarIdx = telemetry.PlayerCarIdx as number | undefined;
+
+  if (playerCarIdx === undefined) return null;
+
+  const driverInfo = sessionInfo?.DriverInfo as Record<string, unknown> | undefined;
+  const drivers = driverInfo?.Drivers as Array<Record<string, unknown>> | undefined;
+  const player = drivers?.find((d) => d.CarIdx === playerCarIdx);
+
+  const posRows: string[][] = [];
+
+  // Player identity
+  if (player) {
+    posRows.push(["Driver", String(player.UserName)]);
+    posRows.push(["Car", `${player.CarScreenName ?? player.CarScreenNameShort ?? "Unknown"} (#${player.CarNumber})`]);
+
+    if (player.TeamName) posRows.push(["Team", String(player.TeamName)]);
+
+    if (player.IRating) posRows.push(["iRating", String(player.IRating)]);
+
+    if (player.LicString) posRows.push(["License", String(player.LicString)]);
+  }
+
+  // Car info from DriverInfo section
+  if (driverInfo) {
+    if (driverInfo.DriverSetupName) posRows.push(["Setup", String(driverInfo.DriverSetupName)]);
+
+    if (driverInfo.DriverCarFuelMaxLtr) posRows.push(["Max Fuel", `${driverInfo.DriverCarFuelMaxLtr} L`]);
+
+    if (driverInfo.DriverCarEstLapTime)
+      posRows.push(["Est. Lap Time", formatTime(Number(driverInfo.DriverCarEstLapTime))]);
+  }
+
+  // Position
+  if (telemetry.PlayerCarPosition !== undefined)
+    posRows.push(["Position (Overall)", String(telemetry.PlayerCarPosition)]);
+
+  if (telemetry.PlayerCarClassPosition !== undefined)
+    posRows.push(["Position (Class)", String(telemetry.PlayerCarClassPosition)]);
+
+  posRows.push(["Track Surface", trkLocToString((telemetry.PlayerTrackSurface as number) ?? TrkLoc.NotInWorld)]);
+
+  if (telemetry.OnPitRoad !== undefined) posRows.push(["On Pit Road", telemetry.OnPitRoad ? "Yes" : "No"]);
+
+  if (telemetry.PlayerCarInPitStall !== undefined)
+    posRows.push(["In Pit Stall", telemetry.PlayerCarInPitStall ? "Yes" : "No"]);
+
+  if (telemetry.PlayerCarMyIncidentCount !== undefined)
+    posRows.push(["Incidents", String(telemetry.PlayerCarMyIncidentCount)]);
+
+  // Lap & timing
+  if (telemetry.Lap !== undefined) posRows.push(["Current Lap", String(telemetry.Lap)]);
+
+  if (telemetry.LapCompleted !== undefined) posRows.push(["Laps Completed", String(telemetry.LapCompleted)]);
+
+  if (telemetry.LapDistPct !== undefined)
+    posRows.push(["Lap Distance %", (Number(telemetry.LapDistPct) * 100).toFixed(4) + "%"]);
+
+  if (telemetry.LapCurrentLapTime !== undefined)
+    posRows.push(["Current Lap Time", formatTime(Number(telemetry.LapCurrentLapTime))]);
+
+  if (telemetry.LapBestLapTime !== undefined && Number(telemetry.LapBestLapTime) > 0)
+    posRows.push(["Best Lap Time", formatTime(Number(telemetry.LapBestLapTime))]);
+
+  if (telemetry.LapLastLapTime !== undefined && Number(telemetry.LapLastLapTime) > 0)
+    posRows.push(["Last Lap Time", formatTime(Number(telemetry.LapLastLapTime))]);
+
+  if (telemetry.LapDeltaToBestLap !== undefined && telemetry.LapDeltaToBestLap_OK)
+    posRows.push([
+      "Delta to Best",
+      `${Number(telemetry.LapDeltaToBestLap) >= 0 ? "+" : ""}${Number(telemetry.LapDeltaToBestLap).toFixed(3)}s`,
+    ]);
+
+  // Vehicle state
+  if (telemetry.Speed !== undefined) posRows.push(["Speed", `${(Number(telemetry.Speed) * 3.6).toFixed(1)} km/h`]);
+
+  if (telemetry.RPM !== undefined) posRows.push(["RPM", String(Math.round(Number(telemetry.RPM)))]);
+
+  if (telemetry.Gear !== undefined)
+    posRows.push([
+      "Gear",
+      Number(telemetry.Gear) === -1 ? "R" : Number(telemetry.Gear) === 0 ? "N" : String(telemetry.Gear),
+    ]);
+
+  if (telemetry.Throttle !== undefined) posRows.push(["Throttle", `${(Number(telemetry.Throttle) * 100).toFixed(0)}%`]);
+
+  if (telemetry.Brake !== undefined) posRows.push(["Brake", `${(Number(telemetry.Brake) * 100).toFixed(0)}%`]);
+
+  if (telemetry.SteeringWheelAngle !== undefined)
+    posRows.push(["Steering Angle", `${(Number(telemetry.SteeringWheelAngle) * (180 / Math.PI)).toFixed(1)}°`]);
+
+  // Fuel
+  if (telemetry.FuelLevel !== undefined) posRows.push(["Fuel Level", `${Number(telemetry.FuelLevel).toFixed(1)} L`]);
+
+  if (telemetry.FuelLevelPct !== undefined)
+    posRows.push(["Fuel %", `${(Number(telemetry.FuelLevelPct) * 100).toFixed(1)}%`]);
+
+  if (telemetry.FuelUsePerHour !== undefined)
+    posRows.push(["Fuel Use/Hour", `${Number(telemetry.FuelUsePerHour).toFixed(1)} L/h`]);
+
+  // Temperatures & electrical
+  if (telemetry.OilTemp !== undefined) posRows.push(["Oil Temp", `${Number(telemetry.OilTemp).toFixed(1)} °C`]);
+
+  if (telemetry.WaterTemp !== undefined) posRows.push(["Water Temp", `${Number(telemetry.WaterTemp).toFixed(1)} °C`]);
+
+  if (telemetry.Voltage !== undefined) posRows.push(["Voltage", `${Number(telemetry.Voltage).toFixed(1)} V`]);
+
+  if (posRows.length === 0) return null;
+
+  return buildMarkdownTable(["", ""], posRows, [false, false]);
+}
+
+/**
+ * Generates the full human-readable Markdown snapshot report (session info,
+ * race/track position orders, driver details, player telemetry).
+ */
+export function generateMarkdown(
+  telemetry: Record<string, unknown>,
+  sessionInfo: Record<string, unknown> | null,
+  now: Date = new Date(),
+): string {
+  const drivers = buildDriverList(telemetry, sessionInfo);
+  const lines: string[] = [];
+
+  lines.push("# Telemetry Snapshot");
+  lines.push("");
+  lines.push(`*${now.toISOString()}*`);
+  lines.push("");
+
+  const sessionTable = getSessionIdentification(sessionInfo);
+
+  if (sessionTable) {
+    lines.push("## Session Info");
+    lines.push("");
+    lines.push(sessionTable);
+    lines.push("");
+  }
+
+  if (drivers.length === 0) {
+    lines.push("No position data available.");
+    lines.push("");
+  } else {
+    const headers = ["Pos", "Car #", "Car Idx", "Driver", "Laps", "Lap Dist %", "Location"];
+    const alignRight = [true, true, true, false, true, true, false];
+
+    const toRow = (d: DriverInfo): string[] => [
+      String(d.position),
+      d.carNumber,
+      String(d.carIdx),
+      d.driverName,
+      String(d.lapsCompleted),
+      (d.lapDistPct * 100).toFixed(4) + "%",
+      d.trackLocation,
+    ];
+
+    // Table 1: sorted by position
+    const byPosition = [...drivers].sort((a, b) => {
+      if (a.position <= 0 && b.position <= 0) return 0;
+
+      if (a.position <= 0) return 1;
+
+      if (b.position <= 0) return -1;
+
+      return a.position - b.position;
+    });
+
+    // Table 2: sorted by lap distance percentage only (track position, not race position)
+    const byTrackProgress = [...drivers].sort((a, b) => b.lapDistPct - a.lapDistPct);
+
+    lines.push("## Race Position Order");
+    lines.push("");
+    lines.push(buildMarkdownTable(headers, byPosition.map(toRow), alignRight));
+    lines.push("");
+    lines.push("## Track Position Order (Car Ahead / Behind)");
+    lines.push("");
+    lines.push(buildMarkdownTable(headers, byTrackProgress.map(toRow), alignRight));
+    lines.push("");
+  }
+
+  const driverTable = buildDriverDetailsTable(sessionInfo);
+
+  if (driverTable) {
+    lines.push("## Driver Details");
+    lines.push("");
+    lines.push(driverTable);
+    lines.push("");
+  }
+
+  const playerTable = buildPlayerTelemetry(telemetry, sessionInfo);
+
+  if (playerTable) {
+    lines.push("## Player Telemetry");
+    lines.push("");
+    lines.push(playerTable);
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Formats a Date as a filesystem-safe snapshot timestamp: "YYYYMMDD-HHMMSS".
+ */
+export function snapshotTimestamp(now: Date = new Date()): string {
+  const pad = (n: number): string => String(n).padStart(2, "0");
+
+  return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+}
+
+/**
+ * Returns the base filename (without extension) for a snapshot taken at the given time.
+ */
+export function snapshotBaseName(now: Date = new Date()): string {
+  return `telemetry-snapshot-${snapshotTimestamp(now)}`;
+}
+
+/**
+ * Builds the JSON envelope written to disk for a snapshot.
+ */
+export function buildSnapshotEnvelope(
+  telemetry: Record<string, unknown>,
+  sessionInfo: Record<string, unknown> | null,
+  includeSession: boolean,
+  now: Date = new Date(),
+): SnapshotEnvelope {
+  const envelope: SnapshotEnvelope = {
+    timestamp: now.toISOString(),
+    telemetry,
+  };
+
+  if (includeSession && sessionInfo) {
+    envelope.sessionInfo = sessionInfo;
+  }
+
+  return envelope;
+}

--- a/packages/iracing-sdk/src/snapshot.ts
+++ b/packages/iracing-sdk/src/snapshot.ts
@@ -457,9 +457,15 @@ export function snapshotTimestamp(now: Date = new Date()): string {
 
 /**
  * Returns the base filename (without extension) for a snapshot taken at the given time.
+ *
+ * Includes milliseconds so two snapshots captured within the same second (e.g. a
+ * rapid double-press of the Stream Deck key, or two CLI runs) do not collide and
+ * silently overwrite each other.
  */
 export function snapshotBaseName(now: Date = new Date()): string {
-  return `telemetry-snapshot-${snapshotTimestamp(now)}`;
+  const ms = String(now.getMilliseconds()).padStart(3, "0");
+
+  return `telemetry-snapshot-${snapshotTimestamp(now)}-${ms}`;
 }
 
 /**


### PR DESCRIPTION
## Related Issue

Fixes #635

## What changed?

Adds a developer **"Take Snapshot"** mode to the **Telemetry Control** action. On press it reads the current telemetry + session info from the SDK controller and writes a timestamped **JSON** envelope plus a **Markdown** companion report — the same output the `pnpm telemetry-snapshot` CLI produces, but from a Stream Deck key (no second SDK connection).

- **Shared module** — the JSON-envelope / Markdown-report / timestamped-filename helpers were extracted from the `telemetry-snapshot` CLI into a new dependency-free `packages/iracing-sdk/src/snapshot.ts`, exported from the package barrel. The CLI now imports them; behaviour-preserving (verified).
- **Output folder** — a per-mode PI setting (shown only for the snapshot mode). Blank defaults to `<home>/iRaceDeck/telemetry-snapshots`. The path is resolved robustly:
  - `%VAR%` and a leading `~` are expanded;
  - a **relative** path resolves against the **home dir**, never the plugin process cwd (which is the install folder);
  - the default deliberately avoids the **Documents** known folder, which is unreliable under OneDrive redirection / localized folder names (e.g. "Tiedostot").
- **Feedback is log-only** (success at info, failures at warn/error). The mode issues no iRacing command, so it is intentionally absent from the comms catalog (no binding-status line, no missing-binding overlay).
- Snapshot filenames include **milliseconds** to avoid same-second overwrites on a rapid double-press.
- Pure builders run inside the write `try/catch` so malformed telemetry can never escape as an unhandled rejection on the Stream Deck event loop.

> Note: this started as a standalone "Telemetry Snapshot" action and was folded into Telemetry Control as a mode per review — so the action count stays at **31** (Telemetry Control gains a 6th mode).

## How to test

1. `pnpm install && pnpm build` (or `pnpm watch:stream-deck`).
2. Add a **Telemetry Control** action to a key, set **Mode → Take Snapshot** (optionally set an Output Folder).
3. With iRacing in a session, press the key.
4. Confirm a `telemetry-snapshot-<timestamp>-<ms>.json` + `.md` pair appears in the output folder (default `%USERPROFILE%\iRaceDeck\telemetry-snapshots`). The folder is created if missing.
5. Disconnected (no telemetry): pressing logs a warning and writes nothing.
6. CLI unchanged: `pnpm telemetry-snapshot --include-session --output-dir=local` still works.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Telemetry Control "Take Snapshot" mode to capture/save current telemetry and session data as timestamped JSON and Markdown files; snapshot-specific output folder settings included.

* **Documentation**
  * Updated feature counts and category totals to reflect new mode; clarified which action modes are absent from the catalog and snapshot behavior.

* **Tests**
  * Added comprehensive tests for snapshot generation, path resolution, and file-writing behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->