### PR TITLE
fix(sim-events-iracing): keep towed cars at their position until they rejoin the track (#733)

### DIFF
--- a/packages/sim-events-iracing/src/diff/overtakes.test.ts
+++ b/packages/sim-events-iracing/src/diff/overtakes.test.ts
@@ -1223,12 +1223,13 @@ describe("diffOvertakes — finished / retired cars (#603)", () => {
     expect(state.positionFrozen.has(1)).toBe(true);
     expect(state.pendingOvertakePos).toBe(-1);
 
-    // Rival starts rolling again → released this tick, drops to its live back-of-
-    // field score, and the player inherits P2. The gain must read fromRetirement
-    // (the rival fell back; the player didn't pass it on track), NOT a real pass.
+    // Rival drives back out of the pit onto the track → released this tick (moving
+    // AND off pit road), drops to its live back-of-field score, and the player
+    // inherits P2. The gain must read fromRetirement (the rival fell back; the
+    // player didn't pass it on track), NOT a real pass.
     tickAt(
       state,
-      mkTel([0.51, 0.06, 0.81], { trackSurface: [TrkLoc.OnTrack, TrkLoc.InPitStall, TrkLoc.OnTrack] }),
+      mkTel([0.51, 0.06, 0.81], { trackSurface: [TrkLoc.OnTrack, TrkLoc.OnTrack, TrkLoc.OnTrack] }),
       200,
       emit,
     );
@@ -1240,7 +1241,7 @@ describe("diffOvertakes — finished / retired cars (#603)", () => {
     // Hold elapsed → emits with fromRetirement=true (no "Nice pass").
     tickAt(
       state,
-      mkTel([0.512, 0.06, 0.812], { trackSurface: [TrkLoc.OnTrack, TrkLoc.InPitStall, TrkLoc.OnTrack] }),
+      mkTel([0.512, 0.06, 0.812], { trackSurface: [TrkLoc.OnTrack, TrkLoc.OnTrack, TrkLoc.OnTrack] }),
       200 + OVERTAKE_HOLD_MS,
       emit,
     );

--- a/packages/sim-events-iracing/src/diff/race-finish.test.ts
+++ b/packages/sim-events-iracing/src/diff/race-finish.test.ts
@@ -3,9 +3,12 @@
  *
  * Each car has a last-known on-track score. A car is FROZEN at that score when
  * it goes `NotInWorld` or teleports (a one-tick discontinuous jump — a tow), and
- * is RELEASED back to its live `lc + dp` the moment it resumes continuous
- * forward motion, wherever it is (#697). A permanently departed car (disconnect
- * / finish into the garage) stays frozen and is passed naturally.
+ * is RELEASED back to its live `lc + dp` once it resumes continuous forward
+ * motion AND is back on the racing surface (off pit road, per
+ * `CarIdxTrackSurface`) — so a car towed into its box is held there until it
+ * drives back out, not released the instant it creeps forward in the box (#697).
+ * A permanently departed car (disconnect / finish into the garage / retire in
+ * the box) stays frozen and is passed naturally.
  */
 import { calculateRacePositions, type TelemetryData, TrkLoc } from "@iracedeck/iracing-sdk";
 import { describe, expect, it } from "vitest";
@@ -244,21 +247,26 @@ describe("TELEPORT_THRESHOLD", () => {
 });
 
 describe("tow / teleport release (issue #697)", () => {
-  it("releases a frozen car once it resumes forward motion, wherever it is", () => {
+  it("keeps a frozen car held while it is on pit road, releasing only once it is back on track", () => {
     const state = createInitialState();
     // Racing on track at lap 5, dp 0.5.
     updatePositionTracking(state, mkTel([0.5]));
-    // Tow: teleports to the pit stall (dp 0.05) — frozen at the pre-tow score.
+    // Tow: teleports into the pit stall (dp 0.05) — frozen at the pre-tow score.
     updatePositionTracking(state, mkTel([0.05], { trackSurface: [TrkLoc.InPitStall] }));
     expect(state.positionFrozen.has(0)).toBe(true);
     expect(state.positionLastKnownScores[0]).toBeCloseTo(5.5, 5);
 
-    // Starts moving again — released even though still in the pit stall (#697:
-    // release on motion, not on location) — and the anchor rolls to live.
+    // Creeps forward while STILL on pit road (being serviced) — stays frozen at
+    // the pre-tow anchor, not released to the pit-box score (#697 refined: hold
+    // through the pit visit, not "release on the first motion, wherever it is").
     updatePositionTracking(state, mkTel([0.06], { trackSurface: [TrkLoc.InPitStall] }));
+    expect(state.positionFrozen.has(0)).toBe(true);
+    expect(state.positionLastKnownScores[0]).toBeCloseTo(5.5, 5);
 
+    // Drives back out onto the track and is moving → released, anchor rolls to live.
+    updatePositionTracking(state, mkTel([0.07], { trackSurface: [TrkLoc.OnTrack] }));
     expect(state.positionFrozen.has(0)).toBe(false);
-    expect(state.positionLastKnownScores[0]).toBeCloseTo(5.06, 5);
+    expect(state.positionLastKnownScores[0]).toBeCloseTo(5.07, 5);
   });
 
   it("holds a NotInWorld-towed car until it moves again (the player-tow case)", () => {
@@ -274,7 +282,7 @@ describe("tow / teleport release (issue #697)", () => {
     expect(state.positionFrozen.has(0)).toBe(true);
     expect(state.positionLastKnownScores[0]).toBeCloseTo(20.5, 5);
 
-    // Now moving again → released to its live (dropped-back) score.
+    // Drives back out onto the track and is moving → released to its live (dropped-back) score.
     updatePositionTracking(state, mkTel([0.06], { lapCompleted: [20], trackSurface: [TrkLoc.OnTrack] }));
     expect(state.positionFrozen.has(0)).toBe(false);
     expect(state.positionLastKnownScores[0]).toBeCloseTo(20.06, 5);
@@ -306,5 +314,44 @@ describe("tow / teleport release (issue #697)", () => {
 
     expect(order[1]).toBe(1); // idx1 genuinely ahead now (5.35)
     expect(order[0]).toBe(2); // player correctly behind at live 5.10 — not pinned ahead at 5.50
+  });
+});
+
+describe("a towed car stays frozen while it is on pit road (pit-box jump-ahead fix)", () => {
+  it("does NOT rank a parked towed car ahead while it sits at a high pit-box dp", () => {
+    const state = createInitialState();
+    // Player idx0 leads at 5.50; rival idx1 races just behind at 5.20.
+    updatePositionTracking(state, mkTel([0.5, 0.2]));
+    expect(calculateFrozenRacePositions(state, mkTel([0.5, 0.2]))).toEqual([1, 2]);
+
+    // Rival tows to its pit box just before S/F (dp 0.95) → frozen at the pre-tow 5.20.
+    updatePositionTracking(state, mkTel([0.51, 0.95], { trackSurface: [TrkLoc.OnTrack, TrkLoc.InPitStall] }));
+    expect(state.positionFrozen.has(1)).toBe(true);
+
+    // Serviced — it creeps forward in the box, STILL on pit road. It must stay
+    // frozen at 5.20, NOT release and snap to the high pit-box score 5.96.
+    updatePositionTracking(state, mkTel([0.52, 0.96], { trackSurface: [TrkLoc.OnTrack, TrkLoc.InPitStall] }));
+    expect(state.positionFrozen.has(1)).toBe(true);
+    expect(state.positionLastKnownScores[1]).toBeCloseTo(5.2, 5);
+
+    const order = calculateFrozenRacePositions(
+      state,
+      mkTel([0.52, 0.96], { trackSurface: [TrkLoc.OnTrack, TrkLoc.InPitStall] }),
+    );
+    // The parked rival stays behind the still-racing player — no jump-ahead.
+    expect(order).toEqual([1, 2]);
+  });
+
+  it("releases the towed car once it drives back out of the pit box onto the track", () => {
+    const state = createInitialState();
+    updatePositionTracking(state, mkTel([0.5, 0.2]));
+    // Rival tows to its box (dp 0.30 here, to avoid an S/F wrap) → frozen at 5.20.
+    updatePositionTracking(state, mkTel([0.51, 0.3], { trackSurface: [TrkLoc.OnTrack, TrkLoc.InPitStall] }));
+    expect(state.positionFrozen.has(1)).toBe(true);
+
+    // Drives back out onto the track (off pit road) and is moving → released to live.
+    updatePositionTracking(state, mkTel([0.52, 0.35], { trackSurface: [TrkLoc.OnTrack, TrkLoc.OnTrack] }));
+    expect(state.positionFrozen.has(1)).toBe(false);
+    expect(state.positionLastKnownScores[1]).toBeCloseTo(5.35, 5);
   });
 });

--- a/packages/sim-events-iracing/src/diff/race-finish.test.ts
+++ b/packages/sim-events-iracing/src/diff/race-finish.test.ts
@@ -354,4 +354,24 @@ describe("a towed car stays frozen while it is on pit road (pit-box jump-ahead f
     expect(state.positionFrozen.has(1)).toBe(false);
     expect(state.positionLastKnownScores[1]).toBeCloseTo(5.35, 5);
   });
+
+  it("keeps the towed car frozen while it is on the pit lane (AproachingPits), releasing only once on track", () => {
+    const state = createInitialState();
+    updatePositionTracking(state, mkTel([0.5, 0.2]));
+    // Rival tows to its box → frozen at 5.20.
+    updatePositionTracking(state, mkTel([0.51, 0.3], { trackSurface: [TrkLoc.OnTrack, TrkLoc.InPitStall] }));
+    expect(state.positionFrozen.has(1)).toBe(true);
+
+    // Drives out of the box onto the pit lane (AproachingPits), still moving. The
+    // gate treats the pit lane as on pit road too, so it stays frozen at 5.20 —
+    // not released while still at its pit-road position.
+    updatePositionTracking(state, mkTel([0.52, 0.32], { trackSurface: [TrkLoc.OnTrack, TrkLoc.AproachingPits] }));
+    expect(state.positionFrozen.has(1)).toBe(true);
+    expect(state.positionLastKnownScores[1]).toBeCloseTo(5.2, 5);
+
+    // Merges back onto the track and is moving → released to live.
+    updatePositionTracking(state, mkTel([0.53, 0.34], { trackSurface: [TrkLoc.OnTrack, TrkLoc.OnTrack] }));
+    expect(state.positionFrozen.has(1)).toBe(false);
+    expect(state.positionLastKnownScores[1]).toBeCloseTo(5.34, 5);
+  });
 });

--- a/packages/sim-events-iracing/src/diff/race-finish.ts
+++ b/packages/sim-events-iracing/src/diff/race-finish.ts
@@ -17,11 +17,15 @@
  * track, and is **frozen at its last-known good value** whenever its telemetry
  * is invalid (`NotInWorld`) or has drifted discontinuously from the last-known
  * point (teleport / tow). A frozen car is held at that score until it **resumes
- * continuous forward motion** — at which point its position rolls back to live,
- * wherever it is (issue #697). Release is judged tick-to-tick, NOT by distance
- * from the now-stale anchor: a towed car returns far from where it vanished, so
- * an anchor-proximity test could never re-open and pinned the car (and the
- * player, after their own tow) at a dead position for the rest of the race.
+ * continuous forward motion while back off pit road** — at which point its
+ * position rolls back to live (issue #697). The pit-road gate matters because a
+ * tow drops the car in its box at a high pit-box `dp`: releasing on the first
+ * creep of service would snap its rank to that pit-box score and make it jump
+ * ahead of cars still racing earlier on the lap, so it is held until it drives
+ * back out. Release is judged tick-to-tick, NOT by distance from the now-stale
+ * anchor: a towed car returns far from where it vanished, so an anchor-proximity
+ * test could never re-open and pinned the car (and the player, after their own
+ * tow) at a dead position for the rest of the race.
  *
  * One rule replaces the per-symptom patches:
  *   - **Blink** (`NotInWorld` for a tick) → held at last → the player's rank
@@ -32,9 +36,10 @@
  *     finishing score (last-known just before vanishing) → the player can't
  *     pass it without finishing too. No separate checkered detection needed.
  *   - **Tow** (teleport to pit stall) → score jumps discontinuously → held at
- *     the pre-tow on-track score while out → released the moment the car drives
- *     off again, so it rejoins the order at its true (dropped-back) position
- *     instead of staying pinned where it was.
+ *     the pre-tow on-track score for the whole pit visit → released only once
+ *     the car drives back out of the pit (off pit road) and is moving, so it
+ *     rejoins the order at its true (dropped-back) position instead of jumping
+ *     ahead at its high pit-box distance or staying pinned where it was.
  *
  * **Celebration rule** (applied by `diffOvertakes`): when the player's rank
  * improves, the gain is `fromRetirement` (no "Nice pass") iff at least one car
@@ -67,13 +72,20 @@ export const TELEPORT_THRESHOLD = 0.05;
  *     last known racing position so nothing reshuffles around it. A car that
  *     merely slows or stops is NOT frozen — it keeps its live position and
  *     correctly loses places to cars still racing.
- *   - **Release when it's moving again.** A frozen car is released the moment it
- *     resumes continuous forward motion (a small positive per-tick advance),
- *     wherever it is, and its position rolls to live. The check is tick-to-tick,
- *     NOT distance from the (now stale) anchor — the old anchor-proximity test
- *     never re-opened once a towed car returned far from where it vanished, so
- *     it pinned the car (and the player, after their own tow) at a dead position
- *     for the rest of the race.
+ *   - **Release when it's moving again AND back on the racing surface.** A frozen
+ *     car is released once it resumes continuous forward motion (a small positive
+ *     per-tick advance) *and* is off pit road — judged from `CarIdxTrackSurface`
+ *     (no longer `InPitStall` / `AproachingPits`), the reliable pit signal, NOT
+ *     `CarIdxOnPitRoad`, which real telemetry shows reading `true` for on-track
+ *     cars and `false` for cars in their box. At that point its position rolls to
+ *     live. The check is tick-to-tick, NOT distance from the (now stale) anchor —
+ *     the old anchor-proximity test never re-opened once a towed car returned far
+ *     from where it vanished, so it pinned the car (and the player, after their
+ *     own tow) at a dead position for the rest of the race. The pit-road gate is
+ *     what keeps a car towed into its box — where it sits at a high pit-box
+ *     LapDistPct — from releasing on the first creep of service and jumping ahead
+ *     of cars still racing earlier on the lap; it stays held at its on-track
+ *     anchor until it drives back out.
  *
  * Cars never seen in-world (no anchor) are seeded on their first in-world tick
  * and stay unfrozen from there.
@@ -126,11 +138,27 @@ export function updatePositionTracking(state: TranslatorState, telemetry: Teleme
     const movingNormally = prev !== undefined && score > prev && score - prev <= TELEPORT_THRESHOLD;
 
     if (state.positionFrozen.has(i)) {
-      // Held after a tow / teleport. Release the moment it's moving normally
-      // again — wherever it is (issue #697) — and roll its position to live.
-      // Flag the release for this tick so the overtake retirement classifier
-      // doesn't read the player's resulting gain as a real on-track pass.
-      if (movingNormally) {
+      // Held after a tow / teleport. Release once it resumes normal motion AND
+      // is back on the racing surface (off pit road). A tow dumps the car in its
+      // pit box at a high pit-box LapDistPct, so releasing the instant it merely
+      // creeps forward in the box (the original #697 "wherever it is" rule)
+      // snapped its anchor to that pit-box score and ranked it AHEAD of cars
+      // still racing earlier on the lap — the car appeared to jump ahead, then
+      // dropped back once you drove past the pits. Hold it at its last on-track
+      // anchor while it is on pit road — its box (`InPitStall`) or the pit lane
+      // (`AproachingPits`) — and roll to live only once it has rejoined the
+      // track. We gate on `CarIdxTrackSurface`, NOT `CarIdxOnPitRoad`: the latter
+      // is unreliable (real telemetry shows it `true` for cars on track and
+      // `false` for cars sitting in their box — see template-context.test.ts), so
+      // it would both miss towed cars and re-pin rejoined ones. A car that
+      // retires in its box never rejoins, so it stays held at its pre-tow anchor
+      // — the intended #603 retirement behavior (the player passes it by lapping
+      // past its anchor). Flag the release for this tick so the overtake
+      // retirement classifier doesn't read the player's resulting gain as a real
+      // on-track pass.
+      const onPitRoad = ts?.[i] === TrkLoc.InPitStall || ts?.[i] === TrkLoc.AproachingPits;
+
+      if (movingNormally && !onPitRoad) {
         state.positionFrozen.delete(i);
         state.positionJustReleased.add(i);
         state.positionLastKnownScores[i] = score;

--- a/packages/website/src/content/docs/changelog.mdx
+++ b/packages/website/src/content/docs/changelog.mdx
@@ -25,6 +25,7 @@ _Unreleased_
 
 **Bug Fixes**
 
+- Cars that are towed into the pits no longer briefly jump ahead of you in the running order while they sit in their pit box — they hold their on-track position for the whole stop and drop back only once they rejoin the track. This keeps the Race Engineer's spoken position, the Session Info Position readout, and the driver-info template prefixes from reading a place too high during another car's pit stop.
 - Links in an action's settings (such as Documentation and Downloads) now open in your default web browser instead of the deck app's small built-in browser window.
 
 **Maintenance**


### PR DESCRIPTION
## Related Issue

Fixes #733

## What changed?

A car towed into its pit box sits at a high pit-box `CarIdxLapDistPct`. The #697 release-on-first-motion rule released the frozen car the instant it crept forward during service, snapping its rank to that pit-box score and jumping it ahead of cars still racing earlier on the same lap; #710 then removed the template's pit-road blend that had masked this on the Telemetry Display.

This holds a frozen (towed) car at its on-track anchor while it is on pit road and releases it only once it has rejoined the racing surface and is moving. The "on pit road" test uses `CarIdxTrackSurface` (`InPitStall` / `AproachingPits`) — **not** `CarIdxOnPitRoad`, which real telemetry shows is unreliable (it reads `true` for cars on track and `false` for cars sitting in their box). `race-finish.ts` is the single source behind the Race Engineer position callouts, Session Info → Position, and the Telemetry Display / Chat / Race Admin prefixes, so all three are fixed from one place. Normally-pitting cars (driving in under their own power) are never frozen and are unaffected.

It also removes the phantom "lose then re-gain": the towed car no longer jumps ahead and back, so there is no spurious gain for the overtake retirement classifier to handle.

## How to test

1. In a race, have a rival get towed (or tow yourself). On the Telemetry Display, Session Info → Position, and the Race Engineer callouts, confirm the towed car holds its position while in the pits and does **not** momentarily jump ahead of cars still racing.
2. Confirm it drops back to its real (dropped-back) position only once it drives back out onto the track.
3. Confirm a car that drives into the pits normally still shows its live position (it is not frozen).

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — N/A: the fix is in the shared `@iracedeck/sim-events-iracing` running order consumed by every plugin; no plugin registration, manifest, or PI change
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cars towed into the pits no longer temporarily jump ahead in the running order while in their pit box.
  * Race Engineer spoken updates and position readouts now correctly reflect the car’s place during pit stops.
  * Towed/teleported cars remain “frozen” until they are both moving continuously and back off pit road; they only resume normal running-order placement once rejoining the racing surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->