### PR TITLE
ci(release): drop obsolete Node 24 force flag from Firebase deploy (#388)

### DIFF
--- a/.github/workflows/firebase-hosting-release.yml
+++ b/.github/workflows/firebase-hosting-release.yml
@@ -15,14 +15,6 @@ on:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
-    # Force GitHub's runner to execute JavaScript actions on Node 24. The Firebase
-    # deploy action below still declares `using: node20`, which GitHub has deprecated:
-    # Node 20 actions are forced to Node 24 from 2026-06-02 and Node 20 is removed
-    # from runners on 2026-09-16. Opting in early verifies the action runs under
-    # Node 24 before the forced cutover. Remove this once
-    # FirebaseExtended/action-hosting-deploy ships a Node 24 release (issue #388).
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Related Issue

Fixes #388

## What changed?

Removed the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` env block (and its explanatory comment) from the `build_and_deploy` job in `firebase-hosting-release.yml`.

That flag was an early opt-in to run `FirebaseExtended/action-hosting-deploy@v0` on Node 24 while the action still declared `using: node20`. It is also exactly what produced the CI warning `…the following actions target Node.js 20 but are being forced to run on Node.js 24`. The action shipped **v0.11.0** on 2026-06-25 with `using: "node24"` natively, and the floating `@v0` tag has already been re-pointed to it (verified via the GitHub API: `@v0` → `action.yml` declares `using: "node24"`). So the force flag is now obsolete — `@v0` runs on Node 24 on its own, and removing the flag clears the warning. Kept `@v0` floating, consistent with the repo's other action pins (`checkout@v6`, `setup-node@v6`, `action-setup@v6`).

## How to test

CI-only change with no runtime/code impact. It exercises only on the **Release** workflow (`v*` tag push → `deploy-website` → `build_and_deploy`), so it can't be verified on this PR's checks. On the next tagged release the Firebase deploy step should run on Node 24 with no "being forced to run on Node.js 24" warning.

## Checklist

- [x] Linked to an approved issue
- [ ] New code has unit tests — n/a, CI workflow YAML only
- [ ] Changes registered in all applicable plugins (Stream Deck, Mirabox) — n/a, no plugin/action change
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Firebase Hosting release workflow to use the default runtime for JavaScript actions instead of forcing a specific Node version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->