### PR TITLE
feat(actions): add expression/calculation support to Telemetry Display templates (#192)

### DIFF
--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -66,7 +66,7 @@ Mode counts reflect the PI Mode/Setting dropdown choices documented in each acti
 | Action | Modes | Mode values |
 |--------|-------|-------------|
 | Session Info | 7 | incidents, time-remaining, laps, position, fuel, flags, track-wetness |
-| Telemetry Display | 1 | template (Mustache-driven display, no Mode dropdown) |
+| Telemetry Display | 1 | template (Mustache-driven display, no Mode dropdown; templates also support `{{= expr }}` expressions — arithmetic, comparisons, ternary, round/floor/ceil/abs/min/max — #192) |
 
 ### Driving Controls
 

--- a/.claude/skills/iracing-telemetry/SKILL.md
+++ b/.claude/skills/iracing-telemetry/SKILL.md
@@ -37,6 +37,8 @@ The canonical user-facing list of template variables (for Telemetry Display and 
 
 This is the **source of truth** for which variables are available in Mustache templates. When adding or modifying template variable support, update this file in the same change.
 
+Templates also support `{{= expression }}` evaluation (arithmetic, comparisons, ternary, `round`/`floor`/`ceil`/`abs`/`min`/`max`), computed on raw full-precision values rather than the display-formatted strings plain placeholders show (#192). The evaluator lives in `packages/iracing-sdk/src/expression-evaluator.ts`; the user-facing syntax is documented in the website template-variables page above, which stays the canonical source.
+
 ## Length Values
 
 | Length | Meaning | TypeScript Type |

--- a/docs/plans/2026-06-12-template-expressions-design.md
+++ b/docs/plans/2026-06-12-template-expressions-design.md
@@ -30,7 +30,7 @@ Pipeline in `expression-evaluator.ts`: `tokenize` → `parseExpression` (recursi
 
 - Strings render as-is; booleans render `Yes`/`No`.
 - Whole-number results render bare (`5`); other numbers render with two decimals (`0.33`).
-- `round(x, n)` carries a fixed-decimals hint through to formatting — exactly `n` decimals (`round(10/2, 1)` → `5.0`). The ternary forwards its chosen branch's hint; all other constructs drop it.
+- `round(x, n)` carries a fixed-decimals hint through to formatting — exactly `n` decimals (`round(10/2, 1)` → `5.0`). The hint survives wherever the value becomes text: the final result, the chosen branch of a ternary, and string-concatenation operands (each `+` operand formats with its own hint). Numeric contexts (arithmetic, comparisons, function arguments) carry only the numeric value.
 - Non-finite results (division by zero, NaN) are runtime errors → empty string.
 
 ## Deliberately Not Done

--- a/docs/plans/2026-06-12-template-expressions-design.md
+++ b/docs/plans/2026-06-12-template-expressions-design.md
@@ -1,0 +1,39 @@
+# Template Expressions
+
+Date: 2026-06-12
+Issue: #192
+Branch: `niklam/ir-192`
+
+## Problem
+
+Templates in Telemetry Display, Chat, and Race Admin could only substitute `{{variable}}` values verbatim. Users could not derive values — unit conversions (m/s → km/h, fuel kg → gallons), rounding, or conditional text — without requesting a new pre-converted variable for every use case (issue #192).
+
+## Design Decisions
+
+- **Syntax**: `{{= expression }}` alongside plain `{{variable}}` placeholders. `=` must immediately follow `{{`; variables are referenced bare with dot notation inside expressions (no inner braces).
+- **Full operator/function set**: arithmetic `+ - * / %`, parentheses, comparisons `> < >= <= == !=` (non-associative — chaining is a parse error), ternary `?:`, string literals in single or double quotes, string concatenation via `+`; functions `round(x)`, `round(x, decimals)` (decimals must be a literal integer 0–20), `floor`, `ceil`, `abs`, `min`, `max`.
+- **Hand-rolled zero-dependency evaluator**: tokenizer + recursive-descent parser + AST interpreter in `packages/iracing-sdk/src/expression-evaluator.ts`. No `eval()`/`new Function()` and no expression-library dependency — user-authored template strings must never reach a JS execution context.
+- **Raw-value combined context**: `TemplateContext` became a `{ display, raw }` pair. Plain placeholders keep reading display-formatted strings (floats to 2 decimals, boolean-ish fields as Yes/No); expressions evaluate against raw full-precision values (numbers stay numbers, boolean-ish 0/1 telemetry fields stay 0/1).
+- **Hybrid error model**: a parse error (typo) leaves the `{{= ... }}` placeholder verbatim in the output so the mistake is visible on the key; a runtime error (unknown variable, division by zero, non-finite result) renders an empty string.
+
+## Architecture
+
+Pipeline in `expression-evaluator.ts`: `tokenize` → `parseExpression` (recursive descent: ternary → comparison → additive → multiplicative → unary minus → primary/call) → `evaluateAst` → `formatResult`.
+
+- **AST cache**: a `Map` keyed by expression source with FIFO eviction at 200 entries. Parse errors are cached too — templates re-resolve on every telemetry tick, and a typo must not re-parse each time.
+- **Length cap**: expressions over 1000 characters are rejected before parsing and never stored as cache keys; the cap also bounds parser/evaluator recursion depth (both are recursive).
+- **Single-pass resolution**: `resolveTemplate` (`template-resolver.ts`) uses one alternation regex matching `{{= expr }}` (lazy, bounded `{0,1000}` to mirror the evaluator cap) or `{{dot.notation}}`, so an unclosed `{{=` can't trigger a long scan. Consequence: `}}` cannot appear inside an expression string literal — the placeholder ends at the first `}}`.
+- **Raw-first field builders**: context builders (`flattenContext`, `fieldsToMaps`, session fields in `template-context.ts`) produce both maps in one walk. The raw map omits unavailable (null/undefined) keys so expressions referencing them fail as unknown variables (→ empty string).
+- **Prototype safety**: variable lookup uses `Object.hasOwn`, so prototype-chain names (`constructor`, `toString`) never resolve as variables.
+
+## Formatting Rules
+
+- Strings render as-is; booleans render `Yes`/`No`.
+- Whole-number results render bare (`5`); other numbers render with two decimals (`0.33`).
+- `round(x, n)` carries a fixed-decimals hint through to formatting — exactly `n` decimals (`round(10/2, 1)` → `5.0`). The ternary forwards its chosen branch's hint; all other constructs drop it.
+- Non-finite results (division by zero, NaN) are runtime errors → empty string.
+
+## Deliberately Not Done
+
+- **Unit-conversion helper functions** (`kmh()`, `gal()`, …) — plain arithmetic already covers conversions; helpers can be added later without changing the syntax.
+- **Chat / Race Admin specific work** — both already route through `resolveTemplate`, so expressions work there transparently; documented as supported, no code changes needed.

--- a/packages/iracing-actions/src/actions/chat/chat.ejs
+++ b/packages/iracing-actions/src/actions/chat/chat.ejs
@@ -25,15 +25,14 @@
 			<sdpi-textarea setting="message" rows="3" placeholder="Enter message to send"></sdpi-textarea>
 		</sdpi-item>
 
-		<sdpi-item id="template-help" class="hidden">
-			<div style="font-size: 12px; color: #9e9e9e; line-height: 1.5;">
-				Supports <b>{{variable}}</b> placeholders for live data.
-				<a href="https://iracedeck.com/docs/template-variables.html"
-				   style="color: #4a90d9;"
-				   target="_blank"
-				   rel="noopener noreferrer">View full list of template variables!</a>
-			</div>
-		</sdpi-item>
+		<div id="template-help" class="ird-supporting-text hidden">
+			Supports <b>{{variable}}</b> placeholders for live data and <b>{{= expression }}</b> calculations
+			(e.g. <b>{{= round(telemetry.Speed * 3.6, 0) }}</b>).
+			<a href="https://iracedeck.com/docs/features/template-variables/"
+			   style="color: #4a90d9;"
+			   target="_blank"
+			   rel="noopener noreferrer">View full list of template variables!</a>
+		</div>
 
 		<sdpi-item label="Macro Number" id="macro-item" class="hidden">
 			<sdpi-select setting="macroNumber" default="1">

--- a/packages/iracing-actions/src/actions/race-admin/race-admin.ejs
+++ b/packages/iracing-actions/src/actions/race-admin/race-admin.ejs
@@ -106,7 +106,7 @@
 		<!-- Message field (for commands with optional/required message) -->
 		<div id="message-section" class="hidden">
 			<sdpi-item label="Message">
-				<sdpi-textarea setting="message" placeholder="Optional message (supports {{templates}})"></sdpi-textarea>
+				<sdpi-textarea setting="message" placeholder="Optional message (supports {{templates}} and {{= expressions }})"></sdpi-textarea>
 			</sdpi-item>
 		</div>
 

--- a/packages/iracing-actions/src/actions/race-admin/race-admin.test.ts
+++ b/packages/iracing-actions/src/actions/race-admin/race-admin.test.ts
@@ -10,7 +10,7 @@ import { generateRaceAdminSvg, RaceAdmin } from "./race-admin.js";
 vi.mock("@iracedeck/iracing-sdk", () => ({
   getCarNumberFromSessionInfo: vi.fn(),
   getAllCarNumbers: vi.fn(() => []),
-  buildTemplateContext: vi.fn(() => ({})),
+  buildTemplateContext: vi.fn(() => ({ display: {}, raw: {} })),
   resolveTemplate: vi.fn((template: string) => template),
 }));
 

--- a/packages/iracing-actions/src/actions/telemetry-display/telemetry-display.ejs
+++ b/packages/iracing-actions/src/actions/telemetry-display/telemetry-display.ejs
@@ -13,16 +13,14 @@
 		<sdpi-item label="Template">
 			<sdpi-textarea setting="template" rows="3" default="#{{self.car_number}}&#10;{{self.first_name}}"></sdpi-textarea>
 		</sdpi-item>
-
-		<sdpi-item>
-			<div style="font-size: 12px; color: #9e9e9e; line-height: 1.5;">
-				Supports <b>{{variable}}</b> placeholders for live data.
-				<a href="https://iracedeck.com/docs/template-variables.html"
-				   style="color: #4a90d9;"
-				   target="_blank"
-				   rel="noopener noreferrer">View full list of template variables!</a>
-			</div>
-		</sdpi-item>
+		<div class="ird-supporting-text">
+			Supports <b>{{variable}}</b> placeholders for live data and <b>{{= expression }}</b> calculations
+			(e.g. <b>{{= round(telemetry.Speed * 3.6, 0) }}</b>).
+			<a href="https://iracedeck.com/docs/features/template-variables/"
+			   style="color: #4a90d9;"
+			   target="_blank"
+			   rel="noopener noreferrer">View full list of template variables!</a>
+		</div>
 
 		<sdpi-item label="Font Size">
 			<sdpi-textfield setting="fontSize" default="15" type="number" min="5" max="36"></sdpi-textfield>

--- a/packages/iracing-sdk/src/SDKController.test.ts
+++ b/packages/iracing-sdk/src/SDKController.test.ts
@@ -261,7 +261,18 @@ describe("SDKController", () => {
       const ctx = controller.getCurrentTemplateContext();
 
       expect(ctx).not.toBeNull();
-      expect(ctx!["telemetry.Speed"]).toBe("100");
+      expect(ctx!.display["telemetry.Speed"]).toBe("100");
+    });
+
+    it("should include raw values in the returned context", () => {
+      vi.mocked(mockSdk.getTelemetry).mockReturnValue({ Speed: 156.789, Gear: 3 });
+      vi.mocked(mockSdk.getSessionInfo).mockReturnValue(null);
+
+      const ctx = controller.getCurrentTemplateContext();
+
+      expect(ctx).not.toBeNull();
+      expect(ctx!.raw["telemetry.Speed"]).toBe(156.789);
+      expect(typeof ctx!.raw["telemetry.Speed"]).toBe("number");
     });
 
     it("should cache context within the same tick", () => {
@@ -291,7 +302,7 @@ describe("SDKController", () => {
       const ctx2 = controller.getCurrentTemplateContext();
 
       expect(ctx2).not.toBe(ctx1);
-      expect(ctx2!["telemetry.Speed"]).toBe("200");
+      expect(ctx2!.display["telemetry.Speed"]).toBe("200");
     });
 
     it("should return null when no telemetry has ever been received", () => {
@@ -311,7 +322,7 @@ describe("SDKController", () => {
 
       const ctxBefore = controller.getCurrentTemplateContext();
       expect(ctxBefore).not.toBeNull();
-      expect(ctxBefore!["telemetry.Speed"]).toBe("100");
+      expect(ctxBefore!.display["telemetry.Speed"]).toBe("100");
 
       // After new telemetry, context should be rebuilt (not the same object)
       vi.mocked(mockSdk.getTelemetry).mockReturnValue({ Speed: 300 });
@@ -319,7 +330,7 @@ describe("SDKController", () => {
 
       const ctxAfter = controller.getCurrentTemplateContext();
       expect(ctxAfter).not.toBe(ctxBefore);
-      expect(ctxAfter!["telemetry.Speed"]).toBe("300");
+      expect(ctxAfter!.display["telemetry.Speed"]).toBe("300");
     });
   });
 

--- a/packages/iracing-sdk/src/expression-evaluator.test.ts
+++ b/packages/iracing-sdk/src/expression-evaluator.test.ts
@@ -190,6 +190,34 @@ describe("parse errors", () => {
   });
 });
 
+describe("expression length limit", () => {
+  it("should return null for an over-limit expression", () => {
+    const source = "1+".repeat(600) + "1";
+
+    expect(source.length).toBeGreaterThan(1000);
+    expect(resolveExpression(source, {})).toBeNull();
+  });
+
+  it("should throw a parse error from parseExpression for an over-limit expression", () => {
+    expect(() => parseExpression("1+".repeat(600) + "1")).toThrowError(
+      expect.objectContaining({ name: "ExpressionParseError" }),
+    );
+  });
+
+  it("should return null for deeply nested parentheses over the limit", () => {
+    const source = "(".repeat(5000) + "1" + ")".repeat(5000);
+
+    expect(resolveExpression(source, {})).toBeNull();
+  });
+
+  it("should still evaluate an expression at a valid length", () => {
+    const source = "(".repeat(450) + "1" + ")".repeat(450);
+
+    expect(source.length).toBeLessThanOrEqual(1000);
+    expect(resolveExpression(source, {})).toBe("1");
+  });
+});
+
 describe("literals", () => {
   it("should evaluate integer literals", () => {
     expect(resolveExpression("42", {})).toBe("42");
@@ -222,6 +250,11 @@ describe("literals", () => {
 
   it("should drop the backslash for unknown escapes", () => {
     expect(resolveExpression("'a\\nb'", {})).toBe("anb");
+  });
+
+  it("should round-trip non-ASCII string literals unchanged", () => {
+    expect(resolveExpression("'Kämäräinen'", {})).toBe("Kämäräinen");
+    expect(resolveExpression("'你好 🏁 ñ' + ''", {})).toBe("你好 🏁 ñ");
   });
 });
 
@@ -476,6 +509,13 @@ describe("variables", () => {
   it("should return empty string for an unknown variable", () => {
     expect(resolveExpression("missing", {})).toBe("");
     expect(resolveExpression("1 + missing", {})).toBe("");
+  });
+
+  it("should not resolve prototype-chain properties as variables", () => {
+    expect(resolveExpression("constructor + 1", {})).toBe("");
+    expect(resolveExpression("toString", {})).toBe("");
+    expect(resolveExpression("hasOwnProperty * 2", {})).toBe("");
+    expect(resolveExpression("constructor ? 1 : 2", {})).toBe("");
   });
 });
 

--- a/packages/iracing-sdk/src/expression-evaluator.test.ts
+++ b/packages/iracing-sdk/src/expression-evaluator.test.ts
@@ -482,6 +482,14 @@ describe("string concatenation", () => {
     expect(resolveExpression("'Lap ' + 5 + '/' + 10", {})).toBe("Lap 5/10");
   });
 
+  it("should preserve round(x, n) precision inside concatenation", () => {
+    expect(resolveExpression("round(1/3, 4) + 's'", {})).toBe("0.3333s");
+    expect(resolveExpression("'v=' + round(51.24, 1)", {})).toBe("v=51.2");
+    expect(resolveExpression("round(telemetry.FuelLevel, 1) + ' L'", { "telemetry.FuelLevel": 42.36789 })).toBe(
+      "42.4 L",
+    );
+  });
+
   it("should stringify booleans as Yes/No", () => {
     expect(resolveExpression("'DRS: ' + on", { on: true })).toBe("DRS: Yes");
     expect(resolveExpression("'DRS: ' + on", { on: false })).toBe("DRS: No");

--- a/packages/iracing-sdk/src/expression-evaluator.test.ts
+++ b/packages/iracing-sdk/src/expression-evaluator.test.ts
@@ -647,10 +647,10 @@ describe("end-to-end examples", () => {
 
     expect(
       resolveExpression(
-        "round(telemetry.dpFuelAddKg / (sessionInfo.DriverInfo.DriverCarFuelKgPerLtr * 0.264172), 1)",
+        "round(telemetry.dpFuelAddKg / (sessionInfo.DriverInfo.DriverCarFuelKgPerLtr * 3.78541), 1)",
         vars,
       ),
-    ).toBe("103.9");
+    ).toBe("7.3");
   });
 });
 

--- a/packages/iracing-sdk/src/expression-evaluator.test.ts
+++ b/packages/iracing-sdk/src/expression-evaluator.test.ts
@@ -1,0 +1,655 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearExpressionCache,
+  evaluateAst,
+  formatResult,
+  parseExpression,
+  resolveExpression,
+  tokenize,
+} from "./expression-evaluator.js";
+
+beforeEach(() => {
+  clearExpressionCache();
+});
+
+describe("tokenize", () => {
+  it("should tokenize a dotted identifier path as a single token", () => {
+    expect(tokenize("sessionInfo.DriverInfo.DriverCarFuelKgPerLtr")).toEqual([
+      { type: "ident", path: "sessionInfo.DriverInfo.DriverCarFuelKgPerLtr" },
+    ]);
+  });
+
+  it("should tokenize numbers, identifiers, and two-char operators with maximal munch", () => {
+    expect(tokenize("a.b.c >= 1.5")).toEqual([
+      { type: "ident", path: "a.b.c" },
+      { type: "op", op: ">=" },
+      { type: "number", value: 1.5 },
+    ]);
+  });
+
+  it("should prefer two-char operators over single-char operators", () => {
+    expect(tokenize("==")).toEqual([{ type: "op", op: "==" }]);
+    expect(tokenize("!=")).toEqual([{ type: "op", op: "!=" }]);
+    expect(tokenize("<=")).toEqual([{ type: "op", op: "<=" }]);
+  });
+
+  it("should skip whitespace including newlines and tabs", () => {
+    expect(tokenize("1\n +\t2")).toEqual([
+      { type: "number", value: 1 },
+      { type: "op", op: "+" },
+      { type: "number", value: 2 },
+    ]);
+  });
+
+  it("should tokenize a number with leading dot", () => {
+    expect(tokenize(".5")).toEqual([{ type: "number", value: 0.5 }]);
+  });
+
+  it("should tokenize string literals with both quote styles", () => {
+    expect(tokenize("'a b'")).toEqual([{ type: "string", value: "a b" }]);
+    expect(tokenize('"a b"')).toEqual([{ type: "string", value: "a b" }]);
+  });
+
+  it("should tokenize punctuation", () => {
+    expect(tokenize("( ) , ? :")).toEqual([
+      { type: "punct", punct: "(" },
+      { type: "punct", punct: ")" },
+      { type: "punct", punct: "," },
+      { type: "punct", punct: "?" },
+      { type: "punct", punct: ":" },
+    ]);
+  });
+
+  it("should throw on an unknown character", () => {
+    expect(() => tokenize("1 @ 2")).toThrow();
+  });
+
+  it("should throw on an unterminated string", () => {
+    expect(() => tokenize("'abc")).toThrow();
+    expect(() => tokenize('"abc')).toThrow();
+  });
+
+  it("should throw on a string ending with a dangling backslash", () => {
+    expect(() => tokenize("'abc\\")).toThrow();
+  });
+
+  it("should throw on a trailing dot in an identifier", () => {
+    expect(() => tokenize("a.")).toThrow();
+  });
+
+  it("should throw on a dot followed by a non-letter in an identifier", () => {
+    expect(() => tokenize("a.5")).toThrow();
+    expect(() => tokenize("a. b")).toThrow();
+  });
+});
+
+describe("parse errors", () => {
+  it("should return null for an unknown character", () => {
+    expect(resolveExpression("1 # 2", {})).toBeNull();
+  });
+
+  it("should return null for an unterminated string", () => {
+    expect(resolveExpression("'abc", {})).toBeNull();
+  });
+
+  it("should return null for an empty expression", () => {
+    expect(resolveExpression("", {})).toBeNull();
+  });
+
+  it("should return null for a whitespace-only expression", () => {
+    expect(resolveExpression("  \n\t ", {})).toBeNull();
+  });
+
+  it("should return null for unbalanced parentheses", () => {
+    expect(resolveExpression("(1 + 2", {})).toBeNull();
+    expect(resolveExpression("1 + 2)", {})).toBeNull();
+  });
+
+  it("should return null for a dangling operator", () => {
+    expect(resolveExpression("1 +", {})).toBeNull();
+  });
+
+  it("should return null for a double operator", () => {
+    expect(resolveExpression("1 + * 2", {})).toBeNull();
+  });
+
+  it("should return null for a bare equals sign", () => {
+    expect(resolveExpression("a = 1", {})).toBeNull();
+  });
+
+  it("should return null for a bare exclamation mark", () => {
+    expect(resolveExpression("!a", {})).toBeNull();
+    expect(resolveExpression("1 ! 2", {})).toBeNull();
+  });
+
+  it("should return null for chained comparisons", () => {
+    expect(resolveExpression("1 < 2 < 3", {})).toBeNull();
+    expect(resolveExpression("1 == 2 == 3", {})).toBeNull();
+    expect(resolveExpression("(1 < 2 < 3) ? 1 : 0", {})).toBeNull();
+  });
+
+  it("should return null for a ternary missing its colon", () => {
+    expect(resolveExpression("1 ? 2", {})).toBeNull();
+  });
+
+  it("should return null for wrong round arity", () => {
+    expect(resolveExpression("round()", {})).toBeNull();
+    expect(resolveExpression("round(1, 2, 3)", {})).toBeNull();
+  });
+
+  it("should return null for wrong floor arity", () => {
+    expect(resolveExpression("floor()", {})).toBeNull();
+    expect(resolveExpression("floor(1, 2)", {})).toBeNull();
+  });
+
+  it("should return null for wrong ceil arity", () => {
+    expect(resolveExpression("ceil()", {})).toBeNull();
+    expect(resolveExpression("ceil(1, 2)", {})).toBeNull();
+  });
+
+  it("should return null for wrong abs arity", () => {
+    expect(resolveExpression("abs()", {})).toBeNull();
+    expect(resolveExpression("abs(1, 2)", {})).toBeNull();
+  });
+
+  it("should return null for min with fewer than 2 arguments", () => {
+    expect(resolveExpression("min(1)", {})).toBeNull();
+  });
+
+  it("should return null for max with fewer than 2 arguments", () => {
+    expect(resolveExpression("max(1)", {})).toBeNull();
+  });
+
+  it("should return null for an unknown function", () => {
+    expect(resolveExpression("foo(1)", {})).toBeNull();
+    expect(resolveExpression("telemetry.fn(1)", {})).toBeNull();
+  });
+
+  it("should return null for round with non-integer decimals", () => {
+    expect(resolveExpression("round(1.234, 1.5)", {})).toBeNull();
+  });
+
+  it("should return null for round with negative decimals", () => {
+    expect(resolveExpression("round(1.234, -1)", {})).toBeNull();
+  });
+
+  it("should return null for round with decimals above 20", () => {
+    expect(resolveExpression("round(1.234, 21)", {})).toBeNull();
+  });
+
+  it("should return null for round with a non-literal decimals argument", () => {
+    expect(resolveExpression("round(1.234, n)", { n: 2 })).toBeNull();
+    expect(resolveExpression("round(1.234, 1 + 1)", {})).toBeNull();
+  });
+
+  it("should return null for trailing tokens after the expression", () => {
+    expect(resolveExpression("1 2", {})).toBeNull();
+    expect(resolveExpression("(1) 2", {})).toBeNull();
+    expect(resolveExpression("1 + 2 :", {})).toBeNull();
+  });
+});
+
+describe("literals", () => {
+  it("should evaluate integer literals", () => {
+    expect(resolveExpression("42", {})).toBe("42");
+  });
+
+  it("should evaluate decimal literals", () => {
+    expect(resolveExpression("3.25", {})).toBe("3.25");
+  });
+
+  it("should evaluate a leading-dot decimal literal", () => {
+    expect(resolveExpression(".5", {})).toBe("0.50");
+  });
+
+  it("should evaluate single-quoted strings", () => {
+    expect(resolveExpression("'hello'", {})).toBe("hello");
+  });
+
+  it("should evaluate double-quoted strings", () => {
+    expect(resolveExpression('"hi"', {})).toBe("hi");
+  });
+
+  it("should unescape an escaped quote", () => {
+    expect(resolveExpression("'it\\'s'", {})).toBe("it's");
+    expect(resolveExpression('"say \\"hi\\""', {})).toBe('say "hi"');
+  });
+
+  it("should unescape an escaped backslash", () => {
+    expect(resolveExpression("'a\\\\b'", {})).toBe("a\\b");
+  });
+
+  it("should drop the backslash for unknown escapes", () => {
+    expect(resolveExpression("'a\\nb'", {})).toBe("anb");
+  });
+});
+
+describe("arithmetic operators", () => {
+  it("should add", () => {
+    expect(resolveExpression("1 + 2", {})).toBe("3");
+  });
+
+  it("should subtract", () => {
+    expect(resolveExpression("7 - 2", {})).toBe("5");
+  });
+
+  it("should multiply", () => {
+    expect(resolveExpression("3 * 4", {})).toBe("12");
+  });
+
+  it("should divide", () => {
+    expect(resolveExpression("10 / 4", {})).toBe("2.50");
+  });
+
+  it("should compute modulo", () => {
+    expect(resolveExpression("10 % 3", {})).toBe("1");
+  });
+});
+
+describe("precedence", () => {
+  it("should evaluate multiplication before addition", () => {
+    expect(resolveExpression("2 + 3 * 4", {})).toBe("14");
+  });
+
+  it("should respect parentheses", () => {
+    expect(resolveExpression("(2 + 3) * 4", {})).toBe("20");
+  });
+
+  it("should evaluate subtraction left-to-right", () => {
+    expect(resolveExpression("10 - 4 - 3", {})).toBe("3");
+  });
+
+  it("should treat modulo at the same tier as multiplication", () => {
+    expect(resolveExpression("7 % 4 * 2", {})).toBe("6");
+    expect(resolveExpression("20 / 2 % 3", {})).toBe("1");
+  });
+
+  it("should evaluate modulo before addition", () => {
+    expect(resolveExpression("1 + 6 % 4", {})).toBe("3");
+  });
+});
+
+describe("unary minus", () => {
+  it("should negate a number", () => {
+    expect(resolveExpression("-5", {})).toBe("-5");
+  });
+
+  it("should allow chained unary minus after a binary minus", () => {
+    expect(resolveExpression("2--3", {})).toBe("5");
+  });
+
+  it("should allow doubled unary minus", () => {
+    expect(resolveExpression("--5", {})).toBe("5");
+  });
+
+  it("should negate a parenthesized expression", () => {
+    expect(resolveExpression("-(2+3)", {})).toBe("-5");
+  });
+});
+
+describe("comparisons", () => {
+  it("should evaluate greater than", () => {
+    expect(resolveExpression("3 > 2", {})).toBe("Yes");
+    expect(resolveExpression("2 > 3", {})).toBe("No");
+  });
+
+  it("should evaluate less than", () => {
+    expect(resolveExpression("1 < 2", {})).toBe("Yes");
+    expect(resolveExpression("2 < 1", {})).toBe("No");
+  });
+
+  it("should evaluate greater than or equal", () => {
+    expect(resolveExpression("2 >= 2", {})).toBe("Yes");
+    expect(resolveExpression("1 >= 2", {})).toBe("No");
+  });
+
+  it("should evaluate less than or equal", () => {
+    expect(resolveExpression("2 <= 2", {})).toBe("Yes");
+    expect(resolveExpression("2 <= 1", {})).toBe("No");
+  });
+
+  it("should coerce strings numerically for ordering comparisons", () => {
+    expect(resolveExpression("'10' > '9'", {})).toBe("Yes");
+  });
+
+  it("should compare equal numbers with ==", () => {
+    expect(resolveExpression("1 == 1", {})).toBe("Yes");
+    expect(resolveExpression("1 == 2", {})).toBe("No");
+  });
+
+  it("should compare numbers with !=", () => {
+    expect(resolveExpression("1 != 1", {})).toBe("No");
+    expect(resolveExpression("1 != 2", {})).toBe("Yes");
+  });
+
+  it("should compare same-type strings strictly", () => {
+    expect(resolveExpression("'a' == 'a'", {})).toBe("Yes");
+    expect(resolveExpression("'a' == 'b'", {})).toBe("No");
+    expect(resolveExpression("'1' == '1.0'", {})).toBe("No");
+  });
+
+  it("should compare same-type booleans strictly", () => {
+    expect(resolveExpression("a == b", { a: true, b: true })).toBe("Yes");
+    expect(resolveExpression("a == b", { a: true, b: false })).toBe("No");
+  });
+
+  it("should coerce mixed types numerically for equality", () => {
+    expect(resolveExpression("'5' == 5", {})).toBe("Yes");
+    expect(resolveExpression("'5.0' == 5", {})).toBe("Yes");
+    expect(resolveExpression("flag == 1", { flag: true })).toBe("Yes");
+    expect(resolveExpression("'3.93 km' == 3.93", {})).toBe("Yes");
+  });
+
+  it("should treat non-coercible mixed types as not equal without erroring", () => {
+    expect(resolveExpression("'abc' == 5", {})).toBe("No");
+    expect(resolveExpression("'abc' != 5", {})).toBe("Yes");
+  });
+});
+
+describe("ternary", () => {
+  it("should pick the true branch when the condition holds", () => {
+    expect(resolveExpression("1 > 0 ? 'yes' : 'no'", {})).toBe("yes");
+  });
+
+  it("should pick the false branch when the condition fails", () => {
+    expect(resolveExpression("0 > 1 ? 'yes' : 'no'", {})).toBe("no");
+  });
+
+  it("should evaluate only the chosen branch", () => {
+    expect(resolveExpression("x != 0 ? 10 / x : 'N/A'", { x: 0 })).toBe("N/A");
+    expect(resolveExpression("x != 0 ? 10 / x : 'N/A'", { x: 4 })).toBe("2.50");
+  });
+
+  it("should nest right-associatively in the else branch", () => {
+    expect(resolveExpression("1 ? 2 : 0 ? 3 : 4", {})).toBe("2");
+    expect(resolveExpression("0 ? 2 : 0 ? 3 : 4", {})).toBe("4");
+    expect(resolveExpression("0 ? 2 : 1 ? 3 : 4", {})).toBe("3");
+  });
+
+  it("should forward the chosen branch's fixedDecimals envelope", () => {
+    expect(resolveExpression("1 > 0 ? round(1/3, 3) : round(1/3, 1)", {})).toBe("0.333");
+    expect(resolveExpression("0 > 1 ? round(1/3, 3) : round(1/3, 1)", {})).toBe("0.3");
+  });
+
+  it("should treat numbers as truthy when non-zero", () => {
+    expect(resolveExpression("5 ? 1 : 2", {})).toBe("1");
+    expect(resolveExpression("0 ? 1 : 2", {})).toBe("2");
+  });
+
+  it("should treat strings as truthy when non-empty", () => {
+    expect(resolveExpression("'x' ? 1 : 2", {})).toBe("1");
+    expect(resolveExpression("'' ? 1 : 2", {})).toBe("2");
+  });
+
+  it("should use boolean conditions directly", () => {
+    expect(resolveExpression("on ? 'a' : 'b'", { on: true })).toBe("a");
+    expect(resolveExpression("on ? 'a' : 'b'", { on: false })).toBe("b");
+  });
+});
+
+describe("functions", () => {
+  it("should round to the nearest integer with one argument", () => {
+    expect(resolveExpression("round(2.5)", {})).toBe("3");
+    expect(resolveExpression("round(2.4)", {})).toBe("2");
+  });
+
+  it("should round to n decimals and format with fixed decimals", () => {
+    expect(resolveExpression("round(1/3, 4)", {})).toBe("0.3333");
+    expect(resolveExpression("round(10/2, 1)", {})).toBe("5.0");
+    expect(resolveExpression("round(2.345, 0)", {})).toBe("2");
+  });
+
+  it("should floor", () => {
+    expect(resolveExpression("floor(2.9)", {})).toBe("2");
+    expect(resolveExpression("floor(-2.1)", {})).toBe("-3");
+  });
+
+  it("should ceil", () => {
+    expect(resolveExpression("ceil(2.1)", {})).toBe("3");
+  });
+
+  it("should compute absolute value", () => {
+    expect(resolveExpression("abs(-3)", {})).toBe("3");
+    expect(resolveExpression("abs(3)", {})).toBe("3");
+  });
+
+  it("should compute min with two or more arguments", () => {
+    expect(resolveExpression("min(2, 1)", {})).toBe("1");
+    expect(resolveExpression("min(3, 1, 2)", {})).toBe("1");
+  });
+
+  it("should compute max with two or more arguments", () => {
+    expect(resolveExpression("max(1, 2)", {})).toBe("2");
+    expect(resolveExpression("max(3, 1, 2)", {})).toBe("3");
+  });
+
+  it("should coerce string arguments numerically", () => {
+    expect(resolveExpression("round('2.6 s')", {})).toBe("3");
+  });
+
+  it("should allow nested calls", () => {
+    expect(resolveExpression("max(min(5, 3), 1)", {})).toBe("3");
+  });
+});
+
+describe("string concatenation", () => {
+  it("should concatenate when either operand is a string", () => {
+    expect(resolveExpression("'P' + 5", {})).toBe("P5");
+    expect(resolveExpression("5 + 'th'", {})).toBe("5th");
+    expect(resolveExpression("'a' + 'b'", {})).toBe("ab");
+  });
+
+  it("should format non-integer numbers with two decimals inside concatenation", () => {
+    expect(resolveExpression("'x: ' + 1/3", {})).toBe("x: 0.33");
+    expect(resolveExpression("'v' + 2.5", {})).toBe("v2.50");
+  });
+
+  it("should chain concatenations left-to-right", () => {
+    expect(resolveExpression("'Lap ' + 5 + '/' + 10", {})).toBe("Lap 5/10");
+  });
+
+  it("should stringify booleans as Yes/No", () => {
+    expect(resolveExpression("'DRS: ' + on", { on: true })).toBe("DRS: Yes");
+    expect(resolveExpression("'DRS: ' + on", { on: false })).toBe("DRS: No");
+  });
+});
+
+describe("variables", () => {
+  it("should look up a flat variable", () => {
+    expect(resolveExpression("speed", { speed: 120 })).toBe("120");
+  });
+
+  it("should look up a string variable", () => {
+    expect(resolveExpression("name", { name: "Dale" })).toBe("Dale");
+  });
+
+  it("should format a boolean variable as Yes/No", () => {
+    expect(resolveExpression("flag", { flag: true })).toBe("Yes");
+    expect(resolveExpression("flag", { flag: false })).toBe("No");
+  });
+
+  it("should look up dotted paths as flat keys", () => {
+    expect(resolveExpression("telemetry.Speed", { "telemetry.Speed": 51.4 })).toBe("51.40");
+  });
+
+  it("should return empty string for an unknown variable", () => {
+    expect(resolveExpression("missing", {})).toBe("");
+    expect(resolveExpression("1 + missing", {})).toBe("");
+  });
+});
+
+describe("coercion", () => {
+  it("should parse a leading number out of a string", () => {
+    expect(resolveExpression("'3.93 km' * 2", {})).toBe("7.86");
+  });
+
+  it("should fail at runtime on a whitespace-only string used numerically", () => {
+    expect(resolveExpression("'  ' * 2", {})).toBe("");
+  });
+
+  it("should fail at runtime on a non-numeric string used numerically", () => {
+    expect(resolveExpression("'abc' * 2", {})).toBe("");
+  });
+
+  it("should coerce booleans to 1 and 0", () => {
+    expect(resolveExpression("t + 1", { t: true })).toBe("2");
+    expect(resolveExpression("f + 1", { f: false })).toBe("1");
+    expect(resolveExpression("t * 5", { t: true })).toBe("5");
+  });
+
+  it("should fail at runtime on a NaN variable used numerically", () => {
+    expect(resolveExpression("n + 1", { n: Number.NaN })).toBe("");
+  });
+
+  it("should fail at runtime on a non-finite variable result", () => {
+    expect(resolveExpression("n", { n: Number.POSITIVE_INFINITY })).toBe("");
+  });
+
+  it("should coerce strings for unary minus and division", () => {
+    expect(resolveExpression("-'2'", {})).toBe("-2");
+    expect(resolveExpression("'10' / '4'", {})).toBe("2.50");
+  });
+});
+
+describe("division by zero", () => {
+  it("should return empty string for division by zero", () => {
+    expect(resolveExpression("1/0", {})).toBe("");
+    expect(resolveExpression("-1/0", {})).toBe("");
+    expect(resolveExpression("1/(2-2)", {})).toBe("");
+  });
+
+  it("should return empty string for zero divided by zero", () => {
+    expect(resolveExpression("0/0", {})).toBe("");
+  });
+
+  it("should return empty string for modulo by zero", () => {
+    expect(resolveExpression("5 % 0", {})).toBe("");
+  });
+
+  it("should return empty string when a non-finite intermediate is used further", () => {
+    expect(resolveExpression("1/0 + 1", {})).toBe("");
+  });
+});
+
+describe("result formatting", () => {
+  it("should render integers without decimals", () => {
+    expect(resolveExpression("4+1", {})).toBe("5");
+    expect(resolveExpression("10/2", {})).toBe("5");
+    expect(resolveExpression("2.5 + 2.5", {})).toBe("5");
+  });
+
+  it("should render non-integers with two decimals by default", () => {
+    expect(resolveExpression("1/3", {})).toBe("0.33");
+  });
+
+  it("should render with fixed decimals from round(x, n)", () => {
+    expect(resolveExpression("round(1/3, 4)", {})).toBe("0.3333");
+    expect(resolveExpression("round(10/2, 1)", {})).toBe("5.0");
+  });
+
+  it("should format plain values directly via formatResult", () => {
+    expect(formatResult({ value: 5 })).toBe("5");
+    expect(formatResult({ value: 5, fixedDecimals: 1 })).toBe("5.0");
+    expect(formatResult({ value: true })).toBe("Yes");
+    expect(formatResult({ value: false })).toBe("No");
+    expect(formatResult({ value: "abc" })).toBe("abc");
+    expect(formatResult({ value: "abc", fixedDecimals: 2 })).toBe("abc");
+  });
+
+  it("should throw on non-finite numbers in formatResult", () => {
+    expect(() => formatResult({ value: Number.POSITIVE_INFINITY })).toThrow();
+    expect(() => formatResult({ value: Number.NaN })).toThrow();
+  });
+});
+
+describe("parseExpression and evaluateAst internals", () => {
+  it("should produce a binary AST node for addition", () => {
+    expect(parseExpression("1 + 2")).toEqual({
+      type: "binary",
+      op: "+",
+      left: { type: "number", value: 1 },
+      right: { type: "number", value: 2 },
+    });
+  });
+
+  it("should store round decimals on the call node, not as an argument", () => {
+    expect(parseExpression("round(1, 2)")).toEqual({
+      type: "call",
+      name: "round",
+      args: [{ type: "number", value: 1 }],
+      fixedDecimals: 2,
+    });
+  });
+
+  it("should attach fixedDecimals to the evaluation envelope", () => {
+    expect(evaluateAst(parseExpression("round(1/3, 2)"), {})).toEqual({ value: 0.33, fixedDecimals: 2 });
+  });
+
+  it("should forward the envelope through a ternary", () => {
+    expect(evaluateAst(parseExpression("1 > 0 ? round(1/3, 3) : 0"), {})).toEqual({
+      value: 0.333,
+      fixedDecimals: 3,
+    });
+  });
+
+  it("should emit hint-free envelopes from other operators", () => {
+    expect(evaluateAst(parseExpression("round(1/3, 2) + 0"), {})).toEqual({ value: 0.33 });
+  });
+});
+
+describe("end-to-end examples", () => {
+  it("should resolve the fuel-add conversion example", () => {
+    const vars = {
+      "telemetry.dpFuelAddKg": 20.4,
+      "sessionInfo.DriverInfo.DriverCarFuelKgPerLtr": 0.743,
+    };
+
+    expect(
+      resolveExpression(
+        "round(telemetry.dpFuelAddKg / (sessionInfo.DriverInfo.DriverCarFuelKgPerLtr * 0.264172), 1)",
+        vars,
+      ),
+    ).toBe("103.9");
+  });
+});
+
+describe("expression cache", () => {
+  it("should reuse the cached AST while applying fresh variables", () => {
+    expect(resolveExpression("x + 1", { x: 1 })).toBe("2");
+    expect(resolveExpression("x + 1", { x: 5 })).toBe("6");
+  });
+
+  it("should cache parse errors", () => {
+    expect(resolveExpression("1 +", {})).toBeNull();
+    expect(resolveExpression("1 +", {})).toBeNull();
+    expect(resolveExpression("1 + 1", {})).toBe("2");
+  });
+
+  it("should keep returning correct results after clearing the cache", () => {
+    expect(resolveExpression("2 * 3", {})).toBe("6");
+    clearExpressionCache();
+
+    expect(resolveExpression("2 * 3", {})).toBe("6");
+  });
+
+  it("should stay correct past the eviction cap", () => {
+    for (let i = 0; i < 205; i++) {
+      expect(resolveExpression(`${i} + 1`, {})).toBe(String(i + 1));
+    }
+
+    for (let i = 0; i < 205; i++) {
+      expect(resolveExpression(`${i} + 1`, {})).toBe(String(i + 1));
+    }
+  });
+
+  it("should re-parse an evicted parse error correctly", () => {
+    expect(resolveExpression("1 +", {})).toBeNull();
+
+    for (let i = 0; i < 205; i++) {
+      resolveExpression(`${i} + 1`, {});
+    }
+
+    expect(resolveExpression("1 +", {})).toBeNull();
+  });
+});

--- a/packages/iracing-sdk/src/expression-evaluator.ts
+++ b/packages/iracing-sdk/src/expression-evaluator.ts
@@ -45,15 +45,21 @@ export type ExprNode =
  */
 export type EvalResult = { value: ExpressionValue; fixedDecimals?: number };
 
-class ExpressionParseError extends Error {}
+class ExpressionParseError extends Error {
+  override name = "ExpressionParseError";
+}
 
-class ExpressionRuntimeError extends Error {}
+class ExpressionRuntimeError extends Error {
+  override name = "ExpressionRuntimeError";
+}
 
 const COMPARISON_OPERATORS: readonly ComparisonOperator[] = ["==", "!=", ">=", "<=", ">", "<"];
 
 const FUNCTION_NAMES: readonly FunctionName[] = ["round", "floor", "ceil", "abs", "min", "max"];
 
 const MAX_ROUND_DECIMALS = 20;
+
+const MAX_EXPRESSION_LENGTH = 1000;
 
 function isDigit(ch: string | undefined): boolean {
   return ch !== undefined && ch >= "0" && ch <= "9";
@@ -420,6 +426,12 @@ function buildCall(name: FunctionName, args: ExprNode[]): ExprNode {
  * including empty input and trailing tokens.
  */
 export function parseExpression(source: string): ExprNode {
+  // The length cap bounds both paren nesting depth and AST recursion depth
+  // (parser and evaluator are recursive) — verified safe well past 1000 chars.
+  if (source.length > MAX_EXPRESSION_LENGTH) {
+    throw new ExpressionParseError(`Expression exceeds ${MAX_EXPRESSION_LENGTH} characters`);
+  }
+
   const tokens = tokenize(source);
 
   if (tokens.length === 0) {
@@ -590,7 +602,9 @@ export function evaluateAst(node: ExprNode, vars: Record<string, ExpressionValue
     case "string":
       return { value: node.value };
     case "variable":
-      if (!(node.path in vars)) {
+      // Object.hasOwn (not `in`) so prototype-chain properties like
+      // "constructor" or "toString" never resolve as variables.
+      if (!Object.hasOwn(vars, node.path)) {
         throw new ExpressionRuntimeError(`Unknown variable "${node.path}"`);
       }
 
@@ -652,6 +666,12 @@ export function clearExpressionCache(): void {
  * error (the caller renders the original source verbatim on parse error).
  */
 export function resolveExpression(source: string, vars: Record<string, ExpressionValue>): string | null {
+  // Reject over-limit sources before touching the cache so huge strings are
+  // never stored as cache keys.
+  if (source.length > MAX_EXPRESSION_LENGTH) {
+    return null;
+  }
+
   let entry = expressionCache.get(source);
 
   if (!entry) {

--- a/packages/iracing-sdk/src/expression-evaluator.ts
+++ b/packages/iracing-sdk/src/expression-evaluator.ts
@@ -59,7 +59,11 @@ const FUNCTION_NAMES: readonly FunctionName[] = ["round", "floor", "ceil", "abs"
 
 const MAX_ROUND_DECIMALS = 20;
 
-const MAX_EXPRESSION_LENGTH = 1000;
+/**
+ * Maximum accepted expression length. Bounds tokenizer/parser recursion depth
+ * and is the single source for the template resolver's scan bound.
+ */
+export const MAX_EXPRESSION_LENGTH = 1000;
 
 function isDigit(ch: string | undefined): boolean {
   return ch !== undefined && ch >= "0" && ch <= "9";
@@ -481,18 +485,6 @@ function formatNumber(value: number): string {
   return Number.isInteger(value) ? String(value) : value.toFixed(2);
 }
 
-function stringifyValue(value: ExpressionValue): string {
-  if (typeof value === "string") {
-    return value;
-  }
-
-  if (typeof value === "boolean") {
-    return value ? "Yes" : "No";
-  }
-
-  return formatNumber(value);
-}
-
 function isTruthy(value: ExpressionValue): boolean {
   if (typeof value === "boolean") {
     return value;
@@ -529,13 +521,17 @@ function evaluateBinary(
   node: Extract<ExprNode, { type: "binary" }>,
   vars: Record<string, ExpressionValue>,
 ): EvalResult {
-  const left = evaluateAst(node.left, vars).value;
-  const right = evaluateAst(node.right, vars).value;
+  const leftResult = evaluateAst(node.left, vars);
+  const rightResult = evaluateAst(node.right, vars);
+  const left = leftResult.value;
+  const right = rightResult.value;
 
   switch (node.op) {
     case "+":
       if (typeof left === "string" || typeof right === "string") {
-        return { value: stringifyValue(left) + stringifyValue(right) };
+        // Each operand formats with its own fixedDecimals hint so
+        // round(x, n) keeps its precision inside concatenation.
+        return { value: formatResult(leftResult) + formatResult(rightResult) };
       }
 
       return { value: toNumber(left) + toNumber(right) };

--- a/packages/iracing-sdk/src/expression-evaluator.ts
+++ b/packages/iracing-sdk/src/expression-evaluator.ts
@@ -1,0 +1,688 @@
+/**
+ * Expression Evaluator
+ *
+ * Safe evaluator for {{= ... }} template expressions: tokenizer,
+ * recursive-descent parser, AST interpreter, and a bounded AST cache.
+ * Pure string/number processing — no SDK or telemetry dependency, and
+ * no eval()/new Function().
+ */
+
+/** Value type for expression variables. */
+export type ExpressionValue = string | number | boolean;
+
+/**
+ * @internal Exported for testing
+ */
+export type Token =
+  | { type: "number"; value: number }
+  | { type: "string"; value: string }
+  | { type: "ident"; path: string }
+  | { type: "op"; op: BinaryOperator }
+  | { type: "punct"; punct: Punctuation };
+
+type BinaryOperator = "+" | "-" | "*" | "/" | "%" | "==" | "!=" | ">=" | "<=" | ">" | "<";
+
+type ComparisonOperator = "==" | "!=" | ">=" | "<=" | ">" | "<";
+
+type Punctuation = "(" | ")" | "," | "?" | ":";
+
+type FunctionName = "round" | "floor" | "ceil" | "abs" | "min" | "max";
+
+/**
+ * @internal Exported for testing
+ */
+export type ExprNode =
+  | { type: "number"; value: number }
+  | { type: "string"; value: string }
+  | { type: "variable"; path: string }
+  | { type: "unary"; op: "-"; operand: ExprNode }
+  | { type: "binary"; op: BinaryOperator; left: ExprNode; right: ExprNode }
+  | { type: "ternary"; condition: ExprNode; whenTrue: ExprNode; whenFalse: ExprNode }
+  | { type: "call"; name: FunctionName; args: ExprNode[]; fixedDecimals?: number };
+
+/**
+ * @internal Exported for testing
+ */
+export type EvalResult = { value: ExpressionValue; fixedDecimals?: number };
+
+class ExpressionParseError extends Error {}
+
+class ExpressionRuntimeError extends Error {}
+
+const COMPARISON_OPERATORS: readonly ComparisonOperator[] = ["==", "!=", ">=", "<=", ">", "<"];
+
+const FUNCTION_NAMES: readonly FunctionName[] = ["round", "floor", "ceil", "abs", "min", "max"];
+
+const MAX_ROUND_DECIMALS = 20;
+
+function isDigit(ch: string | undefined): boolean {
+  return ch !== undefined && ch >= "0" && ch <= "9";
+}
+
+function isIdentStart(ch: string | undefined): boolean {
+  return ch !== undefined && /[a-zA-Z_]/.test(ch);
+}
+
+function isIdentPart(ch: string | undefined): boolean {
+  return ch !== undefined && /[a-zA-Z0-9_]/.test(ch);
+}
+
+/**
+ * @internal Exported for testing
+ *
+ * Splits an expression source string into tokens. Whitespace (including
+ * newlines) is skipped between tokens. Throws on any lexical error.
+ */
+export function tokenize(source: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+
+  while (i < source.length) {
+    const ch = source[i];
+
+    if (/\s/.test(ch)) {
+      i++;
+      continue;
+    }
+
+    if (isDigit(ch) || (ch === "." && isDigit(source[i + 1]))) {
+      let j = i;
+
+      while (isDigit(source[j])) {
+        j++;
+      }
+
+      if (source[j] === "." && isDigit(source[j + 1])) {
+        j++;
+
+        while (isDigit(source[j])) {
+          j++;
+        }
+      }
+
+      tokens.push({ type: "number", value: Number.parseFloat(source.slice(i, j)) });
+      i = j;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"') {
+      let value = "";
+      let j = i + 1;
+      let closed = false;
+
+      while (j < source.length) {
+        const c = source[j];
+
+        if (c === "\\") {
+          // \\ -> \, \' -> ', \" -> ", any other \c -> c
+          if (j + 1 >= source.length) {
+            break;
+          }
+
+          value += source[j + 1];
+          j += 2;
+        } else if (c === ch) {
+          closed = true;
+          j++;
+          break;
+        } else {
+          value += c;
+          j++;
+        }
+      }
+
+      if (!closed) {
+        throw new ExpressionParseError("Unterminated string literal");
+      }
+
+      tokens.push({ type: "string", value });
+      i = j;
+      continue;
+    }
+
+    if (isIdentStart(ch)) {
+      let j = i + 1;
+
+      while (isIdentPart(source[j])) {
+        j++;
+      }
+
+      while (source[j] === ".") {
+        if (!isIdentStart(source[j + 1])) {
+          throw new ExpressionParseError(`Invalid identifier path at "${source.slice(i, j + 1)}"`);
+        }
+
+        j += 2;
+
+        while (isIdentPart(source[j])) {
+          j++;
+        }
+      }
+
+      tokens.push({ type: "ident", path: source.slice(i, j) });
+      i = j;
+      continue;
+    }
+
+    const twoChar = source.slice(i, i + 2);
+
+    if (twoChar === "==" || twoChar === "!=" || twoChar === ">=" || twoChar === "<=") {
+      tokens.push({ type: "op", op: twoChar });
+      i += 2;
+      continue;
+    }
+
+    if (ch === "+" || ch === "-" || ch === "*" || ch === "/" || ch === "%" || ch === ">" || ch === "<") {
+      tokens.push({ type: "op", op: ch });
+      i++;
+      continue;
+    }
+
+    if (ch === "(" || ch === ")" || ch === "," || ch === "?" || ch === ":") {
+      tokens.push({ type: "punct", punct: ch });
+      i++;
+      continue;
+    }
+
+    throw new ExpressionParseError(`Unexpected character "${ch}" in expression`);
+  }
+
+  return tokens;
+}
+
+class Parser {
+  private pos = 0;
+
+  constructor(private readonly tokens: Token[]) {}
+
+  parseExpression(): ExprNode {
+    return this.parseTernary();
+  }
+
+  expectEnd(): void {
+    if (this.pos < this.tokens.length) {
+      throw new ExpressionParseError("Unexpected tokens after expression");
+    }
+  }
+
+  private parseTernary(): ExprNode {
+    const condition = this.parseComparison();
+
+    if (this.matchPunct("?")) {
+      const whenTrue = this.parseExpression();
+      this.expectPunct(":");
+      const whenFalse = this.parseExpression();
+
+      return { type: "ternary", condition, whenTrue, whenFalse };
+    }
+
+    return condition;
+  }
+
+  private parseComparison(): ExprNode {
+    const left = this.parseAdditive();
+    const op = this.matchOp(COMPARISON_OPERATORS);
+
+    if (op) {
+      const right = this.parseAdditive();
+
+      // Comparison is non-associative: a < b < c is a parse error.
+      if (this.peekOp(COMPARISON_OPERATORS)) {
+        throw new ExpressionParseError("Comparison operators cannot be chained");
+      }
+
+      return { type: "binary", op, left, right };
+    }
+
+    return left;
+  }
+
+  private parseAdditive(): ExprNode {
+    let left = this.parseMultiplicative();
+
+    for (let op = this.matchOp(["+", "-"]); op; op = this.matchOp(["+", "-"])) {
+      left = { type: "binary", op, left, right: this.parseMultiplicative() };
+    }
+
+    return left;
+  }
+
+  private parseMultiplicative(): ExprNode {
+    let left = this.parseUnary();
+
+    for (let op = this.matchOp(["*", "/", "%"]); op; op = this.matchOp(["*", "/", "%"])) {
+      left = { type: "binary", op, left, right: this.parseUnary() };
+    }
+
+    return left;
+  }
+
+  private parseUnary(): ExprNode {
+    if (this.matchOp(["-"])) {
+      return { type: "unary", op: "-", operand: this.parseUnary() };
+    }
+
+    return this.parsePrimary();
+  }
+
+  private parsePrimary(): ExprNode {
+    const token = this.next();
+
+    if (!token) {
+      throw new ExpressionParseError("Unexpected end of expression");
+    }
+
+    switch (token.type) {
+      case "number":
+        return { type: "number", value: token.value };
+      case "string":
+        return { type: "string", value: token.value };
+      case "ident":
+        if (this.peekPunct("(")) {
+          return this.parseCall(token.path);
+        }
+
+        return { type: "variable", path: token.path };
+      case "punct":
+        if (token.punct === "(") {
+          const inner = this.parseExpression();
+          this.expectPunct(")");
+
+          return inner;
+        }
+
+        throw new ExpressionParseError(`Unexpected "${token.punct}" in expression`);
+      default:
+        throw new ExpressionParseError("Unexpected operator in expression");
+    }
+  }
+
+  private parseCall(name: string): ExprNode {
+    if (!(FUNCTION_NAMES as readonly string[]).includes(name)) {
+      throw new ExpressionParseError(`Unknown function "${name}"`);
+    }
+
+    this.expectPunct("(");
+    const args: ExprNode[] = [this.parseExpression()];
+
+    while (this.matchPunct(",")) {
+      args.push(this.parseExpression());
+    }
+
+    this.expectPunct(")");
+
+    return buildCall(name as FunctionName, args);
+  }
+
+  private peek(): Token | undefined {
+    return this.tokens[this.pos];
+  }
+
+  private next(): Token | undefined {
+    const token = this.tokens[this.pos];
+
+    if (token) {
+      this.pos++;
+    }
+
+    return token;
+  }
+
+  private peekOp(ops: readonly BinaryOperator[]): boolean {
+    const token = this.peek();
+
+    return token?.type === "op" && ops.includes(token.op);
+  }
+
+  private matchOp<T extends BinaryOperator>(ops: readonly T[]): T | undefined {
+    const token = this.peek();
+
+    if (token?.type === "op" && (ops as readonly BinaryOperator[]).includes(token.op)) {
+      this.pos++;
+
+      return token.op as T;
+    }
+
+    return undefined;
+  }
+
+  private peekPunct(punct: Punctuation): boolean {
+    const token = this.peek();
+
+    return token?.type === "punct" && token.punct === punct;
+  }
+
+  private matchPunct(punct: Punctuation): boolean {
+    if (this.peekPunct(punct)) {
+      this.pos++;
+
+      return true;
+    }
+
+    return false;
+  }
+
+  private expectPunct(punct: Punctuation): void {
+    if (!this.matchPunct(punct)) {
+      throw new ExpressionParseError(`Expected "${punct}" in expression`);
+    }
+  }
+}
+
+function buildCall(name: FunctionName, args: ExprNode[]): ExprNode {
+  switch (name) {
+    case "round": {
+      if (args.length === 1) {
+        return { type: "call", name, args };
+      }
+
+      if (args.length !== 2) {
+        throw new ExpressionParseError("round() takes 1 or 2 arguments");
+      }
+
+      const decimals = args[1];
+
+      if (
+        decimals.type !== "number" ||
+        !Number.isInteger(decimals.value) ||
+        decimals.value < 0 ||
+        decimals.value > MAX_ROUND_DECIMALS
+      ) {
+        throw new ExpressionParseError(
+          `round() decimals must be an integer literal between 0 and ${MAX_ROUND_DECIMALS}`,
+        );
+      }
+
+      return { type: "call", name, args: [args[0]], fixedDecimals: decimals.value };
+    }
+    case "floor":
+    case "ceil":
+    case "abs":
+      if (args.length !== 1) {
+        throw new ExpressionParseError(`${name}() takes exactly 1 argument`);
+      }
+
+      return { type: "call", name, args };
+    case "min":
+    case "max":
+      if (args.length < 2) {
+        throw new ExpressionParseError(`${name}() takes at least 2 arguments`);
+      }
+
+      return { type: "call", name, args };
+  }
+}
+
+/**
+ * @internal Exported for testing
+ *
+ * Tokenizes and parses an expression into an AST. Throws on any parse error,
+ * including empty input and trailing tokens.
+ */
+export function parseExpression(source: string): ExprNode {
+  const tokens = tokenize(source);
+
+  if (tokens.length === 0) {
+    throw new ExpressionParseError("Empty expression");
+  }
+
+  const parser = new Parser(tokens);
+  const node = parser.parseExpression();
+  parser.expectEnd();
+
+  return node;
+}
+
+function toNumber(value: ExpressionValue): number {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new ExpressionRuntimeError("Value is not a finite number");
+    }
+
+    return value;
+  }
+
+  if (typeof value === "boolean") {
+    return value ? 1 : 0;
+  }
+
+  const trimmed = value.trim();
+
+  if (trimmed === "") {
+    throw new ExpressionRuntimeError("Cannot convert an empty string to a number");
+  }
+
+  const parsed = Number.parseFloat(trimmed);
+
+  if (!Number.isFinite(parsed)) {
+    throw new ExpressionRuntimeError(`Cannot convert "${value}" to a number`);
+  }
+
+  return parsed;
+}
+
+function formatNumber(value: number): string {
+  if (!Number.isFinite(value)) {
+    throw new ExpressionRuntimeError("Result is not a finite number");
+  }
+
+  return Number.isInteger(value) ? String(value) : value.toFixed(2);
+}
+
+function stringifyValue(value: ExpressionValue): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No";
+  }
+
+  return formatNumber(value);
+}
+
+function isTruthy(value: ExpressionValue): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    if (Number.isNaN(value)) {
+      throw new ExpressionRuntimeError("Condition is not a number");
+    }
+
+    return value !== 0;
+  }
+
+  return value.length > 0;
+}
+
+function looseEquals(left: ExpressionValue, right: ExpressionValue): boolean {
+  if (typeof left === typeof right) {
+    return left === right;
+  }
+
+  try {
+    return toNumber(left) === toNumber(right);
+  } catch (error) {
+    if (error instanceof ExpressionRuntimeError) {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+function evaluateBinary(
+  node: Extract<ExprNode, { type: "binary" }>,
+  vars: Record<string, ExpressionValue>,
+): EvalResult {
+  const left = evaluateAst(node.left, vars).value;
+  const right = evaluateAst(node.right, vars).value;
+
+  switch (node.op) {
+    case "+":
+      if (typeof left === "string" || typeof right === "string") {
+        return { value: stringifyValue(left) + stringifyValue(right) };
+      }
+
+      return { value: toNumber(left) + toNumber(right) };
+    case "-":
+      return { value: toNumber(left) - toNumber(right) };
+    case "*":
+      return { value: toNumber(left) * toNumber(right) };
+    case "/":
+      return { value: toNumber(left) / toNumber(right) };
+    case "%":
+      return { value: toNumber(left) % toNumber(right) };
+    case ">":
+      return { value: toNumber(left) > toNumber(right) };
+    case "<":
+      return { value: toNumber(left) < toNumber(right) };
+    case ">=":
+      return { value: toNumber(left) >= toNumber(right) };
+    case "<=":
+      return { value: toNumber(left) <= toNumber(right) };
+    case "==":
+      return { value: looseEquals(left, right) };
+    case "!=":
+      return { value: !looseEquals(left, right) };
+  }
+}
+
+function evaluateCall(node: Extract<ExprNode, { type: "call" }>, vars: Record<string, ExpressionValue>): EvalResult {
+  const args = node.args.map((arg) => toNumber(evaluateAst(arg, vars).value));
+
+  switch (node.name) {
+    case "round": {
+      if (node.fixedDecimals === undefined) {
+        return { value: Math.round(args[0]) };
+      }
+
+      const factor = 10 ** node.fixedDecimals;
+
+      return { value: Math.round(args[0] * factor) / factor, fixedDecimals: node.fixedDecimals };
+    }
+    case "floor":
+      return { value: Math.floor(args[0]) };
+    case "ceil":
+      return { value: Math.ceil(args[0]) };
+    case "abs":
+      return { value: Math.abs(args[0]) };
+    case "min":
+      return { value: Math.min(...args) };
+    case "max":
+      return { value: Math.max(...args) };
+  }
+}
+
+/**
+ * @internal Exported for testing
+ *
+ * Evaluates a parsed expression against raw template values. Only the ternary
+ * forwards its chosen branch's envelope (preserving the fixedDecimals hint
+ * from round(x, n)); all other constructs emit hint-free envelopes.
+ */
+export function evaluateAst(node: ExprNode, vars: Record<string, ExpressionValue>): EvalResult {
+  switch (node.type) {
+    case "number":
+      return { value: node.value };
+    case "string":
+      return { value: node.value };
+    case "variable":
+      if (!(node.path in vars)) {
+        throw new ExpressionRuntimeError(`Unknown variable "${node.path}"`);
+      }
+
+      return { value: vars[node.path] };
+    case "unary":
+      return { value: -toNumber(evaluateAst(node.operand, vars).value) };
+    case "binary":
+      return evaluateBinary(node, vars);
+    case "ternary":
+      return evaluateAst(isTruthy(evaluateAst(node.condition, vars).value) ? node.whenTrue : node.whenFalse, vars);
+    case "call":
+      return evaluateCall(node, vars);
+  }
+}
+
+/**
+ * @internal Exported for testing
+ *
+ * Formats an evaluation result for display: strings as-is, booleans as
+ * Yes/No, numbers per the fixedDecimals hint or default number formatting
+ * (integers bare, otherwise two decimals). Throws on non-finite numbers.
+ */
+export function formatResult(result: EvalResult): string {
+  const { value } = result;
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No";
+  }
+
+  if (!Number.isFinite(value)) {
+    throw new ExpressionRuntimeError("Result is not a finite number");
+  }
+
+  return result.fixedDecimals !== undefined ? value.toFixed(result.fixedDecimals) : formatNumber(value);
+}
+
+type CacheEntry = { kind: "ast"; node: ExprNode } | { kind: "parse-error" };
+
+// Parse errors are cached too: templates re-resolve at 60 Hz and a typo must
+// not re-parse on every tick.
+const expressionCache = new Map<string, CacheEntry>();
+
+const EXPRESSION_CACHE_MAX_ENTRIES = 200;
+
+/**
+ * @internal Exported for testing
+ */
+export function clearExpressionCache(): void {
+  expressionCache.clear();
+}
+
+/**
+ * Evaluates a {{= ... }} expression against raw template values.
+ * Returns the formatted result string, "" on runtime error, or null on parse
+ * error (the caller renders the original source verbatim on parse error).
+ */
+export function resolveExpression(source: string, vars: Record<string, ExpressionValue>): string | null {
+  let entry = expressionCache.get(source);
+
+  if (!entry) {
+    try {
+      entry = { kind: "ast", node: parseExpression(source) };
+    } catch (error) {
+      if (!(error instanceof ExpressionParseError)) {
+        throw error;
+      }
+
+      entry = { kind: "parse-error" };
+    }
+
+    if (expressionCache.size >= EXPRESSION_CACHE_MAX_ENTRIES) {
+      expressionCache.delete(expressionCache.keys().next().value as string);
+    }
+
+    expressionCache.set(source, entry);
+  }
+
+  if (entry.kind === "parse-error") {
+    return null;
+  }
+
+  try {
+    return formatResult(evaluateAst(entry.node, vars));
+  } catch (error) {
+    if (error instanceof ExpressionRuntimeError) {
+      return "";
+    }
+
+    throw error;
+  }
+}

--- a/packages/iracing-sdk/src/index.ts
+++ b/packages/iracing-sdk/src/index.ts
@@ -111,6 +111,7 @@ export {
   findDriverByRacePosition,
   formatTimeRemaining,
   type TemplateContext,
+  type TemplateValue,
 } from "./template-context.js";
 
 // Track utilities

--- a/packages/iracing-sdk/src/index.ts
+++ b/packages/iracing-sdk/src/index.ts
@@ -100,11 +100,10 @@ export {
 } from "./commands/index.js";
 
 // Template variable system
-export { resolveTemplate, resolvePathValue } from "./template-resolver.js";
+export { resolveTemplate } from "./template-resolver.js";
 export {
   buildTemplateContext,
   buildTemplateContextFromData,
-  flattenForDisplay,
   prefixKeys,
   splitDriverName,
   findNearestDriverOnTrack,

--- a/packages/iracing-sdk/src/template-context.test.ts
+++ b/packages/iracing-sdk/src/template-context.test.ts
@@ -693,11 +693,11 @@ describe("buildTemplateContextFromData raw map", () => {
     const ctx = buildTemplateContextFromData(telemetry, sessionInfo);
 
     const result = resolveTemplate(
-      "{{= round(telemetry.dpFuelAddKg / (sessionInfo.DriverInfo.DriverCarFuelKgPerLtr * 0.264172), 1) }}",
+      "{{= round(telemetry.dpFuelAddKg / (sessionInfo.DriverInfo.DriverCarFuelKgPerLtr * 3.78541), 1) }}",
       ctx,
     );
 
-    expect(result).toBe("100.9");
+    expect(result).toBe("7.0");
   });
 });
 

--- a/packages/iracing-sdk/src/template-context.test.ts
+++ b/packages/iracing-sdk/src/template-context.test.ts
@@ -10,6 +10,7 @@ import {
   resolveRacePositions,
   splitDriverName,
 } from "./template-context.js";
+import { resolveTemplate } from "./template-resolver.js";
 import type { SessionInfo } from "./types.js";
 import type { TelemetryData } from "./types.js";
 
@@ -340,16 +341,16 @@ describe("buildTemplateContextFromData", () => {
     const telemetry = makeTelemetry();
     const ctx = buildTemplateContextFromData(telemetry, sessionInfo);
 
-    expect(ctx["self.name"]).toBe("John Smith");
-    expect(ctx["self.first_name"]).toBe("John");
-    expect(ctx["self.last_name"]).toBe("Smith");
-    expect(ctx["self.position"]).toBe("2");
-    expect(ctx["self.incidents"]).toBe("3");
-    expect(ctx["session.type"]).toBe("Race");
-    expect(ctx["session.laps_remaining"]).toBe("10");
-    expect(ctx["session.time_remaining"]).toBe("61:01");
-    expect(ctx["track.name"]).toBe("Spa-Francorchamps");
-    expect(ctx["track.short_name"]).toBe("Spa");
+    expect(ctx.display["self.name"]).toBe("John Smith");
+    expect(ctx.display["self.first_name"]).toBe("John");
+    expect(ctx.display["self.last_name"]).toBe("Smith");
+    expect(ctx.display["self.position"]).toBe("2");
+    expect(ctx.display["self.incidents"]).toBe("3");
+    expect(ctx.display["session.type"]).toBe("Race");
+    expect(ctx.display["session.laps_remaining"]).toBe("10");
+    expect(ctx.display["session.time_remaining"]).toBe("61:01");
+    expect(ctx.display["track.name"]).toBe("Spa-Francorchamps");
+    expect(ctx.display["track.short_name"]).toBe("Spa");
   });
 
   it("should return empty fields with null telemetry", () => {
@@ -357,19 +358,19 @@ describe("buildTemplateContextFromData", () => {
     const sessionInfo = makeSessionInfo(drivers, 0);
     const ctx = buildTemplateContextFromData(null, sessionInfo);
 
-    expect(ctx["self.position"]).toBe("");
-    expect(ctx["self.incidents"]).toBe("");
-    expect(ctx["track_ahead.name"]).toBe("");
-    expect(ctx["track_behind.name"]).toBe("");
+    expect(ctx.display["self.position"]).toBe("");
+    expect(ctx.display["self.incidents"]).toBe("");
+    expect(ctx.display["track_ahead.name"]).toBe("");
+    expect(ctx.display["track_behind.name"]).toBe("");
   });
 
   it("should return empty fields with null session info", () => {
     const ctx = buildTemplateContextFromData(null, null);
 
-    expect(ctx["self.name"]).toBe("");
-    expect(ctx["track_ahead.name"]).toBe("");
-    expect(ctx["session.type"]).toBe("");
-    expect(ctx["track.name"]).toBe("");
+    expect(ctx.display["self.name"]).toBe("");
+    expect(ctx.display["track_ahead.name"]).toBe("");
+    expect(ctx.display["session.type"]).toBe("");
+    expect(ctx.display["track.name"]).toBe("");
   });
 
   it("should populate race_ahead and race_behind from race position", () => {
@@ -383,8 +384,8 @@ describe("buildTemplateContextFromData", () => {
     const telemetry = makeTelemetry({ CarIdxPosition: [2, 1, 3] });
     const ctx = buildTemplateContextFromData(telemetry, sessionInfo);
 
-    expect(ctx["race_ahead.name"]).toBe("P1 Driver");
-    expect(ctx["race_behind.name"]).toBe("P3 Driver");
+    expect(ctx.display["race_ahead.name"]).toBe("P1 Driver");
+    expect(ctx.display["race_behind.name"]).toBe("P3 Driver");
   });
 
   it("should use player-specific telemetry for self fields in non-race sessions", () => {
@@ -405,11 +406,11 @@ describe("buildTemplateContextFromData", () => {
 
     const ctx = buildTemplateContextFromData(telemetry, sessionInfo);
 
-    expect(ctx["self.position"]).toBe("5");
-    expect(ctx["self.class_position"]).toBe("3");
-    expect(ctx["self.lap"]).toBe("12");
-    expect(ctx["self.laps_completed"]).toBe("11");
-    expect(ctx["self.incidents"]).toBe("7");
+    expect(ctx.display["self.position"]).toBe("5");
+    expect(ctx.display["self.class_position"]).toBe("3");
+    expect(ctx.display["self.lap"]).toBe("12");
+    expect(ctx.display["self.laps_completed"]).toBe("11");
+    expect(ctx.display["self.incidents"]).toBe("7");
   });
 
   it("should use calculated positions for race sessions", () => {
@@ -431,8 +432,8 @@ describe("buildTemplateContextFromData", () => {
     const ctx = buildTemplateContextFromData(telemetry, sessionInfo);
 
     // self.position should reflect calculated P1, not PlayerCarPosition (2)
-    expect(ctx["self.position"]).toBe("1");
-    expect(ctx["race_behind.name"]).toBe("Leader"); // Car 1 at P2 is behind player at P1
+    expect(ctx.display["self.position"]).toBe("1");
+    expect(ctx.display["race_behind.name"]).toBe("Leader"); // Car 1 at P2 is behind player at P1
   });
 
   it("should use native CarIdxPosition for non-race sessions", () => {
@@ -457,7 +458,7 @@ describe("buildTemplateContextFromData", () => {
     const ctx = buildTemplateContextFromData(telemetry, sessionInfo);
 
     // Non-race: should use PlayerCarPosition (2), not calculated (1)
-    expect(ctx["self.position"]).toBe("2");
+    expect(ctx.display["self.position"]).toBe("2");
   });
 
   it("should use official position for player on pit road in race session", () => {
@@ -479,7 +480,7 @@ describe("buildTemplateContextFromData", () => {
     const ctx = buildTemplateContextFromData(telemetry, sessionInfo);
 
     // Player on pit road: self.position should use PlayerCarPosition=2, not calculated P1
-    expect(ctx["self.position"]).toBe("2");
+    expect(ctx.display["self.position"]).toBe("2");
   });
 
   it("should use official position for other car on pit road in race session", () => {
@@ -507,8 +508,8 @@ describe("buildTemplateContextFromData", () => {
     // Resolved: car 0=P2 (calculated), car 1=P2 (official, on pit road), car 2=P3 (calculated)
     // Player position is P2, so race_ahead is position 1 → no driver has position 1 in resolved
     // Let's check: player is at resolved[0]=P2, race_behind is position 3 = car 2
-    expect(ctx["race_behind.name"]).toBe("Third");
-    expect(ctx["race_behind.position"]).toBe("3");
+    expect(ctx.display["race_behind.name"]).toBe("Third");
+    expect(ctx.display["race_behind.position"]).toBe("3");
   });
 
   it("should fall back to official position when calculated is unavailable in race session", () => {
@@ -531,7 +532,7 @@ describe("buildTemplateContextFromData", () => {
 
     // Car 0 is inactive (calculated=0), falls back to official CarIdxPosition=2
     // PlayerCarPosition is also used for self.position fallback
-    expect(ctx["self.position"]).toBe("2");
+    expect(ctx.display["self.position"]).toBe("2");
   });
 
   it("should include telemetry with prefix and formatted values", () => {
@@ -547,11 +548,11 @@ describe("buildTemplateContextFromData", () => {
     const sessionInfo = makeSessionInfo(drivers, 0);
     const ctx = buildTemplateContextFromData(telemetry, sessionInfo);
 
-    expect(ctx["telemetry.Speed"]).toBe("156.79");
-    expect(ctx["telemetry.OilTemp"]).toBe("95");
-    expect(ctx["telemetry.IsOnTrack"]).toBe("Yes");
-    expect(ctx["telemetry.CarIdxLap"]).toBeUndefined();
-    expect(ctx["telemetry.CarIdxPosition"]).toBeUndefined();
+    expect(ctx.display["telemetry.Speed"]).toBe("156.79");
+    expect(ctx.display["telemetry.OilTemp"]).toBe("95");
+    expect(ctx.display["telemetry.IsOnTrack"]).toBe("Yes");
+    expect(ctx.display["telemetry.CarIdxLap"]).toBeUndefined();
+    expect(ctx.display["telemetry.CarIdxPosition"]).toBeUndefined();
   });
 
   it("should include sessionInfo with prefix and nested dot-notation", () => {
@@ -559,15 +560,115 @@ describe("buildTemplateContextFromData", () => {
     const sessionInfo = makeSessionInfo(drivers, 0);
     const ctx = buildTemplateContextFromData(null, sessionInfo);
 
-    expect(ctx["sessionInfo.WeekendInfo.TrackDisplayName"]).toBe("Spa-Francorchamps");
-    expect(ctx["sessionInfo.WeekendInfo.TrackDisplayShortName"]).toBe("Spa");
+    expect(ctx.display["sessionInfo.WeekendInfo.TrackDisplayName"]).toBe("Spa-Francorchamps");
+    expect(ctx.display["sessionInfo.WeekendInfo.TrackDisplayShortName"]).toBe("Spa");
   });
 
   it("should return empty telemetry and sessionInfo with null data", () => {
     const ctx = buildTemplateContextFromData(null, null);
 
-    expect(ctx["telemetry.Speed"]).toBeUndefined();
-    expect(ctx["sessionInfo.WeekendInfo.TrackDisplayName"]).toBeUndefined();
+    expect(ctx.display["telemetry.Speed"]).toBeUndefined();
+    expect(ctx.display["sessionInfo.WeekendInfo.TrackDisplayName"]).toBeUndefined();
+  });
+});
+
+describe("buildTemplateContextFromData raw map", () => {
+  it("should keep full-precision numbers in raw while display is formatted", () => {
+    const telemetry = makeTelemetry({ Speed: 156.789 } as Partial<TelemetryData>);
+    const sessionInfo = makeSessionInfo([makeDriver({ CarIdx: 0 })], 0);
+
+    const ctx = buildTemplateContextFromData(telemetry, sessionInfo);
+
+    expect(ctx.raw["telemetry.Speed"]).toBe(156.789);
+    expect(ctx.display["telemetry.Speed"]).toBe("156.79");
+  });
+
+  it("should keep booleans as booleans in raw while display is Yes/No", () => {
+    const telemetry = makeTelemetry({ IsOnTrack: true } as Partial<TelemetryData>);
+    const sessionInfo = makeSessionInfo([makeDriver({ CarIdx: 0 })], 0);
+
+    const ctx = buildTemplateContextFromData(telemetry, sessionInfo);
+
+    expect(ctx.raw["telemetry.IsOnTrack"]).toBe(true);
+    expect(ctx.display["telemetry.IsOnTrack"]).toBe("Yes");
+  });
+
+  it("should keep boolean-semantic integer fields as 0/1 numbers in raw while display is Yes/No", () => {
+    const telemetry = makeTelemetry({ PushToPass: 1 } as unknown as Partial<TelemetryData>);
+    const sessionInfo = makeSessionInfo([makeDriver({ CarIdx: 0 })], 0);
+
+    const ctx = buildTemplateContextFromData(telemetry, sessionInfo);
+
+    expect(ctx.raw["telemetry.PushToPass"]).toBe(1);
+    expect(ctx.display["telemetry.PushToPass"]).toBe("Yes");
+  });
+
+  it("should keep driver position as a number in raw while display is a string", () => {
+    const sessionInfo = makeSessionInfo([makeDriver({ CarIdx: 0 })], 0);
+    const telemetry = makeTelemetry();
+
+    const ctx = buildTemplateContextFromData(telemetry, sessionInfo);
+
+    expect(ctx.raw["self.position"]).toBe(Number(ctx.display["self.position"]));
+    expect(typeof ctx.raw["self.position"]).toBe("number");
+    expect(typeof ctx.display["self.position"]).toBe("string");
+  });
+
+  it("should omit missing numeric driver fields from raw but keep empty string in display", () => {
+    const sessionInfo = makeSessionInfo([makeDriver({ CarIdx: 0 })], 0);
+
+    const ctx = buildTemplateContextFromData(null, sessionInfo);
+
+    expect("self.position" in ctx.raw).toBe(false);
+    expect(ctx.display["self.position"]).toBe("");
+  });
+
+  it("should produce essentially empty maps with null telemetry and session info", () => {
+    const ctx = buildTemplateContextFromData(null, null);
+
+    expect(ctx.raw["telemetry.Speed"]).toBeUndefined();
+    expect("self.position" in ctx.raw).toBe(false);
+    expect(ctx.raw["self.name"]).toBe("");
+    expect(ctx.display["self.name"]).toBe("");
+  });
+
+  it("should keep sessionInfo numbers full-precision in raw", () => {
+    const sessionInfo = {
+      DriverInfo: {
+        DriverCarIdx: 0,
+        DriverCarFuelKgPerLtr: 0.75,
+        Drivers: [makeDriver({ CarIdx: 0 })],
+      },
+      WeekendInfo: { TrackDisplayName: "Spa", TrackDisplayShortName: "Spa" },
+      SessionInfo: { Sessions: [{ SessionType: "Race", SessionName: "RACE" }] },
+    } as unknown as SessionInfo;
+
+    const ctx = buildTemplateContextFromData(null, sessionInfo);
+
+    expect(ctx.raw["sessionInfo.DriverInfo.DriverCarFuelKgPerLtr"]).toBe(0.75);
+    expect(ctx.display["sessionInfo.DriverInfo.DriverCarFuelKgPerLtr"]).toBe("0.75");
+  });
+
+  it("should resolve the fuel-add expression end to end with a real built context", () => {
+    const sessionInfo = {
+      DriverInfo: {
+        DriverCarIdx: 0,
+        DriverCarFuelKgPerLtr: 0.75,
+        Drivers: [makeDriver({ CarIdx: 0 })],
+      },
+      WeekendInfo: { TrackDisplayName: "Spa", TrackDisplayShortName: "Spa" },
+      SessionInfo: { Sessions: [{ SessionType: "Race", SessionName: "RACE" }] },
+    } as unknown as SessionInfo;
+    const telemetry = makeTelemetry({ dpFuelAddKg: 20 } as Partial<TelemetryData>);
+
+    const ctx = buildTemplateContextFromData(telemetry, sessionInfo);
+
+    const result = resolveTemplate(
+      "{{= round(telemetry.dpFuelAddKg / (sessionInfo.DriverInfo.DriverCarFuelKgPerLtr * 0.264172), 1) }}",
+      ctx,
+    );
+
+    expect(result).toBe("100.9");
   });
 });
 

--- a/packages/iracing-sdk/src/template-context.test.ts
+++ b/packages/iracing-sdk/src/template-context.test.ts
@@ -4,7 +4,7 @@ import {
   buildTemplateContextFromData,
   findDriverByRacePosition,
   findNearestDriverOnTrack,
-  flattenForDisplay,
+  flattenContext,
   formatTimeRemaining,
   prefixKeys,
   resolveRacePositions,
@@ -373,6 +373,35 @@ describe("buildTemplateContextFromData", () => {
     expect(ctx.display["track.name"]).toBe("");
   });
 
+  it("should omit track_ahead fields from raw when there is no track-ahead driver", () => {
+    const drivers = [makeDriver({ CarIdx: 0, UserName: "Player" })];
+    const sessionInfo = makeSessionInfo(drivers, 0);
+    const telemetry = makeTelemetry({
+      CarIdxPosition: [1],
+      CarIdxClassPosition: [1],
+      CarIdxLap: [5],
+      CarIdxLapCompleted: [4],
+      CarIdxLapDistPct: [0.5],
+      CarIdxOnPitRoad: [false],
+    });
+
+    const ctx = buildTemplateContextFromData(telemetry, sessionInfo);
+
+    expect("track_ahead.position" in ctx.raw).toBe(false);
+    expect(ctx.display["track_ahead.position"]).toBe("");
+  });
+
+  it("should omit session.laps_remaining from raw when SessionLapsRemainEx is negative", () => {
+    const drivers = [makeDriver({ CarIdx: 0 })];
+    const sessionInfo = makeSessionInfo(drivers, 0);
+    const telemetry = makeTelemetry({ SessionLapsRemainEx: -1 });
+
+    const ctx = buildTemplateContextFromData(telemetry, sessionInfo);
+
+    expect("session.laps_remaining" in ctx.raw).toBe(false);
+    expect(ctx.display["session.laps_remaining"]).toBe("");
+  });
+
   it("should populate race_ahead and race_behind from race position", () => {
     const drivers = [
       makeDriver({ CarIdx: 0, UserName: "Player" }),
@@ -733,65 +762,65 @@ describe("resolveRacePositions", () => {
   });
 });
 
-describe("flattenForDisplay", () => {
+describe("flattenContext display map", () => {
   it("should flatten a flat object", () => {
-    const result = flattenForDisplay({ Speed: 100, Gear: 4 });
+    const result = flattenContext({ Speed: 100, Gear: 4 }).display;
 
     expect(result.Speed).toBe("100");
     expect(result.Gear).toBe("4");
   });
 
   it("should flatten nested objects with dot notation", () => {
-    const result = flattenForDisplay({
+    const result = flattenContext({
       WeekendInfo: { TrackDisplayName: "Spa", TrackLength: "7.004 km" },
-    });
+    }).display;
 
     expect(result["WeekendInfo.TrackDisplayName"]).toBe("Spa");
     expect(result["WeekendInfo.TrackLength"]).toBe("7.004 km");
   });
 
   it("should round floating point numbers to 2 decimals", () => {
-    const result = flattenForDisplay({ Speed: 156.789, Throttle: 0.5 });
+    const result = flattenContext({ Speed: 156.789, Throttle: 0.5 }).display;
 
     expect(result.Speed).toBe("156.79");
     expect(result.Throttle).toBe("0.50");
   });
 
   it("should keep integers as integers", () => {
-    const result = flattenForDisplay({ Gear: 4, Lap: 12 });
+    const result = flattenContext({ Gear: 4, Lap: 12 }).display;
 
     expect(result.Gear).toBe("4");
     expect(result.Lap).toBe("12");
   });
 
   it("should convert booleans to Yes/No", () => {
-    const result = flattenForDisplay({ IsOnTrack: true, IsReplayPlaying: false });
+    const result = flattenContext({ IsOnTrack: true, IsReplayPlaying: false }).display;
 
     expect(result.IsOnTrack).toBe("Yes");
     expect(result.IsReplayPlaying).toBe("No");
   });
 
   it("should skip arrays", () => {
-    const result = flattenForDisplay({ CarIdxLap: [1, 2, 3], Speed: 100 });
+    const result = flattenContext({ CarIdxLap: [1, 2, 3], Speed: 100 }).display;
 
     expect(result.CarIdxLap).toBeUndefined();
     expect(result.Speed).toBe("100");
   });
 
   it("should skip arrays at nested levels", () => {
-    const result = flattenForDisplay({
+    const result = flattenContext({
       DriverInfo: { Drivers: [{ Name: "test" }], DriverCarIdx: 0 },
-    });
+    }).display;
 
     expect(result["DriverInfo.Drivers"]).toBeUndefined();
     expect(result["DriverInfo.DriverCarIdx"]).toBe("0");
   });
 
   it("should filter keys by excludePrefix", () => {
-    const result = flattenForDisplay(
+    const result = flattenContext(
       { Speed: 100, CarIdxLap: [1], CarIdxPosition: [1], Gear: 3 },
       { excludePrefix: "CarIdx" },
-    );
+    ).display;
 
     expect(result.Speed).toBe("100");
     expect(result.Gear).toBe("3");
@@ -800,15 +829,15 @@ describe("flattenForDisplay", () => {
   });
 
   it("should handle deeply nested objects", () => {
-    const result = flattenForDisplay({
+    const result = flattenContext({
       CarSetup: { Tires: { LeftFront: { TreadRemaining: 85.5 } } },
-    });
+    }).display;
 
     expect(result["CarSetup.Tires.LeftFront.TreadRemaining"]).toBe("85.50");
   });
 
   it("should convert known boolean-semantic integer fields to Yes/No", () => {
-    const result = flattenForDisplay({ IsOnTrack: 1, IsReplayPlaying: 0, Speed: 100 });
+    const result = flattenContext({ IsOnTrack: 1, IsReplayPlaying: 0, Speed: 100 }).display;
 
     expect(result.IsOnTrack).toBe("Yes");
     expect(result.IsReplayPlaying).toBe("No");
@@ -816,14 +845,14 @@ describe("flattenForDisplay", () => {
   });
 
   it("should not convert unknown integer fields to Yes/No", () => {
-    const result = flattenForDisplay({ Gear: 1, Lap: 0 });
+    const result = flattenContext({ Gear: 1, Lap: 0 }).display;
 
     expect(result.Gear).toBe("1");
     expect(result.Lap).toBe("0");
   });
 
   it("should skip null and undefined values", () => {
-    const result = flattenForDisplay({ a: null, b: undefined, c: "valid" } as Record<string, unknown>);
+    const result = flattenContext({ a: null, b: undefined, c: "valid" } as Record<string, unknown>).display;
 
     expect(result.a).toBeUndefined();
     expect(result.b).toBeUndefined();

--- a/packages/iracing-sdk/src/template-context.ts
+++ b/packages/iracing-sdk/src/template-context.ts
@@ -40,6 +40,10 @@ type DriverFieldValue = string | number | undefined;
 
 /**
  * Shared fields available for all driver groups.
+ *
+ * Must stay a `type` alias (not `interface`): only aliases get the implicit
+ * index signature needed for assignability to `Record<string, DriverFieldValue>`
+ * in `fieldsToMaps`.
  */
 type DriverFields = {
   name: string;
@@ -173,16 +177,6 @@ export function flattenContext(obj: Record<string, unknown>, options?: FlattenOp
 }
 
 /**
- * @internal Exported for testing
- *
- * Flattens a nested object into dot-notation keys with display-formatted string values.
- * Thin wrapper over flattenContext() returning only the display map.
- */
-export function flattenForDisplay(obj: Record<string, unknown>, options?: FlattenOptions): Record<string, string> {
-  return flattenContext(obj, options).display;
-}
-
-/**
  * Builds the full template context from current SDK state.
  */
 export function buildTemplateContext(sdkController: SDKController): TemplateContext {
@@ -209,17 +203,18 @@ export function prefixKeys<T>(prefix: string, record: Record<string, T>): Record
 
 /**
  * Converts a raw driver fields record into the display/raw map pair.
- * Display keeps every key (undefined renders ""); raw omits undefined keys so
- * expressions referencing them fail as unknown variables (rendering "").
+ * Display keeps every key (null/undefined render ""); raw omits null/undefined
+ * keys so expressions referencing them fail as unknown variables (rendering "").
+ * Runtime nulls from YAML session data are treated like undefined.
  */
 function fieldsToMaps(fields: Record<string, DriverFieldValue>): FieldMaps {
   const display: Record<string, string> = {};
   const raw: Record<string, TemplateValue> = {};
 
   for (const [key, value] of Object.entries(fields)) {
-    display[key] = value !== undefined ? String(value) : "";
+    display[key] = value != null ? String(value) : "";
 
-    if (value !== undefined) {
+    if (value != null) {
       raw[key] = value;
     }
   }
@@ -426,11 +421,11 @@ function buildDriverFields(driver: DriverEntry, telemetry: TelemetryData | null,
     last_name: lastName,
     abbrev_name: driver.AbbrevName,
     car_number: driver.CarNumber,
-    position: positions?.[driver.CarIdx] ?? telemetry?.CarIdxPosition?.[driver.CarIdx] ?? undefined,
-    class_position: telemetry?.CarIdxClassPosition?.[driver.CarIdx] ?? undefined,
-    lap: telemetry?.CarIdxLap?.[driver.CarIdx] ?? undefined,
-    laps_completed: telemetry?.CarIdxLapCompleted?.[driver.CarIdx] ?? undefined,
-    irating: driver.IRating ?? undefined,
+    position: positions?.[driver.CarIdx] ?? telemetry?.CarIdxPosition?.[driver.CarIdx],
+    class_position: telemetry?.CarIdxClassPosition?.[driver.CarIdx],
+    lap: telemetry?.CarIdxLap?.[driver.CarIdx],
+    laps_completed: telemetry?.CarIdxLapCompleted?.[driver.CarIdx],
+    irating: driver.IRating,
     license: driver.LicString ?? "",
   };
 }
@@ -453,7 +448,7 @@ function buildSelfFields(
     class_position: telemetry?.PlayerCarClassPosition ?? base.class_position,
     lap: telemetry?.Lap ?? base.lap,
     laps_completed: telemetry?.LapCompleted ?? base.laps_completed,
-    incidents: telemetry?.PlayerCarMyIncidentCount ?? undefined,
+    incidents: telemetry?.PlayerCarMyIncidentCount,
   };
 }
 

--- a/packages/iracing-sdk/src/template-context.ts
+++ b/packages/iracing-sdk/src/template-context.ts
@@ -2,41 +2,65 @@
  * Template Context Builder
  *
  * Assembles a template variable context from iRacing telemetry and session data.
- * Used by resolveTemplate() to hydrate {{variable}} placeholders.
+ * Used by resolveTemplate() to hydrate {{variable}} placeholders (display map)
+ * and {{= expression }} calculations (raw map).
  */
+import type { ExpressionValue } from "./expression-evaluator.js";
 import { calculateRacePositions } from "./position-utils.js";
 import type { SDKController } from "./SDKController.js";
 import { findNearestCarOnTrack } from "./track-utils.js";
 import type { SessionInfo, TelemetryData } from "./types.js";
 
+/** Value type for raw template-context entries. */
+export type TemplateValue = ExpressionValue;
+
+/**
+ * Flat template context — all keys use dot-notation (e.g., "self.name", "telemetry.Speed").
+ */
+export interface TemplateContext {
+  /** Display-formatted strings used by plain {{var}} placeholders. */
+  display: Record<string, string>;
+  /** Full-precision raw values used by {{= expr }} expressions. */
+  raw: Record<string, TemplateValue>;
+}
+
+/**
+ * A display/raw map pair for one context namespace.
+ */
+interface FieldMaps {
+  display: Record<string, string>;
+  raw: Record<string, TemplateValue>;
+}
+
+/**
+ * Raw driver field values — numeric fields stay numbers until display formatting.
+ * `undefined` means "unavailable": display renders "", raw omits the key.
+ */
+type DriverFieldValue = string | number | undefined;
+
 /**
  * Shared fields available for all driver groups.
  */
-interface DriverFields {
+type DriverFields = {
   name: string;
   first_name: string;
   last_name: string;
   abbrev_name: string;
   car_number: string;
-  position: string;
-  class_position: string;
-  lap: string;
-  laps_completed: string;
-  irating: string;
+  position: number | undefined;
+  class_position: number | undefined;
+  lap: number | undefined;
+  laps_completed: number | undefined;
+  irating: number | undefined;
   license: string;
-}
+};
 
 /**
  * Self driver extends DriverFields with additional player-specific data.
  */
-interface SelfDriverFields extends DriverFields {
-  incidents: string;
-}
-
-/**
- * Flat template context — all keys use dot-notation (e.g., "self.name", "telemetry.Speed").
- */
-export type TemplateContext = Record<string, string>;
+type SelfDriverFields = DriverFields & {
+  incidents: number | undefined;
+};
 
 interface DriverEntry {
   CarIdx: number;
@@ -55,17 +79,17 @@ const EMPTY_DRIVER_FIELDS: DriverFields = {
   last_name: "",
   abbrev_name: "",
   car_number: "",
-  position: "",
-  class_position: "",
-  lap: "",
-  laps_completed: "",
-  irating: "",
+  position: undefined,
+  class_position: undefined,
+  lap: undefined,
+  laps_completed: undefined,
+  irating: undefined,
   license: "",
 };
 
 const EMPTY_SELF_FIELDS: SelfDriverFields = {
   ...EMPTY_DRIVER_FIELDS,
-  incidents: "",
+  incidents: undefined,
 };
 
 /**
@@ -95,11 +119,15 @@ interface FlattenOptions {
 /**
  * @internal Exported for testing
  *
- * Flattens a nested object into dot-notation keys with display-formatted string values.
- * Skips arrays, filters keys by prefix, rounds floats to 2 decimals, converts booleans to Yes/No.
+ * Flattens a nested object into dot-notation keys, producing both maps in one walk:
+ * display-formatted strings (floats rounded to 2 decimals, booleans and known
+ * boolean-semantic integers as Yes/No) and full-precision raw values (numbers stay
+ * numbers — including BOOLEAN_INT_FIELDS, which stay 0/1 — booleans stay booleans,
+ * strings stay strings). Skips arrays and filters keys by prefix.
  */
-export function flattenForDisplay(obj: Record<string, unknown>, options?: FlattenOptions): Record<string, string> {
-  const result: Record<string, string> = {};
+export function flattenContext(obj: Record<string, unknown>, options?: FlattenOptions): FieldMaps {
+  const display: Record<string, string> = {};
+  const raw: Record<string, TemplateValue> = {};
   const prefix = options?.excludePrefix;
 
   function walk(current: Record<string, unknown>, path: string): void {
@@ -117,26 +145,41 @@ export function flattenForDisplay(obj: Record<string, unknown>, options?: Flatte
       }
 
       if (typeof value === "boolean") {
-        result[fullKey] = value ? "Yes" : "No";
+        display[fullKey] = value ? "Yes" : "No";
+        raw[fullKey] = value;
       } else if (typeof value === "number") {
         const leafKey = fullKey.includes(".") ? fullKey.substring(fullKey.lastIndexOf(".") + 1) : fullKey;
 
         if (BOOLEAN_INT_FIELDS.has(leafKey) && (value === 0 || value === 1)) {
-          result[fullKey] = value === 1 ? "Yes" : "No";
+          display[fullKey] = value === 1 ? "Yes" : "No";
         } else {
-          result[fullKey] = Number.isInteger(value) ? String(value) : value.toFixed(2);
+          display[fullKey] = Number.isInteger(value) ? String(value) : value.toFixed(2);
         }
+
+        raw[fullKey] = value;
       } else if (typeof value === "string") {
-        result[fullKey] = value;
+        display[fullKey] = value;
+        raw[fullKey] = value;
       } else if (value !== null && value !== undefined) {
-        result[fullKey] = String(value);
+        // Exotic primitive (e.g. bigint): display only — not a valid expression value.
+        display[fullKey] = String(value);
       }
     }
   }
 
   walk(obj, "");
 
-  return result;
+  return { display, raw };
+}
+
+/**
+ * @internal Exported for testing
+ *
+ * Flattens a nested object into dot-notation keys with display-formatted string values.
+ * Thin wrapper over flattenContext() returning only the display map.
+ */
+export function flattenForDisplay(obj: Record<string, unknown>, options?: FlattenOptions): Record<string, string> {
+  return flattenContext(obj, options).display;
 }
 
 /**
@@ -154,8 +197,8 @@ export function buildTemplateContext(sdkController: SDKController): TemplateCont
  *
  * Prefixes all keys in a record with a given prefix.
  */
-export function prefixKeys(prefix: string, record: Record<string, string>): Record<string, string> {
-  const result: Record<string, string> = {};
+export function prefixKeys<T>(prefix: string, record: Record<string, T>): Record<string, T> {
+  const result: Record<string, T> = {};
 
   for (const [key, value] of Object.entries(record)) {
     result[`${prefix}.${key}`] = value;
@@ -165,10 +208,34 @@ export function prefixKeys(prefix: string, record: Record<string, string>): Reco
 }
 
 /**
+ * Converts a raw driver fields record into the display/raw map pair.
+ * Display keeps every key (undefined renders ""); raw omits undefined keys so
+ * expressions referencing them fail as unknown variables (rendering "").
+ */
+function fieldsToMaps(fields: Record<string, DriverFieldValue>): FieldMaps {
+  const display: Record<string, string> = {};
+  const raw: Record<string, TemplateValue> = {};
+
+  for (const [key, value] of Object.entries(fields)) {
+    display[key] = value !== undefined ? String(value) : "";
+
+    if (value !== undefined) {
+      raw[key] = value;
+    }
+  }
+
+  return { display, raw };
+}
+
+function driverMaps(driver: DriverEntry | null, telemetry: TelemetryData | null, positions?: number[]): FieldMaps {
+  return fieldsToMaps(driver ? buildDriverFields(driver, telemetry, positions) : { ...EMPTY_DRIVER_FIELDS });
+}
+
+/**
  * @internal Exported for testing
  *
  * Builds template context from raw telemetry and session data.
- * Returns a single flat Record<string, string> with dot-notation keys.
+ * Returns the combined { display, raw } context with dot-notation keys in both maps.
  */
 export function buildTemplateContextFromData(
   telemetry: TelemetryData | null,
@@ -182,52 +249,62 @@ export function buildTemplateContextFromData(
   const positions = isRaceSession(sessionInfo, telemetry) ? resolveRacePositions(telemetry) : undefined;
 
   const selfDriver = drivers.find((d) => d.CarIdx === playerCarIdx);
-  const selfFields = buildSelfFields(selfDriver, playerCarIdx, telemetry, positions);
+  const self = fieldsToMaps(buildSelfFields(selfDriver, playerCarIdx, telemetry, positions));
 
-  const trackAhead = findNearestDriverOnTrack(playerCarIdx, drivers, telemetry, "ahead");
-  const trackBehind = findNearestDriverOnTrack(playerCarIdx, drivers, telemetry, "behind");
-  const raceAhead = findDriverByRacePosition(playerCarIdx, drivers, telemetry, -1, positions);
-  const raceBehind = findDriverByRacePosition(playerCarIdx, drivers, telemetry, +1, positions);
+  const trackAhead = driverMaps(
+    findNearestDriverOnTrack(playerCarIdx, drivers, telemetry, "ahead"),
+    telemetry,
+    positions,
+  );
+  const trackBehind = driverMaps(
+    findNearestDriverOnTrack(playerCarIdx, drivers, telemetry, "behind"),
+    telemetry,
+    positions,
+  );
+  const raceAhead = driverMaps(
+    findDriverByRacePosition(playerCarIdx, drivers, telemetry, -1, positions),
+    telemetry,
+    positions,
+  );
+  const raceBehind = driverMaps(
+    findDriverByRacePosition(playerCarIdx, drivers, telemetry, +1, positions),
+    telemetry,
+    positions,
+  );
 
   const sessionFields = buildSessionFields(sessionInfo, telemetry);
   const trackFields = buildTrackFields(sessionInfo);
 
+  const telemetryMaps = telemetry
+    ? flattenContext(telemetry as unknown as Record<string, unknown>, { excludePrefix: "CarIdx" })
+    : { display: {}, raw: {} };
+  const sessionInfoMaps = sessionInfo
+    ? flattenContext(sessionInfo as unknown as Record<string, unknown>)
+    : { display: {}, raw: {} };
+
   return {
-    ...prefixKeys("self", selfFields as unknown as Record<string, string>),
-    ...prefixKeys(
-      "track_ahead",
-      (trackAhead
-        ? buildDriverFields(trackAhead, telemetry, positions)
-        : { ...EMPTY_DRIVER_FIELDS }) as unknown as Record<string, string>,
-    ),
-    ...prefixKeys(
-      "track_behind",
-      (trackBehind
-        ? buildDriverFields(trackBehind, telemetry, positions)
-        : { ...EMPTY_DRIVER_FIELDS }) as unknown as Record<string, string>,
-    ),
-    ...prefixKeys(
-      "race_ahead",
-      (raceAhead
-        ? buildDriverFields(raceAhead, telemetry, positions)
-        : { ...EMPTY_DRIVER_FIELDS }) as unknown as Record<string, string>,
-    ),
-    ...prefixKeys(
-      "race_behind",
-      (raceBehind
-        ? buildDriverFields(raceBehind, telemetry, positions)
-        : { ...EMPTY_DRIVER_FIELDS }) as unknown as Record<string, string>,
-    ),
-    ...prefixKeys("session", sessionFields),
-    ...prefixKeys("track", trackFields),
-    ...prefixKeys(
-      "telemetry",
-      telemetry ? flattenForDisplay(telemetry as unknown as Record<string, unknown>, { excludePrefix: "CarIdx" }) : {},
-    ),
-    ...prefixKeys(
-      "sessionInfo",
-      sessionInfo ? flattenForDisplay(sessionInfo as unknown as Record<string, unknown>) : {},
-    ),
+    display: {
+      ...prefixKeys("self", self.display),
+      ...prefixKeys("track_ahead", trackAhead.display),
+      ...prefixKeys("track_behind", trackBehind.display),
+      ...prefixKeys("race_ahead", raceAhead.display),
+      ...prefixKeys("race_behind", raceBehind.display),
+      ...prefixKeys("session", sessionFields.display),
+      ...prefixKeys("track", trackFields),
+      ...prefixKeys("telemetry", telemetryMaps.display),
+      ...prefixKeys("sessionInfo", sessionInfoMaps.display),
+    },
+    raw: {
+      ...prefixKeys("self", self.raw),
+      ...prefixKeys("track_ahead", trackAhead.raw),
+      ...prefixKeys("track_behind", trackBehind.raw),
+      ...prefixKeys("race_ahead", raceAhead.raw),
+      ...prefixKeys("race_behind", raceBehind.raw),
+      ...prefixKeys("session", sessionFields.raw),
+      ...prefixKeys("track", trackFields),
+      ...prefixKeys("telemetry", telemetryMaps.raw),
+      ...prefixKeys("sessionInfo", sessionInfoMaps.raw),
+    },
   };
 }
 
@@ -349,11 +426,11 @@ function buildDriverFields(driver: DriverEntry, telemetry: TelemetryData | null,
     last_name: lastName,
     abbrev_name: driver.AbbrevName,
     car_number: driver.CarNumber,
-    position: positions?.[driver.CarIdx]?.toString() ?? telemetry?.CarIdxPosition?.[driver.CarIdx]?.toString() ?? "",
-    class_position: telemetry?.CarIdxClassPosition?.[driver.CarIdx]?.toString() ?? "",
-    lap: telemetry?.CarIdxLap?.[driver.CarIdx]?.toString() ?? "",
-    laps_completed: telemetry?.CarIdxLapCompleted?.[driver.CarIdx]?.toString() ?? "",
-    irating: driver.IRating?.toString() ?? "",
+    position: positions?.[driver.CarIdx] ?? telemetry?.CarIdxPosition?.[driver.CarIdx] ?? undefined,
+    class_position: telemetry?.CarIdxClassPosition?.[driver.CarIdx] ?? undefined,
+    lap: telemetry?.CarIdxLap?.[driver.CarIdx] ?? undefined,
+    laps_completed: telemetry?.CarIdxLapCompleted?.[driver.CarIdx] ?? undefined,
+    irating: driver.IRating ?? undefined,
     license: driver.LicString ?? "",
   };
 }
@@ -371,12 +448,12 @@ function buildSelfFields(
   return {
     ...base,
     position: telemetry?.OnPitRoad
-      ? (telemetry?.PlayerCarPosition?.toString() ?? base.position)
-      : (positions?.[playerCarIdx]?.toString() ?? telemetry?.PlayerCarPosition?.toString() ?? base.position),
-    class_position: telemetry?.PlayerCarClassPosition?.toString() ?? base.class_position,
-    lap: telemetry?.Lap?.toString() ?? base.lap,
-    laps_completed: telemetry?.LapCompleted?.toString() ?? base.laps_completed,
-    incidents: telemetry?.PlayerCarMyIncidentCount?.toString() ?? "",
+      ? (telemetry?.PlayerCarPosition ?? base.position)
+      : (positions?.[playerCarIdx] ?? telemetry?.PlayerCarPosition ?? base.position),
+    class_position: telemetry?.PlayerCarClassPosition ?? base.class_position,
+    lap: telemetry?.Lap ?? base.lap,
+    laps_completed: telemetry?.LapCompleted ?? base.laps_completed,
+    incidents: telemetry?.PlayerCarMyIncidentCount ?? undefined,
   };
 }
 
@@ -397,16 +474,31 @@ function isRaceSession(sessionInfo: SessionInfo | null, telemetry: TelemetryData
   return (getCurrentSession(sessionInfo, telemetry)?.SessionType as string) === "Race";
 }
 
-function buildSessionFields(sessionInfo: SessionInfo | null, telemetry: TelemetryData | null): Record<string, string> {
+function buildSessionFields(sessionInfo: SessionInfo | null, telemetry: TelemetryData | null): FieldMaps {
   const currentSession = getCurrentSession(sessionInfo, telemetry);
 
   const lapsRemaining = telemetry?.SessionLapsRemainEx;
   const timeRemaining = telemetry?.SessionTimeRemain;
 
+  const type = (currentSession?.SessionType as string) ?? "";
+  const hasLapsRemaining = lapsRemaining !== undefined && lapsRemaining >= 0;
+  // time_remaining keeps the formatted M:SS string in BOTH maps — expressions
+  // wanting math on it should use telemetry.SessionTimeRemain instead.
+  const timeRemainingFormatted = formatTimeRemaining(timeRemaining);
+
+  const raw: Record<string, TemplateValue> = { type, time_remaining: timeRemainingFormatted };
+
+  if (hasLapsRemaining) {
+    raw.laps_remaining = lapsRemaining;
+  }
+
   return {
-    type: (currentSession?.SessionType as string) ?? "",
-    laps_remaining: lapsRemaining !== undefined && lapsRemaining >= 0 ? String(lapsRemaining) : "",
-    time_remaining: formatTimeRemaining(timeRemaining),
+    display: {
+      type,
+      laps_remaining: hasLapsRemaining ? String(lapsRemaining) : "",
+      time_remaining: timeRemainingFormatted,
+    },
+    raw,
   };
 }
 

--- a/packages/iracing-sdk/src/template-resolver.test.ts
+++ b/packages/iracing-sdk/src/template-resolver.test.ts
@@ -140,4 +140,14 @@ describe("resolveTemplate expression integration", () => {
   it("should leave an unclosed expression marker verbatim", () => {
     expect(resolveTemplate("{{= 1 + 2", ctx({}))).toBe("{{= 1 + 2");
   });
+
+  it("should leave over-limit expressions verbatim", () => {
+    const longExpr = "1".repeat(1001);
+
+    expect(resolveTemplate(`{{= ${longExpr} }}`, ctx({}))).toBe(`{{= ${longExpr} }}`);
+  });
+
+  it("should end the expression at the first }}, even inside a string literal", () => {
+    expect(resolveTemplate("{{= 'a }} b' }}", ctx({}))).toBe("{{= 'a }} b' }}");
+  });
 });

--- a/packages/iracing-sdk/src/template-resolver.test.ts
+++ b/packages/iracing-sdk/src/template-resolver.test.ts
@@ -1,84 +1,140 @@
 import { describe, expect, it } from "vitest";
 
+import type { TemplateContext, TemplateValue } from "./template-context.js";
 import { resolvePathValue, resolveTemplate } from "./template-resolver.js";
+
+/** Builds a combined context from a display map (raw defaults to empty). */
+function ctx(display: Record<string, unknown>, raw: Record<string, TemplateValue> = {}): TemplateContext {
+  return { display: display as Record<string, string>, raw };
+}
 
 describe("resolveTemplate", () => {
   it("should replace a simple flat variable", () => {
-    expect(resolveTemplate("Hello {{name}}", { name: "World" })).toBe("Hello World");
+    expect(resolveTemplate("Hello {{name}}", ctx({ name: "World" }))).toBe("Hello World");
   });
 
   it("should replace dot-notation variables via flat key lookup", () => {
-    const context = { "self.first_name": "John", "self.position": "3" };
+    const context = ctx({ "self.first_name": "John", "self.position": "3" });
 
     expect(resolveTemplate("P{{self.position}} - {{self.first_name}}", context)).toBe("P3 - John");
   });
 
   it("should replace the same variable used multiple times", () => {
-    expect(resolveTemplate("{{x}} and {{x}}", { x: "ok" })).toBe("ok and ok");
+    expect(resolveTemplate("{{x}} and {{x}}", ctx({ x: "ok" }))).toBe("ok and ok");
   });
 
   it("should replace multiple different variables", () => {
-    const context = { a: "1", b: "2", c: "3" };
+    const context = ctx({ a: "1", b: "2", c: "3" });
 
     expect(resolveTemplate("{{a}}-{{b}}-{{c}}", context)).toBe("1-2-3");
   });
 
   it("should replace missing variables with empty string", () => {
-    expect(resolveTemplate("Hello {{missing}}", {})).toBe("Hello ");
+    expect(resolveTemplate("Hello {{missing}}", ctx({}))).toBe("Hello ");
   });
 
   it("should replace missing dot-notation key with empty string", () => {
-    const context = { "self.name": "John" };
+    const context = ctx({ "self.name": "John" });
 
     expect(resolveTemplate("{{self.nonexistent}}", context)).toBe("");
   });
 
   it("should replace deeply nested dot-notation key with empty string when missing", () => {
-    const context = { "a.b": "value" };
+    const context = ctx({ "a.b": "value" });
 
     expect(resolveTemplate("{{a.b.c.d}}", context)).toBe("");
   });
 
   it("should resolve deeply nested dot-notation keys", () => {
-    const context = { "sessionInfo.CarSetup.TiresAero.TireType.TireType": "Dry" };
+    const context = ctx({ "sessionInfo.CarSetup.TiresAero.TireType.TireType": "Dry" });
 
     expect(resolveTemplate("{{sessionInfo.CarSetup.TiresAero.TireType.TireType}}", context)).toBe("Dry");
   });
 
   it("should return template unchanged when no placeholders present", () => {
-    expect(resolveTemplate("plain text", { foo: "bar" })).toBe("plain text");
+    expect(resolveTemplate("plain text", ctx({ foo: "bar" }))).toBe("plain text");
   });
 
   it("should handle empty template", () => {
-    expect(resolveTemplate("", { foo: "bar" })).toBe("");
+    expect(resolveTemplate("", ctx({ foo: "bar" }))).toBe("");
   });
 
   it("should handle template with only a variable", () => {
-    expect(resolveTemplate("{{name}}", { name: "John" })).toBe("John");
+    expect(resolveTemplate("{{name}}", ctx({ name: "John" }))).toBe("John");
   });
 
   it("should convert numbers to strings", () => {
-    expect(resolveTemplate("P{{pos}}", { pos: 5 })).toBe("P5");
+    expect(resolveTemplate("P{{pos}}", ctx({ pos: 5 }))).toBe("P5");
   });
 
   it("should replace null values with empty string", () => {
-    expect(resolveTemplate("{{val}}", { val: null })).toBe("");
+    expect(resolveTemplate("{{val}}", ctx({ val: null }))).toBe("");
   });
 
   it("should replace undefined values with empty string", () => {
-    expect(resolveTemplate("{{val}}", { val: undefined })).toBe("");
+    expect(resolveTemplate("{{val}}", ctx({ val: undefined }))).toBe("");
   });
 
   it("should not match malformed placeholders", () => {
-    expect(resolveTemplate("{{missing}", {})).toBe("{{missing}");
-    expect(resolveTemplate("{missing}}", {})).toBe("{missing}}");
-    expect(resolveTemplate("{{ spaced }}", {})).toBe("{{ spaced }}");
+    expect(resolveTemplate("{{missing}", ctx({}))).toBe("{{missing}");
+    expect(resolveTemplate("{missing}}", ctx({}))).toBe("{missing}}");
+    expect(resolveTemplate("{{ spaced }}", ctx({}))).toBe("{{ spaced }}");
   });
 
   it("should support underscores in variable names", () => {
-    const context = { "self.first_name": "John" };
+    const context = ctx({ "self.first_name": "John" });
 
     expect(resolveTemplate("{{self.first_name}}", context)).toBe("John");
+  });
+});
+
+describe("resolveTemplate expression integration", () => {
+  it("should resolve mixed variable and expression placeholders", () => {
+    const context = ctx({ "self.first_name": "John" }, { "telemetry.Speed": 43.5 });
+
+    expect(resolveTemplate("{{self.first_name}}: {{= round(telemetry.Speed * 3.6, 0) }}", context)).toBe("John: 157");
+  });
+
+  it("should resolve expressions without spaces around the delimiters", () => {
+    expect(resolveTemplate("{{=1+2}}", ctx({}))).toBe("3");
+  });
+
+  it("should resolve expressions with spaces around the delimiters", () => {
+    expect(resolveTemplate("{{= 1 + 2 }}", ctx({}))).toBe("3");
+  });
+
+  it("should resolve multiline templates with expressions and variables on different lines", () => {
+    const context = ctx({ "self.name": "John Smith" }, { "telemetry.Speed": 50.4 });
+
+    const result = resolveTemplate("Speed: {{= round(telemetry.Speed, 0) }}\nDriver: {{self.name}}", context);
+
+    expect(result).toBe("Speed: 50\nDriver: John Smith");
+  });
+
+  it("should resolve multiple expressions in one template", () => {
+    expect(resolveTemplate("{{= 1 + 1 }}|{{= 2 * 3 }}", ctx({}))).toBe("2|6");
+  });
+
+  it("should leave a parse-error placeholder verbatim while other placeholders resolve", () => {
+    const context = ctx({ name: "John" }, { x: 2 });
+
+    expect(resolveTemplate("{{= 1 + }} {{name}} {{= x * 2 }}", context)).toBe("{{= 1 + }} John 4");
+  });
+
+  it("should render empty string for a runtime error (unknown variable) in that placeholder only", () => {
+    const context = ctx({ name: "John" });
+
+    expect(resolveTemplate("[{{= missing.var + 1 }}] {{name}}", context)).toBe("[] John");
+  });
+
+  it("should still render plain spaced placeholders literally", () => {
+    expect(resolveTemplate("{{ spaced }}", ctx({ spaced: "value" }))).toBe("{{ spaced }}");
+  });
+
+  it("should resolve expressions with string literals", () => {
+    const context = ctx({}, { "telemetry.OnPitRoad": 1 });
+
+    expect(resolveTemplate("{{= telemetry.OnPitRoad == 1 ? 'PIT' : '' }}", context)).toBe("PIT");
   });
 });
 

--- a/packages/iracing-sdk/src/template-resolver.test.ts
+++ b/packages/iracing-sdk/src/template-resolver.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { TemplateContext, TemplateValue } from "./template-context.js";
-import { resolvePathValue, resolveTemplate } from "./template-resolver.js";
+import { resolveTemplate } from "./template-resolver.js";
 
 /** Builds a combined context from a display map (raw defaults to empty). */
 function ctx(display: Record<string, unknown>, raw: Record<string, TemplateValue> = {}): TemplateContext {
@@ -136,22 +136,8 @@ describe("resolveTemplate expression integration", () => {
 
     expect(resolveTemplate("{{= telemetry.OnPitRoad == 1 ? 'PIT' : '' }}", context)).toBe("PIT");
   });
-});
 
-describe("resolvePathValue", () => {
-  it("should resolve a flat key", () => {
-    expect(resolvePathValue({ name: "John" }, "name")).toBe("John");
-  });
-
-  it("should resolve a dot-notation flat key", () => {
-    expect(resolvePathValue({ "a.b.c": "deep" }, "a.b.c")).toBe("deep");
-  });
-
-  it("should return undefined for missing key", () => {
-    expect(resolvePathValue({}, "missing")).toBeUndefined();
-  });
-
-  it("should return undefined for missing dot-notation key", () => {
-    expect(resolvePathValue({ "a.b": "value" }, "a.b.c")).toBeUndefined();
+  it("should leave an unclosed expression marker verbatim", () => {
+    expect(resolveTemplate("{{= 1 + 2", ctx({}))).toBe("{{= 1 + 2");
   });
 });

--- a/packages/iracing-sdk/src/template-resolver.ts
+++ b/packages/iracing-sdk/src/template-resolver.ts
@@ -17,13 +17,16 @@
  *
  * Pure string processing — no SDK or telemetry dependency.
  */
-import { resolveExpression } from "./expression-evaluator.js";
+import { MAX_EXPRESSION_LENGTH, resolveExpression } from "./expression-evaluator.js";
 import type { TemplateContext } from "./template-context.js";
 
-// The {0,1000} bound mirrors the evaluator's MAX_EXPRESSION_LENGTH (1000) so an
+// The expression branch's scan is bounded to MAX_EXPRESSION_LENGTH so an
 // unclosed `{{=` marker can't trigger a long scan; an over-long or unclosed
 // expression simply stays verbatim (same visible outcome as a parse error).
-const TEMPLATE_PATTERN = /\{\{=([\s\S]{0,1000}?)\}\}|\{\{([a-zA-Z0-9_.]+)\}\}/g;
+const TEMPLATE_PATTERN = new RegExp(
+  `\\{\\{=([\\s\\S]{0,${MAX_EXPRESSION_LENGTH}}?)\\}\\}|\\{\\{([a-zA-Z0-9_.]+)\\}\\}`,
+  "g",
+);
 
 /**
  * Resolves {{dot.notation}} and {{= expression }} placeholders in a template string.

--- a/packages/iracing-sdk/src/template-resolver.ts
+++ b/packages/iracing-sdk/src/template-resolver.ts
@@ -20,7 +20,10 @@
 import { resolveExpression } from "./expression-evaluator.js";
 import type { TemplateContext } from "./template-context.js";
 
-const TEMPLATE_PATTERN = /\{\{=([\s\S]*?)\}\}|\{\{([a-zA-Z0-9_.]+)\}\}/g;
+// The {0,1000} bound mirrors the evaluator's MAX_EXPRESSION_LENGTH (1000) so an
+// unclosed `{{=` marker can't trigger a long scan; an over-long or unclosed
+// expression simply stays verbatim (same visible outcome as a parse error).
+const TEMPLATE_PATTERN = /\{\{=([\s\S]{0,1000}?)\}\}|\{\{([a-zA-Z0-9_.]+)\}\}/g;
 
 /**
  * Resolves {{dot.notation}} and {{= expression }} placeholders in a template string.
@@ -39,15 +42,6 @@ export function resolveTemplate(template: string, context: TemplateContext): str
 
     const value = context.display[path as string];
 
-    return value !== undefined && value !== null ? String(value) : "";
+    return value ?? "";
   });
-}
-
-/**
- * @internal Exported for testing
- *
- * Looks up a dot-notation key in a flat record.
- */
-export function resolvePathValue(obj: Record<string, unknown>, path: string): unknown {
-  return obj[path];
 }

--- a/packages/iracing-sdk/src/template-resolver.ts
+++ b/packages/iracing-sdk/src/template-resolver.ts
@@ -1,22 +1,43 @@
 /**
  * Template Resolver
  *
- * General-purpose template resolution with {{dot.notation}} variable support.
+ * General-purpose template resolution with two placeholder kinds:
+ *
+ * - `{{dot.notation}}` — variable lookup against the context's display map
+ *   (display-formatted strings). Unresolved variables become empty strings.
+ * - `{{= expression }}` — safe expression evaluated against the context's raw
+ *   map (full-precision values).
+ *
+ * Expression error behavior is hybrid: a parse error (typo in the expression)
+ * leaves the `{{= ... }}` placeholder verbatim in the output so the mistake is
+ * visible; a runtime error (e.g. unknown variable) renders an empty string.
+ *
+ * Limitation: `}}` cannot appear inside an expression's string literal — the
+ * placeholder ends at the first `}}`.
+ *
  * Pure string processing — no SDK or telemetry dependency.
  */
+import { resolveExpression } from "./expression-evaluator.js";
+import type { TemplateContext } from "./template-context.js";
+
+const TEMPLATE_PATTERN = /\{\{=([\s\S]*?)\}\}|\{\{([a-zA-Z0-9_.]+)\}\}/g;
 
 /**
- * Resolves {{dot.notation}} placeholders in a template string.
- * Walks nested objects using dot-separated paths.
- * Unresolved variables become empty strings.
+ * Resolves {{dot.notation}} and {{= expression }} placeholders in a template string.
  *
- * @param template - String with {{variable}} placeholders
- * @param context - Nested object with values to substitute
+ * @param template - String with {{variable}} and/or {{= expression }} placeholders
+ * @param context - Combined template context (display strings + raw values)
  * @returns Resolved string with all placeholders replaced
  */
-export function resolveTemplate(template: string, context: object): string {
-  return template.replace(/\{\{([a-zA-Z0-9_.]+)\}\}/g, (_match, path: string) => {
-    const value = resolvePathValue(context as Record<string, unknown>, path);
+export function resolveTemplate(template: string, context: TemplateContext): string {
+  return template.replace(TEMPLATE_PATTERN, (match, expr: string | undefined, path: string | undefined) => {
+    if (expr !== undefined) {
+      const result = resolveExpression(expr, context.raw);
+
+      return result === null ? match : result;
+    }
+
+    const value = context.display[path as string];
 
     return value !== undefined && value !== null ? String(value) : "";
   });

--- a/packages/website/src/content/docs/docs/actions/display-session/telemetry-display.md
+++ b/packages/website/src/content/docs/docs/actions/display-session/telemetry-display.md
@@ -35,6 +35,8 @@ The Mustache template used to render the value. Defaults to `#{{self.car_number}
 
 Multi-line output is supported — newlines in the rendered output stack vertically on the button.
 
+Templates also support calculated values with the `{{= … }}` expression syntax — arithmetic, conditionals, and functions like `round()`. For example, `{{= round(telemetry.Speed * 3.6, 0) }}` shows your speed in km/h. See [Expressions](/docs/features/template-variables/#expressions) for the full syntax.
+
 #### Setting: Font Size
 
 The font size for the rendered value. Defaults to `15`. Adjust to fit more text on the button or to make small values easier to read at a glance.

--- a/packages/website/src/content/docs/docs/features/template-variables.md
+++ b/packages/website/src/content/docs/docs/features/template-variables.md
@@ -41,13 +41,13 @@ Templates also support calculated values with the `{{= expression }}` syntax. Th
 
 ### Result formatting
 
-Whole-number results render bare (`5`); other numbers render with 2 decimals by default (`0.33`). `round(x, decimals)` renders with exactly that many decimals — `{{= round(10 / 2, 1) }}` renders `5.0`. Boolean results render `Yes`/`No`.
+Whole-number results render bare (`5`); other numbers render with 2 decimals by default (`0.33`). `round(x, decimals)` renders with exactly that many decimals when it is the outermost part of the expression (or the chosen branch of a ternary) — `{{= round(10 / 2, 1) }}` renders `5.0`. When its result feeds another operator (like `+` concatenation), the decimals hint is dropped and the final value uses the default formatting instead. Boolean results render `Yes`/`No`.
 
 ### Expressions use raw values
 
 Expressions compute on the raw, full-precision values — not the display-formatted strings that plain `{{variable}}` placeholders show. This has two consequences:
 
-- `{{= telemetry.Speed }}` can show more precision than `{{telemetry.Speed}}`: the plain placeholder rounds floating-point values to 2 decimals for display, while inside an expression the input keeps its full precision and only the end result gets default formatting. Use `round()` when you want controlled output.
+- Intermediate math is exact: `{{= round(telemetry.Speed * 3.6, 0) }}` multiplies the full-precision speed by 3.6 before rounding — not the 2-decimal value that `{{telemetry.Speed}}` displays. Only the final result gets display formatting, so a bare `{{= telemetry.Speed }}` renders the same as `{{telemetry.Speed}}`.
 - Boolean-ish telemetry flags are `0`/`1` (or true/false) inside expressions, not `"Yes"`/`"No"`. Compare against the number: `{{= telemetry.OnPitRoad == 1 ? 'PIT' : '' }}`.
 
 ### Errors
@@ -78,10 +78,10 @@ Show `PIT` while on pit road, otherwise nothing:
 {{= telemetry.OnPitRoad == 1 ? 'PIT' : '' }}
 ```
 
-Fuel level with a unit suffix:
+Fuel level in whole liters with a unit suffix (renders e.g. `42 L`):
 
 ```text
-{{= round(telemetry.FuelLevel, 1) + ' L' }}
+{{= round(telemetry.FuelLevel) + ' L' }}
 ```
 
 ## Driver Info

--- a/packages/website/src/content/docs/docs/features/template-variables.md
+++ b/packages/website/src/content/docs/docs/features/template-variables.md
@@ -1,13 +1,88 @@
 ---
 title: Template Variables
-description: iRacing telemetry and session variables available for Mustache templates in Telemetry Display and Chat actions.
+description: iRacing telemetry and session variables available for Mustache templates in Telemetry Display and Chat actions, plus expression syntax for calculated values.
 ---
 
-These are the variables available for use in Mustache templates. Use them with the `{{variable}}` syntax to display live iRacing data on your Stream Deck buttons or include dynamic values in chat messages.
+These are the variables available for use in Mustache templates. Use them with the `{{variable}}` syntax to display live iRacing data on your Stream Deck buttons or include dynamic values in chat messages, or compute calculated values with the `{{= expression }}` syntax (see [Expressions](#expressions)).
 
 Template variables are supported by:
 - [Telemetry Display](/docs/actions/display-session/telemetry-display/) — show any variable on a Stream Deck button
 - [Chat](/docs/actions/communication/chat/) — include variables in custom chat messages
+
+## Expressions
+
+Templates also support calculated values with the `{{= expression }}` syntax. The `=` must immediately follow the `{{` (no space before it); whitespace inside the expression is fine. Inside an expression, variables are referenced bare with dot notation — no inner braces:
+
+```text
+{{= telemetry.Speed * 3.6 }}
+```
+
+### Operators
+
+| Operator | Description |
+|----------|-------------|
+| `+` `-` `*` `/` `%` | Arithmetic; `+` also concatenates strings |
+| `(` `)` | Grouping |
+| `>` `<` `>=` `<=` `==` `!=` | Comparisons |
+| `condition ? a : b` | Conditional (ternary) |
+| `'text'` or `"text"` | String literals (single or double quotes) |
+
+### Functions
+
+| Function | Description |
+|----------|-------------|
+| `round(x)` | Round to the nearest whole number |
+| `round(x, decimals)` | Round to a fixed number of decimals; `decimals` must be a literal integer between 0 and 20 |
+| `floor(x)` | Round down |
+| `ceil(x)` | Round up |
+| `abs(x)` | Absolute value |
+| `min(a, b, …)` | Smallest of two or more values |
+| `max(a, b, …)` | Largest of two or more values |
+
+### Result formatting
+
+Whole-number results render bare (`5`); other numbers render with 2 decimals by default (`0.33`). `round(x, decimals)` renders with exactly that many decimals — `{{= round(10 / 2, 1) }}` renders `5.0`. Boolean results render `Yes`/`No`.
+
+### Expressions use raw values
+
+Expressions compute on the raw, full-precision values — not the display-formatted strings that plain `{{variable}}` placeholders show. This has two consequences:
+
+- `{{= telemetry.Speed }}` can show more precision than `{{telemetry.Speed}}`: the plain placeholder rounds floating-point values to 2 decimals for display, while inside an expression the input keeps its full precision and only the end result gets default formatting. Use `round()` when you want controlled output.
+- Boolean-ish telemetry flags are `0`/`1` (or true/false) inside expressions, not `"Yes"`/`"No"`. Compare against the number: `{{= telemetry.OnPitRoad == 1 ? 'PIT' : '' }}`.
+
+### Errors
+
+A syntax error (a typo in the expression) leaves the raw `{{= ... }}` text visible on the key so you can spot the mistake. An evaluation problem (unknown variable, division by zero) renders as empty text.
+
+### Limits
+
+Expressions are limited to 1000 characters, and the sequence `}}` cannot appear inside a string literal — the placeholder ends at the first `}}`.
+
+### Examples
+
+Speed in km/h, rounded to a whole number:
+
+```text
+{{= round(telemetry.Speed * 3.6, 0) }}
+```
+
+Fuel to add, converted from kilograms to US gallons with one decimal:
+
+```text
+{{= round(telemetry.dpFuelAddKg / (sessionInfo.DriverInfo.DriverCarFuelKgPerLtr * 0.264172), 1) }}
+```
+
+Show `PIT` while on pit road, otherwise nothing:
+
+```text
+{{= telemetry.OnPitRoad == 1 ? 'PIT' : '' }}
+```
+
+Fuel level with a unit suffix:
+
+```text
+{{= round(telemetry.FuelLevel, 1) + ' L' }}
+```
 
 ## Driver Info
 

--- a/packages/website/src/content/docs/docs/features/template-variables.md
+++ b/packages/website/src/content/docs/docs/features/template-variables.md
@@ -69,7 +69,7 @@ Speed in km/h, rounded to a whole number:
 Fuel to add, converted from kilograms to US gallons with one decimal:
 
 ```text
-{{= round(telemetry.dpFuelAddKg / (sessionInfo.DriverInfo.DriverCarFuelKgPerLtr * 0.264172), 1) }}
+{{= round(telemetry.dpFuelAddKg / (sessionInfo.DriverInfo.DriverCarFuelKgPerLtr * 3.78541), 1) }}
 ```
 
 Show `PIT` while on pit road, otherwise nothing:

--- a/packages/website/src/content/docs/docs/features/template-variables.md
+++ b/packages/website/src/content/docs/docs/features/template-variables.md
@@ -1,6 +1,6 @@
 ---
 title: Template Variables
-description: iRacing telemetry and session variables available for Mustache templates in Telemetry Display and Chat actions, plus expression syntax for calculated values.
+description: iRacing telemetry and session variables available for Mustache templates in the Telemetry Display, Chat, and Race Admin actions, plus expression syntax for calculated values.
 ---
 
 These are the variables available for use in Mustache templates. Use them with the `{{variable}}` syntax to display live iRacing data on your Stream Deck buttons or include dynamic values in chat messages, or compute calculated values with the `{{= expression }}` syntax (see [Expressions](#expressions)).
@@ -8,6 +8,7 @@ These are the variables available for use in Mustache templates. Use them with t
 Template variables are supported by:
 - [Telemetry Display](/docs/actions/display-session/telemetry-display/) — show any variable on a Stream Deck button
 - [Chat](/docs/actions/communication/chat/) — include variables in custom chat messages
+- [Race Admin](/docs/actions/communication/race-admin/) — include variables in admin message templates
 
 ## Expressions
 
@@ -41,7 +42,7 @@ Templates also support calculated values with the `{{= expression }}` syntax. Th
 
 ### Result formatting
 
-Whole-number results render bare (`5`); other numbers render with 2 decimals by default (`0.33`). `round(x, decimals)` renders with exactly that many decimals when it is the outermost part of the expression (or the chosen branch of a ternary) — `{{= round(10 / 2, 1) }}` renders `5.0`. When its result feeds another operator (like `+` concatenation), the decimals hint is dropped and the final value uses the default formatting instead. Boolean results render `Yes`/`No`.
+Whole-number results render bare (`5`); other numbers render with 2 decimals by default (`0.33`). `round(x, decimals)` renders with exactly that many decimals when it is the outermost part of the expression (or the chosen branch of a ternary) — `{{= round(10 / 2, 1) }}` renders `5.0`. When its result feeds another operator or function (like `+` concatenation or `abs(...)`), the decimals hint is dropped and the final value uses the default formatting instead. Boolean results render `Yes`/`No`.
 
 ### Expressions use raw values
 

--- a/packages/website/src/content/docs/docs/features/template-variables.md
+++ b/packages/website/src/content/docs/docs/features/template-variables.md
@@ -50,6 +50,7 @@ Expressions compute on the raw, full-precision values — not the display-format
 
 - Intermediate math is exact: `{{= round(telemetry.Speed * 3.6, 0) }}` multiplies the full-precision speed by 3.6 before rounding — not the 2-decimal value that `{{telemetry.Speed}}` displays. Only the final result gets display formatting, so a bare `{{= telemetry.Speed }}` renders the same as `{{telemetry.Speed}}`.
 - Boolean-ish telemetry flags are `0`/`1` (or true/false) inside expressions, not `"Yes"`/`"No"`. Compare against the number: `{{= telemetry.OnPitRoad == 1 ? 'PIT' : '' }}`.
+- A few convenience variables are pre-formatted strings even in expressions — notably `session.time_remaining` (`M:SS`), which is not usable for math. Use the underlying telemetry value instead, e.g. `{{= round(telemetry.SessionTimeRemain / 60, 0) }}` for whole minutes.
 
 ### Errors
 

--- a/packages/website/src/content/docs/docs/features/template-variables.md
+++ b/packages/website/src/content/docs/docs/features/template-variables.md
@@ -42,7 +42,7 @@ Templates also support calculated values with the `{{= expression }}` syntax. Th
 
 ### Result formatting
 
-Whole-number results render bare (`5`); other numbers render with 2 decimals by default (`0.33`). `round(x, decimals)` renders with exactly that many decimals when it is the outermost part of the expression (or the chosen branch of a ternary) — `{{= round(10 / 2, 1) }}` renders `5.0`. When its result feeds another operator or function (like `+` concatenation or `abs(...)`), the decimals hint is dropped and the final value uses the default formatting instead. Boolean results render `Yes`/`No`.
+Whole-number results render bare (`5`); other numbers render with 2 decimals by default (`0.33`). `round(x, decimals)` renders with exactly that many decimals wherever its result becomes text — as the expression's final result, the chosen branch of a ternary, or an operand of string concatenation: `{{= round(10 / 2, 1) }}` renders `5.0`, and `{{= round(telemetry.FuelLevel, 1) + ' L' }}` renders e.g. `42.4 L`. In numeric contexts (arithmetic, comparisons, function arguments) only the numeric value carries on. Boolean results render `Yes`/`No`.
 
 ### Expressions use raw values
 
@@ -80,10 +80,10 @@ Show `PIT` while on pit road, otherwise nothing:
 {{= telemetry.OnPitRoad == 1 ? 'PIT' : '' }}
 ```
 
-Fuel level in whole liters with a unit suffix (renders e.g. `42 L`):
+Fuel level with one decimal and a unit suffix (renders e.g. `42.4 L`):
 
 ```text
-{{= round(telemetry.FuelLevel) + ' L' }}
+{{= round(telemetry.FuelLevel, 1) + ' L' }}
 ```
 
 ## Driver Info


### PR DESCRIPTION
## Related Issue

Fixes #192

## What changed?

Templates in the Telemetry Display, Chat, and Race Admin actions now support safe expression evaluation with the `{{= expression }}` syntax alongside plain `{{variable}}` placeholders.

- New hand-rolled expression evaluator in `@iracedeck/iracing-sdk` (`expression-evaluator.ts`): tokenizer + recursive-descent parser + evaluator with a 200-entry AST cache. No `eval()`/`new Function()`, zero new dependencies, hardened against prototype-chain lookups and oversized input (1000-char cap).
- Full feature set: arithmetic `+ - * / %`, parentheses, numeric/string literals, dot-notation variable references, comparisons, ternary, `round/floor/ceil/abs/min/max`, and string concatenation via `+`.
- `TemplateContext` became a combined `{ display, raw }` object built in a single walk, so expressions compute on raw full-precision values while plain `{{variable}}` display output stays byte-identical. Zero changes to any action source file — Chat and Race Admin gain expressions transparently through the shared resolver.
- Hybrid error model: a syntax error leaves the raw `{{= … }}` text visible on the key (typo feedback); evaluation problems (unknown variable, division by zero) render as empty text.
- Result formatting matches existing display conventions: integers bare, floats 2 decimals by default, `round(x, n)` renders exactly n decimals, booleans render Yes/No.
- Docs: new Expressions section on the website template-variables page, Telemetry Display action page update, PI help blurbs (Telemetry Display, Chat, Race Admin), skill updates, and a design doc under `docs/plans/`. The issue's fuel example formula was corrected during implementation (kg ÷ (kg/L × 3.78541) — the issue's original constant overstated gallons ~14×).

## How to test

1. Add a Telemetry Display key with template `{{= round(telemetry.dpFuelAddKg / (sessionInfo.DriverInfo.DriverCarFuelKgPerLtr * 3.78541), 1) }}` and verify it shows fuel-to-add in gallons, updating live.
2. Try `{{= round(telemetry.Speed * 3.6, 0) }}` for km/h and `{{= telemetry.OnPitRoad == 1 ? 'PIT' : '' }}` for conditional display.
3. Type a deliberate syntax error (e.g. `{{= round(telemetry.Speed, }}`) and verify the raw text stays visible on the key.
4. Use a `{{= … }}` expression inside a Chat message template and verify it resolves when sent.
5. `pnpm build` (18/18) and `pnpm test` (5268 tests) pass.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added template expressions (`{{= ... }}`) for dynamic calculations in Chat, Race Admin, and Telemetry Display. Supports arithmetic, comparisons, ternary, and math functions (`round`, `floor`, `ceil`, `abs`, `min`, `max`).

* **Behavior Changes**
  * Expressions evaluate against raw full‑precision telemetry (not display-formatted values). Parse errors leave the placeholder verbatim; runtime errors render as an empty string.

* **Documentation**
  * UI help text and docs updated with syntax, examples, and limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->