### PR TITLE
fix(pi): open external Property Inspector links in default browser (#243)

### DIFF
--- a/.claude/rules/pi-templates.md
+++ b/.claude/rules/pi-templates.md
@@ -116,8 +116,8 @@ Located in `packages/pi-components/partials/`:
 - **global-graphic-defaults.ejs** - Global graphic scale default (50-150%, default 100%) in accordion
 - **global-flag-flash.ejs** - Global flag-flash duration default (0-30 seconds, default 15, step 1; `0` = flash forever) in accordion. See issue #490.
 - **global-common-settings.ejs** - Global common settings (window focus, SimHub server) in accordion
-- **docs-link.ejs** - Documentation link to the action's page on iracedeck.com (conditional, hidden when no URL mapped)
-- **version.ejs** - Version footer with downloads link
+- **docs-link.ejs** - Documentation link to the action's page on iracedeck.com (conditional, hidden when no URL mapped). Opens in the default browser (see _External Links_ below).
+- **version.ejs** - Version footer with downloads link. Opens in the default browser (see _External Links_ below).
 
 ## Shared CSS Classes
 
@@ -136,6 +136,16 @@ Common style classes are defined in `head-common.ejs` (loaded by every PI page).
   ```
 
 When a new shared style is needed, add the class to `head-common.ejs` and document it here — do not introduce inline styles in partials or per-action templates.
+
+## External Links — default browser (issue #243)
+
+External links in a PI otherwise open in the deck app's small built-in browser, which no PI link ever wants. A single delegated click handler — `installExternalLinkHandler()` in `packages/pi-components/src/components/external-links.ts`, run on load from the `pi-components.js` bundle entry (`src/components/index.ts`) — reroutes **every** external `http(s)` anchor click through sdpi-components' built-in `openUrl` event. So just author a normal link; it opens in the user's **default browser** automatically, no marker class or per-link wiring:
+
+```html
+<a href="https://iracedeck.com/downloads/" target="_blank" rel="noopener noreferrer">Downloads</a>
+```
+
+That event reaches the OS default browser on every host: Elgato handles it natively, the VSD (Mirabox) host receives it directly, and the Ulanzi PI bridge translates it to its `openurl` cmd (`src/ulanzi-bridge/translate.ts`). No plugin-side code is needed. The handler resolves the anchor's normalized `.href` and only reroutes `http(s)` (the SDK can't open other schemes, e.g. `mailto:`/`app://`, and in-PI/relative targets are left alone). It only intercepts when sdpi-components is loaded, so a load failure falls back to the link's default behavior; the `openUrl` send is fire-and-forget (rejections swallowed) and the listener installs once per document.
 
 ## Title Overrides Partial
 

--- a/packages/pi-components/partials/head-common.ejs
+++ b/packages/pi-components/partials/head-common.ejs
@@ -6,6 +6,12 @@
     display: none !important;
   }
 
+  /* Shared accent for PI links (Documentation, Downloads). Single source so a
+     restyle changes every link at once. */
+  :root {
+    --ird-link-color: #4a90d9;
+  }
+
   /* Collapsible section styles */
   .ird-collapsible {
     margin-top: 12px;
@@ -96,7 +102,7 @@
     border-top: 1px solid #3a3a3a;
   }
   .ird-docs-link a {
-    color: #4a90d9;
+    color: var(--ird-link-color);
     font-family: "Segoe UI", Arial, Roboto, Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
     font-size: 9pt;
     text-decoration: none;
@@ -108,7 +114,7 @@
   .ird-docs-link a:focus-visible {
     color: #6fb0f0;
     text-decoration: underline;
-    outline: 2px solid #4a90d9;
+    outline: 2px solid var(--ird-link-color);
     outline-offset: 2px;
     border-radius: 2px;
   }
@@ -122,6 +128,9 @@
     margin-top: 8px;
     padding-top: 8px;
     border-top: 1px solid #3a3a3a;
+  }
+  .ird-version a {
+    color: var(--ird-link-color);
   }
 
   /* Key bindings section styles */

--- a/packages/pi-components/partials/version.ejs
+++ b/packages/pi-components/partials/version.ejs
@@ -1,7 +1,6 @@
 <div class="ird-version">
 	Version: <%= version %> -
 	<a href="https://iracedeck.com/downloads/"
-	   style="color: #4a90d9;"
 	   target="_blank"
 	   rel="noopener noreferrer">Downloads</a>
 </div>

--- a/packages/pi-components/src/components/external-links.test.ts
+++ b/packages/pi-components/src/components/external-links.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+
+import { installExternalLinkHandler, resolveExternalUrl } from "./external-links.js";
+
+/** Build an anchor in `doc`. Omit `href` for an anchor with no href attribute. */
+function anchor(doc: Document, href?: string): HTMLAnchorElement {
+  const a = doc.createElement("a");
+
+  if (href !== undefined) a.setAttribute("href", href);
+
+  doc.body.appendChild(a);
+
+  return a;
+}
+
+/**
+ * A fresh, browsing-context-less document per handler test. Each
+ * `installExternalLinkHandler` call adds a document-level listener, so isolating
+ * the document keeps listeners (and jsdom navigation) from bleeding across tests.
+ */
+function freshDoc(): Document {
+  return document.implementation.createHTMLDocument("test");
+}
+
+function click(el: Element): MouseEvent {
+  const ev = new MouseEvent("click", { bubbles: true, cancelable: true });
+  el.dispatchEvent(ev);
+
+  return ev;
+}
+
+describe("resolveExternalUrl", () => {
+  it("returns the resolved href for an http(s) link", () => {
+    expect(resolveExternalUrl(anchor(document, "https://iracedeck.com/downloads/"))).toBe(
+      "https://iracedeck.com/downloads/",
+    );
+    expect(resolveExternalUrl(anchor(document, "http://example.com/"))).toBe("http://example.com/");
+  });
+
+  it("resolves the closest anchor when a descendant is clicked", () => {
+    const a = anchor(document, "https://iracedeck.com/docs/");
+    const inner = document.createElement("span");
+    a.appendChild(inner);
+
+    expect(resolveExternalUrl(inner)).toBe("https://iracedeck.com/docs/");
+  });
+
+  it("ignores schemes the SDK cannot open", () => {
+    expect(resolveExternalUrl(anchor(document, "mailto:hi@example.com"))).toBeNull();
+    expect(resolveExternalUrl(anchor(document, "app://open"))).toBeNull();
+  });
+
+  it("ignores an anchor with no href", () => {
+    expect(resolveExternalUrl(anchor(document))).toBeNull();
+  });
+
+  it("returns null when there is no anchor ancestor", () => {
+    expect(resolveExternalUrl(document.createElement("div"))).toBeNull();
+  });
+
+  it("returns null for a non-element / null target", () => {
+    expect(resolveExternalUrl(null)).toBeNull();
+    expect(resolveExternalUrl(document.createTextNode("text"))).toBeNull();
+  });
+});
+
+describe("installExternalLinkHandler", () => {
+  it("reroutes an http(s) link through the openUrl event and prevents default", () => {
+    const doc = freshDoc();
+    const send = vi.fn();
+    installExternalLinkHandler(doc, () => ({ send }));
+
+    const ev = click(anchor(doc, "https://iracedeck.com/downloads/"));
+
+    expect(send).toHaveBeenCalledWith("openUrl", { url: "https://iracedeck.com/downloads/" });
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it("falls back to default link behavior when the sdpi-components client is absent", () => {
+    const doc = freshDoc();
+    installExternalLinkHandler(doc, () => undefined);
+
+    // No client → we must not swallow the click, so the native <a> can open it.
+    expect(click(anchor(doc, "https://iracedeck.com/downloads/")).defaultPrevented).toBe(false);
+  });
+
+  it("ignores non-http(s) links and never calls the client for them", () => {
+    const doc = freshDoc();
+    const send = vi.fn();
+    installExternalLinkHandler(doc, () => ({ send }));
+
+    const ev = click(anchor(doc, "mailto:hi@example.com"));
+
+    expect(send).not.toHaveBeenCalled();
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  it("installs only one listener per document (idempotent)", () => {
+    const doc = freshDoc();
+    const send = vi.fn();
+    installExternalLinkHandler(doc, () => ({ send }));
+    installExternalLinkHandler(doc, () => ({ send }));
+
+    click(anchor(doc, "https://iracedeck.com/downloads/"));
+
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows a rejected send without throwing, still preventing default", () => {
+    const doc = freshDoc();
+    const send = vi.fn().mockRejectedValue(new Error("socket not ready"));
+    installExternalLinkHandler(doc, () => ({ send }));
+
+    const ev = click(anchor(doc, "https://iracedeck.com/downloads/"));
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(ev.defaultPrevented).toBe(true);
+  });
+});

--- a/packages/pi-components/src/components/external-links.ts
+++ b/packages/pi-components/src/components/external-links.ts
@@ -1,0 +1,83 @@
+/**
+ * Open external Property Inspector links in the user's default browser (issue #243).
+ *
+ * Links inside a PI — Documentation (`docs-link.ejs`), Downloads (`version.ejs`),
+ * the template-variable references in the Chat and Telemetry Display actions, and
+ * any future link — otherwise open in the deck app's small built-in browser. No PI
+ * link ever wants that, so a single delegated click handler reroutes every external
+ * `http(s)` anchor click through sdpi-components' built-in `openUrl` event.
+ *
+ * That event reaches the OS default browser on every host: Elgato handles it
+ * natively, the VSD (Mirabox) host — which speaks the Elgato PI protocol directly —
+ * receives it, and the Ulanzi PI bridge translates it to its own `openurl` cmd
+ * (`src/ulanzi-bridge/translate.ts`). No plugin-side code is needed.
+ */
+
+/** Minimal shape of the sdpi-components client this handler depends on. */
+interface StreamDeckClientLike {
+  send(event: string, payload?: Record<string, unknown>): unknown;
+}
+
+interface SDPIComponentsGlobal {
+  SDPIComponents?: { streamDeckClient?: StreamDeckClientLike };
+}
+
+/** Read the sdpi-components client off the global scope, if it has loaded. */
+function defaultClient(): StreamDeckClientLike | undefined {
+  return (globalThis as SDPIComponentsGlobal).SDPIComponents?.streamDeckClient;
+}
+
+/**
+ * Resolve the absolute URL to open for a clicked element, or `null` when the click
+ * should keep its default behavior. Walks up to the nearest `<a>` and reads its
+ * resolved `.href`/`.protocol` (so protocol-relative and whitespace-padded hrefs
+ * are normalized), accepting only `http(s)` — the SDK can't open other schemes
+ * (e.g. `mailto:`, `app://`) or in-PI/relative targets.
+ */
+export function resolveExternalUrl(target: EventTarget | null): string | null {
+  const anchor = target instanceof Element ? target.closest("a") : null;
+
+  if (!anchor) return null;
+
+  // `.protocol` is normalized + lowercased; `.href` is the resolved absolute URL.
+  return anchor.protocol === "http:" || anchor.protocol === "https:" ? anchor.href : null;
+}
+
+/** Documents that already have the click handler installed (idempotency guard). */
+const installedDocs = new WeakSet<Document>();
+
+/**
+ * Install a single delegated click handler that reroutes external `http(s)` link
+ * clicks through sdpi-components' `openUrl` event. Idempotent per document, so the
+ * bundle being evaluated more than once never registers duplicate listeners.
+ *
+ * We only intercept (call `preventDefault`) when the sdpi-components client is
+ * present, so if the library failed to load the link keeps working through the
+ * built-in browser rather than silently doing nothing. `doc`/`getClient` are
+ * injectable for testing; in the browser they default to the document and the
+ * global sdpi-components client resolved at click time.
+ */
+export function installExternalLinkHandler(
+  doc: Document = document,
+  getClient: () => StreamDeckClientLike | undefined = defaultClient,
+): void {
+  if (installedDocs.has(doc)) return;
+
+  installedDocs.add(doc);
+
+  doc.addEventListener("click", (ev) => {
+    const url = resolveExternalUrl(ev.target);
+
+    if (!url) return;
+
+    const client = getClient();
+
+    // No client (sdpi-components unavailable): fall back to default link behavior.
+    if (!client) return;
+
+    ev.preventDefault();
+    // Fire-and-forget; swallow rejections (e.g. the PI socket isn't ready yet) so a
+    // failed send never surfaces as an unhandled promise rejection.
+    void Promise.resolve(client.send("openUrl", { url })).catch(() => {});
+  });
+}

--- a/packages/pi-components/src/components/index.ts
+++ b/packages/pi-components/src/components/index.ts
@@ -1,3 +1,6 @@
+// External links - reroute external http(s) PI link clicks to the OS default browser
+import { installExternalLinkHandler } from "./external-links.js";
+
 /**
  * Property Inspector Components for iRaceDeck Stream Deck plugins
  *
@@ -45,3 +48,6 @@ export { WarningsBanner } from "./warnings.js";
 
 // Binding Status - per-mode communication / binding status line under the Mode selector
 export { BindingStatus } from "./binding-status.js";
+
+// Side effect on bundle load: reroute external PI links to the default browser (issue #243).
+installExternalLinkHandler();

--- a/packages/website/src/content/docs/changelog.mdx
+++ b/packages/website/src/content/docs/changelog.mdx
@@ -22,6 +22,10 @@ _Unreleased_
 
 - Driver-info template prefixes (`self`, `track_ahead`/`track_behind`, `race_ahead`/`race_behind`, `focused`) now report the live race order for both overall and class position — they update continuously as cars move (like the Session Info Position readout while racing on track), instead of only refreshing at the start/finish line.
 
+**Bug Fixes**
+
+- Links in an action's settings (such as Documentation and Downloads) now open in your default web browser instead of the deck app's small built-in browser window.
+
 ## 1.22.2
 
 _2026-06-25_


### PR DESCRIPTION
## Related Issue

Fixes #243

## What changed?

Links in a Property Inspector (Documentation in `docs-link.ejs`, Downloads in `version.ejs`, and the "View full list of template variables!" links in the Chat and Telemetry Display actions) opened in the deck app's small built-in browser. No PI link ever wants that, so a single delegated click handler — `installExternalLinkHandler()` in the new `packages/pi-components/src/components/external-links.ts`, run on load from the `pi-components.js` bundle entry — now reroutes **every** external `http(s)` anchor click through sdpi-components' built-in `openUrl` event.

That event reaches the OS default browser on every host with no plugin-side code: Elgato handles it natively, the VSD (Mirabox) host (which speaks the Elgato PI protocol directly) receives it, and the Ulanzi PI bridge already translates `openUrl` → its `openurl` cmd. The handler resolves the anchor's normalized `.href` and only reroutes `http(s)` (the SDK can't open other schemes, e.g. `mailto:`/`app://`); it only intercepts when sdpi-components is loaded, so a load failure falls back to the link's default behavior; the send is fire-and-forget (rejections swallowed) and the listener installs once per document.

The `#4a90d9` PI link accent was also consolidated into a `--ird-link-color` CSS variable in `head-common.ejs`, replacing the per-link literals.

## How to test

1. Build and load the plugin (`pnpm build`), open any action's Property Inspector.
2. Click the **Documentation** link (bottom of most actions) and the **Downloads** link in the version footer — both should open in your real default browser, not an in-app window.
3. Open the **Chat** or **Telemetry Display** action and click **"View full list of template variables!"** — same behavior.
4. Best-effort: repeat on Mirabox / Ulanzi hardware if available (see note below).

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — shared `@iracedeck/pi-components` bundle, consumed by all three plugins; no per-plugin wiring needed
- [x] No unrelated changes included

## Note on host behavior

`openUrl` is best-effort on non-Elgato hosts: the PI sends the event, but the Stream Dock (Mirabox) / UlanziStudio host must honor it. The SDK gives no success callback, so the handler can't conditionally fall back — same caveat the existing version-check changelog-opener carries. Elgato (the primary target) is reliable. A follow-up issue tracks verifying/​hardening this on Mirabox/Ulanzi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Links in action settings and related PI screens now open in the user’s default web browser instead of the deck app’s built-in browser.
  * External `http`/`https` links are handled more reliably, including clicks on elements nested inside a link.
* **Documentation**
  * Updated PI template guidance and changelog notes with clearer cross-references and an explanation of the default-browser external link behavior.
* **Style**
  * Standardized the PI link/accent color using a shared styling variable for consistent focus and version link accents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->