### PR TITLE
feat(plugins): de-claim dial/encoder support and document dials & touchscreen (#640)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -45,6 +45,7 @@ You can import or reference specific rule files from other markdown using `@.cla
 - `black-box-icons.md`: Design guidelines for iRacing black box key icons: canvas layout, inner frame spec, text labels, layout patterns, and per-icon details. Scoped to black-box-selector files.
 - `build-and-commit.md`: Worktree-based development workflow, pre-commit checks (`pnpm install` + `pnpm build`), build commands, conventional commit conventions, and post-merge worktree cleanup.
 - `code-style.md`: Formatting, linting, type conventions, Zod usage, and general code quality rules.
+- `encoders-and-touchscreen.md`: How Stream Deck+ dials and the LCD touch strip work, verified Mirabox knob/touch findings, current de-claimed state (issue #640), and rules for the planned dial-support rebuild. Full schema/payload reference in `docs/reference/stream-deck-plus-encoders.md`.
 - `global-settings.md`: Plugin-level global settings architecture: Property Inspector usage, `ird-key-binding` with `global` attribute, Zod schema, and settings path conventions.
 - `icons.md`: General icon guidelines: icon types (category, key, template), SVG structure, design specs, color palette, Mustache templates, and distinctiveness rules.
 - `key-icon-types.md`: Standardized key icon type definitions (Default, Black Box, Inverted): canvas layout, two-line label system, Standard vs Inverted label layouts, per-action background colors, and icon content separation patterns. Scoped to icon SVG/TS files.

--- a/.claude/rules/build-and-commit.md
+++ b/.claude/rules/build-and-commit.md
@@ -177,6 +177,7 @@ When creating issues, always include requirements for updating all affected arti
 Merging
 
 - PRs are merged into `master` via `gh pr merge --merge` (regular merge, not squash).
+- **Temporary exception — `release/2.0` integration branch:** the dials/touchscreen clean-slate (#640) and the follow-up dial-rebuild issues are breaking changes that ship as v2.0.0. Their PRs target `release/2.0` (`gh pr create --base release/2.0`), not `master`, and are merged with **squash** (`gh pr merge --squash`) — one commit per feature; the PR title (with its `(#issue)` suffix) becomes the commit message, so title discipline matters doubly here. Master keeps shipping 1.x releases; merge `master` into `release/2.0` periodically to limit drift. The sync merges and the final merge-back are **regular merges** — never squash those. Avoid cherry-picking between the two lines; land shared fixes on `master` and sync them in. When 2.0 ships (`pnpm release major` run from `release/2.0`), the branch merges back into `master` and this exception is removed.
 - Since commits are logical and self-contained, squashing is not needed — the full commit history is preserved on `master`.
 - **PR titles must include the issue number** at the end in parentheses: `<type>(<scope>): <description> (#<issue>)`. Example: `feat(actions): add Camera Focus action (#42)`.
 - **PR titles drive release notes.** The conventional commit prefix determines the release notes category via auto-labeling (see **PR Labels** above). Use the correct prefix so the change appears in the right section.

--- a/.claude/rules/encoders-and-touchscreen.md
+++ b/.claude/rules/encoders-and-touchscreen.md
@@ -1,0 +1,31 @@
+# Encoders (Dials) & Touchscreen
+
+How Stream Deck+ dials and the LCD touch strip work, what Mirabox knobs actually support, and the rules for the planned dial-support rebuild. Full payload/schema tables and sources live in `docs/reference/stream-deck-plus-encoders.md`.
+
+## Current state (issue #640)
+
+Dial/encoder/knob support was **de-claimed**: no action in either plugin manifest declares `Encoder` (Elgato) or `Knob` (Mirabox), every action is Keypad-only (plus the two Mirabox `Information` actions), and no user-facing copy claims dial support. This was intentionally backwards-incompatible — existing user dial assignments were reset.
+
+What stays, dormant, as the rebuild foundation:
+
+- `onDial*` handlers in `packages/iracing-actions` action code (unreachable while manifests don't route dial events)
+- `IDeckDialRotateEvent` / `IDeckDialDownEvent` / `IDeckDialUpEvent` in `deck-core` and the base-action stubs
+- Dial event wiring in both adapters (`deck-adapter-elgato`, `deck-adapter-mirabox`)
+
+**Do not add `Encoder`/`Knob` manifest blocks to new actions** until the rebuild lands. The superseded "Encoder Support" section in `.claude/rules/stream-deck-actions.md` points here.
+
+## Hardware & platform facts (the load-bearing ones)
+
+- Stream Deck+ = 8 LCD keys, 4 push-rotate dials, one 800×100 touch strip; **each encoder action owns a 200×100 slot** of the strip. Strip swipe is consumed by the Stream Deck app (page switching) and never reaches plugins.
+- Elgato events: `dialRotate` (`ticks` signed, coalesces — |ticks| > 1 on fast spins; `pressed` flag for rotate-while-held), `dialDown`/`dialUp`, `touchTap` (`tapPos` relative to the 200×100 slot; `hold: true` = long touch). There is **no native dial long-press event** — time `dialDown`→`dialUp` yourself.
+- Elgato feedback: manifest `Encoder` block (`layout` `$X1`/`$A0`/`$A1`/`$B1`/`$B2`/`$C1` or custom JSON, `TriggerDescription` Rotate/Push/Touch/LongTouch, `Icon`, `background`, `StackColor`); runtime `setFeedback`/`setFeedbackLayout`. For dials, `setTitle` updates the layout `title` item and `setImage` only sets the app-UI dial canvas — strip imagery goes through layout `pixmap` items. **Throttle feedback to ≤ 10 calls/second per dial.**
+- Mirabox (VSD Craft / Stream Dock protocol): manifest uses `"Knob"` (not `"Encoder"`); knob **rotation and press provably reach plugins** (`dialRotate` with `ticks`, `dialDown`/`dialUp` — same event names as Elgato; Mirabox's own knob plugins use them). But: **no plugin-facing touchscreen or feedback API exists** (`setFeedback`/`setFeedbackLayout`/layouts are not in the protocol — update knob icons via `setImage`), and **press-and-hold is unreliable** (`dialUp` reported to fire immediately after `dialDown` on N4-class hardware). Never yet verified through our adapter on a real knob device — the hardware-test checklist is in the reference page §8.
+
+## Rules for the rebuild
+
+1. **Dial behavior lives in shared action code** consuming `IDeck*` events — never platform-specific branches in actions. Elgato-only surfaces (touch strip, feedback layouts) must be gated behind platform feature flags (`.claude/rules/platform-feature-flags.md`) so the Mirabox bundle ships none of it.
+2. **Never design cross-platform dial UX around press-and-hold** — it cannot work on Mirabox knobs. Tap (press+release) and rotation are the common denominator; rotate-while-pressed is Elgato-only (`dialRotate.pressed`).
+3. **Scale steps by `ticks`**, never count events; clamp if a single event's magnitude would overshoot.
+4. Touch support requires new plumbing first: an `IDeckTouchTapEvent` type in `deck-core`, a base-action stub, and adapter wiring — none of that exists today. Per #640's Mirabox findings, build it Elgato-only.
+5. Declaring an action as `["Keypad", "Encoder"]` means `willAppear` fires for both surfaces — branch on `payload.controller`, and remember encoder actions cannot join multi-actions.
+6. Before shipping any Mirabox knob support, run the hardware-test checklist in `docs/reference/stream-deck-plus-encoders.md` §8 on a real N3/N4-class device; its outcome (especially the `dialUp` timing question) gates what Mirabox dial UX is possible.

--- a/.claude/rules/stream-deck-actions.md
+++ b/.claude/rules/stream-deck-actions.md
@@ -365,43 +365,11 @@ const binding = parseBinding(globalSettings["blackBoxLapTiming"]);
 2. **Callback never fires**: Handlers must be registered BEFORE `adapter.connect()`
 3. **Wrong adapter instance**: Always pass the `IDeckPlatformAdapter` to `initGlobalSettings(adapter, logger)`
 
-## Encoder Support
+## Encoder Support (superseded)
 
-For Stream Deck+ encoder (dial) support:
+**Dial/encoder/knob support was de-claimed in #640** — no action declares `Encoder` (Elgato) or `Knob` (Mirabox) in either manifest, and no new action may add those blocks until the planned rebuild. Existing `onDial*` handlers in action code are dormant (the manifests no longer route dial events to them) and stay in place for the rebuild; the `deck-core` dial event types and both adapters' dial wiring also stay.
 
-### Manifest Configuration
-
-```json
-{
-  "Controllers": ["Keypad", "Encoder"],
-  "Encoder": {
-    "layout": "$B1",
-    "TriggerDescription": {
-      "Rotate": "Description for rotation",
-      "Push": "Description for press"
-    }
-  }
-}
-```
-
-### Action Handlers
-
-- `onDialRotate(ev)` - Handle rotation. Use `ev.payload.ticks` (positive = clockwise, negative = counter-clockwise)
-- `onDialDown(ev)` - Handle press (only if needed)
-
-### Rotation Pattern
-
-```typescript
-override async onDialRotate(ev: IDeckDialRotateEvent<Settings>): Promise<void> {
-  const settings = MySettings.parse(ev.payload.settings);
-  // Clockwise (ticks > 0) = next/increase
-  // Counter-clockwise (ticks < 0) = previous/decrease
-  const keyData = ev.payload.ticks > 0 ? settings.keyNext : settings.keyPrevious;
-  if (keyData?.key) {
-    await getKeyboard().sendKeyCombination({ key: keyData.key, modifiers: keyData.modifiers });
-  }
-}
-```
+For how dials and the touchscreen actually work, and the constraints any rebuilt dial UX must respect, see `@.claude/rules/encoders-and-touchscreen.md` and the full reference in `docs/reference/stream-deck-plus-encoders.md`.
 
 ## Per-Mode Communication Method & Binding Status (#612)
 

--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -17,13 +17,15 @@ Each action entry:
   "id": "com.iracedeck.sd.core.session-info",
   "name": "Session Info",
   "file": "session-info.ts",
-  "encoder": true,
+  "encoder": false,
   "settingsKey": "mode",
   "modes": [
     { "value": "incidents", "label": "Incidents", "description": "..." }
   ]
 }
 ```
+
+All actions are currently `encoder: false` — dial/encoder support was de-claimed in issue #640 pending a rebuild (see `.claude/rules/encoders-and-touchscreen.md`).
 
 ## Communication method (per mode) — `action-comms.json` (#612)
 
@@ -94,7 +96,7 @@ Mode counts reflect the PI Mode/Setting dropdown choices documented in each acti
 | Action | Modes | Mode values |
 |--------|-------|-------------|
 | View Adjustment | 5 | fov (+/-), horizon (+/-), driver-height (+/-), recenter-vr, ui-size (+/-) |
-| Replay Control | 27 | play/pause, play-backward, stop, FF, rewind, slow-mo, slow-mo-rewind (FF/RW + slow-mo modes share a configurable Step Rate that walks the speed ladder per press), frame +/-, speed +/-, set-speed, speed-display, session next/prev, lap next/prev, incident next/prev, jump to beginning/live/my car, jump-to-fastest-lap (target: Viewed Car / Always my car; session-scoped; no clean-lap filter; no encoder support), next/prev car, next/prev car number |
+| Replay Control | 27 | play/pause, play-backward, stop, FF, rewind, slow-mo, slow-mo-rewind (FF/RW + slow-mo modes share a configurable Step Rate that walks the speed ladder per press), frame +/-, speed +/-, set-speed, speed-display, session next/prev, lap next/prev, incident next/prev, jump to beginning/live/my car, jump-to-fastest-lap (target: Viewed Car / Always my car; session-scoped; no clean-lap filter), next/prev car, next/prev car number |
 | Camera Controls | 12 | change-camera, cycle (camera / sub-camera / car / driving), focus (your car / leader / incident / most exciting), switch (by position / car number), set-camera-state |
 | Camera Editor Adjustments | 15 | latitude, longitude, altitude, yaw, pitch, fov-zoom, key-step, vanish-x, vanish-y, blimp-radius, blimp-velocity, mic-gain (all +/-), auto-set-mic-gain, f-number (+/-), focus-depth (+/-) |
 | Camera Editor Controls | 30 | Open Camera Tool, 14 toggles (key accel/10x, parabolic mic, temp edits, dampening, zoom, beyond fence, in cockpit, mouse nav, pitch/roll gyro, limit shot range, show camera, shot selection, manual focus), cycle position/aim type, acquire start/end, camera CRUD (insert/remove/copy/paste), group CRUD (copy/paste), track/car save/load |
@@ -157,7 +159,7 @@ When actions are added, removed, or modified (new modes, renamed settings, chang
 
 | File | Role |
 |------|------|
-| `packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/manifest.json` | Action registration, UUIDs, encoder config |
+| `packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/manifest.json` | Action registration, UUIDs |
 | `packages/iracing-actions/src/actions/<name>/` | Per-action folder: `<name>.ts`, `<name>.test.ts`, `<name>.ejs`, `icon.svg`, `key.svg` |
 | `packages/iracing-actions/src/actions/data/key-bindings.json` | Global key binding definitions |
 | `packages/iracing-actions/src/actions/data/icon-defaults.json` | Default icon colors by action/variant |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## Features
 
-**31 actions** with **262+ modes** across 8 categories, with Stream Deck+ dial rotation support on most modes:
+**31 actions** with **262+ modes** across 8 categories:
 
 | Category                | Actions | Modes | Examples                                                              |
 | ----------------------- | ------- | ----- | --------------------------------------------------------------------- |

--- a/docs/plugins/action-types.md
+++ b/docs/plugins/action-types.md
@@ -2,13 +2,15 @@
 
 Common action types used across all iRaceDeck Stream Deck plugins.
 
+> **Note:** No action currently declares encoder (dial) support — dial support was de-claimed in issue #640 pending a rebuild (see `.claude/rules/encoders-and-touchscreen.md` and `docs/reference/stream-deck-plus-encoders.md`).
+
 ## Button
 
 Single press action that sends a key or command once.
 
 - **Behavior**: Triggers on button press
 - **Visual feedback**: None (stateless)
-- **Encoder support**: Typically no
+- **Encoder support**: No
 
 ## Toggle
 
@@ -16,7 +18,7 @@ On/off state action with visual feedback.
 
 - **Behavior**: Alternates between on and off states
 - **Visual feedback**: Icon changes to reflect current state
-- **Encoder support**: Typically no
+- **Encoder support**: No
 
 ## Multi-toggle
 
@@ -26,7 +28,7 @@ Cycles through multiple options.
   - Short press: Next option
   - Long press: Previous option (or opens selector)
 - **Visual feedback**: Icon/label shows current selection
-- **Encoder support**: Yes (rotate to cycle)
+- **Encoder support**: No
 - **Configuration**: Options may be fixed or configurable via property inspector
 
 ## +/- (Increment/Decrement)
@@ -35,7 +37,7 @@ Adjustment action for values that can increase or decrease.
 
 - **Behavior**: Button press triggers the configured direction (increase or decrease)
 - **Visual feedback**: Icon reflects configured direction; may show current value if available from telemetry
-- **Encoder support**: Yes (rotate clockwise = increase, counter-clockwise = decrease)
+- **Encoder support**: No
 - **Property Inspector**: Direction dropdown with "Increase" and "Decrease" options
 
 ### Standard Settings
@@ -52,7 +54,7 @@ SDK-based value adjustment with precise control.
 
 - **Behavior**: Sets or adjusts a specific value via iRacing SDK
 - **Visual feedback**: Shows current value from telemetry
-- **Encoder support**: Yes
+- **Encoder support**: No
 - **Configuration**: May include presets or specific value targets
 
 ## Hold
@@ -69,5 +71,5 @@ Action with behavior determined by settings.
 
 - **Behavior**: Varies based on property inspector configuration
 - **Visual feedback**: Depends on configuration
-- **Encoder support**: Depends on configuration
+- **Encoder support**: No
 - **Configuration**: Dropdown or input fields in property inspector

--- a/docs/plugins/core/actions/adjust-master-volume.md
+++ b/docs/plugins/core/actions/adjust-master-volume.md
@@ -10,16 +10,12 @@ Adjusts the iRacing master audio volume.
 | Type | +/- |
 | SDK Support | No |
 | Communication Method | Key binding |
-| Encoder Support | Yes |
+| Encoder Support | No |
 
 ## Behavior
 
 ### Button Press
 Triggers the direction configured in Settings (louder or quieter).
-
-### Encoder
-- **Rotate clockwise**: Increase volume
-- **Rotate counter-clockwise**: Decrease volume
 
 ## Settings
 

--- a/docs/plugins/core/actions/autofuel-lap-margin.md
+++ b/docs/plugins/core/actions/autofuel-lap-margin.md
@@ -10,16 +10,12 @@ Adjusts the lap margin for automatic fuel calculation.
 | Type | +/- |
 | SDK Support | No |
 | Communication Method | Key binding |
-| Encoder Support | Yes |
+| Encoder Support | No |
 
 ## Behavior
 
 ### Button Press
 Triggers the direction configured in Settings (increase or decrease).
-
-### Encoder
-- **Rotate clockwise**: Increase lap margin
-- **Rotate counter-clockwise**: Decrease lap margin
 
 ## Settings
 

--- a/docs/plugins/core/actions/black-box-selector.md
+++ b/docs/plugins/core/actions/black-box-selector.md
@@ -10,18 +10,13 @@ Cycles through or directly selects iRacing black box screens.
 | Type | Multi-toggle |
 | SDK Support | No |
 | Communication Method | Key binding |
-| Encoder Support | Yes |
+| Encoder Support | No |
 
 ## Behavior
 
 ### Button Press
 - **Direct mode**: Opens the selected black box immediately
 - **Next/Previous mode**: Cycles to the next or previous black box
-
-### Encoder
-- **Rotate clockwise**: Next black box
-- **Rotate counter-clockwise**: Previous black box
-- **Press**: Opens the currently selected black box
 
 ## Settings
 

--- a/docs/plugins/core/actions/driver-height-adjust.md
+++ b/docs/plugins/core/actions/driver-height-adjust.md
@@ -10,16 +10,12 @@ Adjusts the virtual driver's seating height.
 | Type | +/- |
 | SDK Support | No |
 | Communication Method | Key binding |
-| Encoder Support | Yes |
+| Encoder Support | No |
 
 ## Behavior
 
 ### Button Press
 Triggers the direction configured in Settings (increase or decrease).
-
-### Encoder
-- **Rotate clockwise**: Increase height
-- **Rotate counter-clockwise**: Decrease height
 
 ## Settings
 

--- a/docs/plugins/core/actions/escape.md
+++ b/docs/plugins/core/actions/escape.md
@@ -10,7 +10,7 @@ Sends the ESC key to iRacing. Used to exit the car or dismiss dialogs.
 | Type | Car Control sub-action |
 | SDK Support | No |
 | Communication Method | Key binding |
-| Encoder Support | Yes |
+| Encoder Support | No |
 
 ## Settings
 

--- a/docs/plugins/core/actions/fov-adjust.md
+++ b/docs/plugins/core/actions/fov-adjust.md
@@ -10,16 +10,12 @@ Adjusts the driver's field of view.
 | Type | +/- |
 | SDK Support | No |
 | Communication Method | Key binding |
-| Encoder Support | Yes |
+| Encoder Support | No |
 
 ## Behavior
 
 ### Button Press
 Triggers the direction configured in Settings (increase or decrease).
-
-### Encoder
-- **Rotate clockwise**: Increase FOV
-- **Rotate counter-clockwise**: Decrease FOV
 
 ## Settings
 

--- a/docs/plugins/core/actions/fuel-service.md
+++ b/docs/plugins/core/actions/fuel-service.md
@@ -10,7 +10,7 @@ Manages fuel pit stop settings: toggle fueling, add/reduce/set fuel amounts, cle
 | Type | Multi-toggle |
 | SDK Support | Yes (toggle, clear) / No (macros, keyboard modes) |
 | Communication Method | iRacing API (varies by mode — see note) |
-| Encoder Support | Yes |
+| Encoder Support | No |
 
 > **Communication method by mode:** Toggle Fuel Fill and Clear Fuel Checkbox use the **iRacing API**; Add Fuel, Reduce Fuel, and Set Fuel Amount use **Chat command** (`#fuel` macros); Toggle Autofuel and Lap Margin Increase/Decrease use **Key binding**.
 
@@ -24,11 +24,6 @@ Manages fuel pit stop settings: toggle fueling, add/reduce/set fuel amounts, cle
 - **Clear Fuel Checkbox**: Clears the fuel fill checkbox (SDK)
 - **Toggle Autofuel**: Toggles autofuel via keyboard binding
 - **Lap Margin Increase/Decrease**: Adjusts autofuel lap margin via keyboard binding
-
-### Encoder
-- **Rotate clockwise**: Executes the current mode action (or paired increase)
-- **Rotate counter-clockwise**: Executes the opposite action (or paired decrease)
-- **Press**: Same as button press
 
 ### Long-Press (Add/Reduce only)
 Holding the button repeats the action every 250ms.

--- a/docs/plugins/core/actions/horizon-adjust.md
+++ b/docs/plugins/core/actions/horizon-adjust.md
@@ -10,16 +10,12 @@ Adjusts the vertical horizon position in the driver's view.
 | Type | +/- |
 | SDK Support | No |
 | Communication Method | Key binding |
-| Encoder Support | Yes |
+| Encoder Support | No |
 
 ## Behavior
 
 ### Button Press
 Triggers the direction configured in Settings (up or down).
-
-### Encoder
-- **Rotate clockwise**: Shift horizon up
-- **Rotate counter-clockwise**: Shift horizon down
 
 ## Settings
 

--- a/docs/plugins/core/actions/set-ffb-max-force.md
+++ b/docs/plugins/core/actions/set-ffb-max-force.md
@@ -9,16 +9,12 @@ Adjusts the maximum force feedback force.
 | Action ID | `com.iracedeck.sd.core.set-ffb-max-force` |
 | Type | Adjustment |
 | SDK Support | Yes |
-| Encoder Support | Yes |
+| Encoder Support | No |
 
 ## Behavior
 
 ### Button Press
 Sets or adjusts FFB max force based on configured mode.
-
-### Encoder
-- **Rotate clockwise**: Increase max force
-- **Rotate counter-clockwise**: Decrease max force
 
 ## Settings
 

--- a/docs/plugins/core/actions/splits-delta-cycle.md
+++ b/docs/plugins/core/actions/splits-delta-cycle.md
@@ -10,17 +10,12 @@ Manages splits delta display cycling, reference car toggling, custom sector mark
 | Type | Multi-toggle |
 | SDK Support | No |
 | Communication Method | Key binding |
-| Encoder Support | Yes |
+| Encoder Support | No |
 
 ## Behavior
 
 ### Button Press
 Triggers the action configured in Settings.
-
-### Encoder
-- **Rotate clockwise**: Next splits delta display (Cycle mode only)
-- **Rotate counter-clockwise**: Previous splits delta display (Cycle mode only)
-- **Press**: Triggers the configured action (all modes except Cycle)
 
 ## Settings
 

--- a/docs/plugins/core/actions/toggle-display-reference-car.md
+++ b/docs/plugins/core/actions/toggle-display-reference-car.md
@@ -12,7 +12,7 @@ Toggles the reference car display for split-time comparison.
 | Type | Multi-toggle |
 | SDK Support | No |
 | Communication Method | Key binding |
-| Encoder Support | Yes |
+| Encoder Support | No |
 
 ## Migration
 

--- a/docs/plugins/core/actions/ui-size-adjust.md
+++ b/docs/plugins/core/actions/ui-size-adjust.md
@@ -10,16 +10,12 @@ Adjusts the overall UI scale.
 | Type | +/- |
 | SDK Support | No |
 | Communication Method | Key binding |
-| Encoder Support | Yes |
+| Encoder Support | No |
 
 ## Behavior
 
 ### Button Press
 Triggers the direction configured in Settings (up or down).
-
-### Encoder
-- **Rotate clockwise**: Scale UI up
-- **Rotate counter-clockwise**: Scale UI down
 
 ## Settings
 

--- a/docs/reference/actions.json
+++ b/docs/reference/actions.json
@@ -8,7 +8,7 @@
           "id": "com.iracedeck.sd.core.session-info",
           "name": "Session Info",
           "file": "session-info.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKey": "mode",
           "modes": [
             {
@@ -68,7 +68,7 @@
           "id": "com.iracedeck.sd.core.audio-controls",
           "name": "Audio Controls",
           "file": "audio-controls.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKeys": ["category", "action"],
           "modes": [
             { "category": "push-to-talk", "label": "Push to Talk" },
@@ -88,7 +88,7 @@
           "id": "com.iracedeck.sd.core.black-box-selector",
           "name": "Black Box Selector",
           "file": "black-box-selector.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKeys": ["mode", "blackBox"],
           "modes": [
             { "mode": "direct", "blackBox": "lap-timing", "label": "Select Lap Timing" },
@@ -124,7 +124,7 @@
           "id": "com.iracedeck.sd.core.car-control",
           "name": "Car Control",
           "file": "car-control.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKey": "control",
           "modes": [
             { "value": "pit-speed-limiter", "label": "Pit Speed Limiter", "telemetryAware": true },
@@ -173,7 +173,7 @@
           "id": "com.iracedeck.sd.core.cockpit-misc",
           "name": "Cockpit Misc",
           "file": "cockpit-misc.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKeys": ["control", "direction"],
           "modes": [
             { "control": "toggle-wipers", "label": "Toggle Wipers" },
@@ -192,7 +192,7 @@
           "id": "com.iracedeck.sd.core.force-feedback",
           "name": "Force Feedback",
           "file": "force-feedback.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKeys": ["mode", "direction"],
           "modes": [
             { "mode": "auto-compute-ffb-force", "label": "Auto Compute FFB Force" },
@@ -212,7 +212,7 @@
           "id": "com.iracedeck.sd.core.splits-delta-cycle",
           "name": "Splits & Reference",
           "file": "splits-delta-cycle.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKey": "mode",
           "modes": [
             {
@@ -252,7 +252,7 @@
           "id": "com.iracedeck.sd.core.telemetry-control",
           "name": "Telemetry Control",
           "file": "telemetry-control.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKey": "action",
           "modes": [
             { "value": "toggle-logging", "label": "Toggle Logging" },
@@ -271,7 +271,7 @@
           "id": "com.iracedeck.sd.core.toggle-ui-elements",
           "name": "Toggle UI Elements",
           "file": "toggle-ui-elements.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKey": "element",
           "modes": [
             { "value": "dash-box", "label": "Dash Box" },
@@ -300,7 +300,7 @@
           "id": "com.iracedeck.sd.core.view-adjustment",
           "name": "View Adjustment",
           "file": "view-adjustment.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKeys": ["adjustment", "direction"],
           "modes": [
             { "adjustment": "fov", "direction": "increase", "label": "FOV Increase" },
@@ -318,7 +318,7 @@
           "id": "com.iracedeck.sd.core.replay-control",
           "name": "Replay Control",
           "file": "replay-control.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKey": "mode",
           "modes": [
             { "value": "play-pause", "label": "Play / Pause" },
@@ -367,7 +367,7 @@
           "id": "com.iracedeck.sd.core.replay-transport",
           "name": "Replay Transport",
           "file": "replay-transport.ts",
-          "encoder": true,
+          "encoder": false,
           "deprecated": true,
           "replacedBy": "com.iracedeck.sd.core.replay-control",
           "settingsKey": "transport",
@@ -386,7 +386,7 @@
           "id": "com.iracedeck.sd.core.replay-speed",
           "name": "Replay Speed",
           "file": "replay-speed.ts",
-          "encoder": true,
+          "encoder": false,
           "deprecated": true,
           "replacedBy": "com.iracedeck.sd.core.replay-control",
           "settingsKey": "direction",
@@ -399,7 +399,7 @@
           "id": "com.iracedeck.sd.core.replay-navigation",
           "name": "Replay Navigation",
           "file": "replay-navigation.ts",
-          "encoder": true,
+          "encoder": false,
           "deprecated": true,
           "replacedBy": "com.iracedeck.sd.core.replay-control",
           "settingsKey": "navigation",
@@ -421,7 +421,7 @@
           "id": "com.iracedeck.sd.core.camera-editor-adjustments",
           "name": "Camera Editor Adjustments",
           "file": "camera-editor-adjustments.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKeys": ["adjustment", "direction"],
           "modes": [
             { "adjustment": "latitude", "direction": "increase", "label": "Latitude +" },
@@ -459,7 +459,7 @@
           "id": "com.iracedeck.sd.core.camera-editor-controls",
           "name": "Camera Editor Controls",
           "file": "camera-editor-controls.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKey": "control",
           "modes": [
             { "value": "open-camera-tool", "label": "Open Camera Tool" },
@@ -496,7 +496,7 @@
           "id": "com.iracedeck.sd.core.camera-focus",
           "name": "Camera Controls",
           "file": "camera-controls.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKey": "target",
           "modes": [
             { "value": "change-camera", "label": "Change Camera" },
@@ -522,7 +522,7 @@
           "id": "com.iracedeck.sd.core.media-capture",
           "name": "Media Capture",
           "file": "media-capture.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKey": "action",
           "modes": [
             { "value": "start-stop-video", "label": "Start/Stop Video" },
@@ -543,7 +543,7 @@
           "id": "com.iracedeck.sd.core.pit-quick-actions",
           "name": "Pit Quick Actions",
           "file": "pit-quick-actions.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKey": "action",
           "modes": [
             { "value": "clear-all-checkboxes", "label": "Clear All Checkboxes" },
@@ -555,7 +555,7 @@
           "id": "com.iracedeck.sd.core.fuel-service",
           "name": "Fuel Service",
           "file": "fuel-service.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKey": "mode",
           "modes": [
             { "value": "toggle-fuel-fill", "label": "Toggle Fuel Fill" },
@@ -572,7 +572,7 @@
           "id": "com.iracedeck.sd.core.tire-service",
           "name": "Tire Service",
           "file": "tire-service.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKey": "action",
           "telemetryAware": true,
           "modes": [
@@ -599,7 +599,7 @@
           "id": "com.iracedeck.sd.core.setup-brakes",
           "name": "Setup Brakes",
           "file": "setup-brakes.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKeys": ["setting", "direction"],
           "modes": [
             { "setting": "view-brake-bias", "label": "View Brake Bias", "controlType": "view" },
@@ -627,7 +627,7 @@
           "id": "com.iracedeck.sd.core.setup-chassis",
           "name": "Setup Chassis",
           "file": "setup-chassis.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKeys": ["setting", "direction"],
           "modes": [
             { "setting": "view-diff-preload", "label": "View Diff Preload", "controlType": "view" },
@@ -671,7 +671,7 @@
           "id": "com.iracedeck.sd.core.setup-aero",
           "name": "Setup Aero",
           "file": "setup-aero.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKeys": ["setting", "direction"],
           "modes": [
             { "setting": "view-front-wing", "label": "View Front Wing", "controlType": "view" },
@@ -689,7 +689,7 @@
           "id": "com.iracedeck.sd.core.setup-engine",
           "name": "Setup Engine",
           "file": "setup-engine.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKeys": ["setting", "direction"],
           "modes": [
             { "setting": "view-engine-power", "label": "View Engine Power", "controlType": "view" },
@@ -709,7 +709,7 @@
           "id": "com.iracedeck.sd.core.setup-fuel",
           "name": "Setup Fuel",
           "file": "setup-fuel.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKeys": ["setting", "direction"],
           "modes": [
             { "setting": "view-fuel-mixture", "label": "View Fuel Mixture", "controlType": "view" },
@@ -727,7 +727,7 @@
           "id": "com.iracedeck.sd.core.setup-hybrid",
           "name": "Setup Hybrid",
           "file": "setup-hybrid.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKeys": ["setting", "direction"],
           "modes": [
             { "setting": "view-mguk-deploy-mode", "label": "View MGU-K Deploy Mode", "controlType": "view" },
@@ -748,7 +748,7 @@
           "id": "com.iracedeck.sd.core.setup-traction",
           "name": "Setup Traction",
           "file": "setup-traction.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKeys": ["setting", "direction"],
           "modes": [
             { "setting": "view-tc-slot-1", "label": "View TC1", "controlType": "view" },
@@ -775,7 +775,7 @@
           "id": "com.iracedeck.sd.core.chat",
           "name": "Chat",
           "file": "chat.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKey": "mode",
           "modes": [
             { "value": "send-message", "label": "Send Custom Message" },
@@ -805,7 +805,7 @@
           "id": "com.iracedeck.sd.core.race-admin",
           "name": "Race Admin",
           "file": "race-admin.ts",
-          "encoder": true,
+          "encoder": false,
           "settingsKey": "mode",
           "modes": [
             { "value": "yellow", "label": "Throw Yellow Flag", "description": "Throw a caution flag" },

--- a/docs/reference/stream-deck-plus-encoders.md
+++ b/docs/reference/stream-deck-plus-encoders.md
@@ -1,0 +1,158 @@
+# Stream Deck+ Encoders & Touchscreen Reference
+
+Authoritative reference for how Stream Deck+ dials (encoders) and the LCD touch strip actually work, plus the verified state of Mirabox knob/touch support. Produced for issue #640 as the foundation for rebuilding dial support; researched against the official Elgato SDK docs/schemas/Node SDK (v2.1.0, 2026-06-11) and the Mirabox Stream Dock plugin SDK. Project-facing conventions live in `.claude/rules/encoders-and-touchscreen.md`.
+
+**Current project state:** no iRaceDeck action declares `Encoder`/`Knob` in either plugin manifest (de-claimed in #640). The `onDial*` handlers in `@iracedeck/iracing-actions`, the `IDeckDial*` types in `deck-core`, and both adapters' dial wiring remain in place, dormant, for the rebuild.
+
+## 1. Hardware reality
+
+### Elgato devices with encoders
+
+| Device | Type id | Keys | Dials | Touch strip |
+| ------ | ------- | ---- | ----- | ----------- |
+| Stream Deck + | 7 | 8 LCD keys | 4 (360° rotation + push) | 800×100 px (108×14 mm) |
+| Stream Deck + XL | 13 | 36 LCD keys | 6 (rotation + push) | yes, wider |
+| Stream Deck Studio | 10 | 32 LCD keys | 2 (rotation + push) | — |
+
+- The touch strip is divided per dial: **each encoder action renders a 200×100 px slot**, regardless of device. Total strip width scales with dial count.
+- Physical gestures: dial **rotate**, dial **press/release**, strip **tap**, strip **long touch** (delivered as `touchTap` with `hold: true`), and strip **swipe**. Swipe is consumed by the Stream Deck app for page switching and is **never delivered to plugins** — there is no swipe event in the SDK.
+- Stream Deck Neo (type 9) has 2 capacitive touch points and an info bar, but **neither is exposed to plugins** — the dial/touch APIs below are exclusive to encoder-equipped devices.
+
+### Mirabox Stream Dock devices
+
+| Device | Keys | Knobs | Touchscreen |
+| ------ | ---- | ----- | ----------- |
+| 293 / 293S / 293V3 | 15 LCD keys | none | 293S adds a read-only "Information" area |
+| N3 | 6 LCD keys + 3 buttons | 3 (1 large, 2 small; infinite rotation, clickable) | no |
+| N4 / N4 Pro / N4E | 10 LCD keys | 4 | LCD strip (host-managed: shows knob icons, swipes pages) |
+| M18 | 15 LCD keys + 3 buttons | none | no |
+
+The only Mirabox hardware iRaceDeck has been confirmed on is the 293-class (PR #473 added 293S `Information`-area sizing) — i.e. devices **without** knobs.
+
+## 2. Manifest schema (Elgato)
+
+From the official schemas repo (`elgatosf/schemas`, `src/streamdeck/plugins/manifest/latest.ts`):
+
+- **`Controllers`** (per action): array of `"Keypad"` and/or `"Encoder"`, unique items. An action without `"Encoder"` cannot be assigned to a dial. No documented default — declare it explicitly.
+- **`Encoder`** object (per action):
+  - `Icon` — image path, extension omitted; PNG/SVG 72×72 + 144×144 (@2x). Shown in the app's circular dial canvas. User-overridable.
+  - `background` (lowercase) — image path, extension omitted; PNG/SVG 200×100 + 400×200 (@2x). Drawn on the touch strip behind the layout. User-overridable.
+  - `layout` (lowercase) — a pre-defined layout id (`$X1`, `$A0`, `$A1`, `$B1`, `$B2`, `$C1`) or a relative path to a custom layout `.json` inside the plugin folder. No documented default — set it explicitly.
+  - `StackColor` — hex color shown in the app when the action is the current member of a user-created Dial Stack.
+  - `TriggerDescription` — object with optional **PascalCase** fields `Rotate`, `Push`, `Touch`, `LongTouch`; shown to the user in the app's action configuration UI.
+- **Version floor:** encoder manifest support shipped in Stream Deck 6.0; `setTriggerDescription` needs 6.4; the current schema toolchain accepts `Software.MinimumVersion` `"6.4"`–`"7.4"`.
+
+### Mirabox manifest differences
+
+The Stream Dock plugin SDK (sdk.key123.vip) accepts `Controllers` values `"Keypad"`, `"Knob"`, `"Information"`, `"SecondaryScreen"` — **`"Encoder"` is not recognized; use `"Knob"`**. The official docs define **no** `Encoder`/`Knob` config block, no layouts, and no `TriggerDescription`; Mirabox's own first-party knob plugins ship `"Controllers": ["Knob"]` with no block at all. `SecondaryScreen` appears in the manifest docs but has zero usages in Mirabox's own plugins — semantics unknown.
+
+## 3. Built-in layout IDs (Elgato)
+
+The item `key` in each layout is exactly what `setFeedback` addresses. Canvas is always 200×100. Rects are `[x, y, w, h]`.
+
+| ID | Name | Items |
+| --- | ---- | ----- |
+| `$X1` | Icon | `title`: text `[16,10,136,24]`; `icon`: pixmap `[76,40,48,48]` |
+| `$A0` | Canvas | `full-canvas`: pixmap `[0,0,200,100]`; `title`: text (zOrder 1); `canvas`: pixmap `[16,34,136,54]` (zOrder 1) |
+| `$A1` | Value | `title`; `icon`: pixmap `[16,40,48,48]`; `value`: text `[76,40,108,32]` (right-aligned) |
+| `$B1` | Indicator | `title`, `icon`, `value` as `$A1`; `indicator`: bar `[76,74,108,12]` (subtype 4 "Groove") |
+| `$B2` | Gradient Indicator | as `$B1` but `indicator` is a gbar with gradient background |
+| `$C1` | Double Indicator | `title`; `icon1`/`icon2`: pixmaps; `indicator1`/`indicator2`: bars |
+
+A text item keyed exactly `"title"` is special: the user's PI title settings (font/color/alignment) override the layout's, and `setTitle` updates it. User-set custom title/icon take precedence over plugin-sent values.
+
+## 4. Custom layouts (Elgato)
+
+Schema: `https://schemas.elgato.com/streamdeck/plugins/layout.json`. File shape: `{ "id": string, "items": LayoutItem[] }`, referenced from the manifest (`"layout": "layouts/my-layout.json"`) or switched at runtime via `setFeedbackLayout`.
+
+Common item properties:
+
+- `key` (required, `^[A-Za-z0-9\-_]+$`) — the `setFeedback` key. Immutable at runtime.
+- `type` (required) — `"bar" | "gbar" | "pixmap" | "text"`. Immutable.
+- `rect` (required) — `[x, y, w, h]` within the 200×100 canvas. Immutable. Out-of-bounds rects make Stream Deck refuse to render the **whole layout**; items with the same `zOrder` must not overlap.
+- `enabled` (default `true`), `opacity` (0–1, 0.1 steps), `zOrder` (0–700), `background` (color or gradient string `"0:#ff0000,0.5:yellow,1:#00ff00"`).
+
+Per type: **bar** — `value` (required), `range {min,max}` (default 0–100), `bar_bg_c`, `bar_fill_c`, `bar_border_c`, `border_w`, `subtype` (0 Rectangle, 1 DoubleRectangle, 2 Trapezoid, 3 DoubleTrapezoid, 4 Groove = default); **gbar** — bar plus `bar_h`; **pixmap** — `value` is a plugin-relative path, base64 data URI, or inline SVG string; **text** — `value`, `color`, `alignment` (`center`/`left`/`right`), `text-overflow` (`clip`/`ellipsis`/`fade`), `font {size, weight}`.
+
+## 5. Events the plugin receives
+
+All four share the envelope `{ action, context, device, event, payload }`; the payload carries `controller: "Encoder"`, `coordinates: { column, row }`, and `settings`.
+
+- **`dialRotate`** — `ticks: number` (positive = clockwise, negative = counter-clockwise; **fast rotation coalesces detents, so |ticks| > 1 occurs**) and `pressed: boolean` (rotation happened while the dial was held).
+- **`dialDown`** / **`dialUp`** — press/release; no extra payload fields. These replaced `dialPress` (deprecated 6.1, not emitted at all since Stream Deck 6.5).
+- **`touchTap`** — `tapPos: [x, y]` **relative to the action's own 200×100 slot** (not the full strip), and `hold: boolean` (the long-touch signal — there is no separate long-touch event).
+- **`willAppear`/`willDisappear`** — fire for keys and dials alike; branch on `payload.controller` (`"Keypad" | "Encoder"`). For dials `coordinates.row` is always 0. Encoder actions can never be inside multi-actions (`MultiActionPayload.controller` is hard-typed `"Keypad"`).
+
+Mapping to our abstraction: `deck-core` already defines `IDeckDialRotateEvent` (with `ticks`), `IDeckDialDownEvent`, `IDeckDialUpEvent` in `packages/deck-core/src/types.ts`, and both adapters wire them. **There is no touch event type anywhere in our stack yet** — a rebuild adding touch needs a new `IDeckTouchTapEvent` in `deck-core`, wiring in both adapters, and a base-action stub.
+
+## 6. Commands the plugin sends (Elgato)
+
+- **`setFeedback`** — `{ event, context, payload: { "<itemKey>": <value> } }`. Value is a primitive (`string` for text/pixmap, `number` for bar/gbar) or a partial item object (any mutable properties: `value`, `enabled`, `opacity`, `zOrder`, `background`, bar colors, text styling). `key`/`rect`/`type` are immutable.
+- **`setFeedbackLayout`** — `{ payload: { layout: "<$id or relative .json path>" } }`; switch layouts at runtime, then `setFeedback` to populate.
+- **`setTriggerDescription`** (6.4+) — `{ payload: { rotate?, push?, touch?, longTouch? } }`. **camelCase** here vs PascalCase in the manifest; empty payload resets to manifest values.
+- **`setTitle`** on a dial updates the layout's `title` item (the Node SDK literally implements `DialAction.setTitle` as `setFeedback({ title })`). **`setImage`** on a dial sets the circular dial canvas in the app UI — it does **not** draw on the touch strip; strip imagery goes through a `pixmap` layout item.
+
+### Mirabox commands
+
+The Stream Dock events-sent docs define only `setImage`, `setTitle`, `setSettings`, `get`/`setGlobalSettings` (which is exactly what our `vsd-client.ts` implements). **`setFeedback`/`setFeedbackLayout` do not exist** — Mirabox's own porting guide says to use `setImage` to update knob icons.
+
+## 7. @elgato/streamdeck Node SDK surface (v2.x)
+
+- `SingletonAction` optional handlers: `onDialDown`, `onDialRotate`, `onDialUp`, `onTouchTap` (plus `onKeyDown`/`onKeyUp`, `onWillAppear`/`onWillDisappear` for both controllers).
+- `DialAction<T>` (constructed when `willAppear.payload.controller === "Encoder"`): `setFeedback(payload)`, `setFeedbackLayout(layout)`, `setTitle(title)`, `setImage(image)` (app UI canvas), `setTriggerDescription(opts)`.
+- Type narrowing: `action.isDial(): this is DialAction<T>` / `action.isKey()` — needed in `onWillAppear` where the action is a union; in `onDialRotate` etc. it is already a `DialAction`.
+- Version notes: `@elgato/streamdeck` v2 README requires Node 24 and Stream Deck 7.1+ (`resources` payload field is 7.1+); the underlying encoder protocol features are much older (6.0–6.5).
+
+## 8. Mirabox knobs & touch — the verified answer (#640)
+
+**Question:** do Mirabox knobs/touch actually function for third-party plugins via the VSD Craft / Stream Dock plugin WebSocket protocol?
+
+| Claim | Verdict | Basis |
+| ----- | ------- | ----- |
+| Protocol defines `dialRotate` (`ticks`, `pressed`), `dialDown`, `dialUp`, `Controllers: ["Knob"]` | **Verified from docs** | Official SDK reference (sdk.key123.vip) + SDK headers |
+| Host delivers knob events to WebSocket plugins | **Verified from docs / strongly inferred** | Mirabox's own store-shipped VoiceMeeter and Discord plugins are knob-driven over this exact protocol; a Mirabox collaborator confirmed the shipped Discord knob feature; an independent plugin author reports receiving the events on real hardware |
+| Press-and-hold gestures work on knobs | **No (inferred, device-dependent)** | Third-party report: `dialUp` arrives immediately after `dialDown` regardless of physical release; corroborated by Bitfocus Companion's N4 docs ("rotary encoders do not provide individual press and release events" — a hardware limitation) |
+| Our adapter's dial wiring is protocol-correct | **Verified from code** | `deck-adapter-mirabox/src/adapter.ts` registers `dialRotate`/`dialDown`/`dialUp`, passes `ticks` through, tracks `controller: "Knob"`; unit-tested against a mocked client |
+| Our plugin receives knob events through VSD Craft on real knob hardware | **Unknown — needs hardware test** | All in-repo Mirabox hardware evidence is 293-class (no knobs); no commit/test ever recorded an observed knob event |
+| Plugin-drawable touch strip (`touchTap` with position, `setFeedback`, layouts) | **Not supported (verified from docs)** | Absent from the official events docs; zero usages in Mirabox's own plugins; Mirabox's porting guide states `setFeedback`/layouts don't exist and the N4 strip is host-managed (knob icons via `setImage`, built-in swipe paging) |
+
+**Practical implication:** Mirabox dial **rotation and press-as-tap** are worth rebuilding — the protocol demonstrably delivers them and our adapter already speaks it. Mirabox **touchscreen feedback should be written off** (no plugin-facing surface exists), and rebuilt dial UX must **not depend on press-and-hold** on Mirabox.
+
+### Hardware-test checklist (needs an N3/N4-class device owner)
+
+1. Can an action declaring `"Knob"` be dragged onto a knob slot in VSD Craft / Mirabox Space, and does a `Knob` config block (layout/TriggerDescription) break anything? (First-party plugins omit the block.)
+2. On placement, does the plugin log `willAppear` with `payload.controller: "Knob"`? (Enable `debugLogging`; check `<plugin>/log/<date>.log`.)
+3. Rotation: do `dialRotate` events arrive; what is `ticks` per detent; do fast spins coalesce into |ticks| > 1; is `pressed` present?
+4. Press: do `dialDown`/`dialUp` arrive, and does `dialUp` fire at physical release or immediately after `dialDown` (hold for 2+ seconds)? This decides whether hold-style dial actions are possible on Mirabox.
+5. Does `setImage` on a Knob context render to the N4 LCD strip segment above the knob?
+6. Does tapping the LCD strip deliver any event (`touchTap` or otherwise) to the plugin, and with what payload?
+7. Regression check on 293S: `Information` contexts still behave as today.
+
+## 9. Implementation patterns & pitfalls for the rebuild
+
+- **Treat `ticks` as a signed delta, not ±1.** Multiply the step size by `ticks`; never count events.
+- **Rotate-while-pressed** is native on Elgato via `dialRotate.pressed` — no manual `dialDown` state tracking needed for that. But if `dialUp` also triggers a "click" action, suppress the click when a rotation occurred between down and up.
+- **No native dial long-press** exists on Elgato (the trigger vocabulary for the dial is only Rotate/Push) — implement it by timing `dialDown` → `dialUp` yourself. The touchscreen's long-press IS native (`touchTap` with `hold: true`). On Mirabox, do not build long-press at all (see §8).
+- **Touch hit-testing**: `tapPos` is relative to the action's 200×100 slot, so hit-test directly against layout item `rect`s. Elgato guideline: interactive touch targets ≥ 35×35 px.
+- **Throttle feedback**: official guideline is a maximum of **10 `setFeedback` calls per second** per dial (same as key images). Coalesce telemetry-driven updates.
+- **Branch on `controller`** in `willAppear` — an action declaring `["Keypad", "Encoder"]` can be on either surface, and `setImage`/`setFeedback` address different things per surface.
+- **Keypad-only actions on dials**: users can wrap them via Stream Deck's "Action Trigger" feature (rotate/press each fire a key action); the plugin just sees normal key events and cannot detect the wrapping.
+- **Layout authoring traps**: same-`zOrder` overlap is invalid; one out-of-bounds rect kills the whole layout; `key`/`rect`/`type` are immutable — restructure via `enabled`/`opacity`/`zOrder` or `setFeedbackLayout`; name the user-stylable text item exactly `title`.
+- **Platform-agnostic action code**: keep dial behavior in shared `iracing-actions` handlers consuming `IDeck*` events; gate Elgato-only surfaces (touch, feedback layouts) behind platform feature flags per `.claude/rules/platform-feature-flags.md` so the Mirabox bundle never ships dead touch code.
+
+## Sources
+
+- Elgato manifest reference: <https://docs.elgato.com/streamdeck/sdk/references/manifest/>
+- Touch strip layout reference: <https://docs.elgato.com/streamdeck/sdk/references/touch-strip-layout/>
+- Dials guide: <https://docs.elgato.com/streamdeck/sdk/guides/dials/>
+- WebSocket plugin events/commands: <https://docs.elgato.com/streamdeck/sdk/references/websocket/plugin/>
+- WebSocket changelog (6.0/6.1/6.4/6.5 encoder history): <https://docs.elgato.com/streamdeck/sdk/references/websocket/changelog/>
+- Devices guide: <https://docs.elgato.com/streamdeck/sdk/guides/devices/>
+- Marketplace guidelines (10 Hz cap, 35×35 touch targets): <https://docs.elgato.com/guidelines/stream-deck/plugins/>
+- Official schemas: <https://github.com/elgatosf/schemas> (manifest + layout types); layout JSON schema: <https://schemas.elgato.com/streamdeck/plugins/layout.json>
+- Official Node SDK v2.1.0 source: <https://github.com/elgatosf/streamdeck>
+- Elgato help: SD+ specs <https://help.elgato.com/hc/en-us/articles/10567379685901>, touch strip gestures <https://help.elgato.com/hc/en-us/articles/10567698991629>, Dial Stacks <https://help.elgato.com/hc/en-us/articles/10843581380109>, Action Trigger <https://help.elgato.com/hc/en-us/articles/29655069662609>
+- Mirabox Stream Dock SDK: <https://sdk.key123.vip/en/guide/events-received.html>, <https://sdk.key123.vip/en/guide/events-sent.html>, <https://sdk.key123.vip/en/guide/manifest.html>
+- Mirabox SDK + plugins source: <https://github.com/MiraboxSpace/StreamDock-Plugin-SDK>, <https://github.com/MiraboxSpace/StreamDock-Plugins> (VoiceMeeter `gain_adjust.js`, Discord plugin, issue #46)
+- VSDinside porting guide (Encoder→Knob, no layouts/setFeedback, dialUp-after-dialDown report): <https://www.vsdinside.com/blogs/blog/porting-stream-deck-plugins-to-stream-dock-m18-a-practical-guide>
+- Bitfocus Companion Mirabox surface docs (N3/N4/293V3 hardware, encoder press limitation): <https://companion.free/user-guide/v4.2/surfaces/mirabox-streamdock/>

--- a/packages/iracing-actions/src/actions/audio-controls/audio-controls.ejs
+++ b/packages/iracing-actions/src/actions/audio-controls/audio-controls.ejs
@@ -32,7 +32,7 @@
 		</sdpi-item>
 
 		<div class="ird-supporting-text hidden" id="internal-volume-note">
-			Adjusts iRaceDeck's own audio level. Stream Deck&nbsp;+ dial control is not available yet.
+			Adjusts iRaceDeck's own audio level.
 		</div>
 
 		<%- include('title-overrides') %>

--- a/packages/iracing-plugin-mirabox/CLAUDE.md
+++ b/packages/iracing-plugin-mirabox/CLAUDE.md
@@ -7,8 +7,7 @@ Mirrors the structure of `@iracedeck/iracing-plugin-stream-deck` but targets Mir
 ## Key Differences from iracing-plugin-stream-deck
 
 - Uses `VSDPlatformAdapter` instead of `ElgatoPlatformAdapter`
-- Manifest uses `"Knob"` instead of `"Encoder"` for dial actions
-- No `Encoder.layout` field (VSD doesn't support encoder layouts)
+- All actions are currently Keypad-only — do not add a `"Knob"` block (the VSD equivalent of Elgato's `"Encoder"`) to the manifest; dial support was de-claimed in issue #640 (see `.claude/rules/encoders-and-touchscreen.md` for the planned rebuild)
 - Uses `ws` package for WebSocket communication (VSD bundles Node.js 20)
 - `SDKVersion: 1` instead of `3`
 

--- a/packages/iracing-plugin-mirabox/CLAUDE.md
+++ b/packages/iracing-plugin-mirabox/CLAUDE.md
@@ -9,7 +9,7 @@ Mirrors the structure of `@iracedeck/iracing-plugin-stream-deck` but targets Mir
 - Uses `VSDPlatformAdapter` instead of `ElgatoPlatformAdapter`
 - All actions are currently Keypad-only — do not add a `"Knob"` block (the VSD equivalent of Elgato's `"Encoder"`) to the manifest; dial support was de-claimed in issue #640 (see `.claude/rules/encoders-and-touchscreen.md` for the planned rebuild)
 - Uses `ws` package for WebSocket communication (VSD bundles Node.js 20)
-- `SDKVersion: 1` instead of `3`
+- `SDKVersion: 2` instead of `3` (initially shipped as `1`, deliberately bumped to `2` in commit `51515173`)
 
 PI framework (web components, EJS partials, compile plugin, `sdpi-components.js`) comes from `@iracedeck/pi-components`, the same shared package the Elgato plugin consumes. Per-action PI templates, static icons, and template data come from `@iracedeck/iracing-actions` (`src/actions/<name>/*.ejs` + `icon.svg` + `key.svg`, and shared `src/actions/data/*.json`). The `rollup.config.mjs` imports `piTemplatePlugin`, `partialsDir`, and `browserDir` from `@iracedeck/pi-components/build`, computes `actionTemplatesDir` locally from the `@iracedeck/iracing-actions` path, and copies per-action `icon.svg`/`key.svg` into `com.iracedeck.sd.core.sdPlugin/imgs/actions/<name>/`. The plugin-level branding icons in `imgs/plugin/` are still copied from `iracing-plugin-stream-deck` until a dedicated branding package lands. Generated HTML is then stripped of the `lang="en"` attribute (`stripHtmlLangPlugin`) because VSD Craft does not accept it.
 

--- a/packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/manifest.json
+++ b/packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/manifest.json
@@ -27,8 +27,7 @@
       "Tooltip": "Audio volume and mute controls (iRacing voice chat & master; iRaceDeck Race Engineer & Radar)",
       "PropertyInspectorPath": "ui/audio-controls.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -36,14 +35,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Volume up/down",
-          "Push": "Mute/silence"
-        }
-      }
+      ]
     },
     {
       "Name": "Black Box Selector",
@@ -52,8 +44,7 @@
       "Tooltip": "Cycle through or select iRacing black boxes",
       "PropertyInspectorPath": "ui/black-box-selector.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -61,13 +52,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Next/Previous black box"
-        }
-      }
+      ]
     },
     {
       "Name": "Splits & Reference",
@@ -76,8 +61,7 @@
       "Tooltip": "Cycle splits delta display modes or toggle reference car",
       "PropertyInspectorPath": "ui/splits-delta-cycle.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -85,14 +69,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Next/Previous splits delta",
-          "Push": "Toggle reference car"
-        }
-      }
+      ]
     },
     {
       "Name": "Telemetry Control",
@@ -101,8 +78,7 @@
       "Tooltip": "Telemetry logging and recording controls",
       "PropertyInspectorPath": "ui/telemetry-control.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -110,13 +86,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Activate telemetry action"
-        }
-      }
+      ]
     },
     {
       "Name": "Toggle UI Elements",
@@ -125,8 +95,7 @@
       "Tooltip": "Toggle iRacing UI elements on or off",
       "PropertyInspectorPath": "ui/toggle-ui-elements.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -134,13 +103,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Toggle UI element"
-        }
-      }
+      ]
     },
     {
       "Name": "Look Direction",
@@ -149,8 +112,7 @@
       "Tooltip": "Change the driver's view direction",
       "PropertyInspectorPath": "ui/look-direction.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -158,13 +120,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Activate look direction"
-        }
-      }
+      ]
     },
     {
       "Name": "Car Control",
@@ -173,8 +129,7 @@
       "Tooltip": "Control car operations (starter, ignition, pit limiter, and more)",
       "PropertyInspectorPath": "ui/car-control.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -182,13 +137,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Activate car control"
-        }
-      }
+      ]
     },
     {
       "Name": "Cockpit Misc",
@@ -197,8 +146,7 @@
       "Tooltip": "Miscellaneous cockpit controls (toggle/trigger wipers, FFB, latency, dash pages, in-lap mode)",
       "PropertyInspectorPath": "ui/cockpit-misc.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -206,14 +154,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease adjustment",
-          "Push": "Activate control"
-        }
-      }
+      ]
     },
     {
       "Name": "Force Feedback",
@@ -222,8 +163,7 @@
       "Tooltip": "Force feedback controls (FFB force, wheel LFE, bass shaker, haptic intensity)",
       "PropertyInspectorPath": "ui/force-feedback.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -231,14 +171,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease adjustment",
-          "Push": "Activate control"
-        }
-      }
+      ]
     },
     {
       "Name": "Pit Quick Actions",
@@ -247,8 +180,7 @@
       "Tooltip": "Quick pit stop controls (clear all, windshield tearoff, fast repair)",
       "PropertyInspectorPath": "ui/pit-quick-actions.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -256,13 +188,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Activate pit action"
-        }
-      }
+      ]
     },
     {
       "Name": "Fuel Service",
@@ -271,8 +197,7 @@
       "Tooltip": "Fuel management for pit stops (add/reduce fuel, autofuel, lap margin)",
       "PropertyInspectorPath": "ui/fuel-service.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -280,14 +205,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease fuel",
-          "Push": "Activate fuel action"
-        }
-      }
+      ]
     },
     {
       "Name": "Tire Service",
@@ -296,8 +214,7 @@
       "Tooltip": "Tire management for pit stops (toggle tires, change compound, clear)",
       "PropertyInspectorPath": "ui/tire-service.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -305,13 +222,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Activate tire action"
-        }
-      }
+      ]
     },
     {
       "Name": "Pit Crew",
@@ -337,8 +248,7 @@
       "Tooltip": "Text chat operations (open, reply, whisper, send message, macros)",
       "PropertyInspectorPath": "ui/chat.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -346,13 +256,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Activate chat action"
-        }
-      }
+      ]
     },
     {
       "Name": "Race Admin",
@@ -361,8 +265,7 @@
       "Tooltip": "Session admin commands for race directors (yellows, penalties, pit control, chat)",
       "PropertyInspectorPath": "ui/race-admin.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -370,13 +273,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Execute admin command"
-        }
-      }
+      ]
     },
     {
       "Name": "View Adjustment",
@@ -385,8 +282,7 @@
       "Tooltip": "Adjust camera and view settings (FOV, horizon, driver height, VR recenter, UI size)",
       "PropertyInspectorPath": "ui/view-adjustment.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -394,14 +290,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease adjustment",
-          "Push": "Activate adjustment"
-        }
-      }
+      ]
     },
     {
       "Name": "Replay Control",
@@ -410,8 +299,7 @@
       "Tooltip": "Unified replay controls: transport, speed, and navigation",
       "PropertyInspectorPath": "ui/replay-control.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -419,14 +307,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Context-dependent (frame step, speed, navigation)",
-          "Push": "Context-dependent (play, reset speed, navigate)"
-        }
-      }
+      ]
     },
     {
       "Name": "Replay Transport",
@@ -436,8 +317,7 @@
       "PropertyInspectorPath": "ui/replay-transport.html",
       "VisibleInActionsList": false,
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -445,14 +325,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Frame forward/backward",
-          "Push": "Play/Pause"
-        }
-      }
+      ]
     },
     {
       "Name": "Replay Speed",
@@ -462,8 +335,7 @@
       "PropertyInspectorPath": "ui/replay-speed.html",
       "VisibleInActionsList": false,
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -471,14 +343,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease speed",
-          "Push": "Reset to normal speed"
-        }
-      }
+      ]
     },
     {
       "Name": "Camera Controls",
@@ -487,8 +352,7 @@
       "Tooltip": "Cycle through cameras and focus on targets (your car, leader, incidents, positions)",
       "PropertyInspectorPath": "ui/camera-focus.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -496,14 +360,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Next/Previous (cycle modes)",
-          "Push": "Activate selected target"
-        }
-      }
+      ]
     },
     {
       "Name": "Camera Cycle (Legacy)",
@@ -513,8 +370,7 @@
       "PropertyInspectorPath": "ui/camera-focus.html",
       "VisibleInActionsList": false,
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -522,14 +378,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Next/Previous (cycle modes)",
-          "Push": "Activate selected target"
-        }
-      }
+      ]
     },
     {
       "Name": "Camera Editor Adjustments",
@@ -538,8 +387,7 @@
       "Tooltip": "Camera editor adjustments for position, rotation, zoom, and other parameters",
       "PropertyInspectorPath": "ui/camera-editor-adjustments.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -547,14 +395,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease adjustment",
-          "Push": "Activate selected adjustment"
-        }
-      }
+      ]
     },
     {
       "Name": "Camera Editor Controls",
@@ -563,8 +404,7 @@
       "Tooltip": "Camera editor toggles and management controls for broadcasters and content creators",
       "PropertyInspectorPath": "ui/camera-editor-controls.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -572,13 +412,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Activate selected control"
-        }
-      }
+      ]
     },
     {
       "Name": "Media Capture",
@@ -587,8 +421,7 @@
       "Tooltip": "Video recording, screenshots, and texture management",
       "PropertyInspectorPath": "ui/media-capture.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -596,13 +429,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Activate selected capture action"
-        }
-      }
+      ]
     },
     {
       "Name": "Replay Navigation",
@@ -612,8 +439,7 @@
       "PropertyInspectorPath": "ui/replay-navigation.html",
       "VisibleInActionsList": false,
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -621,14 +447,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Next/Previous (session, lap, or incident)",
-          "Push": "Activate navigation action"
-        }
-      }
+      ]
     },
     {
       "Name": "Setup Brakes",
@@ -637,8 +456,7 @@
       "Tooltip": "Brake adjustments (ABS, brake bias, peak bias, engine braking)",
       "PropertyInspectorPath": "ui/setup-brakes.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -646,14 +464,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease brake setting",
-          "Push": "Activate brake adjustment"
-        }
-      }
+      ]
     },
     {
       "Name": "Setup Chassis",
@@ -662,8 +473,7 @@
       "Tooltip": "Chassis adjustments (differential, ARB, springs, shocks, power steering)",
       "PropertyInspectorPath": "ui/setup-chassis.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -671,14 +481,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease chassis setting",
-          "Push": "Activate chassis adjustment"
-        }
-      }
+      ]
     },
     {
       "Name": "Setup Aero",
@@ -687,8 +490,7 @@
       "Tooltip": "Aerodynamic adjustments (front wing, rear wing, qualifying tape, RF brake)",
       "PropertyInspectorPath": "ui/setup-aero.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -696,14 +498,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease aero setting",
-          "Push": "Activate aero adjustment"
-        }
-      }
+      ]
     },
     {
       "Name": "Setup Engine",
@@ -712,8 +507,7 @@
       "Tooltip": "Engine adjustments (power, throttle shaping, boost, launch RPM)",
       "PropertyInspectorPath": "ui/setup-engine.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -721,14 +515,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease engine setting",
-          "Push": "Activate engine adjustment"
-        }
-      }
+      ]
     },
     {
       "Name": "Setup Fuel",
@@ -737,8 +524,7 @@
       "Tooltip": "Fuel adjustments (mixture, fuel cut, low fuel, FCY mode)",
       "PropertyInspectorPath": "ui/setup-fuel.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -746,14 +532,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease fuel setting",
-          "Push": "Activate fuel adjustment"
-        }
-      }
+      ]
     },
     {
       "Name": "Setup Hybrid",
@@ -762,8 +541,7 @@
       "Tooltip": "Hybrid/ERS adjustments (MGU-K regen, deploy modes, HYS boost/regen)",
       "PropertyInspectorPath": "ui/setup-hybrid.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -771,14 +549,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease hybrid setting",
-          "Push": "Activate hybrid adjustment"
-        }
-      }
+      ]
     },
     {
       "Name": "Setup Traction",
@@ -787,8 +558,7 @@
       "Tooltip": "Traction control adjustments (TC Toggle, TC Slots 1-4)",
       "PropertyInspectorPath": "ui/setup-traction.html",
       "Controllers": [
-        "Keypad",
-        "Knob"
+        "Keypad"
       ],
       "States": [
         {
@@ -796,14 +566,7 @@
           "TitleAlignment": "bottom",
           "FontSize": 14
         }
-      ],
-      "Knob": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease TC setting",
-          "Push": "Activate TC adjustment"
-        }
-      }
+      ]
     },
     {
       "Name": "Session Info",

--- a/packages/iracing-plugin-stream-deck/CLAUDE.md
+++ b/packages/iracing-plugin-stream-deck/CLAUDE.md
@@ -30,7 +30,6 @@ import {
   getGlobalSettings,
   getGlobalTitleSettings,
   getKeyboard,
-  type IDeckDialRotateEvent,
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
   type IDeckWillAppearEvent,
@@ -83,7 +82,7 @@ export class {ActionName} extends ConnectionStateAwareAction<{ActionName}Setting
   // The base class receives it: constructor(logger: ILogger)
 
   // Required lifecycle handlers: onWillAppear, onWillDisappear,
-  // onDidReceiveSettings, onKeyDown, onDialRotate
+  // onDidReceiveSettings, onKeyDown
   // IMPORTANT: Call super.onWillAppear(ev) and super.onDidReceiveSettings(ev)
   // as the first line in those handlers (required for flag overlay and CommonSettings).
   // See splits-delta-cycle.ts for the full pattern.
@@ -259,7 +258,7 @@ adapter.registerAction({ACTION_NAME}_UUID, new {ActionName}(adapter.createLogger
 
 #### 7b. Register in Mirabox plugin — `packages/iracing-plugin-mirabox/src/plugin.ts`
 
-Same pattern as above — import from `@iracedeck/iracing-actions` and register via the VSD adapter. Maintain alphabetical order. The manifest at `packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/manifest.json` must also be updated (note: uses `"Knob"` instead of `"Encoder"` for dial actions).
+Same pattern as above — import from `@iracedeck/iracing-actions` and register via the VSD adapter. Maintain alphabetical order. The manifest at `packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/manifest.json` must also be updated.
 
 #### 8. Declare in manifest — `com.iracedeck.sd.core.sdPlugin/manifest.json`
 
@@ -272,14 +271,7 @@ Add entry to the `Actions` array:
   "Icon": "imgs/actions/{action-name}/icon",
   "Tooltip": "Brief description of what the action does",
   "PropertyInspectorPath": "ui/{action-name}.html",
-  "Controllers": ["Keypad", "Encoder"],
-  "Encoder": {
-    "layout": "$B1",
-    "TriggerDescription": {
-      "Rotate": "What rotation does",
-      "Push": "What press does"
-    }
-  },
+  "Controllers": ["Keypad"],
   "States": [
     {
       "Image": "imgs/actions/{action-name}/key",
@@ -290,9 +282,7 @@ Add entry to the `Actions` array:
 }
 ```
 
-- Use `"Controllers": ["Keypad"]` if encoder is not supported
-- Omit the `Encoder` block entirely if Keypad-only
-- Only include `TriggerDescription` keys for handlers the action implements
+- All actions are currently Keypad-only — use `"Controllers": ["Keypad"]` and do not add an `Encoder` block (dial/encoder support was de-claimed in issue #640; see `.claude/rules/encoders-and-touchscreen.md` for the planned rebuild)
 
 #### 9. Add key bindings — `packages/iracing-actions/src/actions/data/key-bindings.json`
 

--- a/packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/manifest.json
+++ b/packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/manifest.json
@@ -28,16 +28,8 @@
       "Tooltip": "Audio volume and mute controls (iRacing voice chat & master; iRaceDeck Race Engineer & Radar)",
       "PropertyInspectorPath": "ui/audio-controls.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Volume up/down",
-          "Push": "Mute/silence"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/audio-controls/key",
@@ -53,15 +45,8 @@
       "Tooltip": "Cycle through or select iRacing black boxes",
       "PropertyInspectorPath": "ui/black-box-selector.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Next/Previous black box"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/black-box-selector/key",
@@ -77,16 +62,8 @@
       "Tooltip": "Cycle splits delta display modes or toggle reference car",
       "PropertyInspectorPath": "ui/splits-delta-cycle.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Next/Previous splits delta",
-          "Push": "Toggle reference car"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/splits-delta-cycle/key",
@@ -102,15 +79,8 @@
       "Tooltip": "Telemetry logging and recording controls",
       "PropertyInspectorPath": "ui/telemetry-control.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Activate telemetry action"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/telemetry-control/key",
@@ -126,15 +96,8 @@
       "Tooltip": "Toggle iRacing UI elements on or off",
       "PropertyInspectorPath": "ui/toggle-ui-elements.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Toggle UI element"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/toggle-ui-elements/key",
@@ -150,15 +113,8 @@
       "Tooltip": "Change the driver's view direction",
       "PropertyInspectorPath": "ui/look-direction.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Activate look direction"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/look-direction/key",
@@ -174,15 +130,8 @@
       "Tooltip": "Control car operations (starter, ignition, pit limiter, and more)",
       "PropertyInspectorPath": "ui/car-control.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Activate car control"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/car-control/key",
@@ -198,16 +147,8 @@
       "Tooltip": "Miscellaneous cockpit controls (toggle/trigger wipers, FFB, latency, dash pages, in-lap mode)",
       "PropertyInspectorPath": "ui/cockpit-misc.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease adjustment",
-          "Push": "Activate control"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/cockpit-misc/key",
@@ -223,16 +164,8 @@
       "Tooltip": "Force feedback controls (FFB force, wheel LFE, bass shaker, haptic intensity)",
       "PropertyInspectorPath": "ui/force-feedback.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease adjustment",
-          "Push": "Activate control"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/force-feedback/key",
@@ -248,15 +181,8 @@
       "Tooltip": "Quick pit stop controls (clear all, windshield tearoff, fast repair)",
       "PropertyInspectorPath": "ui/pit-quick-actions.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Activate pit action"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/pit-quick-actions/key",
@@ -272,16 +198,8 @@
       "Tooltip": "Fuel management for pit stops (add/reduce fuel, autofuel, lap margin)",
       "PropertyInspectorPath": "ui/fuel-service.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease fuel",
-          "Push": "Activate fuel action"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/fuel-service/key",
@@ -297,15 +215,8 @@
       "Tooltip": "Tire management for pit stops (toggle tires, change compound, clear)",
       "PropertyInspectorPath": "ui/tire-service.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Activate tire action"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/tire-service/key",
@@ -338,15 +249,8 @@
       "Tooltip": "Text chat operations (open, reply, whisper, send message, macros)",
       "PropertyInspectorPath": "ui/chat.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Activate chat action"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/chat/key",
@@ -362,15 +266,8 @@
       "Tooltip": "Session admin commands for race directors (yellows, penalties, pit control, chat)",
       "PropertyInspectorPath": "ui/race-admin.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Execute admin command"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/race-admin/key",
@@ -386,16 +283,8 @@
       "Tooltip": "Adjust camera and view settings (FOV, horizon, driver height, VR recenter, UI size)",
       "PropertyInspectorPath": "ui/view-adjustment.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease adjustment",
-          "Push": "Activate adjustment"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/view-adjustment/key",
@@ -411,16 +300,8 @@
       "Tooltip": "Unified replay controls: transport, speed, and navigation",
       "PropertyInspectorPath": "ui/replay-control.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Context-dependent (frame step, speed, navigation)",
-          "Push": "Context-dependent (play, reset speed, navigate)"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/replay-control/key",
@@ -437,16 +318,8 @@
       "PropertyInspectorPath": "ui/replay-transport.html",
       "VisibleInActionsList": false,
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Frame forward/backward",
-          "Push": "Play/Pause"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/replay-transport/key",
@@ -463,16 +336,8 @@
       "PropertyInspectorPath": "ui/replay-speed.html",
       "VisibleInActionsList": false,
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease speed",
-          "Push": "Reset to normal speed"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/replay-speed/key",
@@ -488,16 +353,8 @@
       "Tooltip": "Cycle through cameras and focus on targets (your car, leader, incidents, positions)",
       "PropertyInspectorPath": "ui/camera-focus.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Next/Previous (cycle modes)",
-          "Push": "Activate selected target"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/camera-focus/key",
@@ -514,16 +371,8 @@
       "PropertyInspectorPath": "ui/camera-focus.html",
       "VisibleInActionsList": false,
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Next/Previous (cycle modes)",
-          "Push": "Activate selected target"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/camera-focus/key",
@@ -539,16 +388,8 @@
       "Tooltip": "Camera editor adjustments for position, rotation, zoom, and other parameters",
       "PropertyInspectorPath": "ui/camera-editor-adjustments.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease adjustment",
-          "Push": "Activate selected adjustment"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/camera-editor-adjustments/key",
@@ -564,15 +405,8 @@
       "Tooltip": "Camera editor toggles and management controls for broadcasters and content creators",
       "PropertyInspectorPath": "ui/camera-editor-controls.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Activate selected control"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/camera-editor-controls/key",
@@ -588,15 +422,8 @@
       "Tooltip": "Video recording, screenshots, and texture management",
       "PropertyInspectorPath": "ui/media-capture.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Push": "Activate selected capture action"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/media-capture/key",
@@ -613,16 +440,8 @@
       "PropertyInspectorPath": "ui/replay-navigation.html",
       "VisibleInActionsList": false,
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Next/Previous (session, lap, or incident)",
-          "Push": "Activate navigation action"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/replay-navigation/key",
@@ -638,16 +457,8 @@
       "Tooltip": "Brake adjustments (ABS, brake bias, peak bias, engine braking)",
       "PropertyInspectorPath": "ui/setup-brakes.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease brake setting",
-          "Push": "Activate brake adjustment"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/setup-brakes/key",
@@ -663,16 +474,8 @@
       "Tooltip": "Chassis adjustments (differential, ARB, springs, shocks, power steering)",
       "PropertyInspectorPath": "ui/setup-chassis.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease chassis setting",
-          "Push": "Activate chassis adjustment"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/setup-chassis/key",
@@ -688,16 +491,8 @@
       "Tooltip": "Aerodynamic adjustments (front wing, rear wing, qualifying tape, RF brake)",
       "PropertyInspectorPath": "ui/setup-aero.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease aero setting",
-          "Push": "Activate aero adjustment"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/setup-aero/key",
@@ -713,16 +508,8 @@
       "Tooltip": "Engine adjustments (power, throttle shaping, boost, launch RPM)",
       "PropertyInspectorPath": "ui/setup-engine.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease engine setting",
-          "Push": "Activate engine adjustment"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/setup-engine/key",
@@ -738,16 +525,8 @@
       "Tooltip": "Fuel adjustments (mixture, fuel cut, low fuel, FCY mode)",
       "PropertyInspectorPath": "ui/setup-fuel.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease fuel setting",
-          "Push": "Activate fuel adjustment"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/setup-fuel/key",
@@ -763,16 +542,8 @@
       "Tooltip": "Hybrid/ERS adjustments (MGU-K regen, deploy modes, HYS boost/regen)",
       "PropertyInspectorPath": "ui/setup-hybrid.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease hybrid setting",
-          "Push": "Activate hybrid adjustment"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/setup-hybrid/key",
@@ -788,16 +559,8 @@
       "Tooltip": "Traction control adjustments (TC Toggle, TC Slots 1-4)",
       "PropertyInspectorPath": "ui/setup-traction.html",
       "Controllers": [
-        "Keypad",
-        "Encoder"
+        "Keypad"
       ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease TC setting",
-          "Push": "Activate TC adjustment"
-        }
-      },
       "States": [
         {
           "Image": "imgs/actions/setup-traction/key",

--- a/packages/website/src/content/docs/docs/actions/audio-voice/audio-controls.md
+++ b/packages/website/src/content/docs/docs/actions/audio-voice/audio-controls.md
@@ -20,12 +20,12 @@ Select the mode from the **Mode** dropdown in the Property Inspector. Voice Chat
 
 ### Push to Talk
 
-Hold voice chat push-to-talk for as long as the button is pressed. Release the button to stop transmitting. Works the same on a key and on a dial — pressing the dial holds, releasing the dial stops transmitting.
+Hold voice chat push-to-talk for as long as the button is pressed. Release the button to stop transmitting.
 
 #### Details
 
 - **Method:** Key binding
-- **Dial:** No rotation support; press and hold the dial to transmit, release to stop
+- **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
@@ -42,7 +42,7 @@ Control voice chat volume and mute.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts voice chat volume (clockwise = up, counter-clockwise = down) regardless of the Action setting; pressing the dial **always** toggles mute, even if the Action setting is Volume Up or Volume Down
+- **Dial:** No rotation support
 - **Default binding:** Depends on the selected action — see the **Action** setting below
 - **Telemetry-aware icon:** No
 
@@ -61,7 +61,7 @@ Control the iRacing master volume. The Master mode has no mute option — the Ac
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts master volume (clockwise = up, counter-clockwise = down) regardless of the Action setting; pressing the dial triggers the configured action
+- **Dial:** No rotation support
 - **Default binding:** Depends on the selected action — see the **Action** setting below
 - **Telemetry-aware icon:** No
 
@@ -79,7 +79,7 @@ Adjust iRaceDeck's own **Race Engineer voice** level — the same level as the R
 #### Details
 
 - **Method:** iRaceDeck audio (no iRacing command)
-- **Dial:** Not supported yet — only key presses adjust the volume
+- **Dial:** No rotation support
 - **Default binding:** None — controls iRaceDeck audio directly (no iRacing key binding)
 - **Telemetry-aware icon:** No
 
@@ -97,7 +97,7 @@ Adjust iRaceDeck's own proximity **Radar** tick level — the same level as the 
 #### Details
 
 - **Method:** iRaceDeck audio (no iRacing command)
-- **Dial:** Not supported yet — only key presses adjust the volume
+- **Dial:** No rotation support
 - **Default binding:** None — controls iRaceDeck audio directly (no iRacing key binding)
 - **Telemetry-aware icon:** No
 

--- a/packages/website/src/content/docs/docs/actions/audio-voice/pit-crew.md
+++ b/packages/website/src/content/docs/docs/actions/audio-voice/pit-crew.md
@@ -27,7 +27,7 @@ When iRacing telemetry first starts flowing — typically a few seconds after yo
 
 #### Details
 
-- **Dial:** Not supported
+- **Dial:** No rotation support
 - **Default binding:** None — button-driven feature, no keyboard binding
 - **Telemetry-aware icon:** Yes — the status bar reflects the current global flag
 
@@ -37,7 +37,7 @@ Toggles the directional proximity tick loop on/off. Pressing the button flips `r
 
 #### Details
 
-- **Dial:** Not supported
+- **Dial:** No rotation support
 - **Default binding:** None — button-driven feature, no keyboard binding
 - **Telemetry-aware icon:** Yes — the status bar reflects the current global flag
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-aero.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-aero.md
@@ -39,7 +39,7 @@ Adjust the front wing angle. The **Direction** setting picks whether pressing th
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts the front wing (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Front Wing + and Front Wing - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -57,7 +57,7 @@ Adjust the rear wing angle. The **Direction** setting picks whether pressing the
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts the rear wing (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Rear Wing + and Rear Wing - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -75,7 +75,7 @@ Adjust the amount of qualifying tape covering the radiators. The **Direction** s
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts qualifying tape (clockwise = more tape, counter-clockwise = less tape), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Qualifying Tape + and Qualifying Tape - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-brakes.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-brakes.md
@@ -58,7 +58,7 @@ Step the ABS level up or down. The **Direction** setting picks whether pressing 
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts the ABS level (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both ABS Adjust + and ABS Adjust - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -76,7 +76,7 @@ Shift the brake bias forward or rearward. The **Direction** setting picks whethe
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts brake bias (clockwise = forward, counter-clockwise = rearward), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `=` (increase) and `-` (decrease) — matches iRacing's default brake bias keys
 - **Telemetry-aware icon:** No
 
@@ -94,7 +94,7 @@ Fine-adjust the brake bias in smaller increments than the main Brake Bias mode.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts brake bias fine (clockwise = forward, counter-clockwise = rearward), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Brake Bias Fine + and Brake Bias Fine - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -112,7 +112,7 @@ Adjust the peak brake bias setting.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts peak brake bias (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Peak Brake Bias + and Peak Brake Bias - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -130,7 +130,7 @@ Adjust iRacing's "brake misc" catch-all setting. The exact effect depends on the
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts brake misc (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Brake Misc + and Brake Misc - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -148,7 +148,7 @@ Adjust the engine braking level.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts engine braking (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Engine Braking + and Engine Braking - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-chassis.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-chassis.md
@@ -44,7 +44,7 @@ Adjust the differential preload value.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts differential preload (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Diff Preload + and Diff Preload - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -62,7 +62,7 @@ Adjust the differential entry (on-throttle) setting.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts differential entry (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Diff Entry + and Diff Entry - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -80,7 +80,7 @@ Adjust the differential middle (coasting) setting.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts differential middle (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Diff Middle + and Diff Middle - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -98,7 +98,7 @@ Adjust the differential exit setting.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts differential exit (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Diff Exit + and Diff Exit - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -116,7 +116,7 @@ Adjust the front anti-roll bar stiffness.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts the front ARB (clockwise = stiffer, counter-clockwise = softer), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Front ARB + and Front ARB - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -134,7 +134,7 @@ Adjust the rear anti-roll bar stiffness.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts the rear ARB (clockwise = stiffer, counter-clockwise = softer), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Rear ARB + and Rear ARB - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -152,7 +152,7 @@ Adjust the left-side spring preload.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts the left spring (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Left Spring + and Left Spring - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -170,7 +170,7 @@ Adjust the right-side spring preload.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts the right spring (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Right Spring + and Right Spring - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -188,7 +188,7 @@ Adjust the left-front shock setting.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts the left-front shock (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both LF Shock + and LF Shock - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -206,7 +206,7 @@ Adjust the right-front shock setting.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts the right-front shock (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both RF Shock + and RF Shock - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -224,7 +224,7 @@ Adjust the left-rear shock setting.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts the left-rear shock (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both LR Shock + and LR Shock - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -242,7 +242,7 @@ Adjust the right-rear shock setting.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts the right-rear shock (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both RR Shock + and RR Shock - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -260,7 +260,7 @@ Adjust the power steering assist level.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts power steering (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Power Steering + and Power Steering - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-engine.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-engine.md
@@ -38,7 +38,7 @@ Adjust the engine power setting.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts engine power (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Engine Power + and Engine Power - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -56,7 +56,7 @@ Adjust the throttle shape (linear / progressive curve).
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts throttle shaping (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Throttle Shape + and Throttle Shape - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -74,7 +74,7 @@ Adjust the engine boost level.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts boost (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Boost + and Boost - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -92,7 +92,7 @@ Adjust the launch control RPM target.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts launch RPM (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Launch RPM + and Launch RPM - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-fuel.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-fuel.md
@@ -37,7 +37,7 @@ Adjust the fuel / air mixture setting.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts fuel mixture (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Fuel Mixture + and Fuel Mixture - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -55,7 +55,7 @@ Adjust the fuel cut position setting.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts fuel cut position (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Fuel Cut Position + and Fuel Cut Position - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-hybrid.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-hybrid.md
@@ -38,7 +38,7 @@ Adjust the MGU-K regeneration gain.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts MGU-K regen gain (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both MGU-K Re-Gen Gain + and MGU-K Re-Gen Gain - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -56,7 +56,7 @@ Step through the MGU-K deploy modes.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation steps through MGU-K deploy modes (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both MGU-K Deploy Mode + and MGU-K Deploy Mode - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -74,7 +74,7 @@ Adjust the fixed MGU-K deployment level.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts the fixed deploy level (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both MGU-K Fixed Deploy + and MGU-K Fixed Deploy - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -92,7 +92,7 @@ Hold the HYS boost key for as long as the button is pressed. Release the button 
 #### Details
 
 - **Method:** Key binding
-- **Dial:** No rotation support; press and hold the dial to boost, release to stop
+- **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
@@ -109,7 +109,7 @@ Hold the HYS regen key for as long as the button is pressed. Release the button 
 #### Details
 
 - **Method:** Key binding
-- **Dial:** No rotation support; press and hold the dial to regenerate, release to stop
+- **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 

--- a/packages/website/src/content/docs/docs/actions/car-setup/setup-traction.md
+++ b/packages/website/src/content/docs/docs/actions/car-setup/setup-traction.md
@@ -58,7 +58,7 @@ Adjust TC slot 1.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts TC slot 1 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both TC1 + and TC1 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -76,7 +76,7 @@ Adjust TC slot 2.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts TC slot 2 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both TC2 + and TC2 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -94,7 +94,7 @@ Adjust TC slot 3.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts TC slot 3 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both TC3 + and TC3 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -112,7 +112,7 @@ Adjust TC slot 4.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts TC slot 4 (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both TC4 + and TC4 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 

--- a/packages/website/src/content/docs/docs/actions/cockpit/cockpit-misc.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/cockpit-misc.md
@@ -54,7 +54,7 @@ Adjust the force feedback maximum force. The **Direction** setting picks whether
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts FFB max force (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both FFB Force Increase and FFB Force Decrease must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -89,7 +89,7 @@ Cycle through the pages on dashboard display 1. The **Direction** setting picks 
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation cycles dash page 1 (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Dash Page 1 + and Dash Page 1 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -107,7 +107,7 @@ Cycle through the pages on dashboard display 2. The **Direction** setting picks 
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation cycles dash page 2 (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Dash Page 2 + and Dash Page 2 - must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 

--- a/packages/website/src/content/docs/docs/actions/cockpit/force-feedback.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/force-feedback.md
@@ -15,12 +15,12 @@ Select the mode from the **Mode** dropdown in the Property Inspector. Directiona
 
 ### Auto Compute FFB Force
 
-Toggle iRacing's auto-compute FFB force calibration. This is a disruptive toggle — the dial **press** is intentionally a no-op on Stream Deck+ so you can't flip it by accident while rotating a dial nearby.
+Toggle iRacing's auto-compute FFB force calibration.
 
 #### Details
 
 - **Method:** Key binding
-- **Dial:** No rotation support; dial press is also disabled to prevent accidental toggling
+- **Dial:** No rotation support
 - **Default binding:** `Ctrl+A`
 - **Telemetry-aware icon:** No
 
@@ -37,7 +37,7 @@ Adjust the overall force feedback force. Shares the same global key binding as C
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts FFB force (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both FFB Force Increase and FFB Force Decrease must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -55,7 +55,7 @@ Adjust the wheel LFE (low-frequency effects) loudness.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts wheel LFE loudness (clockwise = louder, counter-clockwise = quieter), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Wheel LFE Louder and Wheel LFE Quieter must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -73,7 +73,7 @@ Adjust the bass shaker LFE loudness.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts bass shaker LFE loudness (clockwise = louder, counter-clockwise = quieter), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Bass Shaker LFE Louder and Bass Shaker LFE Quieter must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -91,7 +91,7 @@ Adjust the wheel LFE intensity curve.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts wheel LFE intensity (clockwise = more intense, counter-clockwise = less intense), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Wheel LFE More Intense and Wheel LFE Less Intense must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -109,7 +109,7 @@ Adjust the haptic LFE intensity curve.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts haptic LFE intensity (clockwise = more intense, counter-clockwise = less intense), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — both Haptic LFE More Intense and Haptic LFE Less Intense must be configured in iRacing and in the Property Inspector
 - **Telemetry-aware icon:** No
 

--- a/packages/website/src/content/docs/docs/actions/cockpit/splits-delta-cycle.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/splits-delta-cycle.md
@@ -15,12 +15,12 @@ Select the mode from the **Mode** dropdown in the Property Inspector.
 
 ### Cycle Splits Delta
 
-Cycle through iRacing's splits delta display modes. When placed on a key, pressing the button sends the direction chosen in the **Direction** setting. When placed on a dial, rotating the dial cycles next / previous regardless of the Direction setting.
+Cycle through iRacing's splits delta display modes. Pressing the button sends the direction chosen in the **Direction** setting.
 
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation cycles splits delta modes (clockwise = next, counter-clockwise = previous); pressing the dial does nothing in this mode
+- **Dial:** No rotation support
 - **Default binding:** Depends on the selected direction — see the **Direction** setting below
 - **Telemetry-aware icon:** No
 

--- a/packages/website/src/content/docs/docs/actions/driving/black-box-selector.md
+++ b/packages/website/src/content/docs/docs/actions/driving/black-box-selector.md
@@ -20,7 +20,7 @@ Open a specific black box overlay. Pressing the button toggles the overlay — p
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation cycles through black boxes (clockwise = next, counter-clockwise = previous), using the **Cycle Next** / **Cycle Previous** bindings regardless of which black box is selected
+- **Dial:** No rotation support
 - **Default binding:** Depends on the selected black box — see the **Black Box** setting below
 - **Telemetry-aware icon:** No
 
@@ -49,7 +49,7 @@ Cycle to the next black box.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation cycles through black boxes (clockwise = next, counter-clockwise = previous)
+- **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
@@ -66,7 +66,7 @@ Cycle to the previous black box.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation cycles through black boxes (clockwise = next, counter-clockwise = previous)
+- **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 

--- a/packages/website/src/content/docs/docs/actions/driving/car-control.md
+++ b/packages/website/src/content/docs/docs/actions/driving/car-control.md
@@ -76,7 +76,7 @@ Flash the headlights while the button is held. Useful for multi-class racing com
 #### Details
 
 - **Method:** Key binding
-- **Dial:** No rotation support; press and hold the dial to flash, release to stop
+- **Dial:** No rotation support
 - **Default binding:** No default key binding — Headlight Flash has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
 - **Telemetry-aware icon:** No
 
@@ -127,7 +127,7 @@ Engage the car starter. Hold the button to crank.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** No rotation support; press and hold the dial to crank, release to stop
+- **Dial:** No rotation support
 - **Default binding:** `S`
 - **Telemetry-aware icon:** No
 
@@ -144,7 +144,7 @@ Context-aware car entry, exit, pit reset, or tow. The icon updates dynamically b
 #### Details
 
 - **Method:** Key binding
-- **Dial:** No rotation support; manual hold holds `Shift+R` while the button is pressed. When auto-hold is on for the active state, a single tap holds it for 1.5 seconds or until you press again
+- **Dial:** No rotation support
 - **Default binding:** `Shift+R`
 - **Telemetry-aware icon:** Yes — out of the car the icon shows the session context (Test / Practice / Qualify / Grid / Race); in the car it switches between Exit Car, Reset to Pits, and Tow on a red background
 
@@ -175,7 +175,7 @@ Send the `Escape` key to exit the car or dismiss dialogs. The `Escape` key is ha
 #### Details
 
 - **Method:** Key binding
-- **Dial:** No rotation support; manual hold holds `Escape` while the button is pressed, auto-hold releases after 1.5 seconds or when you press again
+- **Dial:** No rotation support
 - **Default binding:** `Escape` (hardcoded — iRacing always uses `Escape` for this action, so the binding is not user-configurable)
 - **Telemetry-aware icon:** No
 

--- a/packages/website/src/content/docs/docs/actions/driving/look-direction.md
+++ b/packages/website/src/content/docs/docs/actions/driving/look-direction.md
@@ -7,7 +7,7 @@ sidebar:
     variant: tip
 ---
 
-Look Direction simulates holding a look-direction key for as long as the button is held. Press the button (or dial) to start looking, release it to return to the default view. Unlike most actions that send a single key tap, this one holds the key down until you release the button.
+Look Direction simulates holding a look-direction key for as long as the button is held. Press the button to start looking, release it to return to the default view. Unlike most actions that send a single key tap, this one holds the key down until you release the button.
 
 ## Modes
 

--- a/packages/website/src/content/docs/docs/actions/overview.md
+++ b/packages/website/src/content/docs/docs/actions/overview.md
@@ -23,6 +23,4 @@ iRaceDeck provides 31 actions with 260 modes for iRacing, organized into 9 categ
 
 Most actions support multiple **modes** selectable via the Property Inspector. For example, the Session Info action can display incidents, time remaining, lap count, position, fuel level, or active flags — all from a single action type.
 
-Actions that support dial rotation can also be used with the Stream Deck+ dial for rotation-based input (e.g., cycling through black boxes or adjusting volume).
-
 All keyboard shortcuts used by actions are **user-configurable** through the Property Inspector to match your iRacing key bindings.

--- a/packages/website/src/content/docs/docs/actions/pit-service/fuel-service.md
+++ b/packages/website/src/content/docs/docs/actions/pit-service/fuel-service.md
@@ -32,12 +32,12 @@ Toggle the fuel fill checkbox on or off via the iRacing SDK. The icon shows the 
 
 ### Add Fuel
 
-Queue an "add fuel" chat macro. Pressing the button sends `#fuel +<amount><unit>$` (e.g., `#fuel +2l$`) to increase the pending fuel for the next pit stop. Dial rotation is bidirectional — clockwise adds, counter-clockwise reduces (using the Reduce Fuel macro) so you can fine-tune with a single dial.
+Queue an "add fuel" chat macro. Pressing the button sends `#fuel +<amount><unit>$` (e.g., `#fuel +2l$`) to increase the pending fuel for the next pit stop.
 
 #### Details
 
 - **Method:** Chat command
-- **Dial:** Rotation adjusts fuel (clockwise = add, counter-clockwise = reduce)
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -55,12 +55,12 @@ The increment to add. Numeric — supports comma or period decimal separators (e
 
 ### Reduce Fuel
 
-Queue a "reduce fuel" chat macro. Pressing the button sends `#fuel -<amount><unit>$` (e.g., `#fuel -2l$`) to decrease the pending fuel for the next pit stop. Dial rotation is bidirectional — clockwise reduces, counter-clockwise adds (using the Add Fuel macro).
+Queue a "reduce fuel" chat macro. Pressing the button sends `#fuel -<amount><unit>$` (e.g., `#fuel -2l$`) to decrease the pending fuel for the next pit stop.
 
 #### Details
 
 - **Method:** Chat command
-- **Dial:** Rotation adjusts fuel (clockwise = reduce, counter-clockwise = add)
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -139,12 +139,12 @@ Toggle iRacing's autofuel checkbox on or off. The icon shows a green ON / red OF
 
 ### Lap Margin Increase
 
-Raise the autofuel lap margin by one. Pressing the button taps the iRacing "Lap Margin Increase" hotkey. Dial rotation is bidirectional — clockwise increases, counter-clockwise decreases.
+Raise the autofuel lap margin by one. Pressing the button taps the iRacing "Lap Margin Increase" hotkey.
 
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts lap margin (clockwise = increase, counter-clockwise = decrease)
+- **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 
@@ -156,12 +156,12 @@ Raise the autofuel lap margin by one. Pressing the button taps the iRacing "Lap 
 
 ### Lap Margin Decrease
 
-Lower the autofuel lap margin by one. Pressing the button taps the iRacing "Lap Margin Decrease" hotkey. Dial rotation is bidirectional — clockwise decreases, counter-clockwise increases.
+Lower the autofuel lap margin by one. Pressing the button taps the iRacing "Lap Margin Decrease" hotkey.
 
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts lap margin (clockwise = decrease, counter-clockwise = increase)
+- **Dial:** No rotation support
 - **Default binding:** No default key binding
 - **Telemetry-aware icon:** No
 

--- a/packages/website/src/content/docs/docs/actions/view-camera/camera-editor-adjustments.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/camera-editor-adjustments.md
@@ -20,7 +20,7 @@ Move the camera along the latitude axis.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts latitude (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `D` (increase) and `A` (decrease)
 - **Telemetry-aware icon:** No
 
@@ -38,7 +38,7 @@ Move the camera along the longitude axis.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts longitude (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `S` (increase) and `W` (decrease)
 - **Telemetry-aware icon:** No
 
@@ -56,7 +56,7 @@ Move the camera along the altitude axis.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts altitude (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `Alt+S` (increase) and `Alt+W` (decrease)
 - **Telemetry-aware icon:** No
 
@@ -74,7 +74,7 @@ Rotate the camera on the yaw axis.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts yaw (clockwise = positive, counter-clockwise = negative), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `Ctrl+D` (increase) and `Ctrl+A` (decrease)
 - **Telemetry-aware icon:** No
 
@@ -92,7 +92,7 @@ Tilt the camera on the pitch axis.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts pitch (clockwise = up, counter-clockwise = down), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `Ctrl+W` (increase) and `Ctrl+S` (decrease)
 - **Telemetry-aware icon:** No
 
@@ -110,7 +110,7 @@ Adjust the camera field of view.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts FOV zoom (clockwise = zoom in, counter-clockwise = zoom out), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `[` (increase/zoom in) and `]` (decrease/zoom out)
 - **Telemetry-aware icon:** No
 
@@ -128,7 +128,7 @@ Adjust the camera editor key step size.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts key step size (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `-` (increase) and `=` (decrease)
 - **Telemetry-aware icon:** No
 
@@ -146,7 +146,7 @@ Shift the vanishing point along the X axis.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts the vanishing point X (clockwise = right, counter-clockwise = left), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `Alt+X` (increase/right) and `Ctrl+X` (decrease/left)
 - **Telemetry-aware icon:** No
 
@@ -164,7 +164,7 @@ Shift the vanishing point along the Y axis.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts the vanishing point Y (clockwise = up, counter-clockwise = down), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `Alt+Y` (increase/up) and `Ctrl+Y` (decrease/down)
 - **Telemetry-aware icon:** No
 
@@ -182,7 +182,7 @@ Adjust the blimp camera orbit radius.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts blimp radius (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `Ctrl+H` (increase) and `Ctrl+G` (decrease)
 - **Telemetry-aware icon:** No
 
@@ -200,7 +200,7 @@ Adjust the blimp camera orbit velocity.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts blimp velocity (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `Alt+H` (increase) and `Alt+G` (decrease)
 - **Telemetry-aware icon:** No
 
@@ -218,7 +218,7 @@ Adjust the camera microphone gain.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts mic gain (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `Alt+Up` (increase) and `Alt+Down` (decrease)
 - **Telemetry-aware icon:** No
 
@@ -253,7 +253,7 @@ Adjust the camera aperture (depth of field strength).
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts the F-number (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `Alt+U` (increase) and `Alt+I` (decrease)
 - **Telemetry-aware icon:** No
 
@@ -271,7 +271,7 @@ Adjust the focus depth.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts focus depth (clockwise = increase, counter-clockwise = decrease), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `Ctrl+U` (increase) and `Ctrl+I` (decrease)
 - **Telemetry-aware icon:** No
 

--- a/packages/website/src/content/docs/docs/actions/view-camera/camera-focus.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/camera-focus.md
@@ -1,6 +1,6 @@
 ---
 title: Camera Controls
-description: Cycle cameras, change camera groups, and focus on specific targets with a single button or dial.
+description: Cycle cameras, change camera groups, and focus on specific targets with a single button.
 sidebar:
   badge:
     text: "12 modes"
@@ -35,7 +35,7 @@ Cycle through camera groups. The **Direction** setting picks whether pressing th
 
 #### Details
 
-- **Dial:** Rotation cycles camera groups (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the button shows a preview icon for the currently active camera group (Nose, Cockpit, TV1, etc.)
 
@@ -58,7 +58,7 @@ Cycle sub-cameras within the currently active camera group (e.g., left / right /
 
 #### Details
 
-- **Dial:** Rotation cycles sub-cameras (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -75,7 +75,7 @@ Switch camera focus to the next / previous car in the field.
 
 #### Details
 
-- **Dial:** Rotation cycles cars (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -92,7 +92,7 @@ Cycle through the driving-style cameras (cockpit, bumper, nose, chase, etc.).
 
 #### Details
 
-- **Dial:** Rotation cycles driving cameras (clockwise = next, counter-clockwise = previous), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 

--- a/packages/website/src/content/docs/docs/actions/view-camera/replay-control.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/replay-control.md
@@ -26,7 +26,7 @@ Toggle forward playback. Remembers your last slow-motion speed across pause / re
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation steps playback forward or backward by one frame
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the icon reflects whether the replay is currently playing or paused based on live replay state
 
@@ -43,7 +43,7 @@ Toggle reverse playback. Mirrors slow-motion speed when switching direction.
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation steps playback forward or backward by one frame
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** Yes — the icon reflects whether reverse playback is active based on live replay state
 
@@ -60,7 +60,7 @@ Pause playback and reset the remembered speed so the next Play / Pause starts at
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation steps playback forward or backward by one frame
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -77,7 +77,7 @@ Progressive fast-forward. The first press jumps to 2x; each subsequent press add
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation steps playback forward or backward by one frame
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -94,7 +94,7 @@ Progressive rewind. The first press jumps to −2x; each subsequent press adds *
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation steps playback forward or backward by one frame
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -111,7 +111,7 @@ Progressive slow-motion. The first press jumps to 1/2x; each subsequent press ma
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation steps playback forward or backward by one frame
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -128,7 +128,7 @@ Progressive slow-motion rewind. The first press jumps to −1/2x; each subsequen
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation steps playback forward or backward by one frame
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -145,7 +145,7 @@ Advance exactly one frame.
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation steps playback forward or backward by one frame
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -162,7 +162,7 @@ Step back exactly one frame.
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation steps playback forward or backward by one frame
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -179,7 +179,7 @@ Traverse the full speed range upward: 1/16x → ... → 1/2x → 1x → 2x → .
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation progressively adjusts replay speed (clockwise = increase, counter-clockwise = decrease)
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -196,7 +196,7 @@ Traverse the full speed range downward. Direction-aware — works whether playba
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation progressively adjusts replay speed (clockwise = increase, counter-clockwise = decrease)
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -213,7 +213,7 @@ Set replay playback to a specific speed selected in the Property Inspector.
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation steps playback forward or backward by one frame
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -247,7 +247,7 @@ Jump to the next session in the replay.
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation cycles sessions (clockwise = next, counter-clockwise = previous)
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -264,7 +264,7 @@ Jump to the previous session in the replay.
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation cycles sessions (clockwise = next, counter-clockwise = previous)
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -281,7 +281,7 @@ Jump forward one lap.
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation cycles laps (clockwise = next, counter-clockwise = previous)
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -298,7 +298,7 @@ Jump backward one lap.
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation cycles laps (clockwise = next, counter-clockwise = previous)
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -315,7 +315,7 @@ Jump to the next incident.
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation cycles incidents (clockwise = next, counter-clockwise = previous)
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -332,7 +332,7 @@ Jump to the previous incident.
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation cycles incidents (clockwise = next, counter-clockwise = previous)
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -349,7 +349,7 @@ Jump to the start of the replay.
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation cycles incidents (clockwise = next incident, counter-clockwise = previous incident)
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -366,7 +366,7 @@ Jump to the live point in the session (end of the replay buffer).
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation cycles incidents (clockwise = next incident, counter-clockwise = previous incident)
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -383,7 +383,7 @@ Jump the replay camera to your own car.
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation cycles to the next / previous car on track around your position (clockwise = ahead, counter-clockwise = behind)
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -428,7 +428,7 @@ Switch the replay camera to the next car. Defers to iRacing's own car-ordering b
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Clockwise sends Next Car, counter-clockwise sends Previous Car
+- **Dial:** No rotation support
 - **Default binding:** `V`
 - **Telemetry-aware icon:** No
 
@@ -445,7 +445,7 @@ Switch the replay camera to the previous car. Defers to iRacing's own car-orderi
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Clockwise sends Next Car, counter-clockwise sends Previous Car
+- **Dial:** No rotation support
 - **Default binding:** `Shift+V`
 - **Telemetry-aware icon:** No
 
@@ -462,7 +462,7 @@ Switch the replay camera to the next car by car number order. Includes all cars 
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation cycles cars by number order (clockwise = next, counter-clockwise = previous)
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 
@@ -479,7 +479,7 @@ Switch the replay camera to the previous car by car number order. Includes all c
 #### Details
 
 - **Method:** iRacing API
-- **Dial:** Rotation cycles cars by number order (clockwise = next, counter-clockwise = previous)
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 

--- a/packages/website/src/content/docs/docs/actions/view-camera/view-adjustment.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/view-adjustment.md
@@ -20,7 +20,7 @@ Adjust the field of view.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts FOV (clockwise = wider, counter-clockwise = narrower), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `]` (increase) and `[` (decrease)
 - **Telemetry-aware icon:** No
 
@@ -38,7 +38,7 @@ Adjust the horizon line position.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts horizon (clockwise = up, counter-clockwise = down), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `Shift+]` (increase/up) and `Shift+[` (decrease/down)
 - **Telemetry-aware icon:** No
 
@@ -56,7 +56,7 @@ Adjust the driver eye position.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts driver height (clockwise = raise, counter-clockwise = lower), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `Ctrl+]` (increase/up) and `Ctrl+[` (decrease/down)
 - **Telemetry-aware icon:** No
 
@@ -91,7 +91,7 @@ Adjust the in-sim UI element size.
 #### Details
 
 - **Method:** Key binding
-- **Dial:** Rotation adjusts UI size (clockwise = larger, counter-clockwise = smaller), regardless of the Direction setting
+- **Dial:** No rotation support
 - **Default binding:** `Ctrl+PageUp` (increase) and `Ctrl+PageDown` (decrease)
 - **Telemetry-aware icon:** No
 

--- a/packages/website/src/content/docs/docs/getting-started/installation.md
+++ b/packages/website/src/content/docs/docs/getting-started/installation.md
@@ -40,9 +40,9 @@ GitHub Releases may have a newer version available before it appears on the Elga
 4. The Stream Deck software will open and install the plugin automatically
 5. Look for the **iRaceDeck** category in the Stream Deck action list
 
-### Stream Deck+ Encoder Support
+### Stream Deck+ Dials
 
-Most iRaceDeck actions support the Stream Deck+ encoder (rotary dial). When you place an action on an encoder slot, rotating the dial typically cycles through options or adjusts values, while pressing the dial activates the primary action.
+iRaceDeck works on the Stream Deck+, but its actions are key (button) actions only — they cannot currently be placed on the rotary dials (encoders). Dial support is planned for a future release.
 
 ## Mirabox Ecosystem
 

--- a/packages/website/src/content/docs/docs/reference/action-types.md
+++ b/packages/website/src/content/docs/docs/reference/action-types.md
@@ -5,13 +5,15 @@ description: Common action types used across iRaceDeck Stream Deck actions.
 
 Common action types used across all iRaceDeck actions.
 
+No iRaceDeck action currently supports Stream Deck+ dials (encoders) — all actions are key (button) actions. Dial support is planned for a future release.
+
 ## Button
 
 Single press action that sends a key or command once.
 
 - **Behavior**: Triggers on button press
 - **Visual feedback**: None (stateless)
-- **Encoder support**: Typically no
+- **Encoder support**: No
 
 ## Toggle
 
@@ -19,7 +21,7 @@ On/off state action with visual feedback.
 
 - **Behavior**: Alternates between on and off states
 - **Visual feedback**: Icon changes to reflect current state
-- **Encoder support**: Typically no
+- **Encoder support**: No
 
 ## Multi-toggle
 
@@ -29,7 +31,7 @@ Cycles through multiple options.
   - Short press: Next option
   - Long press: Previous option (or opens selector)
 - **Visual feedback**: Icon/label shows current selection
-- **Encoder support**: Yes (rotate to cycle)
+- **Encoder support**: No
 - **Configuration**: Options may be fixed or configurable via Property Inspector
 
 ## +/- (Increment/Decrement)
@@ -38,7 +40,7 @@ Adjustment action for values that can increase or decrease.
 
 - **Behavior**: Button press triggers the configured direction (increase or decrease)
 - **Visual feedback**: Icon reflects configured direction; may show current value if available from telemetry
-- **Encoder support**: Yes (rotate clockwise = increase, counter-clockwise = decrease)
+- **Encoder support**: No
 - **Property Inspector**: Direction dropdown with "Increase" and "Decrease" options
 
 ### Standard Settings
@@ -55,7 +57,7 @@ SDK-based value adjustment with precise control.
 
 - **Behavior**: Sets or adjusts a specific value via iRacing SDK
 - **Visual feedback**: Shows current value from telemetry
-- **Encoder support**: Yes
+- **Encoder support**: No
 - **Configuration**: May include presets or specific value targets
 
 ## Hold
@@ -72,5 +74,5 @@ Action with behavior determined by settings.
 
 - **Behavior**: Varies based on Property Inspector configuration
 - **Visual feedback**: Depends on configuration
-- **Encoder support**: Depends on configuration
+- **Encoder support**: No
 - **Configuration**: Dropdown or input fields in Property Inspector


### PR DESCRIPTION
## Related Issue

Fixes #640

## What changed?

**⚠️ Backwards-incompatible:** all 31 actions no longer declare `Encoder` (Elgato) / `Knob` (Mirabox) — any existing dial/knob assignments users have are reset when this ships. This is intentional and accepted per #640; no migration is provided. Targets `release/2.0` (ships as v2.0.0), not master.

**Part A — de-claim dial support (manifest-only code change):**

- Both plugin manifests: dropped `Encoder`/`Knob` from every action's `Controllers` and deleted all `Encoder`/`Knob` blocks (62 entries each). Elgato actions are now Keypad-only; the two Mirabox 293S `Information` actions keep `["Keypad", "Information"]` (working, hardware-tested functionality — deliberate deviation from the literal "every action is `[\"Keypad\"]`" wording in the issue).
- Action TypeScript is untouched: the dormant `onDial*` handlers, `deck-core` dial types, and both adapters' dial wiring stay as the rebuild foundation.
- Removed every claim of working dial support: README features line, the false `audio-controls.ejs` PI note, 12 internal action docs (`Encoder Support` → No, `### Encoder` sections removed), `docs/plugins/action-types.md`, `docs/reference/actions.json` (`"encoder": false`), the `iracedeck-actions` skill, both plugin `CLAUDE.md` guides, and 23 website pages (every per-mode `**Dial:**` bullet → `No rotation support`, dial prose removed, installation page now states actions are key-only with dial support planned).

**Part B — study & document dials + touchscreen:**

- New `.claude/rules/encoders-and-touchscreen.md` (indexed in `.claude/CLAUDE.md`): current state, load-bearing platform facts, and rules for the rebuild.
- New `docs/reference/stream-deck-plus-encoders.md`: source-cited reference covering hardware (200×100 strip slot per dial), the manifest `Encoder` schema, layout IDs `$X1`–`$C1`, custom layout JSON, exact event payloads (`dialRotate` ticks/pressed, `dialDown`/`dialUp`, `touchTap` tapPos/hold), `setFeedback`/`setFeedbackLayout`/`setTriggerDescription`, the Node SDK surface, and implementation pitfalls.
- **Verified Mirabox answer recorded:** knob rotation + press provably reach plugins (official Stream Dock protocol docs; Mirabox's own VoiceMeeter/Discord plugins are knob-driven), but press-and-hold is unreliable (`dialUp` reported to fire immediately after `dialDown` on N4-class hardware) and there is **no plugin-facing touchscreen/feedback API** (`setFeedback`/layouts don't exist in the protocol — `setImage` only). Not yet verified through our adapter on real knob hardware; a 7-point hardware-test checklist is included. Practical call: rebuild Mirabox rotation/press, write off Mirabox touch, never design dial UX around holds.
- `stream-deck-actions.md` "Encoder Support" section marked superseded, pointing at the new guide.
- `build-and-commit.md`: documented the temporary `release/2.0` integration-branch workflow (squash-merge PRs into `release/2.0`; regular merges for syncs and the final merge-back).

## How to test

1. `pnpm install && pnpm build` (passes: 18/18 tasks; `pnpm test` 5113/5113; website Astro build clean).
2. Link/restart both plugins (`pnpm relink:stream-deck`, `pnpm relink:mirabox`); verify every action appears and works as a key action and none can be assigned to a dial/knob.
3. On Stream Deck+, confirm previously assigned dial slots show the actions as removed/reset (expected breaking behavior).

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests (N/A — manifest/docs-only change, no new executable code; full suite passes)
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Vastly updated user docs to state Stream Deck+ dial/encoder rotation is not supported; actions now use button/key input only.
  * Added a comprehensive encoder/touchscreen reference and guidance for a planned future dial-support rebuild.

* **Chores**
  * Removed encoder/knob controller entries from Stream Deck and Mirabox plugin manifests.
  * Added a temporary merge exception and guidance for the release/2.0 integration workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->