### PR TITLE
feat(iracing-sdk): detect car capabilities from telemetry field presence + hasPitLimiter/hasVisor/hasWipers helpers (#637)

### DIFF
--- a/.claude/skills/iracing-telemetry/SKILL.md
+++ b/.claude/skills/iracing-telemetry/SKILL.md
@@ -154,6 +154,31 @@ Use `hasFlag()` from `@iracedeck/iracing-sdk` to check bitfield values.
 
 Rising-edge of `(EngineWarnings & (MandRepNeeded \| OptRepNeeded))` is consumed by `sim-events-iracing/diff/damage.ts` to publish `damage.repairNeeded.raised` after a 3000 ms debounce (issue #489). Pair with `PitReadbackSnapshot.hasDamage` (built from the same mask) for damage-aware readback gating.
 
+## Car-capability detection
+
+iRacing only exposes a driver-control (`dc*`) field when the car actually has that control. So the **presence** of a `dc*` field — not its value — tells you whether the car has the feature; the value is just the current on/off state. This is the canonical way to ask "does this car have X?".
+
+| Capability | Field(s) present ⇒ has feature | Notes |
+|------------|-------------------------------|-------|
+| Pit limiter | `dcPitSpeedLimiterToggle` | A car without a pit limiter omits this field entirely. |
+| Tear-off visor | `dcTearOffVisor` | Open-cockpit / visor cars expose this. |
+| Windshield wipers | `dcToggleWindshieldWipers` / `dcTriggerWindshieldWipers` | Presence of either signals wipers. |
+
+Tear-off visor and windshield wipers are **mutually exclusive** per car — a car with a visor does not expose the wiper fields and vice-versa — so "has visor" and "has wipers" are complementary.
+
+Don't re-check these fields ad-hoc. The canonical helpers live in `packages/iracing-sdk/src/telemetry-features.ts` and are exported from `@iracedeck/iracing-sdk`:
+
+```typescript
+import { hasPitLimiter, hasVisor, hasWipers } from "@iracedeck/iracing-sdk";
+import { getLatestTelemetry } from "@iracedeck/sim-events-iracing";
+
+if (!hasPitLimiter(getLatestTelemetry())) {
+  // car has no limiter — skip limiter callouts / grey out the limiter button
+}
+```
+
+Each helper takes `TelemetryData | null` and returns `false` for `null`. Add new capability checks here rather than scattering `dc*`-presence tests across consumers.
+
 ## Common Units
 
 | Unit | Meaning | Count |

--- a/packages/iracing-native/src/defines.ts
+++ b/packages/iracing-native/src/defines.ts
@@ -734,6 +734,14 @@ export interface TelemetryData {
   dcMGUKDeployMode?: number;
   dcMGUKRegenGain?: number;
   dcMGUKDeployFixed?: number;
+  // Capability markers — iRacing exposes these only on cars that have the control, so
+  // field *presence* (not value) signals the capability. See iracing-sdk's
+  // telemetry-features.ts (hasPitLimiter/hasVisor/hasWipers). Visor and wipers are
+  // mutually exclusive per car.
+  dcPitSpeedLimiterToggle?: boolean; // "Track if pit speed limiter system is enabled"
+  dcTearOffVisor?: boolean; // "In car tear off visor film"
+  dcToggleWindshieldWipers?: boolean; // "In car turn wipers on or off"
+  dcTriggerWindshieldWipers?: boolean; // "In car momentarily turn on wipers"
 }
 
 /**

--- a/packages/iracing-sdk/src/index.ts
+++ b/packages/iracing-sdk/src/index.ts
@@ -122,6 +122,9 @@ export { calculateRacePositions, classPositionFromOrder } from "./position-utils
 // Flag utilities
 export { type FlagInfo, FLAG_DEFINITIONS, resolveActiveFlag, resolveAllActiveFlags } from "./flag-utils.js";
 
+// Telemetry feature detection (car-capability helpers)
+export { hasPitLimiter, hasVisor, hasWipers } from "./telemetry-features.js";
+
 // Session info utilities
 export {
   type CameraGroup,

--- a/packages/iracing-sdk/src/telemetry-features.test.ts
+++ b/packages/iracing-sdk/src/telemetry-features.test.ts
@@ -1,0 +1,62 @@
+import type { TelemetryData } from "@iracedeck/iracing-native";
+import { describe, expect, it } from "vitest";
+
+import { hasPitLimiter, hasVisor, hasWipers } from "./telemetry-features.js";
+
+/** Build a minimal TelemetryData mock from a partial set of fields. */
+function telemetry(fields: Partial<TelemetryData>): TelemetryData {
+  return fields as TelemetryData;
+}
+
+describe("telemetry-features", () => {
+  describe("hasPitLimiter", () => {
+    it("returns true when dcPitSpeedLimiterToggle is present", () => {
+      expect(hasPitLimiter(telemetry({ dcPitSpeedLimiterToggle: false }))).toBe(true);
+      expect(hasPitLimiter(telemetry({ dcPitSpeedLimiterToggle: true }))).toBe(true);
+    });
+
+    it("returns false when the field is absent", () => {
+      expect(hasPitLimiter(telemetry({}))).toBe(false);
+    });
+
+    it("returns false for null telemetry", () => {
+      expect(hasPitLimiter(null)).toBe(false);
+    });
+  });
+
+  describe("hasVisor", () => {
+    it("returns true when dcTearOffVisor is present", () => {
+      expect(hasVisor(telemetry({ dcTearOffVisor: false }))).toBe(true);
+    });
+
+    it("returns false when the field is absent", () => {
+      expect(hasVisor(telemetry({}))).toBe(false);
+    });
+
+    it("returns false for null telemetry", () => {
+      expect(hasVisor(null)).toBe(false);
+    });
+  });
+
+  describe("hasWipers", () => {
+    it("returns true when dcToggleWindshieldWipers is present", () => {
+      expect(hasWipers(telemetry({ dcToggleWindshieldWipers: false }))).toBe(true);
+    });
+
+    it("returns true when dcTriggerWindshieldWipers is present", () => {
+      expect(hasWipers(telemetry({ dcTriggerWindshieldWipers: false }))).toBe(true);
+    });
+
+    it("returns true when both wiper fields are present", () => {
+      expect(hasWipers(telemetry({ dcToggleWindshieldWipers: false, dcTriggerWindshieldWipers: false }))).toBe(true);
+    });
+
+    it("returns false when neither wiper field is present", () => {
+      expect(hasWipers(telemetry({}))).toBe(false);
+    });
+
+    it("returns false for null telemetry", () => {
+      expect(hasWipers(null)).toBe(false);
+    });
+  });
+});

--- a/packages/iracing-sdk/src/telemetry-features.ts
+++ b/packages/iracing-sdk/src/telemetry-features.ts
@@ -1,0 +1,55 @@
+/**
+ * iRacing SDK car-capability detection.
+ *
+ * iRacing only exposes a driver-control (`dc*`) telemetry field when the car actually
+ * has that control, so the *presence* of a field — not its value — signals whether the
+ * car has the feature. These pure helpers wrap that field-presence check so consumers
+ * (actions, audio-scenarios, tests) can ask "does this car have X?" consistently.
+ */
+import type { TelemetryData } from "@iracedeck/iracing-native";
+
+/**
+ * Check whether the current car has a pit speed limiter.
+ *
+ * iRacing only exposes `dcPitSpeedLimiterToggle` on cars equipped with a limiter, so
+ * the field's presence is the capability signal (its boolean value is the on/off state).
+ *
+ * @param t - The latest telemetry snapshot, or null when no telemetry is available
+ * @returns true if the car has a pit limiter, false otherwise (including for null)
+ *
+ * @example
+ * if (!hasPitLimiter(getLatestTelemetry())) {
+ *     // skip pit-limiter callouts / grey out the limiter button
+ * }
+ */
+export function hasPitLimiter(t: TelemetryData | null): boolean {
+  return t?.dcPitSpeedLimiterToggle !== undefined;
+}
+
+/**
+ * Check whether the current car has a tear-off visor (typically open-cockpit cars).
+ *
+ * iRacing only exposes `dcTearOffVisor` on cars with a visor. Visor and wipers are
+ * mutually exclusive per car, so {@link hasVisor} and {@link hasWipers} are complementary.
+ *
+ * @param t - The latest telemetry snapshot, or null when no telemetry is available
+ * @returns true if the car has a tear-off visor, false otherwise (including for null)
+ */
+export function hasVisor(t: TelemetryData | null): boolean {
+  return t?.dcTearOffVisor !== undefined;
+}
+
+/**
+ * Check whether the current car has windshield wipers (typically closed-cockpit cars).
+ *
+ * iRacing exposes either `dcToggleWindshieldWipers` (on/off) or `dcTriggerWindshieldWipers`
+ * (momentary) on cars with wipers; presence of either signals the capability. Wipers and
+ * a tear-off visor are mutually exclusive per car, so {@link hasWipers} and {@link hasVisor}
+ * are complementary.
+ *
+ * @param t - The latest telemetry snapshot, or null when no telemetry is available
+ * @returns true if the car has windshield wipers, false otherwise (including for null)
+ */
+export function hasWipers(t: TelemetryData | null): boolean {
+  return t?.dcToggleWindshieldWipers !== undefined || t?.dcTriggerWindshieldWipers !== undefined;
+}


### PR DESCRIPTION
## Related Issue

Fixes #637

## What changed?

Adds a small, pure capability-detection layer derived from the **presence or absence of specific `dc*` telemetry fields**. iRacing only exposes a driver-control (`dc*`) field when the car actually has that control, so the *existence* of a field — not its value — signals whether the car has the feature.

- **New pure module** `packages/iracing-sdk/src/telemetry-features.ts` with `hasPitLimiter`, `hasVisor`, `hasWipers`. Each takes `TelemetryData | null` and returns `false` for `null`; mirrors the existing `utils.ts` / `flag-utils.ts` free-function style (no plugin deps, usable from actions, audio-scenarios, and tests). Exported from `@iracedeck/iracing-sdk`.
- **Unit tests** `telemetry-features.test.ts` — present / absent / `null` for each helper (both wiper fields covered independently).
- **Type the four `dc*` capability fields** on `TelemetryData` in `packages/iracing-native/src/defines.ts` (`dcPitSpeedLimiterToggle`, `dcTearOffVisor`, `dcToggleWindshieldWipers`, `dcTriggerWindshieldWipers`) — previously they flowed only through the `[key: string]` index signature.
- **Document the technique** — new "Car-capability detection" section in the `iracing-telemetry` skill (`.claude/skills/iracing-telemetry/SKILL.md`) explaining field-presence ⇒ capability, the pit-limiter / visor / wipers table (incl. visor⇄wipers mutual exclusivity), and a pointer to `telemetry-features.ts` as the canonical home for these helpers.

This is the foundation for two follow-up issues that consume it (Race Engineer skipping pit-limiter callouts on limiter-less cars; tri-state Pit Limiter button). **No consumers change here** — no changes to plugins, PI templates, audio-scenarios, deck-core, website, or actions.

## How to test

```bash
pnpm install
pnpm test     # full suite incl. new telemetry-features.test.ts (11 cases)
pnpm build    # full workspace tsc build is green
```

- `hasPitLimiter` / `hasVisor` / `hasWipers` return `true` when the field is present, `false` when absent, and `false` for `null`.
- The four `dc*` fields are typed on `TelemetryData`.
- Helpers are exported from `@iracedeck/iracing-sdk`.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — N/A, no plugin-facing changes (consumers land in follow-up issues)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added car capability detection for iRacing telemetry, enabling identification of pit limiter, tear-off visor, and windshield wipers support.
  * Exposed new helper functions to check car feature availability based on telemetry data.

* **Documentation**
  * Added guidance on determining car feature availability through telemetry field detection.

* **Tests**
  * Added test coverage for capability detection helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
