### PR TITLE
fix(camera-controls): respect Title Text in Cycle Camera and label selector "Mode" (#739)

### DIFF
--- a/packages/iracing-actions/src/actions/camera-controls/camera-controls.test.ts
+++ b/packages/iracing-actions/src/actions/camera-controls/camera-controls.test.ts
@@ -148,15 +148,22 @@ vi.mock("@iracedeck/deck-core", () => ({
     glowWidth: 18,
   })),
   resolveGraphicSettings: vi.fn(() => ({ scale: 1 })),
-  resolveTitleSettings: vi.fn((_svg: unknown, _global: unknown, _overrides: unknown, defaultTitle?: string) => ({
-    showTitle: true,
-    showGraphics: true,
-    titleText: defaultTitle ?? "",
-    bold: true,
-    fontSize: 18,
-    position: "bottom" as const,
-    customPosition: 0,
-  })),
+  resolveTitleSettings: vi.fn(
+    (
+      _svg: unknown,
+      _global: unknown,
+      overrides: { titleText?: string; showTitle?: boolean } | undefined,
+      defaultTitle?: string,
+    ) => ({
+      showTitle: overrides?.showTitle ?? true,
+      showGraphics: true,
+      titleText: overrides?.titleText || defaultTitle || "",
+      bold: true,
+      fontSize: 18,
+      position: "bottom" as const,
+      customPosition: 0,
+    }),
+  ),
   assembleIcon: vi.fn(
     ({ graphicSvg, title }: { graphicSvg: string; colors: unknown; title: { titleText: string } }) => {
       const encoded = encodeURIComponent(`<svg>${graphicSvg}${title?.titleText ?? ""}</svg>`);
@@ -171,7 +178,7 @@ vi.mock("@iracedeck/deck-core", () => ({
       .replace(/<desc>[\s\S]*?<\/desc>/, "")
       .trim(),
   ),
-  generateTitleText: vi.fn(() => ""),
+  generateTitleText: vi.fn((opts: { text?: string }) => (opts?.text ? `<text>${opts.text}</text>` : "")),
   ICON_BASE_TEMPLATE: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><rect x="0" y="0" width="144" height="144" fill="{{backgroundColor}}"/>{{graphicContent}}{{titleContent}}</svg>`,
   parseSvgViewBox: vi.fn((svg: string) => {
     const match = svg.match(/<svg[^>]*viewBox="([^"]+)"/);
@@ -439,6 +446,19 @@ describe("CameraControls", () => {
           generateCameraControlsSvg({ target: "cycle-driving", direction: "previous" }),
         );
         expect(decoded).toContain("driving-previous");
+      });
+
+      it("should thread titleOverrides into the cycle-camera grid label", () => {
+        mockGetGlobalSettings.mockReturnValue({});
+        const decoded = decodeURIComponent(
+          generateCameraControlsSvg({
+            target: "cycle-camera",
+            direction: "next",
+            titleOverrides: { titleText: "CUSTOM CAM" },
+          }),
+        );
+        expect(decoded).toContain("CUSTOM CAM");
+        expect(decoded).not.toContain("CYCLE CAM");
       });
     });
 
@@ -739,6 +759,28 @@ describe("CameraControls", () => {
       const result1 = generateCycleCameraGridSvg(["Nose", "Cockpit"], "next");
       const result2 = generateCycleCameraGridSvg(["Chase", "TV1"], "next");
       expect(result1).not.toBe(result2);
+    });
+
+    it("should render custom Title Text from titleOverrides in the grid label", () => {
+      const decoded = decodeURIComponent(
+        generateCycleCameraGridSvg(["Nose", "Cockpit"], "next", undefined, { titleText: "MY CAM" }),
+      );
+      expect(decoded).toContain("MY CAM");
+      expect(decoded).not.toContain("CYCLE CAM");
+    });
+
+    it("should omit the grid label when titleOverrides hides the title", () => {
+      const decoded = decodeURIComponent(
+        generateCycleCameraGridSvg(["Nose", "Cockpit"], "next", undefined, { showTitle: false }),
+      );
+      expect(decoded).not.toContain("CYCLE CAM");
+    });
+
+    it("should apply titleOverrides on the static fallback icon (no groups with icons)", () => {
+      const decoded = decodeURIComponent(
+        generateCycleCameraGridSvg(["NonExistent"], "next", undefined, { titleText: "FALLBACK" }),
+      );
+      expect(decoded).toContain("FALLBACK");
     });
   });
 });

--- a/packages/iracing-actions/src/actions/camera-controls/camera-controls.ts
+++ b/packages/iracing-actions/src/actions/camera-controls/camera-controls.ts
@@ -3,6 +3,7 @@ import {
   CommonSettings,
   ConnectionStateAwareAction,
   extractGraphicContent,
+  generateTitleText,
   getCommands,
   getGlobalBorderSettings,
   getGlobalColors,
@@ -298,6 +299,7 @@ export function generateCameraControlsSvg(
         enabledNames,
         direction,
         settings.colorOverrides,
+        settings.titleOverrides,
         settings.borderOverrides,
         settings.graphicOverrides,
       );
@@ -496,6 +498,7 @@ export function generateCycleCameraGridSvg(
   enabledGroupNames: string[],
   direction: Direction,
   colorOverrides?: Record<string, string>,
+  titleOverrides?: Partial<CommonSettings>["titleOverrides"],
   borderOverrides?: Partial<CommonSettings>["borderOverrides"],
   graphicOverrides?: Partial<CommonSettings>["graphicOverrides"],
 ): string {
@@ -507,7 +510,7 @@ export function generateCycleCameraGridSvg(
     const iconSvg = CYCLE_ICONS["cycle-camera"][direction];
     const titleText = CYCLE_TITLES["cycle-camera"][direction];
     const colors = resolveIconColors(iconSvg, getGlobalColors(), colorOverrides);
-    const title = resolveTitleSettings(iconSvg, getGlobalTitleSettings(), undefined, titleText);
+    const title = resolveTitleSettings(iconSvg, getGlobalTitleSettings(), titleOverrides, titleText);
     const border = resolveBorderSettings(iconSvg, getGlobalBorderSettings(), borderOverrides);
     const graphic = resolveGraphicSettings(getGlobalGraphicSettings(), graphicOverrides);
 
@@ -522,6 +525,21 @@ export function generateCycleCameraGridSvg(
   const colors = resolveIconColors(baseSvg, getGlobalColors(), colorOverrides);
   const bgColor = colors.backgroundColor || "#2a3a4a";
   const textColor = colors.textColor || "#ffffff";
+
+  // Resolve the label through the shared title pipeline so the grid honors the
+  // per-action Title Text override (and show/hide, bold, font size, position)
+  // exactly like every other icon. Default label is "CYCLE CAM".
+  const title = resolveTitleSettings(baseSvg, getGlobalTitleSettings(), titleOverrides, "CYCLE CAM");
+  const label = title.showTitle
+    ? generateTitleText({
+        text: title.titleText,
+        fontSize: title.fontSize,
+        bold: title.bold,
+        position: title.position,
+        customPosition: title.customPosition,
+        fill: textColor,
+      })
+    : "";
 
   // Build thumbnail SVGs
   let thumbnails = "";
@@ -549,9 +567,7 @@ export function generateCycleCameraGridSvg(
     thumbnails += `<g transform="translate(${pos.x + offsetX}, ${pos.y + offsetY}) scale(${scale})">${artwork}</g>`;
   }
 
-  const plusIndicator = "";
-
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><g filter="url(#activity-state)"><rect x="0" y="0" width="144" height="144" fill="${bgColor}"/>${thumbnails}${plusIndicator}<text x="72" y="138" text-anchor="middle" dominant-baseline="central" fill="${textColor}" font-family="Arial, sans-serif" font-size="20" font-weight="bold">CYCLE CAM</text></g></svg>`;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><g filter="url(#activity-state)"><rect x="0" y="0" width="144" height="144" fill="${bgColor}"/>${thumbnails}${label}</g></svg>`;
 
   return svgToDataUri(svg);
 }
@@ -975,6 +991,7 @@ export class CameraControls extends ConnectionStateAwareAction<CameraControlsSet
           getEnabledGroupNames(settings.cameraGroupSubset),
           settings.direction,
           settings.colorOverrides,
+          settings.titleOverrides,
           settings.borderOverrides,
           settings.graphicOverrides,
         );
@@ -984,6 +1001,7 @@ export class CameraControls extends ConnectionStateAwareAction<CameraControlsSet
             getEnabledGroupNames(settings.cameraGroupSubset),
             settings.direction,
             settings.colorOverrides,
+            settings.titleOverrides,
             settings.borderOverrides,
             settings.graphicOverrides,
           ),

--- a/packages/iracing-actions/src/actions/camera-focus/camera-focus.ejs
+++ b/packages/iracing-actions/src/actions/camera-focus/camera-focus.ejs
@@ -69,7 +69,7 @@
 	<body>
 		<%- include('section-header', { title: 'Action Settings' }) %>
 
-		<sdpi-item label="Target">
+		<sdpi-item label="Mode">
 			<sdpi-select id="target-select" setting="target" default="change-camera">
 				<option value="change-camera">Change Camera</option>
 				<option value="cycle-camera">Cycle Camera</option>

--- a/packages/website/src/content/docs/changelog.mdx
+++ b/packages/website/src/content/docs/changelog.mdx
@@ -17,6 +17,10 @@ _Unreleased_
 
 - iRaceDeck now bundles ready-made Stream Deck profiles — **iRaceDeck Default** and **iRaceDeck Replay** for the Stream Deck XL — so you get a full iRacing layout without building one yourself. A new **Switch Profile** action lets you put a profile switch on any key (its icon reflects the chosen profile), and a **Stream Deck Profiles** section in every action's settings lets you switch from there too. The Stream Deck app installs a profile the first time you switch to it.
 
+**Bug Fixes**
+
+- Camera Controls' **Cycle Camera** mode now applies your custom Title Text to the button instead of always showing "CYCLE CAM", and its mode selector is now labeled **Mode** (it was mislabeled **Target**).
+
 ## 1.23.0
 
 _2026-06-30_

--- a/packages/website/src/content/docs/docs/actions/view-camera/camera-focus.md
+++ b/packages/website/src/content/docs/docs/actions/view-camera/camera-focus.md
@@ -11,7 +11,7 @@ Camera Controls combines camera group selection, camera cycling, and focus targe
 
 ## Modes
 
-Select the mode from the **Target** dropdown in the Property Inspector.
+Select the mode from the **Mode** dropdown in the Property Inspector.
 
 ### Change Camera
 


### PR DESCRIPTION
## Related Issue

Fixes #739

## What changed?

- **Cycle Camera now respects the Title Text override.** Its default grid icon hardcoded a `CYCLE CAM` label and bypassed the shared title pipeline, so a custom Title Text had no effect. The grid label now resolves through `resolveTitleSettings` + `generateTitleText` (the same helpers `assembleIcon` uses), honoring Title Text plus show/hide, bold, font size, and position like every other icon. `titleOverrides` is threaded through `generateCameraControlsSvg`, `generateCycleCameraGridSvg` (including its no-icon fallback), and the `updateCycleIcon` restore path. The telemetry-driven per-group icon already honored it.
- **Renamed the mode selector label from "Target" to "Mode"** in the Camera Controls Property Inspector, matching every other multi-mode action. The internal `target` setting key and type are unchanged, so no settings migration is needed.
- Updated the website action doc (`camera-focus.md`) and added a `1.24.0` **Bug Fixes** changelog entry.

## How to test

1. Add a **Camera Controls** action and set the mode dropdown (now labeled **Mode**) to **Cycle Camera**.
2. In **Title Overrides**, enter custom Title Text — the key shows your text instead of `CYCLE CAM`, both on the idle grid icon and once telemetry drives a specific camera group. Toggle **Show Title** off and confirm the label disappears.
3. Confirm the mode dropdown reads **Mode** and any existing selection is preserved (the setting key is unchanged).

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — the action lives in the shared `@iracedeck/iracing-actions` package, so the fix propagates to all plugins (Stream Deck, Mirabox, Ulanzi) with no per-plugin registration change
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cycle Camera now respects custom title text and title visibility instead of always showing “CYCLE CAM.”
  * The Cycle Camera grid icon keeps custom title overrides even when it falls back to the static icon.
  * The camera focus settings label is now correctly shown as **Mode** instead of **Target**.
* **Documentation**
  * Updated the camera focus guide to reference the **Mode** dropdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->