### PR TITLE
fix(release): harden and dedupe plugin-manifest version discovery (#701, #702)

### DIFF
--- a/scripts/lib/version-discovery.mjs
+++ b/scripts/lib/version-discovery.mjs
@@ -4,7 +4,7 @@ import { join } from "node:path";
 /**
  * Plugin-folder suffixes whose `manifest.json` carries the Elgato-style
  * `Version` field the release bumps. Discovery is anchored to these suffixes
- * rather than "any `packages/*​/<dir>/manifest.json` that declares a string
+ * rather than "any `packages/<pkg>/<dir>/manifest.json` that declares a string
  * `Version`", so an unrelated manifest (e.g. the audio-assets clip manifest)
  * can never be clobbered with the build number (issue #701, defect 3).
  *
@@ -30,6 +30,21 @@ export function pluginManifestRelPaths(root, pkgName) {
   return readdirSync(pkgDir, { withFileTypes: true })
     .filter((sub) => sub.isDirectory() && PLUGIN_FOLDER_SUFFIXES.some((suffix) => sub.name.endsWith(suffix)))
     .map((sub) => `packages/${pkgName}/${sub.name}/manifest.json`);
+}
+
+/**
+ * Forward-slashed relative paths to every plugin folder's `manifest.json` across
+ * all packages, regardless of SKIPPED_PACKAGES or whether the manifest declares
+ * a `Version`. Lets a caller tell "no plugin folders exist at all" (a layout /
+ * anchor bug) apart from "every plugin folder was skipped" (intentional).
+ *
+ * @param {string} root absolute repository root
+ * @returns {string[]}
+ */
+export function allPluginManifestRelPaths(root) {
+  return readdirSync(join(root, "packages"), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .flatMap((entry) => pluginManifestRelPaths(root, entry.name));
 }
 
 /**

--- a/scripts/lib/version-discovery.mjs
+++ b/scripts/lib/version-discovery.mjs
@@ -1,0 +1,96 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Plugin-folder suffixes whose `manifest.json` carries the Elgato-style
+ * `Version` field the release bumps. Discovery is anchored to these suffixes
+ * rather than "any `packages/*​/<dir>/manifest.json` that declares a string
+ * `Version`", so an unrelated manifest (e.g. the audio-assets clip manifest)
+ * can never be clobbered with the build number (issue #701, defect 3).
+ *
+ * NOTE: adding a new deck ecosystem whose plugin folder uses a different suffix
+ * requires adding that suffix here — otherwise its manifest is silently never
+ * bumped.
+ */
+export const PLUGIN_FOLDER_SUFFIXES = [".sdPlugin", ".ulanziPlugin"];
+
+/**
+ * Forward-slashed relative paths to the `manifest.json` of every plugin folder
+ * (`*.sdPlugin` / `*.ulanziPlugin`) inside a single package directory.
+ *
+ * Paths are returned forward-slashed (git accepts them on Windows, and the
+ * caller joins them onto `root` only for filesystem access).
+ *
+ * @param {string} root absolute repository root
+ * @param {string} pkgName a directory name under `packages/`
+ * @returns {string[]}
+ */
+export function pluginManifestRelPaths(root, pkgName) {
+  const pkgDir = join(root, "packages", pkgName);
+  return readdirSync(pkgDir, { withFileTypes: true })
+    .filter((sub) => sub.isDirectory() && PLUGIN_FOLDER_SUFFIXES.some((suffix) => sub.name.endsWith(suffix)))
+    .map((sub) => `packages/${pkgName}/${sub.name}/manifest.json`);
+}
+
+/**
+ * Discover every versioned JSON file under `packages/*`.
+ *
+ * Walks `packages/*` once. For each package it resolves the owning
+ * `package.json` (its `name` drives the `skip` opt-out, and it is reused so the
+ * package.json candidate is not read twice), then keeps every candidate file
+ * that carries a string `versionField`. The parsed object is captured on each
+ * result so the caller can mutate and re-serialize without a second read+parse
+ * (issue #702).
+ *
+ * `JSON.parse` is intentionally unguarded: a malformed file aborts the release
+ * loudly instead of being silently dropped and shipped stale (issue #701,
+ * defect 1).
+ *
+ * @param {string} root absolute repository root
+ * @param {object} opts
+ * @param {(pkgName: string) => string[]} opts.candidatesFor forward-slashed rel paths to consider for a package
+ * @param {string} opts.versionField `"version"` (package.json) or `"Version"` (manifest.json)
+ * @param {Set<string>|null} [opts.skip] package names (the `name` field) to opt out of the bump entirely
+ * @param {boolean} [opts.required] when true, throw if a candidate path is missing or lacks a string `versionField`
+ * @returns {{ rel: string, filePath: string, data: Record<string, unknown> }[]} sorted by `rel`
+ */
+export function discoverVersionedFiles(root, { candidatesFor, versionField, skip = null, required = false }) {
+  const results = [];
+
+  for (const pkgEntry of readdirSync(join(root, "packages"), { withFileTypes: true })) {
+    // Skips files and (un-followed) symlinks at the packages/* level, as before.
+    if (!pkgEntry.isDirectory()) continue;
+    const pkgName = pkgEntry.name;
+
+    // Resolve the owning package.json once: it supplies the `name` for `skip`,
+    // and is reused below so the package.json candidate is not parsed twice.
+    const pkgJsonRel = `packages/${pkgName}/package.json`;
+    const pkgJsonPath = join(root, pkgJsonRel);
+    const pkgData = existsSync(pkgJsonPath) ? JSON.parse(readFileSync(pkgJsonPath, "utf-8")) : undefined;
+
+    // Opt a package out entirely — both its package.json AND its plugin
+    // manifest — before any `required` check, so a skipped plugin's
+    // intentionally un-bumped manifest never throws (issue #701, defect 2).
+    if (skip && pkgData?.name && skip.has(pkgData.name)) {
+      console.log(`  Skipping ${pkgData.name} (opted out via SKIPPED_PACKAGES)`);
+      continue;
+    }
+
+    for (const rel of candidatesFor(pkgName)) {
+      const filePath = join(root, rel);
+      if (!existsSync(filePath)) {
+        if (required) throw new Error(`Expected ${versionField} file is missing: ${rel}`);
+        continue;
+      }
+      const data = rel === pkgJsonRel && pkgData ? pkgData : JSON.parse(readFileSync(filePath, "utf-8"));
+      if (typeof data[versionField] !== "string") {
+        if (required) throw new Error(`${rel} has no string "${versionField}" field`);
+        continue;
+      }
+      results.push({ rel, filePath, data });
+    }
+  }
+
+  // Default string sort (UTF-16 code units), matching the previous `.sort()`.
+  return results.sort((a, b) => (a.rel < b.rel ? -1 : a.rel > b.rel ? 1 : 0));
+}

--- a/scripts/lib/version-discovery.test.mjs
+++ b/scripts/lib/version-discovery.test.mjs
@@ -1,0 +1,177 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { discoverVersionedFiles, PLUGIN_FOLDER_SUFFIXES, pluginManifestRelPaths } from "./version-discovery.mjs";
+
+let root;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "ird-version-discovery-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+/** Write `obj` as canonical JSON (the exact form release-hooks writes). */
+function writeJson(rel, obj) {
+  const filePath = join(root, rel);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(obj, null, 2) + "\n");
+}
+
+/** Write raw text (used for malformed-JSON fixtures). */
+function writeRaw(rel, text) {
+  const filePath = join(root, rel);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, text);
+}
+
+const packageCandidates = (pkgName) => [`packages/${pkgName}/package.json`];
+const manifestCandidates = (pkgName) => pluginManifestRelPaths(root, pkgName);
+
+/** A small but representative fixture tree. */
+function buildStandardTree() {
+  // Two real plugin packages, one .sdPlugin and one .ulanziPlugin.
+  writeJson("packages/plugin-a/package.json", { name: "@x/plugin-a", version: "1.0.0" });
+  writeJson("packages/plugin-a/com.x.a.sdPlugin/manifest.json", { Name: "A", Version: "1.0.0.0" });
+  writeJson("packages/plugin-b/package.json", { name: "@x/plugin-b", version: "1.0.0" });
+  writeJson("packages/plugin-b/com.x.b.ulanziPlugin/manifest.json", { Name: "B", Version: "1.0.0.0" });
+
+  // A library package with a version but no plugin folder.
+  writeJson("packages/lib-c/package.json", { name: "@x/lib-c", version: "1.0.0" });
+
+  // A package without a version (e.g. a private tooling package): skipped leniently.
+  writeJson("packages/no-version/package.json", { name: "@x/no-version", private: true });
+
+  // A decoy: a NON-plugin manifest.json at depth 2 that declares a string
+  // Version. The plugin-folder anchor must exclude it (issue #701 defect 3).
+  writeJson("packages/decoy/package.json", { name: "@x/decoy", version: "1.0.0" });
+  writeJson("packages/decoy/assets/manifest.json", { Version: "9.9.9", clips: [] });
+
+  // A stray file at the packages/* level — must be ignored (not a directory).
+  writeRaw("packages/not-a-dir.txt", "ignore me\n");
+}
+
+describe("PLUGIN_FOLDER_SUFFIXES", () => {
+  it("covers the Elgato/Mirabox and Ulanzi plugin folders", () => {
+    expect(PLUGIN_FOLDER_SUFFIXES).toEqual([".sdPlugin", ".ulanziPlugin"]);
+  });
+});
+
+describe("pluginManifestRelPaths", () => {
+  it("returns only plugin-folder manifests, forward-slashed", () => {
+    buildStandardTree();
+    expect(pluginManifestRelPaths(root, "plugin-a")).toEqual(["packages/plugin-a/com.x.a.sdPlugin/manifest.json"]);
+    expect(pluginManifestRelPaths(root, "plugin-b")).toEqual(["packages/plugin-b/com.x.b.ulanziPlugin/manifest.json"]);
+  });
+
+  it("excludes non-plugin subfolders (the decoy anchor)", () => {
+    buildStandardTree();
+    expect(pluginManifestRelPaths(root, "decoy")).toEqual([]);
+  });
+
+  it("never emits backslashes (git needs forward slashes on Windows)", () => {
+    buildStandardTree();
+    for (const rel of pluginManifestRelPaths(root, "plugin-a")) {
+      expect(rel).not.toContain("\\");
+    }
+  });
+});
+
+describe("discoverVersionedFiles — package.json", () => {
+  it("discovers every package with a string version, sorted, skipping version-less ones", () => {
+    buildStandardTree();
+    const found = discoverVersionedFiles(root, { candidatesFor: packageCandidates, versionField: "version" });
+    expect(found.map((f) => f.rel)).toEqual([
+      "packages/decoy/package.json",
+      "packages/lib-c/package.json",
+      "packages/plugin-a/package.json",
+      "packages/plugin-b/package.json",
+    ]);
+  });
+
+  it("captures the parsed object on each result", () => {
+    buildStandardTree();
+    const found = discoverVersionedFiles(root, { candidatesFor: packageCandidates, versionField: "version" });
+    const a = found.find((f) => f.rel === "packages/plugin-a/package.json");
+    expect(a.data).toMatchObject({ name: "@x/plugin-a", version: "1.0.0" });
+  });
+});
+
+describe("discoverVersionedFiles — manifests (anchored, required)", () => {
+  it("discovers only the plugin manifests and excludes the decoy", () => {
+    buildStandardTree();
+    const found = discoverVersionedFiles(root, {
+      candidatesFor: manifestCandidates,
+      versionField: "Version",
+      required: true,
+    });
+    expect(found.map((f) => f.rel)).toEqual([
+      "packages/plugin-a/com.x.a.sdPlugin/manifest.json",
+      "packages/plugin-b/com.x.b.ulanziPlugin/manifest.json",
+    ]);
+  });
+
+  it("throws when a plugin folder's manifest is missing", () => {
+    writeJson("packages/plugin-a/package.json", { name: "@x/plugin-a", version: "1.0.0" });
+    mkdirSync(join(root, "packages/plugin-a/com.x.a.sdPlugin"), { recursive: true });
+    expect(() =>
+      discoverVersionedFiles(root, { candidatesFor: manifestCandidates, versionField: "Version", required: true }),
+    ).toThrow(/missing/i);
+  });
+
+  it("throws when a plugin manifest lacks a string Version", () => {
+    writeJson("packages/plugin-a/package.json", { name: "@x/plugin-a", version: "1.0.0" });
+    writeJson("packages/plugin-a/com.x.a.sdPlugin/manifest.json", { Name: "A" });
+    expect(() =>
+      discoverVersionedFiles(root, { candidatesFor: manifestCandidates, versionField: "Version", required: true }),
+    ).toThrow(/Version/);
+  });
+
+  it("aborts loudly on a malformed manifest instead of silently dropping it", () => {
+    writeJson("packages/plugin-a/package.json", { name: "@x/plugin-a", version: "1.0.0" });
+    writeRaw("packages/plugin-a/com.x.a.sdPlugin/manifest.json", "{ this is not json ");
+    expect(() =>
+      discoverVersionedFiles(root, { candidatesFor: manifestCandidates, versionField: "Version", required: true }),
+    ).toThrow();
+  });
+});
+
+describe("discoverVersionedFiles — SKIPPED_PACKAGES", () => {
+  it("opts a package out of BOTH its package.json and its manifest", () => {
+    buildStandardTree();
+    const skip = new Set(["@x/plugin-a"]);
+
+    const pkgs = discoverVersionedFiles(root, { candidatesFor: packageCandidates, versionField: "version", skip });
+    expect(pkgs.map((f) => f.rel)).not.toContain("packages/plugin-a/package.json");
+
+    // required:true would otherwise throw on plugin-a's manifest — skip must win.
+    const manifests = discoverVersionedFiles(root, {
+      candidatesFor: manifestCandidates,
+      versionField: "Version",
+      skip,
+      required: true,
+    });
+    expect(manifests.map((f) => f.rel)).toEqual(["packages/plugin-b/com.x.b.ulanziPlugin/manifest.json"]);
+  });
+});
+
+describe("write-path round-trip", () => {
+  it("re-serializes captured data byte-identically to the on-disk form", () => {
+    // A key order that is NOT alphabetical, to prove insertion order is preserved.
+    const original = { Name: "A", UUID: "com.x.a", Version: "1.0.0.0", Nested: { b: 1, a: 2 } };
+    writeJson("packages/plugin-a/package.json", { name: "@x/plugin-a", version: "1.0.0" });
+    writeJson("packages/plugin-a/com.x.a.sdPlugin/manifest.json", original);
+
+    const [{ data }] = discoverVersionedFiles(root, {
+      candidatesFor: manifestCandidates,
+      versionField: "Version",
+      required: true,
+    });
+    // The exact serializer release-hooks.mjs uses.
+    expect(JSON.stringify(data, null, 2) + "\n").toBe(JSON.stringify(original, null, 2) + "\n");
+  });
+});

--- a/scripts/lib/version-discovery.test.mjs
+++ b/scripts/lib/version-discovery.test.mjs
@@ -3,7 +3,12 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { discoverVersionedFiles, PLUGIN_FOLDER_SUFFIXES, pluginManifestRelPaths } from "./version-discovery.mjs";
+import {
+  allPluginManifestRelPaths,
+  discoverVersionedFiles,
+  PLUGIN_FOLDER_SUFFIXES,
+  pluginManifestRelPaths,
+} from "./version-discovery.mjs";
 
 let root;
 
@@ -156,6 +161,37 @@ describe("discoverVersionedFiles — SKIPPED_PACKAGES", () => {
       required: true,
     });
     expect(manifests.map((f) => f.rel)).toEqual(["packages/plugin-b/com.x.b.ulanziPlugin/manifest.json"]);
+  });
+
+  it("returns no manifests when every plugin package is skipped, even though the folders still exist", () => {
+    buildStandardTree();
+    const skip = new Set(["@x/plugin-a", "@x/plugin-b"]);
+
+    const manifests = discoverVersionedFiles(root, {
+      candidatesFor: manifestCandidates,
+      versionField: "Version",
+      skip,
+      required: true,
+    });
+    // Legitimately empty (all opted out) — the orchestrator's floor must NOT
+    // abort here, which is why it cross-checks allPluginManifestRelPaths().
+    expect(manifests).toEqual([]);
+    expect(allPluginManifestRelPaths(root).length).toBeGreaterThan(0);
+  });
+});
+
+describe("allPluginManifestRelPaths", () => {
+  it("lists every plugin folder's manifest path, ignoring skip and Version presence", () => {
+    buildStandardTree();
+    expect(allPluginManifestRelPaths(root).sort()).toEqual([
+      "packages/plugin-a/com.x.a.sdPlugin/manifest.json",
+      "packages/plugin-b/com.x.b.ulanziPlugin/manifest.json",
+    ]);
+  });
+
+  it("is empty when no plugin folders exist at all (the genuine floor-abort case)", () => {
+    writeJson("packages/lib-only/package.json", { name: "@x/lib-only", version: "1.0.0" });
+    expect(allPluginManifestRelPaths(root)).toEqual([]);
   });
 });
 

--- a/scripts/release-hooks.mjs
+++ b/scripts/release-hooks.mjs
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { writeFileSync } from "node:fs";
+
+import { discoverVersionedFiles, pluginManifestRelPaths } from "./lib/version-discovery.mjs";
 
 const version = process.argv[2];
 if (!version) {
@@ -12,37 +13,30 @@ const root = new URL("..", import.meta.url).pathname.replace(/^\/([A-Z]:)/, "$1"
 
 // Packages that intentionally track their own versions and must NOT be bumped
 // by the release process. Empty today — add the package name here if a
-// package ever decouples from the monorepo's shared version.
+// package ever decouples from the monorepo's shared version. A skipped package
+// opts BOTH its package.json and its plugin manifest out of the bump.
 const SKIPPED_PACKAGES = new Set();
 
-// Discover every workspace package under packages/* that declares a `version`.
-// Replaces the previous hardcoded list which silently skipped new packages
-// (see issue #435 — eight packages had drifted multiple minors behind because
-// they were never added to the static array).
-const packagesDir = join(root, "packages");
-const packageJsonPaths = readdirSync(packagesDir, { withFileTypes: true })
-  .filter((entry) => entry.isDirectory())
-  .map((entry) => `packages/${entry.name}/package.json`)
-  .filter((rel) => {
-    const filePath = join(root, rel);
-    if (!existsSync(filePath)) return false;
-    const pkg = JSON.parse(readFileSync(filePath, "utf-8"));
-    if (!pkg.version) return false;
-    if (SKIPPED_PACKAGES.has(pkg.name)) {
-      console.log(`  Skipping ${pkg.name} (opted out via SKIPPED_PACKAGES)`);
-      return false;
-    }
-    return true;
-  })
-  .sort();
+// Discover the files to bump. `package.json` (`version`) and plugin
+// `manifest.json` (`Version`) share discoverVersionedFiles() so the parse-error
+// handling, SKIPPED_PACKAGES opt-out, and sort stay identical for both file
+// types (issue #702 — the two hand-rolled pipelines had drifted: the manifest
+// one swallowed parse errors and ignored SKIPPED_PACKAGES, issue #701).
+//
+// The previous hardcoded lists silently skipped new entries — eight packages
+// drifted multiple minors behind (issue #435) and the Ulanzi manifest stayed at
+// 1.22.0.0 while the others advanced — which is why both are auto-discovered.
+const packageJsonFiles = discoverVersionedFiles(root, {
+  candidatesFor: (pkgName) => [`packages/${pkgName}/package.json`],
+  versionField: "version",
+  skip: SKIPPED_PACKAGES,
+});
 
-// Bump Version in manifest.json files. Discovered dynamically — the same way as
-// the package.json files above — rather than a hardcoded list: scan every
-// `packages/*/<plugin-folder>/manifest.json` that declares a `Version`. The old
-// static array silently skipped the Ulanzi plugin's manifest (it stayed at
-// 1.22.0.0 while the others advanced), exactly the drift issue #435 fixed for
-// package.json; auto-discovery picks up any current or future plugin manifest
-// (`.sdPlugin` / `.ulanziPlugin`) automatically.
+// Manifests are anchored to real plugin folders (`*.sdPlugin` / `*.ulanziPlugin`)
+// so an unrelated `packages/*​/<dir>/manifest.json` that happens to declare a
+// string `Version` is never clobbered (issue #701, defect 3). `required: true`
+// makes a plugin folder whose manifest is missing or malformed abort the
+// release rather than ship it stale (defect 4).
 //
 // Elgato's manifest schema requires a strict 4-part numeric format
 // `{major}.{minor}.{patch}.{build}` (^(0|[1-9]\d*)(\.(0|[1-9]\d*)){3}$), so
@@ -51,25 +45,21 @@ const packageJsonPaths = readdirSync(packagesDir, { withFileTypes: true })
 // alike) gets a unique 4-part version; the final naturally outranks its
 // preceding pre-releases because release-it commits the version bump between
 // runs, which advances the commit count.
-const manifestPaths = readdirSync(packagesDir, { withFileTypes: true })
-  .filter((entry) => entry.isDirectory())
-  .flatMap((pkgEntry) => {
-    const pkgDir = join(packagesDir, pkgEntry.name);
-    return readdirSync(pkgDir, { withFileTypes: true })
-      .filter((sub) => sub.isDirectory())
-      .map((sub) => `packages/${pkgEntry.name}/${sub.name}/manifest.json`);
-  })
-  .filter((rel) => {
-    const filePath = join(root, rel);
-    if (!existsSync(filePath)) return false;
-    try {
-      const manifest = JSON.parse(readFileSync(filePath, "utf-8"));
-      return typeof manifest.Version === "string";
-    } catch {
-      return false;
-    }
-  })
-  .sort();
+const manifestFiles = discoverVersionedFiles(root, {
+  candidatesFor: (pkgName) => pluginManifestRelPaths(root, pkgName),
+  versionField: "Version",
+  skip: SKIPPED_PACKAGES,
+  required: true,
+});
+
+// Sanity floor (issue #701, defect 4): if the plugin-folder anchor matched
+// nothing — every plugin folder renamed/removed, or PLUGIN_FOLDER_SUFFIXES out
+// of date — no candidates are generated and the per-candidate `required` check
+// never fires; only an explicit floor catches that. (All plugins landing in
+// SKIPPED_PACKAGES would also trip this, which is review-worthy, not silent.)
+if (manifestFiles.length === 0) {
+  throw new Error("No plugin manifests discovered — refusing to release with a potentially stale manifest set.");
+}
 
 const numericVersion = version.replace(/[-+].*$/, "");
 const buildNumber = execFileSync("git", ["rev-list", "--count", "HEAD"], {
@@ -78,35 +68,48 @@ const buildNumber = execFileSync("git", ["rev-list", "--count", "HEAD"], {
 }).trim();
 const manifestVersion = `${numericVersion}.${buildNumber}`;
 
+const allPaths = [...packageJsonFiles, ...manifestFiles].map(({ rel }) => rel);
+
+// Preflight (issue #701, defect 5): confirm every file we're about to bump can
+// be staged BEFORE writing anything. `git add --dry-run` mirrors the real
+// `git add` exactly (a gitignored path makes it exit non-zero and name the
+// offender) but touches neither the working tree nor the index — so a stray
+// ignored path aborts here with a clean tree instead of throwing mid-write and
+// leaving a half-bumped tree behind. Runs before the dry-run branch so
+// `release:dry` is a true preflight. The real `git add` below deliberately
+// stays without `-f`: force-adding a gitignored build artifact into a release
+// commit is the wrong fix.
+try {
+  execFileSync("git", ["add", "--dry-run", "--", ...allPaths], { cwd: root, stdio: "inherit" });
+} catch {
+  throw new Error("Refusing to release: a file slated for a version bump is gitignored (see the git output above).");
+}
+
 // release-it runs before:bump hooks even in dry-run mode, which would otherwise
 // modify real package.json / manifest.json files and stage them with `git add`.
 // `scripts/release.mjs` sets RELEASE_IT_DRY_RUN=1 when --dry-run is passed.
 if (process.env.RELEASE_IT_DRY_RUN === "1") {
-  console.log(`  [dry-run] Would bump ${packageJsonPaths.length} package.json files to version ${version}:`);
-  for (const rel of packageJsonPaths) console.log(`    - ${rel}`);
-  console.log(`  [dry-run] Would bump ${manifestPaths.length} manifest.json files to version ${manifestVersion}:`);
-  for (const rel of manifestPaths) console.log(`    - ${rel}`);
+  console.log(`  [dry-run] Would bump ${packageJsonFiles.length} package.json files to version ${version}:`);
+  for (const { rel } of packageJsonFiles) console.log(`    - ${rel}`);
+  console.log(`  [dry-run] Would bump ${manifestFiles.length} manifest.json files to version ${manifestVersion}:`);
+  for (const { rel } of manifestFiles) console.log(`    - ${rel}`);
   process.exit(0);
 }
 
-for (const rel of packageJsonPaths) {
-  const filePath = join(root, rel);
-  const pkg = JSON.parse(readFileSync(filePath, "utf-8"));
-  pkg.version = version;
-  writeFileSync(filePath, JSON.stringify(pkg, null, 2) + "\n");
+// Reuse the objects captured during discovery — no second read+parse (#702).
+for (const { rel, filePath, data } of packageJsonFiles) {
+  data.version = version;
+  writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n");
   console.log(`  Updated ${rel} → ${version}`);
 }
 
-for (const rel of manifestPaths) {
-  const filePath = join(root, rel);
-  const manifest = JSON.parse(readFileSync(filePath, "utf-8"));
-  manifest.Version = manifestVersion;
-  writeFileSync(filePath, JSON.stringify(manifest, null, 2) + "\n");
+for (const { rel, filePath, data } of manifestFiles) {
+  data.Version = manifestVersion;
+  writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n");
   console.log(`  Updated ${rel} → ${manifestVersion}`);
 }
 
 // Stage all modified files. Use argv form (no shell) so package directory
 // names containing spaces or shell metacharacters can't break or inject into
 // the git invocation.
-const allPaths = [...packageJsonPaths, ...manifestPaths];
 execFileSync("git", ["add", "--", ...allPaths], { cwd: root, stdio: "inherit" });

--- a/scripts/release-hooks.mjs
+++ b/scripts/release-hooks.mjs
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { writeFileSync } from "node:fs";
 
-import { discoverVersionedFiles, pluginManifestRelPaths } from "./lib/version-discovery.mjs";
+import { allPluginManifestRelPaths, discoverVersionedFiles, pluginManifestRelPaths } from "./lib/version-discovery.mjs";
 
 const version = process.argv[2];
 if (!version) {
@@ -33,7 +33,7 @@ const packageJsonFiles = discoverVersionedFiles(root, {
 });
 
 // Manifests are anchored to real plugin folders (`*.sdPlugin` / `*.ulanziPlugin`)
-// so an unrelated `packages/*​/<dir>/manifest.json` that happens to declare a
+// so an unrelated `packages/<pkg>/<dir>/manifest.json` that happens to declare a
 // string `Version` is never clobbered (issue #701, defect 3). `required: true`
 // makes a plugin folder whose manifest is missing or malformed abort the
 // release rather than ship it stale (defect 4).
@@ -52,13 +52,16 @@ const manifestFiles = discoverVersionedFiles(root, {
   required: true,
 });
 
-// Sanity floor (issue #701, defect 4): if the plugin-folder anchor matched
-// nothing — every plugin folder renamed/removed, or PLUGIN_FOLDER_SUFFIXES out
-// of date — no candidates are generated and the per-candidate `required` check
-// never fires; only an explicit floor catches that. (All plugins landing in
-// SKIPPED_PACKAGES would also trip this, which is review-worthy, not silent.)
-if (manifestFiles.length === 0) {
-  throw new Error("No plugin manifests discovered — refusing to release with a potentially stale manifest set.");
+// Sanity floor (issue #701, defect 4): abort only when NO plugin folders exist
+// on disk at all — the anchor matched nothing (every plugin folder renamed or
+// removed, or PLUGIN_FOLDER_SUFFIXES out of date), so no candidates were
+// generated and the per-candidate `required` check never fired. An empty
+// `manifestFiles` while plugin folders DO exist means every plugin package was
+// opted out via SKIPPED_PACKAGES — intentional, so it is not a failure.
+if (manifestFiles.length === 0 && allPluginManifestRelPaths(root).length === 0) {
+  throw new Error(
+    "No plugin manifests found under packages/*/{*.sdPlugin,*.ulanziPlugin} — refusing to release with a potentially stale manifest set.",
+  );
 }
 
 const numericVersion = version.replace(/[-+].*$/, "");

--- a/scripts/release-hooks.test.mjs
+++ b/scripts/release-hooks.test.mjs
@@ -1,0 +1,33 @@
+import { execFileSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// scripts/release-hooks.test.mjs lives in scripts/, so the repo root is one up.
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function git(...args) {
+  return execFileSync("git", args, { cwd: repoRoot, encoding: "utf-8" });
+}
+
+describe("release-hooks.mjs (dry run)", () => {
+  it("discovers all three plugin manifests and stages nothing", () => {
+    const before = git("status", "--porcelain");
+
+    const stdout = execFileSync("node", ["scripts/release-hooks.mjs", "9.9.9"], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: { ...process.env, RELEASE_IT_DRY_RUN: "1" },
+    });
+
+    // The dry-run preflight + branch must not touch the tree or the index.
+    expect(git("status", "--porcelain")).toBe(before);
+
+    expect(stdout).toMatch(/Would bump \d+ manifest\.json files/);
+    // The three live plugin manifests, including the Ulanzi one the old static
+    // list silently skipped.
+    expect(stdout).toContain("packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/manifest.json");
+    expect(stdout).toContain("packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/manifest.json");
+    expect(stdout).toContain("packages/iracing-plugin-ulanzi/com.ulanzi.iracedeck.ulanziPlugin/manifest.json");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -57,6 +57,6 @@ export default defineConfig({
   test: {
     globals: true,
     setupFiles: ["./test-setup.ts"],
-    include: ["packages/*/src/**/*.test.ts"],
+    include: ["packages/*/src/**/*.test.ts", "scripts/**/*.test.mjs"],
   },
 });


### PR DESCRIPTION
## Related Issue

Fixes #701
Fixes #702

## What changed?

`scripts/release-hooks.mjs` (the release-it `before:bump` hook that bumps `version` in every `packages/*/package.json` and `Version` in every plugin `manifest.json`) had two hand-rolled discovery pipelines that had drifted apart. This extracts one shared, pure helper and fixes five correctness defects.

**Refactor (#702)** — new `scripts/lib/version-discovery.mjs` exporting `discoverVersionedFiles()`, `pluginManifestRelPaths()`, and `PLUGIN_FOLDER_SUFFIXES`. Both the package.json and manifest discovery now route through it, so parse-error handling, the `SKIPPED_PACKAGES` opt-out, and sorting are identical for both file types. The object parsed during discovery is captured and reused in the write loop (no second read+parse).

**Hardening (#701)** — five correctness defects in the manifest pipeline:

1. **Unguarded parse** — a malformed plugin manifest now aborts the release loudly instead of being silently dropped and shipped stale.
2. **`SKIPPED_PACKAGES` honored** for manifests, not just package.json.
3. **Plugin-folder anchor** — manifests are discovered only under `*.sdPlugin` / `*.ulanziPlugin` folders, so an unrelated `manifest.json` that happens to declare a string `Version` (e.g. `packages/audio-assets/manifest.json`) can never be clobbered with the build number.
4. **Sanity floor** — a plugin folder with a missing/invalid manifest, or zero discovered manifests, aborts the release instead of shipping a stale manifest set.
5. **`git add --dry-run` preflight** before writing — a gitignored target aborts with a clean tree instead of throwing mid-`git add` and leaving a half-bumped tree. The real `git add` deliberately stays without `-f`.

Entrypoint contract is unchanged (`node scripts/release-hooks.mjs <version>`), and on-disk output stays byte-identical (`JSON.stringify(data, null, 2) + "\n"`, key order preserved).

## How to test

- `pnpm test` — covers the new `scripts/lib/version-discovery.test.mjs` (anchor/decoy exclusion, skip-both-files, malformed→throw, missing/Version-less→throw, byte-identical round-trip) and `scripts/release-hooks.test.mjs` (dry-run subprocess smoke test asserting a clean tree). `vitest.config.ts` now includes `scripts/**/*.test.mjs`.
- `RELEASE_IT_DRY_RUN=1 node scripts/release-hooks.mjs 9.9.9` — lists 22 package.jsons + the 3 plugin manifests (incl. the Ulanzi `.ulanziPlugin` one) and leaves `git status` byte-identical.
- `pnpm build` and `pnpm format` pass.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — N/A: release tooling only, no action/plugin changes
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release version updates now consistently detect and bump package `package.json` files and all supported plugin manifests.
  * Dry-run mode reports the exact set of files that would be updated.
* **Bug Fixes**
  * Release automation now avoids updating gitignored files and won’t proceed when required plugin manifests are missing or invalid.
  * Invalid or nonconforming manifest version fields are handled safely.
* **Tests**
  * Added test coverage for version discovery, plugin manifest detection, and dry-run safety.
  * Expanded test discovery to include script-based test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->