### PR TITLE
Add sorted session car selector slots

### DIFF
--- a/packages/deck-core/src/index.ts
+++ b/packages/deck-core/src/index.ts
@@ -286,3 +286,12 @@ export {
 
 // Version-check / changelog opener (issue #680)
 export { CHANGELOG_BASE_URL, buildChangelogUrl, runVersionCheck, shouldOpenChangelog } from "./version-check.js";
+
+// Selected-car target singleton (shared across camera, admin, and replay actions)
+export {
+  setSelectedCar,
+  getSelectedCar,
+  clearSelectedCar,
+  onSelectedCarChange,
+  type SelectedCar,
+} from "./selected-car.js";

--- a/packages/deck-core/src/selected-car.test.ts
+++ b/packages/deck-core/src/selected-car.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { clearSelectedCar, getSelectedCar, onSelectedCarChange, setSelectedCar } from "./selected-car.js";
+
+describe("selected-car", () => {
+  beforeEach(() => {
+    clearSelectedCar();
+  });
+
+  afterEach(() => {
+    clearSelectedCar();
+  });
+
+  describe("getSelectedCar", () => {
+    it("returns null initially", () => {
+      expect(getSelectedCar()).toBeNull();
+    });
+  });
+
+  describe("setSelectedCar", () => {
+    it("sets and returns the selected car", () => {
+      setSelectedCar({ carIdx: 5, carNumber: "042", carNumberRaw: 42 });
+      expect(getSelectedCar()).toEqual({ carIdx: 5, carNumber: "042", carNumberRaw: 42 });
+    });
+
+    it("replaces a previously set car", () => {
+      setSelectedCar({ carIdx: 5, carNumber: "042", carNumberRaw: 42 });
+      setSelectedCar({ carIdx: 10, carNumber: "007", carNumberRaw: 7 });
+      expect(getSelectedCar()).toEqual({ carIdx: 10, carNumber: "007", carNumberRaw: 7 });
+    });
+  });
+
+  describe("clearSelectedCar", () => {
+    it("sets selected car back to null", () => {
+      setSelectedCar({ carIdx: 5, carNumber: "042", carNumberRaw: 42 });
+      clearSelectedCar();
+      expect(getSelectedCar()).toBeNull();
+    });
+
+    it("is a no-op when already null", () => {
+      expect(() => clearSelectedCar()).not.toThrow();
+      expect(getSelectedCar()).toBeNull();
+    });
+  });
+
+  describe("onSelectedCarChange", () => {
+    it("fires listener when car is set", () => {
+      const listener = vi.fn();
+      onSelectedCarChange(listener);
+
+      setSelectedCar({ carIdx: 5, carNumber: "042", carNumberRaw: 42 });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith({ carIdx: 5, carNumber: "042", carNumberRaw: 42 });
+    });
+
+    it("fires listener with null when car is cleared", () => {
+      const listener = vi.fn();
+      setSelectedCar({ carIdx: 5, carNumber: "042", carNumberRaw: 42 });
+      onSelectedCarChange(listener);
+
+      clearSelectedCar();
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(null);
+    });
+
+    it("stops firing after unsubscribe", () => {
+      const listener = vi.fn();
+      const unsubscribe = onSelectedCarChange(listener);
+
+      unsubscribe();
+      setSelectedCar({ carIdx: 5, carNumber: "042", carNumberRaw: 42 });
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("supports multiple listeners", () => {
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+      onSelectedCarChange(listener1);
+      onSelectedCarChange(listener2);
+
+      setSelectedCar({ carIdx: 3, carNumber: "003", carNumberRaw: 3 });
+
+      expect(listener1).toHaveBeenCalledTimes(1);
+      expect(listener2).toHaveBeenCalledTimes(1);
+    });
+
+    it("unsubscribing one listener does not affect others", () => {
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+      const unsubscribe1 = onSelectedCarChange(listener1);
+      onSelectedCarChange(listener2);
+
+      unsubscribe1();
+      setSelectedCar({ carIdx: 3, carNumber: "003", carNumberRaw: 3 });
+
+      expect(listener1).not.toHaveBeenCalled();
+      expect(listener2).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/deck-core/src/selected-car.ts
+++ b/packages/deck-core/src/selected-car.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared selected-car singleton.
+ *
+ * Set by the `select-reference-car` button. Camera-controls, race-admin, and
+ * replay-control actions read this to target the chosen car independently of
+ * which car the camera is currently watching.
+ */
+
+export interface SelectedCar {
+  /** iRacing driver index (0–63) */
+  carIdx: number;
+  /** Display car number used in admin chat commands, e.g. "042" */
+  carNumber: string;
+  /** Raw car number used by the camera API, e.g. 3042 */
+  carNumberRaw: number;
+}
+
+let selectedCar: SelectedCar | null = null;
+const listeners = new Set<(car: SelectedCar | null) => void>();
+
+/**
+ * Set the currently selected car. Notifies all subscribers.
+ */
+export function setSelectedCar(car: SelectedCar): void {
+  selectedCar = car;
+
+  for (const listener of listeners) listener(car);
+}
+
+/**
+ * Get the currently selected car, or null if none is selected.
+ */
+export function getSelectedCar(): SelectedCar | null {
+  return selectedCar;
+}
+
+/**
+ * Clear the selected car. Notifies all subscribers.
+ */
+export function clearSelectedCar(): void {
+  selectedCar = null;
+
+  for (const listener of listeners) listener(null);
+}
+
+/**
+ * Subscribe to selected-car changes.
+ * @returns A cleanup function that unsubscribes the listener.
+ */
+export function onSelectedCarChange(listener: (car: SelectedCar | null) => void): () => void {
+  listeners.add(listener);
+
+  return () => listeners.delete(listener);
+}

--- a/packages/icons/preview/splits-delta-cycle/display-ref-car.svg
+++ b/packages/icons/preview/splits-delta-cycle/display-ref-car.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 76 54" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#412244","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"CAR\nREFERENCE"},"border":{"color":"#714474"}}</desc>
+  <desc>{"colors":{"backgroundColor":"#412244","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"CAR\nREFERENCE","fontSize":16,"locked":["fontSize"]},"border":{"color":"#714474"}}</desc>
   
 
     <rect x="10" y="2" width="56" height="28" rx="8" fill="none" stroke="#ffffff" stroke-width="3"/>

--- a/packages/icons/splits-delta-cycle/display-ref-car.svg
+++ b/packages/icons/splits-delta-cycle/display-ref-car.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 76 54" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#412244","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"CAR\nREFERENCE"},"border":{"color":"#714474"}}</desc>
+  <desc>{"colors":{"backgroundColor":"#412244","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"CAR\nREFERENCE","fontSize":16,"locked":["fontSize"]},"border":{"color":"#714474"}}</desc>
   
 
     <rect x="10" y="2" width="56" height="28" rx="8" fill="none" stroke="{{graphic1Color}}" stroke-width="3"/>

--- a/packages/iracing-actions/src/actions/camera-controls/camera-controls.ts
+++ b/packages/iracing-actions/src/actions/camera-controls/camera-controls.ts
@@ -1,5 +1,6 @@
 import {
   assembleIcon,
+  clearSelectedCar,
   CommonSettings,
   ConnectionStateAwareAction,
   extractGraphicContent,
@@ -917,6 +918,11 @@ export class CameraControls extends ConnectionStateAwareAction<CameraControlsSet
         }
 
         const success = camera.switchNum(selected.carNumberRaw, groupNum, cameraNum);
+
+        if (success) {
+          clearSelectedCar();
+        }
+
         this.logger.info("Focus on selected car executed");
         this.logger.debug(`Result: ${success}, carNumberRaw: ${selected.carNumberRaw}, carIdx: ${selected.carIdx}`);
         break;

--- a/packages/iracing-actions/src/actions/camera-controls/camera-controls.ts
+++ b/packages/iracing-actions/src/actions/camera-controls/camera-controls.ts
@@ -9,6 +9,7 @@ import {
   getGlobalGraphicSettings,
   getGlobalSettings,
   getGlobalTitleSettings,
+  getSelectedCar,
   type IDeckDialDownEvent,
   type IDeckDialRotateEvent,
   type IDeckDidReceiveSettingsEvent,
@@ -79,6 +80,7 @@ const FOCUS_TARGET_VALUES = [
   "focus-on-leader",
   "focus-on-incident",
   "focus-on-most-exciting",
+  "focus-selected-car",
   "switch-by-position",
   "switch-by-car-number",
   "set-camera-state",
@@ -255,6 +257,7 @@ const FOCUS_ICONS: Record<string, string> = {
   "focus-on-leader": focusOnLeaderSvg,
   "focus-on-incident": focusOnIncidentSvg,
   "focus-on-most-exciting": focusOnMostExcitingSvg,
+  "focus-selected-car": switchByCarNumberSvg,
   "switch-by-position": switchByPositionSvg,
   "switch-by-car-number": switchByCarNumberSvg,
   "set-camera-state": setCameraStateSvg,
@@ -265,6 +268,7 @@ const FOCUS_TITLES: Record<string, string> = {
   "focus-on-leader": "FOCUS\nLEADER",
   "focus-on-incident": "FOCUS\nINCIDENT",
   "focus-on-most-exciting": "MOST\nEXCITING",
+  "focus-selected-car": "FOCUS\nSELECTED",
   "switch-by-position": "SWITCH\nPOSITION",
   "switch-by-car-number": "SWITCH\nCAR #",
   "set-camera-state": "SET\nCAM STATE",
@@ -902,6 +906,19 @@ export class CameraControls extends ConnectionStateAwareAction<CameraControlsSet
         const success = camera.focusOnMostExciting(groupNum, cameraNum);
         this.logger.info("Focus on most exciting executed");
         this.logger.debug(`Result: ${success}`);
+        break;
+      }
+      case "focus-selected-car": {
+        const selected = getSelectedCar();
+
+        if (!selected) {
+          this.logger.warn("Cannot focus selected car: no car has been selected via a Select Reference Car button");
+          break;
+        }
+
+        const success = camera.switchNum(selected.carNumberRaw, groupNum, cameraNum);
+        this.logger.info("Focus on selected car executed");
+        this.logger.debug(`Result: ${success}, carNumberRaw: ${selected.carNumberRaw}, carIdx: ${selected.carIdx}`);
         break;
       }
       case "switch-by-position": {

--- a/packages/iracing-actions/src/actions/camera-focus/camera-focus.ejs
+++ b/packages/iracing-actions/src/actions/camera-focus/camera-focus.ejs
@@ -80,6 +80,7 @@
 				<option value="focus-on-leader">Focus on Leader</option>
 				<option value="focus-on-incident">Focus on Incident</option>
 				<option value="focus-on-most-exciting">Focus on Most Exciting</option>
+				<option value="focus-selected-car">Focus Selected Car</option>
 				<option value="switch-by-position">Switch by Position</option>
 				<option value="switch-by-car-number">Switch by Car Number</option>
 				<option value="set-camera-state">Set Camera State</option>

--- a/packages/iracing-actions/src/actions/comms-catalog.ts
+++ b/packages/iracing-actions/src/actions/comms-catalog.ts
@@ -104,6 +104,7 @@ export const COMMS_CATALOG: Record<string, ActionCommEntry> = {
   "splits-delta-cycle": entry("mode", {
     cycle: keybindBy("direction", { next: "splitsDeltaNext", previous: "splitsDeltaPrevious" }),
     "toggle-ref-car": keybind("toggleUiDisplayRefCar"),
+    "select-reference-car": api,
     "custom-sector-start": keybind("splitsDeltaCustomSectorStart"),
     "custom-sector-end": keybind("splitsDeltaCustomSectorEnd"),
     "active-reset-set": keybind("splitsDeltaActiveResetSet"),
@@ -423,6 +424,7 @@ export const COMMS_CATALOG: Record<string, ActionCommEntry> = {
       "jump-to-beginning",
       "jump-to-live",
       "jump-to-my-car",
+      "jump-to-selected-car",
       "jump-to-fastest-lap",
       "next-car-number",
       "prev-car-number",

--- a/packages/iracing-actions/src/actions/data/action-comms.json
+++ b/packages/iracing-actions/src/actions/data/action-comms.json
@@ -122,6 +122,9 @@
         "key": "toggleUiDisplayRefCar"
       }
     },
+    "select-reference-car": {
+      "method": "api"
+    },
     "custom-sector-start": {
       "method": "keybind",
       "binding": {
@@ -2036,6 +2039,9 @@
       "method": "api"
     },
     "jump-to-my-car": {
+      "method": "api"
+    },
+    "jump-to-selected-car": {
       "method": "api"
     },
     "jump-to-fastest-lap": {

--- a/packages/iracing-actions/src/actions/race-admin/race-admin-commands.ts
+++ b/packages/iracing-actions/src/actions/race-admin/race-admin-commands.ts
@@ -3,11 +3,12 @@
  *
  * Pure functions for constructing admin chat command strings.
  */
+import { getSelectedCar } from "@iracedeck/deck-core";
 import { buildTemplateContext, resolveTemplate, type SDKController } from "@iracedeck/iracing-sdk";
 
 import { RACE_ADMIN_MODE_META, type RaceAdminMode, type RaceAdminModeMeta } from "./race-admin-modes.js";
 
-export type DriverTarget = "viewed-car" | "specific" | "type-in-chat";
+export type DriverTarget = "viewed-car" | "selected-car" | "specific" | "type-in-chat";
 
 export interface RaceAdminSettings {
   mode: RaceAdminMode;
@@ -40,6 +41,10 @@ export function resolveDriverTarget(
 
   if (settings.driverTarget === "viewed-car") {
     return viewedCarNumber ?? null;
+  }
+
+  if (settings.driverTarget === "selected-car") {
+    return getSelectedCar()?.carNumber ?? null;
   }
 
   if (settings.driverTarget === "specific") {

--- a/packages/iracing-actions/src/actions/race-admin/race-admin.ejs
+++ b/packages/iracing-actions/src/actions/race-admin/race-admin.ejs
@@ -49,9 +49,10 @@
 
 		<!-- Driver targeting (shown for modes that accept a driver parameter) -->
 		<div id="driver-section" class="hidden">
-			<sdpi-item label="Driver Target">
-				<sdpi-select id="driver-target-select" setting="driverTarget" default="type-in-chat">
-					<option value="viewed-car">Use Viewed Car</option>
+				<sdpi-item id="driver-target-item" label="Driver Target">
+					<sdpi-select id="driver-target-select" setting="driverTarget" default="type-in-chat">
+						<option value="viewed-car">Use Viewed Car</option>
+						<option value="selected-car">Use Selected Car</option>
 					<option value="specific">Specific Car Number</option>
 					<option value="type-in-chat">Type in Chat</option>
 				</sdpi-select>

--- a/packages/iracing-actions/src/actions/race-admin/race-admin.ts
+++ b/packages/iracing-actions/src/actions/race-admin/race-admin.ts
@@ -17,6 +17,7 @@ import {
   getGlobalSettings,
   getGlobalTitleSettings,
   getKeyboard,
+  getSelectedCar,
   type IDeckDialDownEvent,
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
@@ -65,7 +66,7 @@ import { RACE_ADMIN_MODE_META, RACE_ADMIN_MODES, type RaceAdminMode } from "./ra
 
 const RaceAdminSettings = CommonSettings.extend({
   mode: z.enum(RACE_ADMIN_MODES).default("yellow"),
-  driverTarget: z.enum(["viewed-car", "specific", "type-in-chat"]).default("type-in-chat"),
+  driverTarget: z.enum(["viewed-car", "selected-car", "specific", "type-in-chat"]).default("type-in-chat"),
   carNumber: z.string().default(""),
   message: z.string().default(""),
   penaltyType: z.enum(["time", "laps", "drivethrough"]).default("time"),
@@ -235,6 +236,13 @@ export class RaceAdmin extends ConnectionStateAwareAction<RaceAdminSettings> {
     // the command is dispatched normally via the SDK.
     if (meta.needsDriver && settings.driverTarget === "type-in-chat") {
       await this.executeTypeInChat(contextId, mode);
+
+      return;
+    }
+
+    // "Selected car" requires a prior selection via a Select Reference Car button.
+    if (meta.needsDriver && settings.driverTarget === "selected-car" && !getSelectedCar()) {
+      this.logger.warn("Cannot execute admin command: no car selected — press a Select Reference Car button first");
 
       return;
     }

--- a/packages/iracing-actions/src/actions/race-admin/race-admin.ts
+++ b/packages/iracing-actions/src/actions/race-admin/race-admin.ts
@@ -7,6 +7,7 @@
 // ── Icon Imports ────────────────────────────────────────────────
 import {
   assembleIcon,
+  clearSelectedCar,
   CommonSettings,
   ConnectionStateAwareAction,
   getClipboard,
@@ -261,6 +262,10 @@ export class RaceAdmin extends ConnectionStateAwareAction<RaceAdminSettings> {
 
     if (success) {
       this.logger.info("Admin command executed");
+
+      if (settings.driverTarget === "selected-car") {
+        clearSelectedCar();
+      }
     } else {
       this.logger.warn("Failed to send admin command");
     }

--- a/packages/iracing-actions/src/actions/replay-control/replay-control.ejs
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.ejs
@@ -38,6 +38,7 @@
 				</optgroup>
 				<optgroup label="Camera">
 					<option value="jump-to-my-car">Jump to My Car</option>
+					<option value="jump-to-selected-car">Jump to Selected Car</option>
 					<option value="next-car">Next Car</option>
 					<option value="prev-car">Previous Car</option>
 					<option value="next-car-number">Next Car (Number Order)</option>

--- a/packages/iracing-actions/src/actions/replay-control/replay-control.ts
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.ts
@@ -13,6 +13,7 @@ import {
   getGlobalGraphicSettings,
   getGlobalSettings,
   getGlobalTitleSettings,
+  getSelectedCar,
   ICON_BASE_TEMPLATE,
   type IDeckDialDownEvent,
   type IDeckDialRotateEvent,
@@ -92,6 +93,7 @@ const REPLAY_CONTROL_MODES = [
   "jump-to-beginning",
   "jump-to-live",
   "jump-to-my-car",
+  "jump-to-selected-car",
   "jump-to-fastest-lap",
   "next-car",
   "prev-car",
@@ -124,6 +126,7 @@ const REPLAY_CONTROL_ICONS: Record<ReplayControlMode, string> = {
   "jump-to-beginning": jumpToBeginningIconSvg,
   "jump-to-live": jumpToLiveIconSvg,
   "jump-to-my-car": jumpToMyCarIconSvg,
+  "jump-to-selected-car": jumpToMyCarIconSvg,
   "jump-to-fastest-lap": jumpToFastestLapIconSvg,
   "next-car": nextCarIconSvg,
   "prev-car": prevCarIconSvg,
@@ -154,6 +157,7 @@ const REPLAY_CONTROL_TITLES: Record<ReplayControlMode, string> = {
   "jump-to-beginning": "JUMP TO\nBEGINNING",
   "jump-to-live": "JUMP TO\nLIVE",
   "jump-to-my-car": "JUMP TO\nMY CAR",
+  "jump-to-selected-car": "JUMP TO\nSELECTED",
   "jump-to-fastest-lap": "FASTEST\nLAP",
   "next-car": "CAR\nNEXT",
   "prev-car": "CAR\nPREVIOUS",
@@ -1691,6 +1695,20 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
         const success = camera.switchNum(carNum, 0, 0);
         this.logger.info("Jump to my car executed");
         this.logger.debug(`Result: ${success}, carNum: ${carNum}`);
+        break;
+      }
+      case "jump-to-selected-car": {
+        const selected = getSelectedCar();
+
+        if (!selected) {
+          this.logger.warn("Cannot jump to selected car: no car selected — press a Select Reference Car button first");
+          break;
+        }
+
+        const jumpCamera = getCommands().camera;
+        const jumpSuccess = jumpCamera.switchNum(selected.carNumberRaw, 0, 0);
+        this.logger.info("Jump to selected car executed");
+        this.logger.debug(`Result: ${jumpSuccess}, carNumberRaw: ${selected.carNumberRaw}, carIdx: ${selected.carIdx}`);
         break;
       }
       case "jump-to-fastest-lap": {

--- a/packages/iracing-actions/src/actions/replay-control/replay-control.ts
+++ b/packages/iracing-actions/src/actions/replay-control/replay-control.ts
@@ -1,6 +1,7 @@
 import {
   applyGraphicTransform,
   assembleIcon,
+  clearSelectedCar,
   CommonSettings,
   computeGraphicArea,
   ConnectionStateAwareAction,
@@ -1707,6 +1708,11 @@ export class ReplayControl extends ConnectionStateAwareAction<ReplayControlSetti
 
         const jumpCamera = getCommands().camera;
         const jumpSuccess = jumpCamera.switchNum(selected.carNumberRaw, 0, 0);
+
+        if (jumpSuccess) {
+          clearSelectedCar();
+        }
+
         this.logger.info("Jump to selected car executed");
         this.logger.debug(`Result: ${jumpSuccess}, carNumberRaw: ${selected.carNumberRaw}, carIdx: ${selected.carIdx}`);
         break;

--- a/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ejs
+++ b/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ejs
@@ -10,6 +10,7 @@
 			<sdpi-select id="mode-select" setting="mode" default="cycle">
 				<option value="cycle">Cycle Splits Delta</option>
 				<option value="toggle-ref-car">Toggle Reference Car</option>
+				<option value="select-reference-car">Select Reference Car</option>
 				<option value="custom-sector-start">Custom Sector Start</option>
 				<option value="custom-sector-end">Custom Sector End</option>
 				<option value="active-reset-set">Set Active Reset Point</option>
@@ -25,6 +26,10 @@
 				<option value="next">Next</option>
 				<option value="previous">Previous</option>
 			</sdpi-select>
+		</sdpi-item>
+
+		<sdpi-item id="car-idx-item" label="Car Index" class="hidden">
+			<sdpi-textfield id="car-idx-field" setting="carIdx" default="0" placeholder="0–63" inputmode="numeric" pattern="[0-9]*"></sdpi-textfield>
 		</sdpi-item>
 
 		<%- include('title-overrides') %>
@@ -52,6 +57,7 @@
 				await customElements.whenDefined("sdpi-select");
 
 				const modeSelect = document.getElementById("mode-select");
+				const carIdxField = document.getElementById("car-idx-field");
 				if (modeSelect) {
 					updateVisibility(modeSelect.value || "cycle");
 
@@ -71,14 +77,31 @@
 						}
 					}, 100);
 				}
+
+				if (carIdxField) {
+					carIdxField.addEventListener("input", () => {
+						const input = carIdxField.shadowRoot
+							? carIdxField.shadowRoot.querySelector("input")
+							: carIdxField.querySelector("input");
+						if (input && input.value !== input.value.replace(/[^0-9]/g, "")) {
+							input.value = input.value.replace(/[^0-9]/g, "");
+						}
+					});
+				}
 			}
 
 			function updateVisibility(mode) {
 				const directionItem = document.getElementById("direction-item");
+				const carIdxItem = document.getElementById("car-idx-item");
 				if (mode === "cycle") {
 					directionItem?.classList.remove("hidden");
+					carIdxItem?.classList.add("hidden");
+				} else if (mode === "select-reference-car") {
+					directionItem?.classList.add("hidden");
+					carIdxItem?.classList.remove("hidden");
 				} else {
 					directionItem?.classList.add("hidden");
+					carIdxItem?.classList.add("hidden");
 				}
 			}
 

--- a/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ejs
+++ b/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ejs
@@ -28,8 +28,8 @@
 			</sdpi-select>
 		</sdpi-item>
 
-		<sdpi-item id="car-idx-item" label="Car Index" class="hidden">
-			<sdpi-textfield id="car-idx-field" setting="carIdx" default="0" placeholder="0–63" inputmode="numeric" pattern="[0-9]*"></sdpi-textfield>
+		<sdpi-item id="slot-index-item" label="Slot Index" class="hidden">
+			<sdpi-textfield id="slot-index-field" setting="slotIndex" default="0" placeholder="0, 1, 2, …" inputmode="numeric" pattern="[0-9]*"></sdpi-textfield>
 		</sdpi-item>
 
 		<%- include('title-overrides') %>
@@ -57,7 +57,7 @@
 				await customElements.whenDefined("sdpi-select");
 
 				const modeSelect = document.getElementById("mode-select");
-				const carIdxField = document.getElementById("car-idx-field");
+				const slotIndexField = document.getElementById("slot-index-field");
 				if (modeSelect) {
 					updateVisibility(modeSelect.value || "cycle");
 
@@ -78,11 +78,11 @@
 					}, 100);
 				}
 
-				if (carIdxField) {
-					carIdxField.addEventListener("input", () => {
-						const input = carIdxField.shadowRoot
-							? carIdxField.shadowRoot.querySelector("input")
-							: carIdxField.querySelector("input");
+				if (slotIndexField) {
+					slotIndexField.addEventListener("input", () => {
+						const input = slotIndexField.shadowRoot
+							? slotIndexField.shadowRoot.querySelector("input")
+							: slotIndexField.querySelector("input");
 						if (input && input.value !== input.value.replace(/[^0-9]/g, "")) {
 							input.value = input.value.replace(/[^0-9]/g, "");
 						}
@@ -92,16 +92,16 @@
 
 			function updateVisibility(mode) {
 				const directionItem = document.getElementById("direction-item");
-				const carIdxItem = document.getElementById("car-idx-item");
+				const slotIndexItem = document.getElementById("slot-index-item");
 				if (mode === "cycle") {
 					directionItem?.classList.remove("hidden");
-					carIdxItem?.classList.add("hidden");
+					slotIndexItem?.classList.add("hidden");
 				} else if (mode === "select-reference-car") {
 					directionItem?.classList.add("hidden");
-					carIdxItem?.classList.remove("hidden");
+					slotIndexItem?.classList.remove("hidden");
 				} else {
 					directionItem?.classList.add("hidden");
-					carIdxItem?.classList.add("hidden");
+					slotIndexItem?.classList.add("hidden");
 				}
 			}
 

--- a/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.test.ts
+++ b/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.test.ts
@@ -72,6 +72,9 @@ vi.mock("@iracedeck/deck-core", () => ({
     startRole: vi.fn().mockResolvedValue(true),
     stopRole: vi.fn().mockResolvedValue(true),
   })),
+  setSelectedCar: vi.fn(),
+  getSelectedCar: vi.fn(() => null),
+  onSelectedCarChange: vi.fn(() => vi.fn()),
   getGlobalTitleSettings: vi.fn(() => ({})),
   resolveIconColors: vi.fn((_svg, _global, _overrides) => ({})),
   resolveBorderSettings: vi.fn((_svg: unknown, _global: unknown, _overrides?: unknown, _stateColor?: string) => ({
@@ -180,6 +183,30 @@ describe("SplitsDeltaCycle", () => {
 
       expect(result).toContain("data:image/svg+xml");
       expect(decodeURIComponent(result)).toContain("ref-car");
+    });
+
+    it("should show the selected target car for select-reference-car mode", () => {
+      const result = generateSplitsDeltaCycleSvg(
+        { mode: "select-reference-car", direction: "next", carIdx: 5 },
+        false,
+        "42",
+      );
+      const decoded = decodeURIComponent(result);
+
+      expect(result).toContain("data:image/svg+xml");
+      expect(decoded).toContain("42");
+    });
+
+    it("should show em-dash for select-reference-car mode when no car resolved", () => {
+      const result = generateSplitsDeltaCycleSvg(
+        { mode: "select-reference-car", direction: "next", carIdx: 5 },
+        false,
+        null,
+      );
+      const decoded = decodeURIComponent(result);
+
+      expect(result).toContain("data:image/svg+xml");
+      expect(decoded).toContain("\u2014");
     });
 
     it("should include REFERENCE and CAR labels for toggle-ref-car mode", () => {

--- a/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.test.ts
+++ b/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.test.ts
@@ -1,3 +1,4 @@
+import { assembleIcon } from "@iracedeck/deck-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { generateSplitsDeltaCycleSvg, GLOBAL_KEY_NAMES } from "./splits-delta-cycle.js";
@@ -188,7 +189,7 @@ describe("SplitsDeltaCycle", () => {
 
     it("should show the selected target car for select-reference-car mode", () => {
       const result = generateSplitsDeltaCycleSvg(
-        { mode: "select-reference-car", direction: "next", carIdx: 5 },
+        { mode: "select-reference-car", direction: "next", slotIndex: 0 },
         false,
         "42",
       );
@@ -200,14 +201,29 @@ describe("SplitsDeltaCycle", () => {
 
     it("should show em-dash for select-reference-car mode when no car resolved", () => {
       const result = generateSplitsDeltaCycleSvg(
-        { mode: "select-reference-car", direction: "next", carIdx: 5 },
+        { mode: "select-reference-car", direction: "next", slotIndex: 0 },
         false,
         null,
       );
       const decoded = decodeURIComponent(result);
 
       expect(result).toContain("data:image/svg+xml");
-      expect(decoded).toContain("\u2014");
+      expect(decoded).toContain("—");
+    });
+
+    it("should apply dim background color when isOffline is true", () => {
+      vi.mocked(assembleIcon).mockClear();
+
+      generateSplitsDeltaCycleSvg(
+        { mode: "select-reference-car", direction: "next", slotIndex: 2 },
+        false,
+        "7",
+        false,
+        true,
+      );
+
+      const call = vi.mocked(assembleIcon).mock.calls[0]?.[0] as { colors: Record<string, string> } | undefined;
+      expect(call?.colors?.backgroundColor).toBe("#333333");
     });
 
     it("should include REFERENCE and CAR labels for toggle-ref-car mode", () => {

--- a/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.test.ts
+++ b/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.test.ts
@@ -75,6 +75,7 @@ vi.mock("@iracedeck/deck-core", () => ({
   setSelectedCar: vi.fn(),
   getSelectedCar: vi.fn(() => null),
   onSelectedCarChange: vi.fn(() => vi.fn()),
+  clearSelectedCar: vi.fn(),
   getGlobalTitleSettings: vi.fn(() => ({})),
   resolveIconColors: vi.fn((_svg, _global, _overrides) => ({})),
   resolveBorderSettings: vi.fn((_svg: unknown, _global: unknown, _overrides?: unknown, _stateColor?: string) => ({

--- a/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ts
+++ b/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ts
@@ -28,11 +28,7 @@ import customSectorStartIconSvg from "@iracedeck/icons/splits-delta-cycle/custom
 import displayRefCarIconSvg from "@iracedeck/icons/splits-delta-cycle/display-ref-car.svg";
 import nextIconSvg from "@iracedeck/icons/splits-delta-cycle/next.svg";
 import previousIconSvg from "@iracedeck/icons/splits-delta-cycle/previous.svg";
-import {
-  getCarNumberFromSessionInfo,
-  getCarNumberRawFromSessionInfo,
-  type TelemetryData,
-} from "@iracedeck/iracing-sdk";
+import { type ActiveSessionCar, getActiveSessionCars, type TelemetryData, TrkLoc } from "@iracedeck/iracing-sdk";
 import z from "zod";
 
 const DIRECTION_ICONS: Record<string, string> = {
@@ -68,7 +64,12 @@ const SplitsDeltaCycleSettings = CommonSettings.extend({
     ])
     .default("cycle"),
   direction: z.enum(["next", "previous"]).default("next"),
-  carIdx: z.coerce.number().int().min(0).max(63).default(0),
+  /**
+   * 0-based index into the session car list sorted by car number.
+   * Slot 0 = lowest car number, slot 1 = next lowest, etc.
+   * The real carIdx for targeting is resolved at runtime from the sorted list.
+   */
+  slotIndex: z.coerce.number().int().min(0).default(0),
 });
 
 type SplitsDeltaCycleSettings = z.infer<typeof SplitsDeltaCycleSettings>;
@@ -102,6 +103,7 @@ export function generateSplitsDeltaCycleSvg(
   bindingMissing = false,
   resolvedCarNumber: string | null = null,
   isSelected = false,
+  isOffline = false,
 ): string {
   const { mode, direction } = settings;
 
@@ -123,7 +125,10 @@ export function generateSplitsDeltaCycleSvg(
   }
 
   if (mode === "select-reference-car") {
-    const colors = resolveIconColors(displayRefCarIconSvg, getGlobalColors(), settings.colorOverrides);
+    const baseColors = resolveIconColors(displayRefCarIconSvg, getGlobalColors(), settings.colorOverrides);
+    // Dim the background when the driver is offline/disconnected so the user
+    // knows the slot is occupied but unavailable.
+    const colors = isOffline ? { ...baseColors, backgroundColor: "#333333" } : baseColors;
     const defaultTitle = resolvedCarNumber?.trim() ? `#${resolvedCarNumber.trim()}` : "—";
     const title = resolveTitleSettings(
       displayRefCarIconSvg,
@@ -187,7 +192,18 @@ export class SplitsDeltaCycle extends ConnectionStateAwareAction<SplitsDeltaCycl
   private activeContexts = new Map<string, SplitsDeltaCycleSettings>();
   private resolvedCarNumbers = new Map<string, string | null>();
   private resolvedCarRaws = new Map<string, number | null>();
+  private resolvedCarIdxs = new Map<string, number | null>();
+  private resolvedOfflineStates = new Map<string, boolean>();
   private selectedCarUnsubscribers = new Map<string, () => void>();
+
+  /**
+   * Stable session car list sorted by car number.
+   * Cars are never removed from this list — disconnected drivers remain
+   * so that slot assignments don't shift unexpectedly.
+   */
+  private sessionCarList: ActiveSessionCar[] = [];
+  /** Fast lookup set of carIdxs already present in sessionCarList. */
+  private knownCarIdxSet = new Set<number>();
 
   override async onWillAppear(ev: IDeckWillAppearEvent<SplitsDeltaCycleSettings>): Promise<void> {
     await super.onWillAppear(ev);
@@ -195,10 +211,23 @@ export class SplitsDeltaCycle extends ConnectionStateAwareAction<SplitsDeltaCycl
     this.activeContexts.set(ev.action.id, settings);
     this.setActiveBinding(this.resolveSettingKey(settings));
     await this.updateDisplay(ev, settings);
-    // Subscribe to session info updates to resolve car number for select-reference-car mode
-    this.sdkController.subscribe(ev.action.id, (_telemetry: TelemetryData | null) => {
-      if (settings.mode === "select-reference-car") {
-        this.updateCarFromSession(ev.action.id, settings);
+    // Subscribe to telemetry to keep slot data current (car list + offline status)
+    this.sdkController.subscribe(ev.action.id, (telemetry: TelemetryData | null) => {
+      const currentSettings = this.activeContexts.get(ev.action.id);
+
+      if (currentSettings?.mode !== "select-reference-car") return;
+
+      const listChanged = this.updateSessionCarList(this.sdkController.getSessionInfo());
+
+      if (listChanged) {
+        // A new driver joined — refresh all visible select-reference-car buttons
+        for (const [ctxId, ctxSettings] of this.activeContexts) {
+          if (ctxSettings.mode === "select-reference-car") {
+            this.updateCarFromSession(ctxId, ctxSettings, telemetry);
+          }
+        }
+      } else {
+        this.updateCarFromSession(ev.action.id, currentSettings, telemetry);
       }
     });
     // Subscribe to selected-car changes to refresh the active/inactive state
@@ -208,15 +237,18 @@ export class SplitsDeltaCycle extends ConnectionStateAwareAction<SplitsDeltaCycl
       if (currentSettings?.mode !== "select-reference-car") return;
 
       const carNum = this.resolvedCarNumbers.get(ev.action.id) ?? null;
-      const isSelected = getSelectedCar()?.carIdx === currentSettings.carIdx;
-      const svg = generateSplitsDeltaCycleSvg(currentSettings, false, carNum, isSelected);
+      const resolvedCarIdx = this.resolvedCarIdxs.get(ev.action.id) ?? null;
+      const isSelected = resolvedCarIdx !== null && getSelectedCar()?.carIdx === resolvedCarIdx;
+      const isOffline = this.resolvedOfflineStates.get(ev.action.id) ?? false;
+      const svg = generateSplitsDeltaCycleSvg(currentSettings, false, carNum, isSelected, isOffline);
       void this.updateKeyImage(ev.action.id, svg);
     });
     this.selectedCarUnsubscribers.set(ev.action.id, unsubscribe);
 
-    // Initial resolution
+    // Initial resolution: seed the car list from current session info
     if (settings.mode === "select-reference-car") {
-      this.updateCarFromSession(ev.action.id, settings);
+      this.updateSessionCarList(this.sdkController.getSessionInfo());
+      this.updateCarFromSession(ev.action.id, settings, null);
     }
   }
 
@@ -228,6 +260,8 @@ export class SplitsDeltaCycle extends ConnectionStateAwareAction<SplitsDeltaCycl
     this.activeContexts.delete(ev.action.id);
     this.resolvedCarNumbers.delete(ev.action.id);
     this.resolvedCarRaws.delete(ev.action.id);
+    this.resolvedCarIdxs.delete(ev.action.id);
+    this.resolvedOfflineStates.delete(ev.action.id);
   }
 
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<SplitsDeltaCycleSettings>): Promise<void> {
@@ -237,7 +271,7 @@ export class SplitsDeltaCycle extends ConnectionStateAwareAction<SplitsDeltaCycl
     this.setActiveBinding(this.resolveSettingKey(settings));
 
     if (settings.mode === "select-reference-car") {
-      this.updateCarFromSession(ev.action.id, settings);
+      this.updateCarFromSession(ev.action.id, settings, null);
     }
 
     await this.updateDisplay(ev, settings);
@@ -250,24 +284,27 @@ export class SplitsDeltaCycle extends ConnectionStateAwareAction<SplitsDeltaCycl
     if (settings.mode === "select-reference-car") {
       const carNumber = this.resolvedCarNumbers.get(ev.action.id) ?? null;
       const carNumberRaw = this.resolvedCarRaws.get(ev.action.id) ?? null;
+      const resolvedCarIdx = this.resolvedCarIdxs.get(ev.action.id) ?? null;
 
-      if (carNumber === null || carNumberRaw === null) {
-        this.logger.warn("Cannot select reference car: car number not yet resolved from session info");
+      if (resolvedCarIdx === null || carNumber === null || carNumberRaw === null) {
+        this.logger.warn("Cannot select reference car: no car assigned to this slot");
 
         return;
       }
 
       // Toggle: deselect if this car is already the active target
-      if (getSelectedCar()?.carIdx === settings.carIdx) {
+      if (getSelectedCar()?.carIdx === resolvedCarIdx) {
         clearSelectedCar();
         this.logger.info("Reference car deselected");
 
         return;
       }
 
-      setSelectedCar({ carIdx: settings.carIdx, carNumber, carNumberRaw });
+      setSelectedCar({ carIdx: resolvedCarIdx, carNumber, carNumberRaw });
       this.logger.info("Reference car selected");
-      this.logger.debug(`carIdx: ${settings.carIdx}, carNumber: ${carNumber}, carNumberRaw: ${carNumberRaw}`);
+      this.logger.debug(
+        `slotIndex: ${settings.slotIndex}, carIdx: ${resolvedCarIdx}, carNumber: ${carNumber}, carNumberRaw: ${carNumberRaw}`,
+      );
 
       return;
     }
@@ -327,47 +364,119 @@ export class SplitsDeltaCycle extends ConnectionStateAwareAction<SplitsDeltaCycl
     settings: SplitsDeltaCycleSettings,
   ): Promise<void> {
     const carNum = this.resolveTargetCarNumber(ev.action.id, settings);
-    const isSelected = settings.mode === "select-reference-car" ? getSelectedCar()?.carIdx === settings.carIdx : false;
+    const resolvedCarIdx = this.resolvedCarIdxs.get(ev.action.id) ?? null;
+    const isSelected =
+      settings.mode === "select-reference-car"
+        ? resolvedCarIdx !== null && getSelectedCar()?.carIdx === resolvedCarIdx
+        : false;
+    const isOffline = this.resolvedOfflineStates.get(ev.action.id) ?? false;
     const svgDataUri = generateSplitsDeltaCycleSvg(
       settings,
       this.isBindingMissing(this.resolveSettingKey(settings)),
       carNum,
       isSelected,
+      isOffline,
     );
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
     this.setRegenerateCallback(ev.action.id, () => {
       const currentCarNum = this.resolveTargetCarNumber(ev.action.id, settings);
+      const currentResolvedCarIdx = this.resolvedCarIdxs.get(ev.action.id) ?? null;
       const currentIsSelected =
-        settings.mode === "select-reference-car" ? getSelectedCar()?.carIdx === settings.carIdx : false;
+        settings.mode === "select-reference-car"
+          ? currentResolvedCarIdx !== null && getSelectedCar()?.carIdx === currentResolvedCarIdx
+          : false;
+      const currentIsOffline = this.resolvedOfflineStates.get(ev.action.id) ?? false;
 
       return generateSplitsDeltaCycleSvg(
         settings,
         this.isBindingMissing(this.resolveSettingKey(settings)),
         currentCarNum,
         currentIsSelected,
+        currentIsOffline,
       );
     });
   }
 
-  private updateCarFromSession(contextId: string, settings: SplitsDeltaCycleSettings): void {
-    const sessionInfo = this.sdkController.getSessionInfo();
-    const carNumber = getCarNumberFromSessionInfo(sessionInfo, settings.carIdx);
-    const carNumberRaw = getCarNumberRawFromSessionInfo(sessionInfo, settings.carIdx);
+  /**
+   * Integrate new drivers from the latest session info into the stable car list.
+   * Existing entries are never removed — disconnected drivers stay in place so
+   * slot assignments remain stable throughout the session.
+   *
+   * @returns `true` when new drivers were added (callers should refresh all slots).
+   */
+  private updateSessionCarList(sessionInfo: unknown): boolean {
+    const snapshot = getActiveSessionCars(sessionInfo);
+    const newCars = snapshot.filter((c) => !this.knownCarIdxSet.has(c.carIdx));
 
-    const prev = this.resolvedCarNumbers.get(contextId);
+    if (newCars.length === 0) return false;
+
+    for (const car of newCars) {
+      this.sessionCarList.push(car);
+      this.knownCarIdxSet.add(car.carIdx);
+    }
+
+    // Re-sort the combined list by car number (numeric first, then alphabetic)
+    this.sessionCarList.sort((a, b) => {
+      const aNum = Number(a.carNumber);
+      const bNum = Number(b.carNumber);
+      const aIsNum = a.carNumber !== "" && !Number.isNaN(aNum);
+      const bIsNum = b.carNumber !== "" && !Number.isNaN(bNum);
+
+      if (aIsNum && bIsNum) return aNum - bNum;
+
+      if (aIsNum) return -1;
+
+      if (bIsNum) return 1;
+
+      return a.carNumber.localeCompare(b.carNumber);
+    });
+
+    this.logger.debug(`Session car list updated: ${this.sessionCarList.length} cars (added ${newCars.length})`);
+
+    return true;
+  }
+
+  /**
+   * Resolve the car assigned to a button's slot, check its online status, and
+   * re-render the button if anything has changed.
+   */
+  private updateCarFromSession(
+    contextId: string,
+    settings: SplitsDeltaCycleSettings,
+    telemetry: TelemetryData | null,
+  ): void {
+    const car = this.sessionCarList[settings.slotIndex] ?? null;
+
+    const carNumber = car?.carNumber ?? null;
+    const carNumberRaw = car?.carNumberRaw ?? null;
+    const carIdx = car?.carIdx ?? null;
+
+    // Detect offline status: CarIdxTrackSurface is -1 (TrkLoc.NotInWorld) when
+    // the car is not spawned / driver has disconnected.
+    const trackSurfaces = telemetry?.CarIdxTrackSurface as number[] | undefined;
+    const isOffline =
+      carIdx !== null && trackSurfaces !== undefined ? trackSurfaces[carIdx] === TrkLoc.NotInWorld : false;
+
+    const prevCarNumber = this.resolvedCarNumbers.get(contextId);
+    const prevCarIdx = this.resolvedCarIdxs.get(contextId) ?? null;
+    const prevIsOffline = this.resolvedOfflineStates.get(contextId) ?? false;
+
     this.resolvedCarNumbers.set(contextId, carNumber);
     this.resolvedCarRaws.set(contextId, carNumberRaw);
+    this.resolvedCarIdxs.set(contextId, carIdx);
+    this.resolvedOfflineStates.set(contextId, isOffline);
 
-    // Only re-render if the displayed number changed
-    if (carNumber === prev) return;
+    // Only re-render when something visible has changed
+    if (carNumber === prevCarNumber && carIdx === prevCarIdx && isOffline === prevIsOffline) return;
 
-    const isSelected = getSelectedCar()?.carIdx === settings.carIdx;
+    const isSelected = carIdx !== null && getSelectedCar()?.carIdx === carIdx;
     const svg = generateSplitsDeltaCycleSvg(
       settings,
       this.isBindingMissing(this.resolveSettingKey(settings)),
       carNumber,
       isSelected,
+      isOffline,
     );
     void this.updateKeyImage(contextId, svg);
   }

--- a/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ts
+++ b/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ts
@@ -1,5 +1,6 @@
 import {
   assembleIcon,
+  clearSelectedCar,
   CommonSettings,
   ConnectionStateAwareAction,
   getGlobalBorderSettings,
@@ -131,14 +132,15 @@ export function generateSplitsDeltaCycleSvg(
       defaultTitle,
     );
 
-    // Green border when this button is the active selected target
+    // Green border forced on when this button is the active selected target
     const stateColor = isSelected ? "#2ecc71" : undefined;
-    const border = resolveBorderSettings(
+    const resolvedBorder = resolveBorderSettings(
       displayRefCarIconSvg,
       getGlobalBorderSettings(),
       settings.borderOverrides,
       stateColor,
     );
+    const border = isSelected ? { ...resolvedBorder, enabled: true } : resolvedBorder;
 
     const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
@@ -251,6 +253,14 @@ export class SplitsDeltaCycle extends ConnectionStateAwareAction<SplitsDeltaCycl
 
       if (carNumber === null || carNumberRaw === null) {
         this.logger.warn("Cannot select reference car: car number not yet resolved from session info");
+
+        return;
+      }
+
+      // Toggle: deselect if this car is already the active target
+      if (getSelectedCar()?.carIdx === settings.carIdx) {
+        clearSelectedCar();
+        this.logger.info("Reference car deselected");
 
         return;
       }

--- a/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ts
+++ b/packages/iracing-actions/src/actions/splits-delta-cycle/splits-delta-cycle.ts
@@ -6,15 +6,19 @@ import {
   getGlobalColors,
   getGlobalGraphicSettings,
   getGlobalTitleSettings,
+  getSelectedCar,
   type IDeckDialDownEvent,
   type IDeckDialRotateEvent,
   type IDeckDidReceiveSettingsEvent,
   type IDeckKeyDownEvent,
   type IDeckWillAppearEvent,
+  type IDeckWillDisappearEvent,
+  onSelectedCarChange,
   resolveBorderSettings,
   resolveGraphicSettings,
   resolveIconColors,
   resolveTitleSettings,
+  setSelectedCar,
 } from "@iracedeck/deck-core";
 import activeResetRunIconSvg from "@iracedeck/icons/splits-delta-cycle/active-reset-run.svg";
 import activeResetSetIconSvg from "@iracedeck/icons/splits-delta-cycle/active-reset-set.svg";
@@ -23,6 +27,11 @@ import customSectorStartIconSvg from "@iracedeck/icons/splits-delta-cycle/custom
 import displayRefCarIconSvg from "@iracedeck/icons/splits-delta-cycle/display-ref-car.svg";
 import nextIconSvg from "@iracedeck/icons/splits-delta-cycle/next.svg";
 import previousIconSvg from "@iracedeck/icons/splits-delta-cycle/previous.svg";
+import {
+  getCarNumberFromSessionInfo,
+  getCarNumberRawFromSessionInfo,
+  type TelemetryData,
+} from "@iracedeck/iracing-sdk";
 import z from "zod";
 
 const DIRECTION_ICONS: Record<string, string> = {
@@ -35,6 +44,7 @@ const MODE_ICONS: Record<string, string> = {
   "custom-sector-end": customSectorEndIconSvg,
   "active-reset-set": activeResetSetIconSvg,
   "active-reset-run": activeResetRunIconSvg,
+  "select-reference-car": displayRefCarIconSvg,
 };
 
 const MODE_TITLES: Record<string, string> = {
@@ -49,6 +59,7 @@ const SplitsDeltaCycleSettings = CommonSettings.extend({
     .enum([
       "cycle",
       "toggle-ref-car",
+      "select-reference-car",
       "custom-sector-start",
       "custom-sector-end",
       "active-reset-set",
@@ -56,6 +67,7 @@ const SplitsDeltaCycleSettings = CommonSettings.extend({
     ])
     .default("cycle"),
   direction: z.enum(["next", "previous"]).default("next"),
+  carIdx: z.coerce.number().int().min(0).max(63).default(0),
 });
 
 type SplitsDeltaCycleSettings = z.infer<typeof SplitsDeltaCycleSettings>;
@@ -84,7 +96,12 @@ const MODE_KEY_MAP: Record<string, string> = {
 /**
  * @internal Exported for testing
  */
-export function generateSplitsDeltaCycleSvg(settings: SplitsDeltaCycleSettings, bindingMissing = false): string {
+export function generateSplitsDeltaCycleSvg(
+  settings: SplitsDeltaCycleSettings,
+  bindingMissing = false,
+  resolvedCarNumber: string | null = null,
+  isSelected = false,
+): string {
   const { mode, direction } = settings;
 
   // toggle-ref-car uses a dedicated icon from splits-delta-cycle
@@ -98,6 +115,30 @@ export function generateSplitsDeltaCycleSvg(settings: SplitsDeltaCycleSettings, 
     );
 
     const border = resolveBorderSettings(displayRefCarIconSvg, getGlobalBorderSettings(), settings.borderOverrides);
+
+    const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
+
+    return assembleIcon({ graphicSvg: displayRefCarIconSvg, colors, title, border, graphic, bindingMissing });
+  }
+
+  if (mode === "select-reference-car") {
+    const colors = resolveIconColors(displayRefCarIconSvg, getGlobalColors(), settings.colorOverrides);
+    const defaultTitle = resolvedCarNumber?.trim() ? `#${resolvedCarNumber.trim()}` : "—";
+    const title = resolveTitleSettings(
+      displayRefCarIconSvg,
+      getGlobalTitleSettings(),
+      settings.titleOverrides,
+      defaultTitle,
+    );
+
+    // Green border when this button is the active selected target
+    const stateColor = isSelected ? "#2ecc71" : undefined;
+    const border = resolveBorderSettings(
+      displayRefCarIconSvg,
+      getGlobalBorderSettings(),
+      settings.borderOverrides,
+      stateColor,
+    );
 
     const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), settings.graphicOverrides);
 
@@ -141,29 +182,98 @@ export function generateSplitsDeltaCycleSvg(settings: SplitsDeltaCycleSettings, 
 export const SPLITS_DELTA_CYCLE_UUID = "com.iracedeck.sd.core.splits-delta-cycle" as const;
 
 export class SplitsDeltaCycle extends ConnectionStateAwareAction<SplitsDeltaCycleSettings> {
+  private activeContexts = new Map<string, SplitsDeltaCycleSettings>();
+  private resolvedCarNumbers = new Map<string, string | null>();
+  private resolvedCarRaws = new Map<string, number | null>();
+  private selectedCarUnsubscribers = new Map<string, () => void>();
+
   override async onWillAppear(ev: IDeckWillAppearEvent<SplitsDeltaCycleSettings>): Promise<void> {
     await super.onWillAppear(ev);
     const settings = this.parseSettings(ev.payload.settings);
+    this.activeContexts.set(ev.action.id, settings);
     this.setActiveBinding(this.resolveSettingKey(settings));
     await this.updateDisplay(ev, settings);
+    // Subscribe to session info updates to resolve car number for select-reference-car mode
+    this.sdkController.subscribe(ev.action.id, (_telemetry: TelemetryData | null) => {
+      if (settings.mode === "select-reference-car") {
+        this.updateCarFromSession(ev.action.id, settings);
+      }
+    });
+    // Subscribe to selected-car changes to refresh the active/inactive state
+    const unsubscribe = onSelectedCarChange(() => {
+      const currentSettings = this.activeContexts.get(ev.action.id);
+
+      if (currentSettings?.mode !== "select-reference-car") return;
+
+      const carNum = this.resolvedCarNumbers.get(ev.action.id) ?? null;
+      const isSelected = getSelectedCar()?.carIdx === currentSettings.carIdx;
+      const svg = generateSplitsDeltaCycleSvg(currentSettings, false, carNum, isSelected);
+      void this.updateKeyImage(ev.action.id, svg);
+    });
+    this.selectedCarUnsubscribers.set(ev.action.id, unsubscribe);
+
+    // Initial resolution
+    if (settings.mode === "select-reference-car") {
+      this.updateCarFromSession(ev.action.id, settings);
+    }
+  }
+
+  override async onWillDisappear(ev: IDeckWillDisappearEvent<SplitsDeltaCycleSettings>): Promise<void> {
+    await super.onWillDisappear(ev);
+    this.sdkController.unsubscribe(ev.action.id);
+    this.selectedCarUnsubscribers.get(ev.action.id)?.();
+    this.selectedCarUnsubscribers.delete(ev.action.id);
+    this.activeContexts.delete(ev.action.id);
+    this.resolvedCarNumbers.delete(ev.action.id);
+    this.resolvedCarRaws.delete(ev.action.id);
   }
 
   override async onDidReceiveSettings(ev: IDeckDidReceiveSettingsEvent<SplitsDeltaCycleSettings>): Promise<void> {
     await super.onDidReceiveSettings(ev);
     const settings = this.parseSettings(ev.payload.settings);
+    this.activeContexts.set(ev.action.id, settings);
     this.setActiveBinding(this.resolveSettingKey(settings));
+
+    if (settings.mode === "select-reference-car") {
+      this.updateCarFromSession(ev.action.id, settings);
+    }
+
     await this.updateDisplay(ev, settings);
   }
 
   override async onKeyDown(ev: IDeckKeyDownEvent<SplitsDeltaCycleSettings>): Promise<void> {
     this.logger.info("Key down received");
     const settings = this.parseSettings(ev.payload.settings);
-    await this.tapBinding(this.resolveSettingKey(settings));
+
+    if (settings.mode === "select-reference-car") {
+      const carNumber = this.resolvedCarNumbers.get(ev.action.id) ?? null;
+      const carNumberRaw = this.resolvedCarRaws.get(ev.action.id) ?? null;
+
+      if (carNumber === null || carNumberRaw === null) {
+        this.logger.warn("Cannot select reference car: car number not yet resolved from session info");
+
+        return;
+      }
+
+      setSelectedCar({ carIdx: settings.carIdx, carNumber, carNumberRaw });
+      this.logger.info("Reference car selected");
+      this.logger.debug(`carIdx: ${settings.carIdx}, carNumber: ${carNumber}, carNumberRaw: ${carNumberRaw}`);
+
+      return;
+    }
+
+    const settingKey = this.resolveSettingKey(settings);
+
+    if (settingKey) {
+      await this.tapBinding(settingKey);
+    }
   }
 
   override async onDialDown(ev: IDeckDialDownEvent<SplitsDeltaCycleSettings>): Promise<void> {
     this.logger.info("Dial down received");
     const settings = this.parseSettings(ev.payload.settings);
+
+    if (settings.mode === "select-reference-car") return;
 
     const settingKey = MODE_KEY_MAP[settings.mode];
 
@@ -188,21 +298,67 @@ export class SplitsDeltaCycle extends ConnectionStateAwareAction<SplitsDeltaCycl
     return parsed.success ? parsed.data : SplitsDeltaCycleSettings.parse({});
   }
 
-  private resolveSettingKey(settings: SplitsDeltaCycleSettings): string {
+  private resolveSettingKey(settings: SplitsDeltaCycleSettings): string | null {
+    if (settings.mode === "select-reference-car") return null;
+
     return (
       MODE_KEY_MAP[settings.mode] ?? (settings.direction === "next" ? GLOBAL_KEY_NAMES.NEXT : GLOBAL_KEY_NAMES.PREVIOUS)
     );
+  }
+
+  private resolveTargetCarNumber(contextId: string, settings: SplitsDeltaCycleSettings): string | null {
+    if (settings.mode !== "select-reference-car") return null;
+
+    return this.resolvedCarNumbers.get(contextId) ?? null;
   }
 
   private async updateDisplay(
     ev: IDeckWillAppearEvent<SplitsDeltaCycleSettings> | IDeckDidReceiveSettingsEvent<SplitsDeltaCycleSettings>,
     settings: SplitsDeltaCycleSettings,
   ): Promise<void> {
-    const svgDataUri = generateSplitsDeltaCycleSvg(settings, this.isBindingMissing(this.resolveSettingKey(settings)));
+    const carNum = this.resolveTargetCarNumber(ev.action.id, settings);
+    const isSelected = settings.mode === "select-reference-car" ? getSelectedCar()?.carIdx === settings.carIdx : false;
+    const svgDataUri = generateSplitsDeltaCycleSvg(
+      settings,
+      this.isBindingMissing(this.resolveSettingKey(settings)),
+      carNum,
+      isSelected,
+    );
     await ev.action.setTitle("");
     await this.setKeyImage(ev, svgDataUri);
-    this.setRegenerateCallback(ev.action.id, () =>
-      generateSplitsDeltaCycleSvg(settings, this.isBindingMissing(this.resolveSettingKey(settings))),
+    this.setRegenerateCallback(ev.action.id, () => {
+      const currentCarNum = this.resolveTargetCarNumber(ev.action.id, settings);
+      const currentIsSelected =
+        settings.mode === "select-reference-car" ? getSelectedCar()?.carIdx === settings.carIdx : false;
+
+      return generateSplitsDeltaCycleSvg(
+        settings,
+        this.isBindingMissing(this.resolveSettingKey(settings)),
+        currentCarNum,
+        currentIsSelected,
+      );
+    });
+  }
+
+  private updateCarFromSession(contextId: string, settings: SplitsDeltaCycleSettings): void {
+    const sessionInfo = this.sdkController.getSessionInfo();
+    const carNumber = getCarNumberFromSessionInfo(sessionInfo, settings.carIdx);
+    const carNumberRaw = getCarNumberRawFromSessionInfo(sessionInfo, settings.carIdx);
+
+    const prev = this.resolvedCarNumbers.get(contextId);
+    this.resolvedCarNumbers.set(contextId, carNumber);
+    this.resolvedCarRaws.set(contextId, carNumberRaw);
+
+    // Only re-render if the displayed number changed
+    if (carNumber === prev) return;
+
+    const isSelected = getSelectedCar()?.carIdx === settings.carIdx;
+    const svg = generateSplitsDeltaCycleSvg(
+      settings,
+      this.isBindingMissing(this.resolveSettingKey(settings)),
+      carNumber,
+      isSelected,
     );
+    void this.updateKeyImage(contextId, svg);
   }
 }

--- a/packages/iracing-sdk/src/index.ts
+++ b/packages/iracing-sdk/src/index.ts
@@ -128,10 +128,12 @@ export { hasPitLimiter, hasVisor, hasWipers, isLiveOnTrack, isPostRace, isPreGre
 // Session info utilities
 export {
   type CameraGroup,
+  type ActiveSessionCar,
   getCameraGroupsFromSessionInfo,
   getCarNumberFromSessionInfo,
   getCarNumberRawFromSessionInfo,
   getAllCarNumbers,
+  getActiveSessionCars,
 } from "./session-utils.js";
 
 // Telemetry snapshot formatting utilities

--- a/packages/iracing-sdk/src/session-utils.test.ts
+++ b/packages/iracing-sdk/src/session-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  getActiveSessionCars,
   getAllCarNumbers,
   getCameraGroupsFromSessionInfo,
   getCarNumberFromSessionInfo,
@@ -220,5 +221,277 @@ describe("getCameraGroupsFromSessionInfo", () => {
 
   it("should return empty array when Groups is empty", () => {
     expect(getCameraGroupsFromSessionInfo({ CameraInfo: { Groups: [] } })).toEqual([]);
+  });
+});
+
+describe("getActiveSessionCars", () => {
+  it("should return cars sorted by car number numerically, excluding pace car and spectators", () => {
+    const sessionInfo = {
+      DriverInfo: {
+        Drivers: [
+          {
+            CarIdx: 0,
+            CarNumber: "99",
+            CarNumberRaw: 99,
+            CarIsPaceCar: 0,
+            IsSpectator: 0,
+            UserName: "Alice",
+            CarClassShortName: "GT3",
+          },
+          {
+            CarIdx: 1,
+            CarNumber: "0",
+            CarNumberRaw: 0,
+            CarIsPaceCar: 1,
+            IsSpectator: 0,
+            UserName: "Pace",
+            CarClassShortName: "",
+          },
+          {
+            CarIdx: 2,
+            CarNumber: "4",
+            CarNumberRaw: 4,
+            CarIsPaceCar: 0,
+            IsSpectator: 0,
+            UserName: "Bob",
+            CarClassShortName: "GT4",
+          },
+          {
+            CarIdx: 3,
+            CarNumber: "42",
+            CarNumberRaw: 42,
+            CarIsPaceCar: 0,
+            IsSpectator: 1,
+            UserName: "Spectator",
+            CarClassShortName: "",
+          },
+          {
+            CarIdx: 4,
+            CarNumber: "7",
+            CarNumberRaw: 7,
+            CarIsPaceCar: 0,
+            IsSpectator: 0,
+            UserName: "Carol",
+            CarClassShortName: "GT3",
+          },
+        ],
+      },
+    };
+    expect(getActiveSessionCars(sessionInfo)).toEqual([
+      { carIdx: 2, carNumber: "4", carNumberRaw: 4, driverName: "Bob", carClass: "GT4" },
+      { carIdx: 4, carNumber: "7", carNumberRaw: 7, driverName: "Carol", carClass: "GT3" },
+      { carIdx: 0, carNumber: "99", carNumberRaw: 99, driverName: "Alice", carClass: "GT3" },
+    ]);
+  });
+
+  it("should preserve leading zeros in car number", () => {
+    const sessionInfo = {
+      DriverInfo: {
+        Drivers: [
+          {
+            CarIdx: 0,
+            CarNumber: "070",
+            CarNumberRaw: 3070,
+            CarIsPaceCar: 0,
+            IsSpectator: 0,
+            UserName: "A",
+            CarClassShortName: "",
+          },
+          {
+            CarIdx: 1,
+            CarNumber: "9",
+            CarNumberRaw: 9,
+            CarIsPaceCar: 0,
+            IsSpectator: 0,
+            UserName: "B",
+            CarClassShortName: "",
+          },
+        ],
+      },
+    };
+    const result = getActiveSessionCars(sessionInfo);
+    expect(result[0].carNumber).toBe("9");
+    expect(result[1].carNumber).toBe("070");
+  });
+
+  it("should place non-numeric car numbers after all numeric ones, sorted alphabetically", () => {
+    const sessionInfo = {
+      DriverInfo: {
+        Drivers: [
+          {
+            CarIdx: 0,
+            CarNumber: "ABC",
+            CarNumberRaw: 0,
+            CarIsPaceCar: 0,
+            IsSpectator: 0,
+            UserName: "X",
+            CarClassShortName: "",
+          },
+          {
+            CarIdx: 1,
+            CarNumber: "10",
+            CarNumberRaw: 10,
+            CarIsPaceCar: 0,
+            IsSpectator: 0,
+            UserName: "Y",
+            CarClassShortName: "",
+          },
+          {
+            CarIdx: 2,
+            CarNumber: "AAA",
+            CarNumberRaw: 0,
+            CarIsPaceCar: 0,
+            IsSpectator: 0,
+            UserName: "Z",
+            CarClassShortName: "",
+          },
+          {
+            CarIdx: 3,
+            CarNumber: "5",
+            CarNumberRaw: 5,
+            CarIsPaceCar: 0,
+            IsSpectator: 0,
+            UserName: "W",
+            CarClassShortName: "",
+          },
+        ],
+      },
+    };
+    const result = getActiveSessionCars(sessionInfo);
+    expect(result.map((c) => c.carIdx)).toEqual([3, 1, 2, 0]); // 5, 10, AAA, ABC
+  });
+
+  it("should populate driverName and carClass fields", () => {
+    const sessionInfo = {
+      DriverInfo: {
+        Drivers: [
+          {
+            CarIdx: 0,
+            CarNumber: "1",
+            CarNumberRaw: 1,
+            CarIsPaceCar: 0,
+            IsSpectator: 0,
+            UserName: "Test Driver",
+            CarClassShortName: "GTP",
+          },
+        ],
+      },
+    };
+    const result = getActiveSessionCars(sessionInfo);
+    expect(result[0].driverName).toBe("Test Driver");
+    expect(result[0].carClass).toBe("GTP");
+  });
+
+  it("should use empty strings for missing driverName and carClass", () => {
+    const sessionInfo = {
+      DriverInfo: {
+        Drivers: [
+          { CarIdx: 0, CarNumber: "1", CarNumberRaw: 1, CarIsPaceCar: 0 },
+        ],
+      },
+    };
+    const result = getActiveSessionCars(sessionInfo);
+    expect(result[0].driverName).toBe("");
+    expect(result[0].carClass).toBe("");
+  });
+
+  it("should exclude pace cars", () => {
+    const sessionInfo = {
+      DriverInfo: {
+        Drivers: [
+          {
+            CarIdx: 0,
+            CarNumber: "1",
+            CarNumberRaw: 1,
+            CarIsPaceCar: 1,
+            IsSpectator: 0,
+            UserName: "Pace",
+            CarClassShortName: "",
+          },
+          {
+            CarIdx: 1,
+            CarNumber: "2",
+            CarNumberRaw: 2,
+            CarIsPaceCar: 0,
+            IsSpectator: 0,
+            UserName: "Driver",
+            CarClassShortName: "",
+          },
+        ],
+      },
+    };
+    const result = getActiveSessionCars(sessionInfo);
+    expect(result).toHaveLength(1);
+    expect(result[0].carIdx).toBe(1);
+  });
+
+  it("should exclude spectators", () => {
+    const sessionInfo = {
+      DriverInfo: {
+        Drivers: [
+          {
+            CarIdx: 0,
+            CarNumber: "1",
+            CarNumberRaw: 1,
+            CarIsPaceCar: 0,
+            IsSpectator: 1,
+            UserName: "Spec",
+            CarClassShortName: "",
+          },
+          {
+            CarIdx: 1,
+            CarNumber: "2",
+            CarNumberRaw: 2,
+            CarIsPaceCar: 0,
+            IsSpectator: 0,
+            UserName: "Driver",
+            CarClassShortName: "",
+          },
+        ],
+      },
+    };
+    const result = getActiveSessionCars(sessionInfo);
+    expect(result).toHaveLength(1);
+    expect(result[0].carIdx).toBe(1);
+  });
+
+  it("should return empty array when session info is null", () => {
+    expect(getActiveSessionCars(null)).toEqual([]);
+  });
+
+  it("should return empty array when DriverInfo is missing", () => {
+    expect(getActiveSessionCars({})).toEqual([]);
+  });
+
+  it("should include cars with empty car number after cleaning (non-numeric)", () => {
+    const sessionInfo = {
+      DriverInfo: {
+        Drivers: [
+          {
+            CarIdx: 0,
+            CarNumber: "ABC",
+            CarNumberRaw: 0,
+            CarIsPaceCar: 0,
+            IsSpectator: 0,
+            UserName: "A",
+            CarClassShortName: "",
+          },
+          {
+            CarIdx: 1,
+            CarNumber: "5",
+            CarNumberRaw: 5,
+            CarIsPaceCar: 0,
+            IsSpectator: 0,
+            UserName: "B",
+            CarClassShortName: "",
+          },
+        ],
+      },
+    };
+    // Both should be included — non-numeric sorted after numeric
+    const result = getActiveSessionCars(sessionInfo);
+    expect(result).toHaveLength(2);
+    expect(result[0].carIdx).toBe(1); // "5" first
+    expect(result[1].carIdx).toBe(0); // "ABC" second
   });
 });

--- a/packages/iracing-sdk/src/session-utils.ts
+++ b/packages/iracing-sdk/src/session-utils.ts
@@ -9,6 +9,88 @@ interface DriverEntry {
   CarNumber: string;
   CarNumberRaw: number;
   CarIsPaceCar?: number;
+  IsSpectator?: number;
+  UserName?: string;
+  CarClassShortName?: string;
+}
+
+/**
+ * A session car entry with driver and class details.
+ * Returned by {@link getActiveSessionCars}.
+ */
+export interface ActiveSessionCar {
+  /** iRacing car index (0–63). Used for all targeting commands. */
+  carIdx: number;
+  /** Display car number string (e.g. "042"), preserving leading zeros. */
+  carNumber: string;
+  /** Raw car number used by the iRacing camera API (e.g. 3042). */
+  carNumberRaw: number;
+  /** Driver display name. Empty string when not available. */
+  driverName: string;
+  /** Car class short name (e.g. "GT3"). Empty string when not available. */
+  carClass: string;
+}
+
+/**
+ * Get all non-pace-car, non-spectator session cars from session info.
+ *
+ * Returns a sorted list of every valid driver: numeric car numbers come first
+ * (sorted ascending), followed by any non-numeric car numbers (sorted
+ * alphabetically). The sort is stable for the same input so the list can be
+ * diffed incrementally.
+ *
+ * Unlike {@link getAllCarNumbers}, this function:
+ * - Excludes spectators
+ * - Includes cars with non-numeric car numbers (sorted at the end)
+ * - Returns driver name and car class
+ *
+ * @param sessionInfo - The iRacing session info object
+ * @returns Sorted array of active session cars
+ */
+export function getActiveSessionCars(sessionInfo: unknown): ActiveSessionCar[] {
+  const driverInfo = (sessionInfo as Record<string, unknown>)?.DriverInfo as Record<string, unknown> | undefined;
+  const drivers = driverInfo?.Drivers as DriverEntry[] | undefined;
+
+  if (!drivers) return [];
+
+  const result: ActiveSessionCar[] = [];
+
+  for (const driver of drivers) {
+    if (driver.CarIsPaceCar === 1) continue;
+
+    if (driver.IsSpectator === 1) continue;
+
+    const cleaned = driver.CarNumber.replace(/[^0-9]/g, "");
+    // If cleaning strips everything (fully non-numeric like "ABC"), keep the
+    // original string so it is sortable alphabetically below numeric cars.
+    const carNumber = cleaned.length > 0 ? cleaned : driver.CarNumber;
+
+    result.push({
+      carIdx: driver.CarIdx,
+      carNumber,
+      carNumberRaw: driver.CarNumberRaw,
+      driverName: driver.UserName ?? "",
+      carClass: driver.CarClassShortName ?? "",
+    });
+  }
+
+  result.sort((a, b) => {
+    const aNum = Number(a.carNumber);
+    const bNum = Number(b.carNumber);
+    const aIsNum = a.carNumber !== "" && !Number.isNaN(aNum);
+    const bIsNum = b.carNumber !== "" && !Number.isNaN(bNum);
+
+    if (aIsNum && bIsNum) return aNum - bNum;
+
+    if (aIsNum) return -1;
+
+    if (bIsNum) return 1;
+
+    // Both non-numeric: alphabetical
+    return a.carNumber.localeCompare(b.carNumber);
+  });
+
+  return result;
 }
 
 /**

--- a/packages/website/src/content/docs/docs/actions/cockpit/splits-delta-cycle.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/splits-delta-cycle.md
@@ -3,11 +3,11 @@ title: Splits & Reference
 description: Cycle splits delta modes, toggle reference car, mark custom sectors, and use active reset.
 sidebar:
   badge:
-    text: "6 modes"
+    text: "7 modes"
     variant: tip
 ---
 
-Switch between iRacing's split-time delta display modes, toggle the reference car display, mark custom sector start and end points, or use active reset to practice specific track sections without leaving the cockpit.
+Switch between iRacing's split-time delta display modes, toggle the reference car display, target a specific reference car for future actions, mark custom sector start and end points, or use active reset to practice specific track sections without leaving the cockpit.
 
 ## Modes
 
@@ -47,6 +47,29 @@ Toggle the reference car overlay on or off. Replaces the old "Display Reference 
 #### Settings
 
 - No additional settings
+
+---
+
+### Select Reference Car
+
+Assign this button to a fixed iRacing driver index (0–63). The button displays that car's number from session info. Pressing the button sets it as the **selected car target** — a shared slot read by Camera Controls (**Focus Selected Car**), Race Admin (**Use Selected Car**), and Replay Control (**Jump to Selected Car**). No camera switch happens on press; this mode is purely for targeting.
+
+A **green border** appears on the button when its car index is the currently active target, so you can see at a glance which car is selected across a row of selector buttons.
+
+#### Details
+
+- **Method:** API (sets the shared selected car target)
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** Yes — displays the car number for the assigned driver index
+
+#### Setting: Car Index
+
+The iRacing driver index (0–63) this button is assigned to. Defaults to `0`. The button shows the car number for that index once session info is available.
+
+:::tip
+Place multiple **Select Reference Car** buttons side by side, each assigned to a different car index. The green border tells you which one is the active target. Press a different button to re-target instantly.
+:::
 
 ---
 

--- a/packages/website/src/content/docs/docs/actions/communication/race-admin.md
+++ b/packages/website/src/content/docs/docs/actions/communication/race-admin.md
@@ -520,10 +520,11 @@ Required. Supports template variables.
 
 ### Driver Target
 
-Every mode that accepts a `<driver>` parameter shares a single targeting setting with three options:
+Every mode that accepts a `<driver>` parameter shares a single targeting setting with four options:
 
 - **Type in Chat** (default) — One-tap "open chat with the right command pre-filled, let me type the number myself". The action opens iRacing chat, pastes the command prefix (e.g. `!clear `, with a trailing space), and **stops** — it does not press Enter. You type the car number off the standings sheet and press Enter to submit. Useful for league admins who handle a different driver each lap and don't want to pre-bind a specific number.
 - **Use Viewed Car** — The action reads the car number of the car currently being followed in the replay / broadcast view at send time. View a car and press the button; the command targets that car.
+- **Use Selected Car** — The action uses the car most recently targeted using a **Select Reference Car** button (Splits & Reference action). Press the selector button to lock in a target, then press the admin command button to act on it — no need to have that car in the camera view. If no car has been selected yet, pressing the button does nothing.
 - **Specific Car Number** — Selecting this reveals a number input. The same car number is used on every press, regardless of which car is being viewed, and is also rendered on the button icon so you can tell which car the button targets.
 
 :::caution

--- a/packages/website/src/content/docs/docs/actions/view-camera/camera-focus.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/camera-focus.md
@@ -3,7 +3,7 @@ title: Camera Controls
 description: Cycle cameras, change camera groups, and focus on specific targets with a single button or dial.
 sidebar:
   badge:
-    text: "12 modes"
+    text: "13 modes"
     variant: tip
 ---
 
@@ -196,6 +196,26 @@ Switch camera focus to a car by its car number.
 #### Setting: Car Number
 
 The car number to focus. Integer. Defaults to `0`.
+
+---
+
+### Focus Selected Car
+
+Switch camera focus to the car most recently targeted using a **Select Reference Car** button (Splits & Reference action). Useful when you set up a row of car-index buttons and want a second button that switches to whichever one you last pressed.
+
+#### Details
+
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+#### Settings
+
+- No additional settings
+
+:::tip
+Combine with **Select Reference Car** buttons: press the selector to pick a target, then press **Focus Selected Car** (or a Race Admin / Replay Control button) to act on it.
+:::
 
 ---
 

--- a/packages/website/src/content/docs/docs/actions/view-camera/replay-control.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/replay-control.md
@@ -3,7 +3,7 @@ title: Replay Control
 description: Full replay transport, speed, and navigation in a single configurable action.
 sidebar:
   badge:
-    text: "27 modes"
+    text: "28 modes"
     variant: tip
 ---
 
@@ -384,6 +384,23 @@ Jump the replay camera to your own car.
 
 - **Method:** iRacing API
 - **Dial:** Rotation cycles to the next / previous car on track around your position (clockwise = ahead, counter-clockwise = behind)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+#### Settings
+
+- No additional settings
+
+---
+
+### Jump to Selected Car
+
+Jump the replay camera to the car most recently targeted using a **Select Reference Car** button (Splits & Reference action). If no car has been selected yet, pressing the button does nothing.
+
+#### Details
+
+- **Method:** iRacing API
+- **Dial:** No rotation support
 - **Default binding:** No keyboard binding
 - **Telemetry-aware icon:** No
 


### PR DESCRIPTION
## Summary

Adds slot-based dynamic session car selection for the reference car selector.

Previously, placeholder buttons were tied directly to `CarIdx`. This change separates the visible button slot from the actual iRacing `CarIdx`, allowing buttons to populate in numerical car-number order while still targeting the correct real car.

## Changes

* Adds `getActiveSessionCars()` to build a selectable session car list.
* Sorts session cars by car number, with numeric numbers first.
* Replaces `carIdx` setting with `slotIndex`.
* Stores the resolved real `CarIdx` separately per button/context.
* Keeps disconnected cars in the list and supports greyed/offline display.
* Adds newly joined cars to the session list and refreshes selector buttons.
* Updates the property inspector label from `Car Index` to `Slot Index`.
* Adds tests for session car sorting and selector behaviour.

## Testing

* `pnpm test --run`
* `pnpm build:ts`

Both passed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared selected-car selection that can be set, cleared, and watched for changes.
  * Added “Select Reference Car” in Splits & Reference, plus new camera, replay, and race admin actions that use the selected car.
  * Added a new “Focus Selected Car” / “Jump to Selected Car” workflow and updated related settings options.

* **Documentation**
  * Updated action docs to include the new mode and its behavior.

* **Tests**
  * Added coverage for selected-car state handling and related action behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->