### PR TITLE
chore(website): track plugin download clicks in Google Analytics (#685)

### DIFF
--- a/packages/website/src/components/DownloadLink.astro
+++ b/packages/website/src/components/DownloadLink.astro
@@ -1,0 +1,55 @@
+---
+// Renders a download / install link and reports a GA4 `file_download` event when
+// it is clicked, so install activity can be broken down by platform, install
+// method, and the app version that was current at the time. A single bundled
+// <script> (below) wires every <DownloadLink> on the page from its data-
+// attributes — Astro dedupes the script, so it is emitted and runs once no
+// matter how many links use this component.
+interface Props {
+  /** Destination URL (a direct-download redirect or an external store page). */
+  href: string;
+  /** Ecosystem id, matching the values used elsewhere (see ChangelogLeadIn). */
+  platform: "stream-deck" | "mirabox" | "ulanzi";
+  /** How the user installs: our direct download, or an external store. */
+  method: "direct" | "store";
+  /** Optional CSS class forwarded to the anchor (e.g. "download-button"). */
+  class?: string;
+}
+
+const { href, platform, method, class: className } = Astro.props;
+
+// Latest-release version, resolved at build time from the same source as the
+// version badge. Empty when no release version is injected (e.g. local dev) — it
+// is then omitted from the event rather than reported as a blank value.
+const appVersion = import.meta.env.PUBLIC_IRACEDECK_VERSION ?? "";
+---
+
+<a
+  href={href}
+  class={className}
+  data-download-link
+  data-platform={platform}
+  data-method={method}
+  data-app-version={appVersion}
+>
+  <slot />
+</a>
+
+<script>
+  // gtag() is defined synchronously in the document head (it queues into
+  // dataLayer until the GA library finishes loading), so the event is captured
+  // even on the click that navigates away — GA4 flushes it via sendBeacon. We
+  // never delay or block the navigation / download.
+  for (const el of document.querySelectorAll<HTMLAnchorElement>("a[data-download-link]")) {
+    el.addEventListener("click", () => {
+      const gtag = (window as unknown as { gtag?: (...args: unknown[]) => void }).gtag;
+      if (typeof gtag !== "function") return;
+
+      gtag("event", "file_download", {
+        platform: el.dataset.platform,
+        method: el.dataset.method,
+        app_version: el.dataset.appVersion || undefined,
+      });
+    });
+  }
+</script>

--- a/packages/website/src/content/docs/downloads.mdx
+++ b/packages/website/src/content/docs/downloads.mdx
@@ -9,6 +9,8 @@ hero:
   tagline: Get the latest plugin for your device.
 ---
 
+import DownloadLink from "../../components/DownloadLink.astro";
+
 export const version = import.meta.env.PUBLIC_IRACEDECK_VERSION;
 
 {version && <p class="version-badge">Latest release: <strong>{version}</strong></p>}
@@ -17,14 +19,14 @@ export const version = import.meta.env.PUBLIC_IRACEDECK_VERSION;
   <div class="download-card">
     <span class="download-title">Elgato Stream Deck</span>
     <span class="download-desc">For Stream Deck, Stream Deck Mini, Stream Deck XL, and Stream Deck+. Requires Stream Deck software version 7.1 or newer.</span>
-    <a class="download-button" href="/downloads/plugin/latest/streamdeck">Download for Stream Deck</a>
-    <span class="download-alt">Or install from <a href="https://marketplace.elgato.com/product/iracedeck-042a0efb-58aa-428c-b1de-8b6169edd21d">Elgato Marketplace</a></span>
+    <DownloadLink class="download-button" href="/downloads/plugin/latest/streamdeck" platform="stream-deck" method="direct">Download for Stream Deck</DownloadLink>
+    <span class="download-alt">Or install from <DownloadLink href="https://marketplace.elgato.com/product/iracedeck-042a0efb-58aa-428c-b1de-8b6169edd21d" platform="stream-deck" method="store">Elgato Marketplace</DownloadLink></span>
   </div>
   <div class="download-card">
     <span class="download-title">Mirabox Ecosystem</span>
     <span class="download-desc">For Stream Dock, SOOMFON, VAPOURD, KILOGOGRAPH, HALCONTORNO, VSDinside, Nouvolo, and other Mirabox devices.</span>
-    <a class="download-button" href="/downloads/plugin/latest/mirabox">Download for Mirabox</a>
-    <span class="download-alt">Or install from <a href="https://space.key123.vip/product?id=20260322000598">Mirabox Space</a></span>
+    <DownloadLink class="download-button" href="/downloads/plugin/latest/mirabox" platform="mirabox" method="direct">Download for Mirabox</DownloadLink>
+    <span class="download-alt">Or install from <DownloadLink href="https://space.key123.vip/product?id=20260322000598" platform="mirabox" method="store">Mirabox Space</DownloadLink></span>
   </div>
 </div>
 


### PR DESCRIPTION
## Related Issue

Fixes #685

## What changed?

Adds GA4 event tracking to the download links on `/downloads/` so install activity can be analysed by **platform**, **install method**, and the **app version** current at the time. GA4 is already loaded site-wide (`G-HKB3F7KB00`); previously no custom events were fired.

- New `packages/website/src/components/DownloadLink.astro` — renders the anchor and, via a single Astro-deduped bundled `<script>`, attaches a click handler to every `a[data-download-link]` that fires `gtag("event", "file_download", { platform, method, app_version })`. Mirrors the existing `ChangelogLeadIn.astro` pattern (no inline `<script>` in MDX).
- `downloads.mdx` now uses the component for all four links: the two direct-download buttons (`method="direct"`) and the two store links (`method="store"`), tagged `platform="stream-deck"` / `"mirabox"`.

Event parameters:

| Param | Values |
|-------|--------|
| `platform` | `stream-deck`, `mirabox` (ready for `ulanzi`) — reuses the ecosystem ids from the changelog version-check flow |
| `method` | `direct` (our download redirect) or `store` (Elgato Marketplace / Mirabox Space) |
| `app_version` | `PUBLIC_IRACEDECK_VERSION` at build time; omitted when blank |

The handler no-ops if `gtag` is unavailable and never blocks the navigation/download — GA4 flushes the event via `sendBeacon`. Forward-compatible: when Ulanzi joins the downloads page it is instrumented identically with `platform="ulanzi"`, no new event name.

**Follow-up outside the repo:** `platform`, `method`, and `app_version` must be registered as custom dimensions in the GA4 property to be queryable in reports.

No changelog entry — internal instrumentation, invisible to users (per the changelog rule).

## How to test

1. `cd packages/website && pnpm dev`
2. Open `http://localhost:4321/downloads/`.
3. DevTools → **Network**, filter `collect`. Clicking any of the four links fires a request with `en=file_download` and `ep.platform` / `ep.method` / `ep.app_version` (GA4 **DebugView** shows the same). Dev uses the fallback version `1.22.0-dev.0`.

Verified locally: `pnpm --filter @iracedeck/website build` passes and the built `/downloads/index.html` carries the data attributes + inlined tracking script; `pnpm lint`, `pnpm format`, and the full `pnpm test` suite (177 files / 5401 tests) are green.

## Checklist

- [x] Linked to an approved issue
- [ ] New code has unit tests — N/A: the website package has no test harness; the change is an `.astro` component with no testable TS logic (same as the existing `ChangelogLeadIn.astro`). Verified via build + built-output inspection instead.
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — N/A: website-only change, no plugin/action code touched.
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved analytics tracking for download actions across all supported platforms (Stream Deck, Mirabox, and Ulanzi) and installation methods (direct downloads and marketplace installations) to better measure user engagement and download patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->