### PR TITLE
feat(actions): add backup driver input modes to Car Control (#183)

### DIFF
--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -48,14 +48,14 @@ When asked about actions or controls:
 | Category | Actions | Modes | Description |
 |----------|---------|-------|-------------|
 | Display & Session | 2 | 8 | Live session data: incidents, laps, position, fuel, flags, track wetness |
-| Driving Controls | 6 | 31 | AI spotter, audio (incl. Race Engineer & Radar volume), black boxes, look direction, car control, pit crew (Race Engineer toggle + radar) |
+| Driving Controls | 6 | 35 | AI spotter, audio (incl. Race Engineer & Radar volume), black boxes, look direction, car control, pit crew (Race Engineer toggle + radar) |
 | Cockpit & Interface | 5 | 35 | Wipers, force feedback, splits & reference, telemetry, UI toggles |
 | View & Camera | 5 | 88 | FOV, replay, camera controls, broadcast tools |
 | Media | 1 | 7 | Video recording, screenshots, texture management |
 | Pit Service | 3 | 15 | Fuel, tires, compounds, tearoff, fast repair |
 | Car Setup | 7 | 73 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control — adjustment modes plus live-display "View …" sub-modes; each View sub-mode also supports dual-press (tap = configured direction, long-press = opposite) so one key both shows the value and adjusts it (#540) |
 | Communication | 2 | 34 | Chat, macros (15), whisper, toggle, reply, race admin commands |
-| **Total** | **31** | **291** | |
+| **Total** | **31** | **295** | |
 
 Mode counts reflect the PI Mode/Setting dropdown choices documented in each action page. Directional variants (Increase/Decrease) are treated as a single mode with a Direction sub-setting, matching the per-mode website format. Legacy replay actions (Replay Transport, Replay Speed, Replay Navigation) and Camera Cycle (Legacy) still exist in the plugin manifest for backward compatibility but are not counted as documented actions.
 
@@ -76,7 +76,7 @@ Mode counts reflect the PI Mode/Setting dropdown choices documented in each acti
 | Audio Controls | 5 | push-to-talk (hold), voice-chat (with volume-up/down/mute action), master (with volume-up/down action), race-engineer (with volume-up/down action; steps global raceEngineerVolume ±5, respects the master enable gate), radar (with volume-up/down action; steps global radarVolume ±5). The race-engineer/radar categories control iRaceDeck's own audio buses directly (no keyboard binding); dial control is out of scope for now (#590). |
 | Black Box Selector | 3 | direct (with 11 Black Box options), next, previous |
 | Look Direction | 4 | look-left, look-right, look-up, look-down (all hold pattern) |
-| Car Control | 10 | pit-speed-limiter (telemetry-aware), push-to-pass (telemetry-aware), drs (telemetry-aware), headlight-flash (hold), tear-off-visor, ignition, starter (hold), enter-exit-tow (hold, telemetry-aware, session-context icon/color/label when out of car: Test/Practice/Qualify/Grid/Race, red background in-car, per-state auto-hold options for exit/reset/tow), escape (hardcoded ESC, auto-hold option), pause-sim |
+| Car Control | 14 | pit-speed-limiter (telemetry-aware), push-to-pass (telemetry-aware), drs (telemetry-aware), headlight-flash (hold), tear-off-visor, ignition, starter (hold), enter-exit-tow (hold, telemetry-aware, session-context icon/color/label when out of car: Test/Practice/Qualify/Grid/Race, red background in-car, per-state auto-hold options for exit/reset/tow), escape (hardcoded ESC, auto-hold option), pause-sim, handbrake (hold), second-clutch (hold), second-up-shift, second-down-shift (backup driver inputs, #183 — no default iRacing bindings) |
 | Pit Crew | 2 | race-engineer (Race Engineer Toggle — flips the engineer voice gate on/off), radar (toggles the directional proximity tick loop). The radar-volume mode moved to the Audio Controls action (#590) — hidden from the Pit Crew Mode dropdown but kept functional so existing buttons keep working. The Spotter is NOT a mode — it's a Race Engineer voice callout family (spoken side-awareness — "car left", "three wide", "clear"), gated by the Race Engineer master (`pitCrewRaceEngineerEnabled`) plus two PI opt-ins `calloutEnabledSpotterCars` + `calloutEnabledSpotterStillThere` (both default on); issue #651. |
 
 ### Cockpit & Interface

--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -9,7 +9,7 @@ description: Use when looking up Stream Deck actions, sub-actions, modes, catego
 
 Complete action definitions: `docs/reference/actions.json`
 
-This skill file documents **31 actions with 291 modes** using a detailed per-mode count (the totals in the category table below). The user-facing website (`packages/website/src/content/docs/`) uses a coarser counting convention and shows a lower total (**260 modes**) — treat the website as the source of truth for user-facing copy and this skill file as the detailed inventory. `docs/reference/actions.json` has not yet been re-synced to the per-mode counting convention; treat it as a detailed inventory of individual mode values that is occasionally out of date.
+This skill file documents **31 actions with 295 modes** using a detailed per-mode count (the totals in the category table below). The user-facing website (`packages/website/src/content/docs/`) uses a coarser counting convention and shows a lower total (**260 modes**) — treat the website as the source of truth for user-facing copy and this skill file as the detailed inventory. `docs/reference/actions.json` has not yet been re-synced to the per-mode counting convention; treat it as a detailed inventory of individual mode values that is occasionally out of date.
 
 Each action entry:
 ```json

--- a/docs/reference/actions.json
+++ b/docs/reference/actions.json
@@ -136,7 +136,11 @@
             { "value": "starter", "label": "Starter", "controlType": "hold" },
             { "value": "enter-exit-tow", "label": "Enter/Exit/Tow", "controlType": "hold", "telemetryAware": true },
             { "value": "escape", "label": "Escape", "controlType": "hold" },
-            { "value": "pause-sim", "label": "Pause Sim" }
+            { "value": "pause-sim", "label": "Pause Sim" },
+            { "value": "handbrake", "label": "Handbrake", "controlType": "hold" },
+            { "value": "second-clutch", "label": "Second Clutch", "controlType": "hold" },
+            { "value": "second-up-shift", "label": "Second Up Shift" },
+            { "value": "second-down-shift", "label": "Second Down Shift" }
           ]
         },
         {

--- a/docs/superpowers/plans/2026-07-02-issue-183-backup-driver-inputs.md
+++ b/docs/superpowers/plans/2026-07-02-issue-183-backup-driver-inputs.md
@@ -1,0 +1,688 @@
+# Backup Driver Input Controls (Issue #183) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add four backup driver input modes — Handbrake, Second Clutch, Second Up Shift, Second Down Shift — to the existing Car Control action.
+
+**Architecture:** Extend the Car Control action's mode enum, dispatch tables, and static-icon maps; add four graphic-snippet SVGs, four key-binding entries, and four comms-catalog descriptors. All icon assembly, hold/tap dispatch, missing-binding warnings, and PI status lines are handled by existing generic code once the mappings exist. Spec: `docs/superpowers/specs/2026-07-02-issue-183-backup-driver-inputs-design.md`.
+
+**Tech Stack:** TypeScript, Zod, Vitest, EJS PI templates, Mustache SVG snippets, pnpm/turbo monorepo.
+
+## Global Constraints
+
+- Naming follows iRacing's Controls UI (per `docs/keyboard-shortcuts.md`): labels **Handbrake**, **Second Clutch**, **Second Up Shift**, **Second Down Shift**; control values `handbrake`, `second-clutch`, `second-up-shift`, `second-down-shift`; global setting keys `carControlHandbrake`, `carControlSecondClutch`, `carControlSecondUpShift`, `carControlSecondDownShift`.
+- All four modes are key-binding only: no SDK support, no default key (empty `default` everywhere), no telemetry awareness.
+- Handbrake and Second Clutch use the **hold** pattern; the two shifts are **tap**.
+- Icons use only safe SVG Tiny 1.2 features (shapes, text, opacity — no filters/masks/clipPath/`<style>`), per `.claude/rules/svg-platform-compatibility.md`.
+- Working directory: `C:\Users\Niklas\Projects\iRaceDeck\ir-183` (worktree, branch `feat/backup-driver-inputs`). No watcher is running — run all builds/tests manually. All commands run from the worktree root.
+- If a full `pnpm build` fails with EPERM on `iracing_native.node`, a deck host app (Stream Deck / UlanziStudio) is holding the lock — stop and ask the user to quit it.
+- Commit after every task with a conventional-commit message ending in `(#183)`.
+
+---
+
+### Task 1: Icon SVGs + generated previews/defaults
+
+**Files:**
+- Create: `packages/icons/car-control/handbrake.svg`
+- Create: `packages/icons/car-control/second-clutch.svg`
+- Create: `packages/icons/car-control/second-up-shift.svg`
+- Create: `packages/icons/car-control/second-down-shift.svg`
+- Generated: `packages/icons/preview/car-control/*.svg` (script output)
+- Generated: `packages/iracing-actions/src/actions/data/icon-defaults.json` (script output)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: SVG modules imported by Task 2 as `@iracedeck/icons/car-control/<name>.svg`. Each has `<desc>` JSON metadata with `backgroundColor` `#2a3a2a` and a `title.text` default.
+
+- [ ] **Step 1: Author `handbrake.svg`**
+
+The dashboard handbrake warning symbol — circle with an exclamation mark, flanked by parenthesis arcs — in fixed semantic red (`#e74c3c`, like starter's fixed red; no `{{graphic1Color}}`, so global color presets can't clash):
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 48" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff"},"title":{"text":"HANDBRAKE"},"border":{"color":"#5a6a5a"}}</desc>
+
+    <path d="M 12 5 A 25 25 0 0 0 12 43" fill="none" stroke="#e74c3c" stroke-width="5" stroke-linecap="round"/>
+    <path d="M 60 5 A 25 25 0 0 1 60 43" fill="none" stroke="#e74c3c" stroke-width="5" stroke-linecap="round"/>
+    <circle cx="36" cy="24" r="17" fill="none" stroke="#e74c3c" stroke-width="5"/>
+    <rect x="34" y="13" width="4" height="13" rx="2" fill="#e74c3c" stroke="none"/>
+    <circle cx="36" cy="32" r="2.5" fill="#e74c3c" stroke="none"/>
+
+</svg>
+```
+
+- [ ] **Step 2: Author the three "2ND" icons**
+
+All three share a gold `#f39c12` "2ND" badge (dark text, fixed colors — text inside graphics is never colorizable) to distinguish them from other arrow/disc icons; primary artwork uses `{{graphic1Color}}`.
+
+`second-clutch.svg` — clutch friction disc (rim, hub, four spring circles) + badge:
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 66" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nCLUTCH"},"border":{"color":"#5a6a5a"}}</desc>
+
+    <circle cx="30" cy="30" r="27" fill="none" stroke="{{graphic1Color}}" stroke-width="4"/>
+    <circle cx="30" cy="30" r="7" fill="{{graphic1Color}}" stroke="none"/>
+    <circle cx="30" cy="13" r="4.5" fill="{{graphic1Color}}" stroke="none" opacity="0.6"/>
+    <circle cx="30" cy="47" r="4.5" fill="{{graphic1Color}}" stroke="none" opacity="0.6"/>
+    <circle cx="13" cy="30" r="4.5" fill="{{graphic1Color}}" stroke="none" opacity="0.6"/>
+    <circle cx="47" cy="30" r="4.5" fill="{{graphic1Color}}" stroke="none" opacity="0.6"/>
+    <rect x="34" y="48" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
+    <text x="49" y="57" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
+
+</svg>
+```
+
+`second-up-shift.svg` — bold up arrow + badge:
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 58 64" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nSHIFT UP"},"border":{"color":"#5a6a5a"}}</desc>
+
+    <polygon points="25,0 46,24 34,24 34,46 16,46 16,24 4,24" fill="{{graphic1Color}}" stroke="none"/>
+    <rect x="28" y="46" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
+    <text x="43" y="55" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
+
+</svg>
+```
+
+`second-down-shift.svg` — the same arrow pointing down (badge in the same spot):
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 58 64" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nSHIFT DOWN"},"border":{"color":"#5a6a5a"}}</desc>
+
+    <polygon points="25,46 4,22 16,22 16,0 34,0 34,22 46,22" fill="{{graphic1Color}}" stroke="none"/>
+    <rect x="28" y="46" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
+    <text x="43" y="55" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
+
+</svg>
+```
+
+(On `second-down-shift.svg` the arrow occupies y 0–46 and the badge y 46–64; the down arrow head is at the bottom-left region, so the badge overlapping bottom-right stays legible. Inspect the generated previews and nudge coordinates if anything clips — the viewBox must stay trimmed to the artwork extent.)
+
+- [ ] **Step 3: Regenerate previews and icon defaults**
+
+```bash
+node scripts/generate-icon-previews.mjs
+node scripts/generate-icon-defaults.mjs
+```
+
+Expected: four new files under `packages/icons/preview/car-control/`; `icon-defaults.json` diff only adds/changes nothing for `car-control` (the PI defaults for car-control come from its existing entry — verify the diff and keep whatever the script writes).
+
+- [ ] **Step 4: Visually inspect the previews**
+
+Read the four files in `packages/icons/preview/car-control/` (they have colors baked in) and confirm: nothing clips outside the viewBox, the badge doesn't cover the arrow head, the handbrake symbol reads as ⚠-style brake light. Adjust source SVGs and re-run the preview script if needed.
+
+- [ ] **Step 5: Run the icon freshness test**
+
+```bash
+npx vitest run packages/icons
+```
+
+Expected: PASS (previews match templates).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/icons packages/iracing-actions/src/actions/data/icon-defaults.json
+git commit -m "feat(icons): add handbrake, second clutch, and second shift car-control icons (#183)"
+```
+
+---
+
+### Task 2: Car Control action — modes, dispatch, tests (TDD)
+
+**Files:**
+- Modify: `packages/iracing-actions/src/actions/car-control/car-control.ts`
+- Test: `packages/iracing-actions/src/actions/car-control/car-control.test.ts`
+
+**Interfaces:**
+- Consumes: the four SVG modules from Task 1.
+- Produces: control values `handbrake` / `second-clutch` / `second-up-shift` / `second-down-shift` accepted by `CarControlSettings`; `CAR_CONTROL_GLOBAL_KEYS` entries `carControlHandbrake` / `carControlSecondClutch` / `carControlSecondUpShift` / `carControlSecondDownShift` (Tasks 3–5 must use these exact strings).
+
+- [ ] **Step 1: Write the failing tests**
+
+In `car-control.test.ts`, add icon mocks next to the existing `vi.mock` blocks (top of file):
+
+```typescript
+vi.mock("@iracedeck/icons/car-control/handbrake.svg", () => ({
+  default: "<svg>handbrake-icon</svg>",
+}));
+vi.mock("@iracedeck/icons/car-control/second-clutch.svg", () => ({
+  default: "<svg>second-clutch-icon</svg>",
+}));
+vi.mock("@iracedeck/icons/car-control/second-up-shift.svg", () => ({
+  default: "<svg>second-up-shift-icon</svg>",
+}));
+vi.mock("@iracedeck/icons/car-control/second-down-shift.svg", () => ({
+  default: "<svg>second-down-shift-icon</svg>",
+}));
+```
+
+In the `CAR_CONTROL_GLOBAL_KEYS` describe block, add four mapping tests and update the count test (10 → 14):
+
+```typescript
+it("should have correct mapping for handbrake", () => {
+  expect(CAR_CONTROL_GLOBAL_KEYS["handbrake"]).toBe("carControlHandbrake");
+});
+
+it("should have correct mapping for second-clutch", () => {
+  expect(CAR_CONTROL_GLOBAL_KEYS["second-clutch"]).toBe("carControlSecondClutch");
+});
+
+it("should have correct mapping for second-up-shift", () => {
+  expect(CAR_CONTROL_GLOBAL_KEYS["second-up-shift"]).toBe("carControlSecondUpShift");
+});
+
+it("should have correct mapping for second-down-shift", () => {
+  expect(CAR_CONTROL_GLOBAL_KEYS["second-down-shift"]).toBe("carControlSecondDownShift");
+});
+
+it("should have exactly 14 entries", () => {
+  expect(Object.keys(CAR_CONTROL_GLOBAL_KEYS)).toHaveLength(14);
+});
+```
+
+(The existing `"should have exactly 10 entries"` test is replaced by the 14-entry version — delete the old one.)
+
+Add a new describe block for the backup input modes (place after the `"long-press behavior (starter)"` block):
+
+```typescript
+describe("backup driver inputs (issue #183)", () => {
+  let action: CarControl;
+
+  beforeEach(() => {
+    action = new CarControl();
+  });
+
+  it("should generate valid data URIs with the default titles for all four modes", () => {
+    const expected: Record<string, string[]> = {
+      handbrake: ["HANDBRAKE"],
+      "second-clutch": ["2ND", "CLUTCH"],
+      "second-up-shift": ["2ND", "SHIFT UP"],
+      "second-down-shift": ["2ND", "SHIFT DOWN"],
+    };
+
+    for (const [control, labels] of Object.entries(expected)) {
+      const result = generateCarControlSvg({ control: control as any });
+
+      expect(result).toContain("data:image/svg+xml");
+      const decoded = decodeURIComponent(result);
+
+      for (const label of labels) {
+        expect(decoded).toContain(label);
+      }
+    }
+  });
+
+  it("should produce a distinct icon per mode", () => {
+    const controls = ["handbrake", "second-clutch", "second-up-shift", "second-down-shift"] as const;
+    const unique = new Set(controls.map((control) => generateCarControlSvg({ control })));
+
+    expect(unique.size).toBe(controls.length);
+  });
+
+  it("should hold the handbrake binding on keyDown and release on keyUp", async () => {
+    await action.onKeyDown(fakeEvent("action-1", { control: "handbrake" }) as any);
+
+    expect(mockHoldBinding).toHaveBeenCalledWith("action-1", "carControlHandbrake");
+    expect(mockTapBinding).not.toHaveBeenCalled();
+
+    await action.onKeyUp(fakeEvent("action-1") as any);
+
+    expect(mockReleaseBinding).toHaveBeenCalledWith("action-1");
+  });
+
+  it("should hold the second-clutch binding on keyDown and release on keyUp", async () => {
+    await action.onKeyDown(fakeEvent("action-1", { control: "second-clutch" }) as any);
+
+    expect(mockHoldBinding).toHaveBeenCalledWith("action-1", "carControlSecondClutch");
+    expect(mockTapBinding).not.toHaveBeenCalled();
+
+    await action.onKeyUp(fakeEvent("action-1") as any);
+
+    expect(mockReleaseBinding).toHaveBeenCalledWith("action-1");
+  });
+
+  it("should hold on dialDown and release on dialUp for handbrake", async () => {
+    await action.onDialDown(fakeEvent("action-1", { control: "handbrake" }) as any);
+
+    expect(mockHoldBinding).toHaveBeenCalledWith("action-1", "carControlHandbrake");
+
+    await action.onDialUp(fakeEvent("action-1") as any);
+
+    expect(mockReleaseBinding).toHaveBeenCalledWith("action-1");
+  });
+
+  it("should tap the second-up-shift binding on keyDown", async () => {
+    await action.onKeyDown(fakeEvent("action-1", { control: "second-up-shift" }) as any);
+
+    expect(mockTapBinding).toHaveBeenCalledWith("carControlSecondUpShift");
+    expect(mockHoldBinding).not.toHaveBeenCalled();
+  });
+
+  it("should tap the second-down-shift binding on keyDown", async () => {
+    await action.onKeyDown(fakeEvent("action-1", { control: "second-down-shift" }) as any);
+
+    expect(mockTapBinding).toHaveBeenCalledWith("carControlSecondDownShift");
+    expect(mockHoldBinding).not.toHaveBeenCalled();
+  });
+
+  it("should release a held handbrake on onWillDisappear", async () => {
+    await action.onKeyDown(fakeEvent("action-1", { control: "handbrake" }) as any);
+    await action.onWillDisappear(fakeEvent("action-1", { control: "handbrake" }) as any);
+
+    expect(mockReleaseBinding).toHaveBeenCalledWith("action-1");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+npx vitest run packages/iracing-actions/src/actions/car-control/car-control.test.ts
+```
+
+Expected: FAIL — the four mapping tests get `undefined`, the 14-entry test gets 10, the icon tests fall back to the starter icon (no distinct icons), and the dispatch tests warn "No global key mapping".
+
+- [ ] **Step 3: Implement in `car-control.ts`**
+
+Add SVG imports (keep the import list alphabetical by path):
+
+```typescript
+import handbrakeIcon from "@iracedeck/icons/car-control/handbrake.svg";
+import secondClutchIcon from "@iracedeck/icons/car-control/second-clutch.svg";
+import secondDownShiftIcon from "@iracedeck/icons/car-control/second-down-shift.svg";
+import secondUpShiftIcon from "@iracedeck/icons/car-control/second-up-shift.svg";
+```
+
+Extend `CarControlType` (append after `"escape"`):
+
+```typescript
+type CarControlType =
+  | "starter"
+  | "ignition"
+  | "pit-speed-limiter"
+  | "enter-exit-tow"
+  | "pause-sim"
+  | "headlight-flash"
+  | "push-to-pass"
+  | "drs"
+  | "tear-off-visor"
+  | "escape"
+  | "handbrake"
+  | "second-clutch"
+  | "second-up-shift"
+  | "second-down-shift";
+```
+
+Extend `CAR_CONTROL_STATIC_TITLES`:
+
+```typescript
+  escape: "ESCAPE",
+  handbrake: "HANDBRAKE",
+  "second-clutch": "2ND\nCLUTCH",
+  "second-up-shift": "2ND\nSHIFT UP",
+  "second-down-shift": "2ND\nSHIFT DOWN",
+```
+
+Extend `HOLD_CONTROLS`:
+
+```typescript
+const HOLD_CONTROLS = new Set<CarControlType>([
+  "starter",
+  "headlight-flash",
+  "enter-exit-tow",
+  "handbrake",
+  "second-clutch",
+]);
+```
+
+Extend `STATIC_CAR_CONTROL_ICONS`:
+
+```typescript
+  escape: escapeIcon,
+  handbrake: handbrakeIcon,
+  "second-clutch": secondClutchIcon,
+  "second-up-shift": secondUpShiftIcon,
+  "second-down-shift": secondDownShiftIcon,
+```
+
+Extend `CAR_CONTROL_GLOBAL_KEYS`:
+
+```typescript
+  "tear-off-visor": "carControlTearOffVisor",
+  escape: "",
+  handbrake: "carControlHandbrake",
+  "second-clutch": "carControlSecondClutch",
+  "second-up-shift": "carControlSecondUpShift",
+  "second-down-shift": "carControlSecondDownShift",
+```
+
+Extend the Zod enum in `CarControlSettings` (append after `"pause-sim"`):
+
+```typescript
+      "pause-sim",
+      "handbrake",
+      "second-clutch",
+      "second-up-shift",
+      "second-down-shift",
+```
+
+Update the class JSDoc line listing hold controls:
+
+```typescript
+ * Provides core car operation controls (starter, ignition, pit limiter, enter/exit/tow, pause,
+ * headlight flash, push to pass, DRS, tear off visor, escape, and backup inputs: handbrake,
+ * second clutch, second up/down shift).
+ * Starter, headlight flash, enter/exit/tow, handbrake, and second clutch use long-press
+ * (hold while pressed); all others use tap.
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+npx vitest run packages/iracing-actions/src/actions/car-control/car-control.test.ts
+```
+
+Expected: PASS (all existing + new tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/iracing-actions/src/actions/car-control/car-control.ts packages/iracing-actions/src/actions/car-control/car-control.test.ts
+git commit -m "feat(actions): add backup driver input modes to Car Control (#183)"
+```
+
+---
+
+### Task 3: Key bindings + comms catalog
+
+**Files:**
+- Modify: `packages/iracing-actions/src/actions/data/key-bindings.json` (the `carControl` array)
+- Modify: `packages/iracing-actions/src/actions/comms-catalog.ts` (the `"car-control"` entry, ~line 120)
+- Generated: `packages/iracing-actions/src/actions/data/action-comms.json` (via `pnpm generate:action-comms`)
+
+**Interfaces:**
+- Consumes: the setting keys produced by Task 2 (`carControlHandbrake`, `carControlSecondClutch`, `carControlSecondUpShift`, `carControlSecondDownShift`) — must match exactly (a cross-check test verifies every comms keybind key exists in `key-bindings.json`).
+- Produces: PI key-binding rows (rendered by the `global-key-bindings` partial) and per-mode comms descriptors (consumed by `ird-binding-status` and by the docs in Task 5).
+
+- [ ] **Step 1: Append the four entries to `key-bindings.json` → `carControl`**
+
+After the `tearOffVisor` entry:
+
+```json
+    {
+      "id": "handbrake",
+      "label": "Handbrake",
+      "default": "",
+      "setting": "carControlHandbrake"
+    },
+    {
+      "id": "secondClutch",
+      "label": "Second Clutch",
+      "default": "",
+      "setting": "carControlSecondClutch"
+    },
+    {
+      "id": "secondUpShift",
+      "label": "Second Up Shift",
+      "default": "",
+      "setting": "carControlSecondUpShift"
+    },
+    {
+      "id": "secondDownShift",
+      "label": "Second Down Shift",
+      "default": "",
+      "setting": "carControlSecondDownShift"
+    }
+```
+
+- [ ] **Step 2: Extend the `"car-control"` entry in `comms-catalog.ts`**
+
+Insert before the `// Hardcoded Escape` comment line:
+
+```typescript
+    handbrake: keybind("carControlHandbrake"),
+    "second-clutch": keybind("carControlSecondClutch"),
+    "second-up-shift": keybind("carControlSecondUpShift"),
+    "second-down-shift": keybind("carControlSecondDownShift"),
+```
+
+- [ ] **Step 3: Regenerate the comms JSON**
+
+```bash
+pnpm generate:action-comms
+```
+
+Expected: `packages/iracing-actions/src/actions/data/action-comms.json` diff shows the four new `car-control` keybind modes.
+
+- [ ] **Step 4: Run the iracing-actions test suite (freshness + cross-check + car-control)**
+
+```bash
+npx vitest run packages/iracing-actions
+```
+
+Expected: PASS — including the comms freshness test and the key cross-check against `key-bindings.json`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/iracing-actions/src/actions/data/key-bindings.json packages/iracing-actions/src/actions/comms-catalog.ts packages/iracing-actions/src/actions/data/action-comms.json
+git commit -m "feat(actions): register backup input key bindings and comms descriptors (#183)"
+```
+
+---
+
+### Task 4: Property Inspector dropdown + build
+
+**Files:**
+- Modify: `packages/iracing-actions/src/actions/car-control/car-control.ejs`
+
+**Interfaces:**
+- Consumes: control values from Task 2, comms JSON from Task 3 (already wired via the existing `ird-binding-status` include).
+- Produces: compiled `ui/car-control.html` in each plugin (build output, not committed).
+
+- [ ] **Step 1: Append the four options to the Control dropdown**
+
+After `<option value="pause-sim">Pause Sim</option>`:
+
+```html
+					<option value="handbrake">Handbrake</option>
+					<option value="second-clutch">Second Clutch</option>
+					<option value="second-up-shift">Second Up Shift</option>
+					<option value="second-down-shift">Second Down Shift</option>
+```
+
+(The file uses tab indentation — match it.)
+
+- [ ] **Step 2: Full build to compile templates and type-check everything**
+
+```bash
+pnpm build
+```
+
+Expected: success. (If EPERM on `iracing_native.node`: a deck host app holds the lock — ask the user to quit it, don't work around.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/iracing-actions/src/actions/car-control/car-control.ejs
+git commit -m "feat(pi): add backup driver input options to the Car Control dropdown (#183)"
+```
+
+---
+
+### Task 5: Docs, reference data, skill, changelog
+
+**Files:**
+- Modify: `packages/website/src/content/docs/docs/actions/driving/car-control.md`
+- Modify: `packages/website/src/content/docs/changelog.mdx` (1.24.0 section)
+- Modify: `docs/reference/actions.json` (car-control `modes` array, ~line 129)
+- Modify: `.claude/skills/iracedeck-actions/SKILL.md` (category table + Car Control row)
+
+**Interfaces:**
+- Consumes: final mode labels/values and hold/tap semantics from Tasks 2–4.
+- Produces: user-facing docs; nothing downstream.
+
+- [ ] **Step 1: Update the website car-control page**
+
+Frontmatter badge: `text: "10 modes"` → `text: "14 modes"`. Intro paragraph — replace the existing sentence with:
+
+```markdown
+Quick access to essential car functions: toggle the pit speed limiter, headlights, Push To Pass, DRS, starter, ignition, or tear off your visor — plus exit the car with Escape, pause the sim, and backup driver inputs (handbrake, second clutch, second shift) for when primary hardware fails — all from a single button.
+```
+
+Append after the Pause Sim section (which currently ends the file — add a `---` separator before each new section, none after the last):
+
+```markdown
+---
+
+### Handbrake
+
+Apply the handbrake while the button is held — a backup control for when your handbrake hardware fails mid-session.
+
+#### Details
+
+- **Method:** Key binding
+- **Dial:** No rotation support; press and hold the dial to apply the handbrake, release to let go
+- **Default binding:** No default key binding — Handbrake has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
+- **Telemetry-aware icon:** No
+
+#### Settings
+
+- No additional settings
+
+---
+
+### Second Clutch
+
+Engage iRacing's Second Clutch while the button is held — a backup for a failed clutch pedal.
+
+#### Details
+
+- **Method:** Key binding
+- **Dial:** No rotation support; press and hold the dial to engage the clutch, release to let go
+- **Default binding:** No default key binding — Second Clutch has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
+- **Telemetry-aware icon:** No
+
+#### Settings
+
+- No additional settings
+
+---
+
+### Second Up Shift
+
+Shift up a gear via iRacing's Second Up Shift control — a backup for a broken upshift paddle.
+
+#### Details
+
+- **Method:** Key binding
+- **Dial:** No rotation support
+- **Default binding:** No default key binding — Second Up Shift has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
+- **Telemetry-aware icon:** No
+
+#### Settings
+
+- No additional settings
+
+---
+
+### Second Down Shift
+
+Shift down a gear via iRacing's Second Down Shift control — a backup for a broken downshift paddle.
+
+#### Details
+
+- **Method:** Key binding
+- **Dial:** No rotation support
+- **Default binding:** No default key binding — Second Down Shift has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
+- **Telemetry-aware icon:** No
+
+#### Settings
+
+- No additional settings
+```
+
+- [ ] **Step 2: Add the changelog entry**
+
+In `changelog.mdx`, under `## 1.24.0` → `**Features**`, append the bullet:
+
+```markdown
+- Car Control gained four backup driver input modes — **Handbrake**, **Second Clutch**, **Second Up Shift**, and **Second Down Shift** — so you can keep driving when a shifter paddle, clutch pedal, or handbrake fails mid-session. Handbrake and Second Clutch stay engaged while the button is held; the shifts are single taps. None have default iRacing bindings, so set the binding in both iRacing and the Property Inspector.
+```
+
+- [ ] **Step 3: Update `docs/reference/actions.json`**
+
+Append to the car-control `modes` array after the `pause-sim` entry:
+
+```json
+            { "value": "handbrake", "label": "Handbrake", "controlType": "hold" },
+            { "value": "second-clutch", "label": "Second Clutch", "controlType": "hold" },
+            { "value": "second-up-shift", "label": "Second Up Shift" },
+            { "value": "second-down-shift", "label": "Second Down Shift" }
+```
+
+- [ ] **Step 4: Update the `iracedeck-actions` skill**
+
+In `.claude/skills/iracedeck-actions/SKILL.md`:
+
+- Category table: `| Driving Controls | 6 | 31 |` → `| Driving Controls | 6 | 35 |`; total row `| **Total** | **31** | **291** |` → `| **Total** | **31** | **295** |`.
+- Car Control row: change `| Car Control | 10 |` to `| Car Control | 14 |` and append to its mode list (before the closing ` |`):
+
+```text
+, handbrake (hold), second-clutch (hold), second-up-shift, second-down-shift (backup driver inputs, #183 — no default iRacing bindings)
+```
+
+- [ ] **Step 5: Build the website**
+
+```bash
+pnpm --filter @iracedeck/website build
+```
+
+Expected: success; the changelog page and `/docs/actions/driving/car-control/` render.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/website/src/content/docs/docs/actions/driving/car-control.md packages/website/src/content/docs/changelog.mdx docs/reference/actions.json .claude/skills/iracedeck-actions/SKILL.md
+git commit -m "docs: document Car Control backup driver input modes (#183)"
+```
+
+---
+
+### Task 6: Full verification
+
+**Files:** none new — verification only (plus any fixups it forces).
+
+- [ ] **Step 1: Lint and format**
+
+```bash
+pnpm lint:fix
+pnpm format:fix
+```
+
+Expected: exit 0. Fix any reported issue (never dismiss pre-existing ones — fix them too).
+
+- [ ] **Step 2: Full build and full test suite**
+
+```bash
+pnpm build
+pnpm test
+```
+
+Expected: both pass. (`pnpm build` catches type errors vitest's esbuild path tolerates — do not skip it.)
+
+- [ ] **Step 3: Commit any fixup diffs**
+
+```bash
+git status --short
+```
+
+If lint/format changed files: `git add -A && git commit -m "chore: lint/format fixups (#183)"`. If clean, nothing to do.
+
+- [ ] **Step 4: STOP — hand back to the user**
+
+Do NOT push and do NOT create a PR. The user manually tests in iRacing first (per project workflow), then decides on push/PR.

--- a/docs/superpowers/specs/2026-07-02-issue-183-backup-driver-inputs-design.md
+++ b/docs/superpowers/specs/2026-07-02-issue-183-backup-driver-inputs-design.md
@@ -76,3 +76,7 @@ Append four options to the Control dropdown: Handbrake, Second Clutch, Second Up
 
 - Second Throttle / Second Brake (analog axes — not button-mappable, listed adjacent in iRacing's controls but excluded by the issue).
 - Telemetry-aware state for any of the four modes (no `dc*` variables exist).
+
+## Amendment (2026-07-02, post-review)
+
+After device-icon review, the "2ND" gold badge and the `2ND\n` title prefix were dropped by user decision — the info added no value on the key. Final default titles: `HANDBRAKE`, `CLUTCH`, `SHIFT UP`, `SHIFT DOWN` (all single-line). The shift icons are plain solid arrows (viewBox retrimmed); the clutch icon was redesigned as a clutch friction disc (outer rim, eight-segment friction band with rivet dots, pressure-plate rings, center hub), all in `{{graphic1Color}}`.

--- a/docs/superpowers/specs/2026-07-02-issue-183-backup-driver-inputs-design.md
+++ b/docs/superpowers/specs/2026-07-02-issue-183-backup-driver-inputs-design.md
@@ -1,0 +1,78 @@
+# Issue #183 — Backup driver input controls (Car Control modes) — Design
+
+**Issue:** [#183](https://github.com/niklam/iracedeck/issues/183) — Add backup driver input controls: Handbrake, Second Clutch, Second Upshift/Downshift
+
+**Approach:** Extend the existing **Car Control** action with four new modes (approved over a separate dedicated action). This matches the issue's framing ("sub-actions under Car Control") and the precedent of the last four-mode addition. No new UUIDs, no manifest changes; all three plugins pick the modes up automatically.
+
+## Naming decision
+
+The issue writes "Second Up-Shift" / "Second Downshift", but `docs/keyboard-shortcuts.md` (the authoritative source for iRacing control names) and iRacing's own Controls UI use **"Second Up Shift"** and **"Second Down Shift"**. The iRacing naming was approved and is used everywhere: labels, control values, setting keys, docs.
+
+## New modes
+
+| Mode | Control value | Global setting key | Pattern | iRacing Setting | Default key |
+|------|---------------|--------------------|---------|-----------------|-------------|
+| Handbrake | `handbrake` | `carControlHandbrake` | Hold | Handbrake | *(none)* |
+| Second Clutch | `second-clutch` | `carControlSecondClutch` | Hold | Second Clutch | *(none)* |
+| Second Up Shift | `second-up-shift` | `carControlSecondUpShift` | Tap | Second Up Shift | *(none)* |
+| Second Down Shift | `second-down-shift` | `carControlSecondDownShift` | Tap | Second Down Shift | *(none)* |
+
+All four are **key binding only** — no SDK support, no `dc*` telemetry variables, no default iRacing key binding (the user must configure the binding in both iRacing and the Property Inspector). Static icons only; `TELEMETRY_AWARE_CONTROLS` is untouched.
+
+## Behavior (`car-control.ts`)
+
+- Add the four control values to the `CarControlSettings` Zod enum and the `CarControlType` union.
+- Add the four global setting keys to `CAR_CONTROL_GLOBAL_KEYS`.
+- Add `handbrake` and `second-clutch` to `HOLD_CONTROLS` — press on keyDown/dialDown via `holdBinding`, release on keyUp/dialUp via the existing generic release path (same as starter and headlight flash).
+- The two shift modes dispatch through the existing default `tapBinding` path — no new code.
+- Static icon rendering flows through the existing `STATIC_CAR_CONTROL_ICONS` / `CAR_CONTROL_STATIC_TITLES` path, including the missing-binding ⚠️ overlay (the `CAR_CONTROL_GLOBAL_KEYS` mapping is all the generic code needs).
+
+## Icons (`packages/icons/car-control/`)
+
+Four new trimmed-viewBox graphic snippets, safe SVG Tiny 1.2 features only (shapes, text, fill/stroke, opacity), car-control's standard `#2a3a2a` background in `<desc>`:
+
+- `handbrake.svg` — the dashboard handbrake symbol: circle with "!" flanked by parenthesis arcs, in semantic red (`#e74c3c`). The red is semantic and fixed; if the outline uses `{{graphic1Color}}` alongside it, lock the slot via `"locked"` so global presets can't clash.
+- `second-clutch.svg` — clutch disc (segmented circle) with a small "2ND" badge.
+- `second-up-shift.svg` — bold up arrow with a "2ND" badge.
+- `second-down-shift.svg` — bold down arrow with a "2ND" badge.
+
+The "2ND" badge distinguishes the shift arrows from other arrow-based icons (volume, view adjustments) per the icon distinctiveness rule.
+
+Default titles (in `<desc>` title metadata): `HANDBRAKE`, `2ND\nCLUTCH`, `2ND\nSHIFT UP`, `2ND\nSHIFT DOWN`.
+
+After authoring: run `node scripts/generate-icon-previews.mjs` and `node scripts/generate-icon-defaults.mjs`.
+
+## Property Inspector (`car-control.ejs`)
+
+Append four options to the Control dropdown: Handbrake, Second Clutch, Second Up Shift, Second Down Shift. No new conditional settings (auto-hold stays escape/enter-exit-tow only). The `ird-binding-status` line picks the new modes up from the regenerated comms catalog.
+
+## Data / catalog
+
+- `packages/iracing-actions/src/actions/data/key-bindings.json` — four new `carControl` entries (ids `handbrake`, `secondClutch`, `secondUpShift`, `secondDownShift`; empty `default`).
+- `packages/iracing-actions/src/actions/comms-catalog.ts` — four `keybind(...)` descriptors under `car-control`; regenerate with `pnpm generate:action-comms` (freshness + key cross-check tests guard this).
+
+## Tests (`car-control.test.ts`)
+
+- Icon generation returns a valid SVG data URI for each new mode.
+- `CAR_CONTROL_GLOBAL_KEYS` maps the four new control values to the expected setting keys.
+- Hold behavior: keyDown on handbrake / second-clutch calls `holdBinding`; keyUp calls `releaseBinding`.
+- Tap behavior: keyDown on the shift modes calls `tapBinding`.
+
+## Docs & sync artifacts
+
+- **Website** `packages/website/src/content/docs/docs/actions/driving/car-control.md` — four new mode sections in the per-mode format (Method: Key binding; Dial: no rotation support, hold-on-dial-press noted for the hold modes; Default binding: none; Telemetry-aware icon: No), sidebar badge 10 → **14 modes**, intro sentence updated.
+- **Changelog** `packages/website/src/content/docs/changelog.mdx` — one `**Features**` line under the in-development version.
+- `docs/reference/actions.json` — four mode entries under `com.iracedeck.sd.core.car-control`.
+- `.claude/skills/iracedeck-actions/SKILL.md` — Car Control mode list 10 → 14; Driving Controls category modes 31 → 35.
+- `docs/keyboard-shortcuts.md` — already lists all four controls (SDK: No); no change needed.
+- No internal per-mode doc pages under `docs/plugins/core/actions/` (precedent: none were added for the last four car-control modes).
+- No manifest, README action-count, or architecture-page changes (no new action, no structural change). Verify during implementation that no count mentioning car-control modes exists elsewhere.
+
+## Verification
+
+`pnpm build`, `pnpm lint:fix`, `pnpm format:fix`, `pnpm test` (no watcher running — all manual), plus the icon preview/defaults scripts and `pnpm generate:action-comms`. Manual iRacing test by the user before any push/PR.
+
+## Out of scope
+
+- Second Throttle / Second Brake (analog axes — not button-mappable, listed adjacent in iRacing's controls but excluded by the issue).
+- Telemetry-aware state for any of the four modes (no `dc*` variables exist).

--- a/packages/icons/car-control/handbrake.svg
+++ b/packages/icons/car-control/handbrake.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 48" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff"},"title":{"text":"HANDBRAKE"},"border":{"color":"#5a6a5a"}}</desc>
+
+    <path d="M 12 5 A 25 25 0 0 0 12 43" fill="none" stroke="#e74c3c" stroke-width="5" stroke-linecap="round"/>
+    <path d="M 60 5 A 25 25 0 0 1 60 43" fill="none" stroke="#e74c3c" stroke-width="5" stroke-linecap="round"/>
+    <circle cx="36" cy="24" r="17" fill="none" stroke="#e74c3c" stroke-width="5"/>
+    <rect x="34" y="13" width="4" height="13" rx="2" fill="#e74c3c" stroke="none"/>
+    <circle cx="36" cy="32" r="2.5" fill="#e74c3c" stroke="none"/>
+
+</svg>

--- a/packages/icons/car-control/second-clutch.svg
+++ b/packages/icons/car-control/second-clutch.svg
@@ -1,13 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 66" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nCLUTCH"},"border":{"color":"#5a6a5a"}}</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"CLUTCH"},"border":{"color":"#5a6a5a"}}</desc>
 
-    <circle cx="30" cy="30" r="27" fill="none" stroke="{{graphic1Color}}" stroke-width="4"/>
-    <circle cx="30" cy="30" r="7" fill="{{graphic1Color}}" stroke="none"/>
-    <circle cx="30" cy="13" r="4.5" fill="{{graphic1Color}}" stroke="none" opacity="0.6"/>
-    <circle cx="30" cy="47" r="4.5" fill="{{graphic1Color}}" stroke="none" opacity="0.6"/>
-    <circle cx="13" cy="30" r="4.5" fill="{{graphic1Color}}" stroke="none" opacity="0.6"/>
-    <circle cx="47" cy="30" r="4.5" fill="{{graphic1Color}}" stroke="none" opacity="0.6"/>
-    <rect x="34" y="48" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
-    <text x="49" y="57" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
+    <circle cx="32" cy="32" r="30" fill="none" stroke="{{graphic1Color}}" stroke-width="4"/>
+
+    <line x1="53" y1="32" x2="59.5" y2="32" stroke="{{graphic1Color}}" stroke-width="2.5"/>
+    <line x1="46.85" y1="46.85" x2="51.45" y2="51.45" stroke="{{graphic1Color}}" stroke-width="2.5"/>
+    <line x1="32" y1="53" x2="32" y2="59.5" stroke="{{graphic1Color}}" stroke-width="2.5"/>
+    <line x1="17.15" y1="46.85" x2="12.55" y2="51.45" stroke="{{graphic1Color}}" stroke-width="2.5"/>
+    <line x1="11" y1="32" x2="4.5" y2="32" stroke="{{graphic1Color}}" stroke-width="2.5"/>
+    <line x1="17.15" y1="17.15" x2="12.55" y2="12.55" stroke="{{graphic1Color}}" stroke-width="2.5"/>
+    <line x1="32" y1="11" x2="32" y2="4.5" stroke="{{graphic1Color}}" stroke-width="2.5"/>
+    <line x1="46.85" y1="17.15" x2="51.45" y2="12.55" stroke="{{graphic1Color}}" stroke-width="2.5"/>
+
+    <circle cx="54.2" cy="41.2" r="2" fill="{{graphic1Color}}" stroke="none"/>
+    <circle cx="41.2" cy="54.2" r="2" fill="{{graphic1Color}}" stroke="none"/>
+    <circle cx="22.8" cy="54.2" r="2" fill="{{graphic1Color}}" stroke="none"/>
+    <circle cx="9.8" cy="41.2" r="2" fill="{{graphic1Color}}" stroke="none"/>
+    <circle cx="9.8" cy="22.8" r="2" fill="{{graphic1Color}}" stroke="none"/>
+    <circle cx="22.8" cy="9.8" r="2" fill="{{graphic1Color}}" stroke="none"/>
+    <circle cx="41.2" cy="9.8" r="2" fill="{{graphic1Color}}" stroke="none"/>
+    <circle cx="54.2" cy="22.8" r="2" fill="{{graphic1Color}}" stroke="none"/>
+
+    <circle cx="32" cy="32" r="19" fill="none" stroke="{{graphic1Color}}" stroke-width="4"/>
+    <circle cx="32" cy="32" r="14" fill="none" stroke="{{graphic1Color}}" stroke-width="2"/>
+    <circle cx="32" cy="32" r="6.5" fill="none" stroke="{{graphic1Color}}" stroke-width="4"/>
 
 </svg>

--- a/packages/icons/car-control/second-clutch.svg
+++ b/packages/icons/car-control/second-clutch.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 66" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nCLUTCH"},"border":{"color":"#5a6a5a"}}</desc>
+
+    <circle cx="30" cy="30" r="27" fill="none" stroke="{{graphic1Color}}" stroke-width="4"/>
+    <circle cx="30" cy="30" r="7" fill="{{graphic1Color}}" stroke="none"/>
+    <circle cx="30" cy="13" r="4.5" fill="{{graphic1Color}}" stroke="none" opacity="0.6"/>
+    <circle cx="30" cy="47" r="4.5" fill="{{graphic1Color}}" stroke="none" opacity="0.6"/>
+    <circle cx="13" cy="30" r="4.5" fill="{{graphic1Color}}" stroke="none" opacity="0.6"/>
+    <circle cx="47" cy="30" r="4.5" fill="{{graphic1Color}}" stroke="none" opacity="0.6"/>
+    <rect x="34" y="48" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
+    <text x="49" y="57" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
+
+</svg>

--- a/packages/icons/car-control/second-down-shift.svg
+++ b/packages/icons/car-control/second-down-shift.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 58 64" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nSHIFT DOWN"},"border":{"color":"#5a6a5a"}}</desc>
+
+    <polygon points="25,46 4,22 16,22 16,0 34,0 34,22 46,22" fill="{{graphic1Color}}" stroke="none"/>
+    <rect x="28" y="46" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
+    <text x="43" y="55" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
+
+</svg>

--- a/packages/icons/car-control/second-down-shift.svg
+++ b/packages/icons/car-control/second-down-shift.svg
@@ -1,8 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 58 64" stroke-width="0.5" stroke="#fff" fill="#fff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54 64" stroke-width="0.5" stroke="#fff" fill="#fff">
   <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nSHIFT DOWN"},"border":{"color":"#5a6a5a"}}</desc>
 
-    <polygon points="25,46 4,22 16,22 16,0 34,0 34,22 46,22" fill="{{graphic1Color}}" stroke="none"/>
-    <rect x="28" y="46" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
-    <text x="43" y="55" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
+    <polygon points="21,46 0,22 12,22 12,0 30,0 30,22 42,22" fill="{{graphic1Color}}" stroke="none"/>
+    <rect x="24" y="46" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
+    <text x="39" y="55" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
 
 </svg>

--- a/packages/icons/car-control/second-down-shift.svg
+++ b/packages/icons/car-control/second-down-shift.svg
@@ -1,8 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54 64" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nSHIFT DOWN"},"border":{"color":"#5a6a5a"}}</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 42 46" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"SHIFT DOWN"},"border":{"color":"#5a6a5a"}}</desc>
 
     <polygon points="21,46 0,22 12,22 12,0 30,0 30,22 42,22" fill="{{graphic1Color}}" stroke="none"/>
-    <rect x="24" y="46" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
-    <text x="39" y="55" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
 
 </svg>

--- a/packages/icons/car-control/second-up-shift.svg
+++ b/packages/icons/car-control/second-up-shift.svg
@@ -1,8 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54 64" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nSHIFT UP"},"border":{"color":"#5a6a5a"}}</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 42 46" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"SHIFT UP"},"border":{"color":"#5a6a5a"}}</desc>
 
     <polygon points="21,0 42,24 30,24 30,46 12,46 12,24 0,24" fill="{{graphic1Color}}" stroke="none"/>
-    <rect x="24" y="46" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
-    <text x="39" y="55" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
 
 </svg>

--- a/packages/icons/car-control/second-up-shift.svg
+++ b/packages/icons/car-control/second-up-shift.svg
@@ -1,8 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 58 64" stroke-width="0.5" stroke="#fff" fill="#fff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54 64" stroke-width="0.5" stroke="#fff" fill="#fff">
   <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nSHIFT UP"},"border":{"color":"#5a6a5a"}}</desc>
 
-    <polygon points="25,0 46,24 34,24 34,46 16,46 16,24 4,24" fill="{{graphic1Color}}" stroke="none"/>
-    <rect x="28" y="46" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
-    <text x="43" y="55" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
+    <polygon points="21,0 42,24 30,24 30,46 12,46 12,24 0,24" fill="{{graphic1Color}}" stroke="none"/>
+    <rect x="24" y="46" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
+    <text x="39" y="55" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
 
 </svg>

--- a/packages/icons/car-control/second-up-shift.svg
+++ b/packages/icons/car-control/second-up-shift.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 58 64" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nSHIFT UP"},"border":{"color":"#5a6a5a"}}</desc>
+
+    <polygon points="25,0 46,24 34,24 34,46 16,46 16,24 4,24" fill="{{graphic1Color}}" stroke="none"/>
+    <rect x="28" y="46" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
+    <text x="43" y="55" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
+
+</svg>

--- a/packages/icons/preview/car-control/handbrake.svg
+++ b/packages/icons/preview/car-control/handbrake.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 48" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff"},"title":{"text":"HANDBRAKE"},"border":{"color":"#5a6a5a"}}</desc>
+
+    <path d="M 12 5 A 25 25 0 0 0 12 43" fill="none" stroke="#e74c3c" stroke-width="5" stroke-linecap="round"/>
+    <path d="M 60 5 A 25 25 0 0 1 60 43" fill="none" stroke="#e74c3c" stroke-width="5" stroke-linecap="round"/>
+    <circle cx="36" cy="24" r="17" fill="none" stroke="#e74c3c" stroke-width="5"/>
+    <rect x="34" y="13" width="4" height="13" rx="2" fill="#e74c3c" stroke="none"/>
+    <circle cx="36" cy="32" r="2.5" fill="#e74c3c" stroke="none"/>
+
+</svg>

--- a/packages/icons/preview/car-control/second-clutch.svg
+++ b/packages/icons/preview/car-control/second-clutch.svg
@@ -1,13 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 66" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nCLUTCH"},"border":{"color":"#5a6a5a"}}</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"CLUTCH"},"border":{"color":"#5a6a5a"}}</desc>
 
-    <circle cx="30" cy="30" r="27" fill="none" stroke="#ffffff" stroke-width="4"/>
-    <circle cx="30" cy="30" r="7" fill="#ffffff" stroke="none"/>
-    <circle cx="30" cy="13" r="4.5" fill="#ffffff" stroke="none" opacity="0.6"/>
-    <circle cx="30" cy="47" r="4.5" fill="#ffffff" stroke="none" opacity="0.6"/>
-    <circle cx="13" cy="30" r="4.5" fill="#ffffff" stroke="none" opacity="0.6"/>
-    <circle cx="47" cy="30" r="4.5" fill="#ffffff" stroke="none" opacity="0.6"/>
-    <rect x="34" y="48" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
-    <text x="49" y="57" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
+    <circle cx="32" cy="32" r="30" fill="none" stroke="#ffffff" stroke-width="4"/>
+
+    <line x1="53" y1="32" x2="59.5" y2="32" stroke="#ffffff" stroke-width="2.5"/>
+    <line x1="46.85" y1="46.85" x2="51.45" y2="51.45" stroke="#ffffff" stroke-width="2.5"/>
+    <line x1="32" y1="53" x2="32" y2="59.5" stroke="#ffffff" stroke-width="2.5"/>
+    <line x1="17.15" y1="46.85" x2="12.55" y2="51.45" stroke="#ffffff" stroke-width="2.5"/>
+    <line x1="11" y1="32" x2="4.5" y2="32" stroke="#ffffff" stroke-width="2.5"/>
+    <line x1="17.15" y1="17.15" x2="12.55" y2="12.55" stroke="#ffffff" stroke-width="2.5"/>
+    <line x1="32" y1="11" x2="32" y2="4.5" stroke="#ffffff" stroke-width="2.5"/>
+    <line x1="46.85" y1="17.15" x2="51.45" y2="12.55" stroke="#ffffff" stroke-width="2.5"/>
+
+    <circle cx="54.2" cy="41.2" r="2" fill="#ffffff" stroke="none"/>
+    <circle cx="41.2" cy="54.2" r="2" fill="#ffffff" stroke="none"/>
+    <circle cx="22.8" cy="54.2" r="2" fill="#ffffff" stroke="none"/>
+    <circle cx="9.8" cy="41.2" r="2" fill="#ffffff" stroke="none"/>
+    <circle cx="9.8" cy="22.8" r="2" fill="#ffffff" stroke="none"/>
+    <circle cx="22.8" cy="9.8" r="2" fill="#ffffff" stroke="none"/>
+    <circle cx="41.2" cy="9.8" r="2" fill="#ffffff" stroke="none"/>
+    <circle cx="54.2" cy="22.8" r="2" fill="#ffffff" stroke="none"/>
+
+    <circle cx="32" cy="32" r="19" fill="none" stroke="#ffffff" stroke-width="4"/>
+    <circle cx="32" cy="32" r="14" fill="none" stroke="#ffffff" stroke-width="2"/>
+    <circle cx="32" cy="32" r="6.5" fill="none" stroke="#ffffff" stroke-width="4"/>
 
 </svg>

--- a/packages/icons/preview/car-control/second-clutch.svg
+++ b/packages/icons/preview/car-control/second-clutch.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 66" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nCLUTCH"},"border":{"color":"#5a6a5a"}}</desc>
+
+    <circle cx="30" cy="30" r="27" fill="none" stroke="#ffffff" stroke-width="4"/>
+    <circle cx="30" cy="30" r="7" fill="#ffffff" stroke="none"/>
+    <circle cx="30" cy="13" r="4.5" fill="#ffffff" stroke="none" opacity="0.6"/>
+    <circle cx="30" cy="47" r="4.5" fill="#ffffff" stroke="none" opacity="0.6"/>
+    <circle cx="13" cy="30" r="4.5" fill="#ffffff" stroke="none" opacity="0.6"/>
+    <circle cx="47" cy="30" r="4.5" fill="#ffffff" stroke="none" opacity="0.6"/>
+    <rect x="34" y="48" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
+    <text x="49" y="57" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
+
+</svg>

--- a/packages/icons/preview/car-control/second-down-shift.svg
+++ b/packages/icons/preview/car-control/second-down-shift.svg
@@ -1,8 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54 64" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nSHIFT DOWN"},"border":{"color":"#5a6a5a"}}</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 42 46" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"SHIFT DOWN"},"border":{"color":"#5a6a5a"}}</desc>
 
     <polygon points="21,46 0,22 12,22 12,0 30,0 30,22 42,22" fill="#ffffff" stroke="none"/>
-    <rect x="24" y="46" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
-    <text x="39" y="55" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
 
 </svg>

--- a/packages/icons/preview/car-control/second-down-shift.svg
+++ b/packages/icons/preview/car-control/second-down-shift.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 58 64" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nSHIFT DOWN"},"border":{"color":"#5a6a5a"}}</desc>
+
+    <polygon points="25,46 4,22 16,22 16,0 34,0 34,22 46,22" fill="#ffffff" stroke="none"/>
+    <rect x="28" y="46" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
+    <text x="43" y="55" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
+
+</svg>

--- a/packages/icons/preview/car-control/second-down-shift.svg
+++ b/packages/icons/preview/car-control/second-down-shift.svg
@@ -1,8 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 58 64" stroke-width="0.5" stroke="#fff" fill="#fff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54 64" stroke-width="0.5" stroke="#fff" fill="#fff">
   <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nSHIFT DOWN"},"border":{"color":"#5a6a5a"}}</desc>
 
-    <polygon points="25,46 4,22 16,22 16,0 34,0 34,22 46,22" fill="#ffffff" stroke="none"/>
-    <rect x="28" y="46" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
-    <text x="43" y="55" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
+    <polygon points="21,46 0,22 12,22 12,0 30,0 30,22 42,22" fill="#ffffff" stroke="none"/>
+    <rect x="24" y="46" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
+    <text x="39" y="55" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
 
 </svg>

--- a/packages/icons/preview/car-control/second-up-shift.svg
+++ b/packages/icons/preview/car-control/second-up-shift.svg
@@ -1,8 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 58 64" stroke-width="0.5" stroke="#fff" fill="#fff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54 64" stroke-width="0.5" stroke="#fff" fill="#fff">
   <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nSHIFT UP"},"border":{"color":"#5a6a5a"}}</desc>
 
-    <polygon points="25,0 46,24 34,24 34,46 16,46 16,24 4,24" fill="#ffffff" stroke="none"/>
-    <rect x="28" y="46" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
-    <text x="43" y="55" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
+    <polygon points="21,0 42,24 30,24 30,46 12,46 12,24 0,24" fill="#ffffff" stroke="none"/>
+    <rect x="24" y="46" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
+    <text x="39" y="55" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
 
 </svg>

--- a/packages/icons/preview/car-control/second-up-shift.svg
+++ b/packages/icons/preview/car-control/second-up-shift.svg
@@ -1,8 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54 64" stroke-width="0.5" stroke="#fff" fill="#fff">
-  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nSHIFT UP"},"border":{"color":"#5a6a5a"}}</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 42 46" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"SHIFT UP"},"border":{"color":"#5a6a5a"}}</desc>
 
     <polygon points="21,0 42,24 30,24 30,46 12,46 12,24 0,24" fill="#ffffff" stroke="none"/>
-    <rect x="24" y="46" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
-    <text x="39" y="55" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
 
 </svg>

--- a/packages/icons/preview/car-control/second-up-shift.svg
+++ b/packages/icons/preview/car-control/second-up-shift.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 58 64" stroke-width="0.5" stroke="#fff" fill="#fff">
+  <desc>{"colors":{"backgroundColor":"#2a3a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"2ND\nSHIFT UP"},"border":{"color":"#5a6a5a"}}</desc>
+
+    <polygon points="25,0 46,24 34,24 34,46 16,46 16,24 4,24" fill="#ffffff" stroke="none"/>
+    <rect x="28" y="46" width="30" height="18" rx="4" fill="#f39c12" stroke="none"/>
+    <text x="43" y="55" text-anchor="middle" dominant-baseline="central" fill="#2a2a2a" font-family="Arial, sans-serif" font-size="11" font-weight="bold" stroke="none">2ND</text>
+
+</svg>

--- a/packages/iracing-actions/src/actions/car-control/car-control.ejs
+++ b/packages/iracing-actions/src/actions/car-control/car-control.ejs
@@ -18,6 +18,10 @@
 				<option value="enter-exit-tow">Enter/Exit/Tow Car</option>
 				<option value="escape">Escape</option>
 				<option value="pause-sim">Pause Sim</option>
+				<option value="handbrake">Handbrake</option>
+				<option value="second-clutch">Second Clutch</option>
+				<option value="second-up-shift">Second Up Shift</option>
+				<option value="second-down-shift">Second Down Shift</option>
 			</sdpi-select>
 		</sdpi-item>
 

--- a/packages/iracing-actions/src/actions/car-control/car-control.test.ts
+++ b/packages/iracing-actions/src/actions/car-control/car-control.test.ts
@@ -68,6 +68,18 @@ vi.mock("@iracedeck/icons/car-control/session-grid.svg", () => ({
 vi.mock("@iracedeck/icons/car-control/session-race.svg", () => ({
   default: '<svg xmlns="http://www.w3.org/2000/svg">session-race</svg>',
 }));
+vi.mock("@iracedeck/icons/car-control/handbrake.svg", () => ({
+  default: "<svg>handbrake-icon</svg>",
+}));
+vi.mock("@iracedeck/icons/car-control/second-clutch.svg", () => ({
+  default: "<svg>second-clutch-icon</svg>",
+}));
+vi.mock("@iracedeck/icons/car-control/second-up-shift.svg", () => ({
+  default: "<svg>second-up-shift-icon</svg>",
+}));
+vi.mock("@iracedeck/icons/car-control/second-down-shift.svg", () => ({
+  default: "<svg>second-down-shift-icon</svg>",
+}));
 
 vi.mock("@iracedeck/iracing-sdk", () => ({
   hasFlag: (value: number, flag: number) => (value & flag) !== 0,
@@ -221,8 +233,40 @@ describe("CarControl", () => {
       expect(CAR_CONTROL_GLOBAL_KEYS["escape"]).toBe("");
     });
 
-    it("should have exactly 10 entries", () => {
-      expect(Object.keys(CAR_CONTROL_GLOBAL_KEYS)).toHaveLength(10);
+    it("should have correct mapping for headlight-flash", () => {
+      expect(CAR_CONTROL_GLOBAL_KEYS["headlight-flash"]).toBe("carControlHeadlightFlash");
+    });
+
+    it("should have correct mapping for push-to-pass", () => {
+      expect(CAR_CONTROL_GLOBAL_KEYS["push-to-pass"]).toBe("carControlPushToPass");
+    });
+
+    it("should have correct mapping for drs", () => {
+      expect(CAR_CONTROL_GLOBAL_KEYS["drs"]).toBe("carControlDRS");
+    });
+
+    it("should have correct mapping for tear-off-visor", () => {
+      expect(CAR_CONTROL_GLOBAL_KEYS["tear-off-visor"]).toBe("carControlTearOffVisor");
+    });
+
+    it("should have correct mapping for handbrake", () => {
+      expect(CAR_CONTROL_GLOBAL_KEYS["handbrake"]).toBe("carControlHandbrake");
+    });
+
+    it("should have correct mapping for second-clutch", () => {
+      expect(CAR_CONTROL_GLOBAL_KEYS["second-clutch"]).toBe("carControlSecondClutch");
+    });
+
+    it("should have correct mapping for second-up-shift", () => {
+      expect(CAR_CONTROL_GLOBAL_KEYS["second-up-shift"]).toBe("carControlSecondUpShift");
+    });
+
+    it("should have correct mapping for second-down-shift", () => {
+      expect(CAR_CONTROL_GLOBAL_KEYS["second-down-shift"]).toBe("carControlSecondDownShift");
+    });
+
+    it("should have exactly 14 entries", () => {
+      expect(Object.keys(CAR_CONTROL_GLOBAL_KEYS)).toHaveLength(14);
     });
   });
 
@@ -793,6 +837,94 @@ describe("CarControl", () => {
       await action.onKeyDown(fakeEvent("action-1", { control: "starter" }) as any);
 
       expect(mockHoldBinding).toHaveBeenCalledWith("action-1", "carControlStarter");
+    });
+  });
+
+  describe("backup driver inputs (issue #183)", () => {
+    let action: CarControl;
+
+    beforeEach(() => {
+      action = new CarControl();
+    });
+
+    it("should generate valid data URIs with the default titles for all four modes", () => {
+      const expected: Record<string, string[]> = {
+        handbrake: ["HANDBRAKE"],
+        "second-clutch": ["2ND", "CLUTCH"],
+        "second-up-shift": ["2ND", "SHIFT UP"],
+        "second-down-shift": ["2ND", "SHIFT DOWN"],
+      };
+
+      for (const [control, labels] of Object.entries(expected)) {
+        const result = generateCarControlSvg({ control: control as any });
+
+        expect(result).toContain("data:image/svg+xml");
+        const decoded = decodeURIComponent(result);
+
+        for (const label of labels) {
+          expect(decoded).toContain(label);
+        }
+      }
+    });
+
+    it("should produce a distinct icon per mode", () => {
+      const controls = ["handbrake", "second-clutch", "second-up-shift", "second-down-shift"] as const;
+      const unique = new Set(controls.map((control) => generateCarControlSvg({ control })));
+
+      expect(unique.size).toBe(controls.length);
+    });
+
+    it("should hold the handbrake binding on keyDown and release on keyUp", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { control: "handbrake" }) as any);
+
+      expect(mockHoldBinding).toHaveBeenCalledWith("action-1", "carControlHandbrake");
+      expect(mockTapBinding).not.toHaveBeenCalled();
+
+      await action.onKeyUp(fakeEvent("action-1") as any);
+
+      expect(mockReleaseBinding).toHaveBeenCalledWith("action-1");
+    });
+
+    it("should hold the second-clutch binding on keyDown and release on keyUp", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { control: "second-clutch" }) as any);
+
+      expect(mockHoldBinding).toHaveBeenCalledWith("action-1", "carControlSecondClutch");
+      expect(mockTapBinding).not.toHaveBeenCalled();
+
+      await action.onKeyUp(fakeEvent("action-1") as any);
+
+      expect(mockReleaseBinding).toHaveBeenCalledWith("action-1");
+    });
+
+    it("should hold on dialDown and release on dialUp for handbrake", async () => {
+      await action.onDialDown(fakeEvent("action-1", { control: "handbrake" }) as any);
+
+      expect(mockHoldBinding).toHaveBeenCalledWith("action-1", "carControlHandbrake");
+
+      await action.onDialUp(fakeEvent("action-1") as any);
+
+      expect(mockReleaseBinding).toHaveBeenCalledWith("action-1");
+    });
+
+    it("should tap the second-up-shift binding on keyDown", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { control: "second-up-shift" }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("carControlSecondUpShift");
+      expect(mockHoldBinding).not.toHaveBeenCalled();
+    });
+
+    it("should tap the second-down-shift binding on keyDown", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { control: "second-down-shift" }) as any);
+
+      expect(mockTapBinding).toHaveBeenCalledWith("carControlSecondDownShift");
+      expect(mockHoldBinding).not.toHaveBeenCalled();
+    });
+
+    it("should release a held handbrake on onWillDisappear", async () => {
+      await action.onKeyDown(fakeEvent("action-1", { control: "handbrake" }) as any);
+      await action.onWillDisappear(fakeEvent("action-1", { control: "handbrake" }) as any);
+
+      expect(mockReleaseBinding).toHaveBeenCalledWith("action-1");
     });
   });
 

--- a/packages/iracing-actions/src/actions/car-control/car-control.test.ts
+++ b/packages/iracing-actions/src/actions/car-control/car-control.test.ts
@@ -850,9 +850,9 @@ describe("CarControl", () => {
     it("should generate valid data URIs with the default titles for all four modes", () => {
       const expected: Record<string, string[]> = {
         handbrake: ["HANDBRAKE"],
-        "second-clutch": ["2ND", "CLUTCH"],
-        "second-up-shift": ["2ND", "SHIFT UP"],
-        "second-down-shift": ["2ND", "SHIFT DOWN"],
+        "second-clutch": ["CLUTCH"],
+        "second-up-shift": ["SHIFT UP"],
+        "second-down-shift": ["SHIFT DOWN"],
       };
 
       for (const [control, labels] of Object.entries(expected)) {

--- a/packages/iracing-actions/src/actions/car-control/car-control.test.ts
+++ b/packages/iracing-actions/src/actions/car-control/car-control.test.ts
@@ -242,7 +242,7 @@ describe("CarControl", () => {
     });
 
     it("should have correct mapping for drs", () => {
-      expect(CAR_CONTROL_GLOBAL_KEYS["drs"]).toBe("carControlDRS");
+      expect(CAR_CONTROL_GLOBAL_KEYS["drs"]).toBe("carControlDrs");
     });
 
     it("should have correct mapping for tear-off-visor", () => {

--- a/packages/iracing-actions/src/actions/car-control/car-control.ts
+++ b/packages/iracing-actions/src/actions/car-control/car-control.ts
@@ -104,9 +104,9 @@ const CAR_CONTROL_STATIC_TITLES: Partial<Record<CarControlType, string>> = {
   "tear-off-visor": "VISOR\nTEAR OFF",
   escape: "ESCAPE",
   handbrake: "HANDBRAKE",
-  "second-clutch": "2ND\nCLUTCH",
-  "second-up-shift": "2ND\nSHIFT UP",
-  "second-down-shift": "2ND\nSHIFT DOWN",
+  "second-clutch": "CLUTCH",
+  "second-up-shift": "SHIFT UP",
+  "second-down-shift": "SHIFT DOWN",
 };
 
 const DEFAULT_PIT_SPEED = 80;

--- a/packages/iracing-actions/src/actions/car-control/car-control.ts
+++ b/packages/iracing-actions/src/actions/car-control/car-control.ts
@@ -243,7 +243,7 @@ export const CAR_CONTROL_GLOBAL_KEYS: Record<CarControlType, string> = {
   "pause-sim": "carControlPauseSim",
   "headlight-flash": "carControlHeadlightFlash",
   "push-to-pass": "carControlPushToPass",
-  drs: "carControlDRS",
+  drs: "carControlDrs",
   "tear-off-visor": "carControlTearOffVisor",
   escape: "",
   handbrake: "carControlHandbrake",

--- a/packages/iracing-actions/src/actions/car-control/car-control.ts
+++ b/packages/iracing-actions/src/actions/car-control/car-control.ts
@@ -28,10 +28,14 @@ import {
 import enterCarIcon from "@iracedeck/icons/car-control/enter-car.svg";
 import escapeIcon from "@iracedeck/icons/car-control/escape.svg";
 import exitCarIcon from "@iracedeck/icons/car-control/exit-car.svg";
+import handbrakeIcon from "@iracedeck/icons/car-control/handbrake.svg";
 import headlightFlashIcon from "@iracedeck/icons/car-control/headlight-flash.svg";
 import ignitionIcon from "@iracedeck/icons/car-control/ignition.svg";
 import pauseSimIcon from "@iracedeck/icons/car-control/pause-sim.svg";
 import resetToPitsIcon from "@iracedeck/icons/car-control/reset-to-pits.svg";
+import secondClutchIcon from "@iracedeck/icons/car-control/second-clutch.svg";
+import secondDownShiftIcon from "@iracedeck/icons/car-control/second-down-shift.svg";
+import secondUpShiftIcon from "@iracedeck/icons/car-control/second-up-shift.svg";
 import sessionGridIcon from "@iracedeck/icons/car-control/session-grid.svg";
 import sessionQualifyIcon from "@iracedeck/icons/car-control/session-qualify.svg";
 import sessionRaceIcon from "@iracedeck/icons/car-control/session-race.svg";
@@ -69,7 +73,11 @@ type CarControlType =
   | "push-to-pass"
   | "drs"
   | "tear-off-visor"
-  | "escape";
+  | "escape"
+  | "handbrake"
+  | "second-clutch"
+  | "second-up-shift"
+  | "second-down-shift";
 
 /** @internal Exported for testing */
 export type EnterExitTowState = "enter-car" | "exit-car" | "reset-to-pits" | "tow";
@@ -95,6 +103,10 @@ const CAR_CONTROL_STATIC_TITLES: Partial<Record<CarControlType, string>> = {
   "headlight-flash": "FLASH\nHEADLIGHT",
   "tear-off-visor": "VISOR\nTEAR OFF",
   escape: "ESCAPE",
+  handbrake: "HANDBRAKE",
+  "second-clutch": "2ND\nCLUTCH",
+  "second-up-shift": "2ND\nSHIFT UP",
+  "second-down-shift": "2ND\nSHIFT DOWN",
 };
 
 const DEFAULT_PIT_SPEED = 80;
@@ -111,7 +123,13 @@ const TELEMETRY_AWARE_CONTROLS = new Set<CarControlType>([
 ]);
 
 /** Controls that use hold pattern (press on keyDown, release on keyUp) */
-const HOLD_CONTROLS = new Set<CarControlType>(["starter", "headlight-flash", "enter-exit-tow"]);
+const HOLD_CONTROLS = new Set<CarControlType>([
+  "starter",
+  "headlight-flash",
+  "enter-exit-tow",
+  "handbrake",
+  "second-clutch",
+]);
 
 /** Hardcoded ESC key combination (not configurable — ESC is always ESC in iRacing) */
 const ESC_KEY = { key: "escape", code: "Escape" } as const;
@@ -206,6 +224,10 @@ const STATIC_CAR_CONTROL_ICONS: Partial<Record<CarControlType, string>> = {
   "headlight-flash": headlightFlashIcon,
   "tear-off-visor": tearOffVisorIcon,
   escape: escapeIcon,
+  handbrake: handbrakeIcon,
+  "second-clutch": secondClutchIcon,
+  "second-up-shift": secondUpShiftIcon,
+  "second-down-shift": secondDownShiftIcon,
 };
 
 /**
@@ -221,9 +243,13 @@ export const CAR_CONTROL_GLOBAL_KEYS: Record<CarControlType, string> = {
   "pause-sim": "carControlPauseSim",
   "headlight-flash": "carControlHeadlightFlash",
   "push-to-pass": "carControlPushToPass",
-  drs: "carControlDrs",
+  drs: "carControlDRS",
   "tear-off-visor": "carControlTearOffVisor",
   escape: "",
+  handbrake: "carControlHandbrake",
+  "second-clutch": "carControlSecondClutch",
+  "second-up-shift": "carControlSecondUpShift",
+  "second-down-shift": "carControlSecondDownShift",
 };
 
 /**
@@ -438,6 +464,10 @@ const CarControlSettings = CommonSettings.extend({
       "enter-exit-tow",
       "escape",
       "pause-sim",
+      "handbrake",
+      "second-clutch",
+      "second-up-shift",
+      "second-down-shift",
     ])
     .default("pit-speed-limiter"),
   autoHold: z
@@ -612,8 +642,10 @@ export function generateCarControlSvg(
 /**
  * Car Control Action
  * Provides core car operation controls (starter, ignition, pit limiter, enter/exit/tow, pause,
- * headlight flash, push to pass, DRS, tear off visor, escape).
- * Starter, headlight flash, and enter/exit/tow use long-press (hold while pressed); all others use tap.
+ * headlight flash, push to pass, DRS, tear off visor, escape, and backup inputs: handbrake,
+ * second clutch, second up/down shift).
+ * Starter, headlight flash, enter/exit/tow, handbrake, and second clutch use long-press
+ * (hold while pressed); all others use tap.
  * Escape uses direct keyboard (hardcoded ESC key) with optional auto-hold.
  */
 export const CAR_CONTROL_UUID = "com.iracedeck.sd.core.car-control" as const;

--- a/packages/iracing-actions/src/actions/comms-catalog.ts
+++ b/packages/iracing-actions/src/actions/comms-catalog.ts
@@ -127,6 +127,10 @@ export const COMMS_CATALOG: Record<string, ActionCommEntry> = {
     starter: keybind("carControlStarter"),
     "enter-exit-tow": keybind("carControlEnterExitTow"),
     "pause-sim": keybind("carControlPauseSim"),
+    handbrake: keybind("carControlHandbrake"),
+    "second-clutch": keybind("carControlSecondClutch"),
+    "second-up-shift": keybind("carControlSecondUpShift"),
+    "second-down-shift": keybind("carControlSecondDownShift"),
     // Hardcoded Escape — no user binding.
     escape: keybindFixed(),
   }),

--- a/packages/iracing-actions/src/actions/data/action-comms.json
+++ b/packages/iracing-actions/src/actions/data/action-comms.json
@@ -251,6 +251,34 @@
         "key": "carControlPauseSim"
       }
     },
+    "handbrake": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "carControlHandbrake"
+      }
+    },
+    "second-clutch": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "carControlSecondClutch"
+      }
+    },
+    "second-up-shift": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "carControlSecondUpShift"
+      }
+    },
+    "second-down-shift": {
+      "method": "keybind",
+      "binding": {
+        "scope": "global",
+        "key": "carControlSecondDownShift"
+      }
+    },
     "escape": {
       "method": "keybind"
     }

--- a/packages/iracing-actions/src/actions/data/key-bindings.json
+++ b/packages/iracing-actions/src/actions/data/key-bindings.json
@@ -78,7 +78,31 @@
     { "id": "headlightFlash", "label": "Headlight Flash", "default": "", "setting": "carControlHeadlightFlash" },
     { "id": "pushToPass", "label": "Push To Pass", "default": "", "setting": "carControlPushToPass" },
     { "id": "drs", "label": "DRS", "default": "", "setting": "carControlDrs" },
-    { "id": "tearOffVisor", "label": "Tear Off Visor", "default": "", "setting": "carControlTearOffVisor" }
+    { "id": "tearOffVisor", "label": "Tear Off Visor", "default": "", "setting": "carControlTearOffVisor" },
+    {
+      "id": "handbrake",
+      "label": "Handbrake",
+      "default": "",
+      "setting": "carControlHandbrake"
+    },
+    {
+      "id": "secondClutch",
+      "label": "Second Clutch",
+      "default": "",
+      "setting": "carControlSecondClutch"
+    },
+    {
+      "id": "secondUpShift",
+      "label": "Second Up Shift",
+      "default": "",
+      "setting": "carControlSecondUpShift"
+    },
+    {
+      "id": "secondDownShift",
+      "label": "Second Down Shift",
+      "default": "",
+      "setting": "carControlSecondDownShift"
+    }
   ],
   "viewAdjustment": [
     { "id": "fovIncrease", "label": "FOV Increase", "default": "]", "setting": "viewAdjustFovIncrease" },

--- a/packages/website/src/content/docs/changelog.mdx
+++ b/packages/website/src/content/docs/changelog.mdx
@@ -16,6 +16,7 @@ _Unreleased_
 **Features**
 
 - iRaceDeck now bundles ready-made Stream Deck profiles — **iRaceDeck Default** and **iRaceDeck Replay** for the Stream Deck XL — so you get a full iRacing layout without building one yourself. A new **Switch Profile** action lets you put a profile switch on any key (its icon reflects the chosen profile), and a **Stream Deck Profiles** section in every action's settings lets you switch from there too. The Stream Deck app installs a profile the first time you switch to it.
+- Car Control gained four backup driver input modes — **Handbrake**, **Second Clutch**, **Second Up Shift**, and **Second Down Shift** — so you can keep driving when a shifter paddle, clutch pedal, or handbrake fails mid-session. Handbrake and Second Clutch stay engaged while the button is held; the shifts are single taps. None have default iRacing bindings, so set the binding in both iRacing and the Property Inspector.
 
 **Improvements**
 

--- a/packages/website/src/content/docs/docs/actions/driving/car-control.md
+++ b/packages/website/src/content/docs/docs/actions/driving/car-control.md
@@ -7,7 +7,7 @@ sidebar:
     variant: tip
 ---
 
-Quick access to essential car functions: toggle the pit speed limiter, headlights, Push To Pass, DRS, starter, ignition, or tear off your visor — plus exit the car with Escape, pause the sim, and backup driver inputs (handbrake, second clutch, second shift) for when primary hardware fails — all from a single button.
+Quick access to essential car functions: toggle the pit speed limiter, headlights, Push To Pass, DRS, starter, ignition, or tear off your visor — plus exit the car with Escape, pause the sim, and use backup driver inputs (handbrake, second clutch, second shift) for when primary hardware fails — all from a single button.
 
 ## Modes
 

--- a/packages/website/src/content/docs/docs/actions/driving/car-control.md
+++ b/packages/website/src/content/docs/docs/actions/driving/car-control.md
@@ -3,11 +3,11 @@ title: Car Control
 description: Control car functions — starter, ignition, pit limiter, headlights, DRS, Push To Pass, escape, and more.
 sidebar:
   badge:
-    text: "10 modes"
+    text: "14 modes"
     variant: tip
 ---
 
-Quick access to essential car functions: toggle the pit speed limiter, headlights, Push To Pass, DRS, starter, ignition, or tear off your visor — plus exit the car with Escape or pause the sim — all from a single button.
+Quick access to essential car functions: toggle the pit speed limiter, headlights, Push To Pass, DRS, starter, ignition, or tear off your visor — plus exit the car with Escape, pause the sim, and backup driver inputs (handbrake, second clutch, second shift) for when primary hardware fails — all from a single button.
 
 ## Modes
 
@@ -195,6 +195,74 @@ Pause the simulation.
 - **Method:** Key binding
 - **Dial:** No rotation support
 - **Default binding:** `Shift+P`
+- **Telemetry-aware icon:** No
+
+#### Settings
+
+- No additional settings
+
+---
+
+### Handbrake
+
+Apply the handbrake while the button is held — a backup control for when your handbrake hardware fails mid-session.
+
+#### Details
+
+- **Method:** Key binding
+- **Dial:** No rotation support; press and hold the dial to apply the handbrake, release to let go
+- **Default binding:** No default key binding — Handbrake has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
+- **Telemetry-aware icon:** No
+
+#### Settings
+
+- No additional settings
+
+---
+
+### Second Clutch
+
+Engage iRacing's Second Clutch while the button is held — a backup for a failed clutch pedal.
+
+#### Details
+
+- **Method:** Key binding
+- **Dial:** No rotation support; press and hold the dial to engage the clutch, release to let go
+- **Default binding:** No default key binding — Second Clutch has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
+- **Telemetry-aware icon:** No
+
+#### Settings
+
+- No additional settings
+
+---
+
+### Second Up Shift
+
+Shift up a gear via iRacing's Second Up Shift control — a backup for a broken upshift paddle.
+
+#### Details
+
+- **Method:** Key binding
+- **Dial:** No rotation support
+- **Default binding:** No default key binding — Second Up Shift has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
+- **Telemetry-aware icon:** No
+
+#### Settings
+
+- No additional settings
+
+---
+
+### Second Down Shift
+
+Shift down a gear via iRacing's Second Down Shift control — a backup for a broken downshift paddle.
+
+#### Details
+
+- **Method:** Key binding
+- **Dial:** No rotation support
+- **Default binding:** No default key binding — Second Down Shift has no default iRacing binding, so you must configure it in both iRacing and the Property Inspector
 - **Telemetry-aware icon:** No
 
 #### Settings


### PR DESCRIPTION
## Related Issue

Fixes #183

## What changed?

Four backup driver input modes added to the **Car Control** action for when primary hardware fails mid-session — all named per iRacing's Controls UI:

- **Handbrake** and **Second Clutch** — hold pattern (engaged while the button/dial is pressed, released on release; same as Starter/Headlight Flash)
- **Second Up Shift** and **Second Down Shift** — single-tap modes

All four are key-binding only (no SDK support, no default iRacing binding, no telemetry awareness), so the existing missing-binding ⚠️ icon overlay and PI binding-status line apply until a binding is configured. The modes ride the existing generic dispatch — no new action UUIDs, no manifest changes, works on all three plugins (Stream Deck, Mirabox, Ulanzi).

Includes: four new static icons (handbrake dashboard telltale in semantic red; clutch friction disc; solid up/down shift arrows) + regenerated previews, `key-bindings.json` + `comms-catalog.ts` entries + regenerated `action-comms.json`, PI dropdown options, website action page (10 → 14 modes) + changelog entry under 1.24.0, `docs/reference/actions.json`, and `iracedeck-actions` skill count updates. Design spec + implementation plan committed under `docs/superpowers/`.

## How to test

1. `pnpm install && pnpm build`, then link the plugin (`pnpm relink:stream-deck` or the mirabox/ulanzi variant) and restart the deck host.
2. Add a **Car Control** key and pick each new mode from the Control dropdown — the key shows the new icon with a centered ⚠️ until its binding is set.
3. In iRacing's Controls, bind Handbrake / Second Clutch / Second Up Shift / Second Down Shift; set matching bindings in the PI's *Related Key Bindings* section — the ⚠️ clears live.
4. In-car: hold the Handbrake / Second Clutch key (input active while held, releases on key-up, dial press works the same); tap the shift keys (one gear change per tap).

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four new **Car Control** backup-driver modes: **Handbrake**, **Second Clutch**, **Second Up Shift**, and **Second Down Shift**.
  * Updated the Car Control selector, key/dial mappings, and icon set so the new modes can be configured and operated; includes hold vs tap behavior per mode.
* **Documentation**
  * Expanded the Car Control docs and changelog, including updated mode counts and details about configuring modes (no default iRacing bindings).
  * Refreshed the public reference inventory for the updated mode list.
* **Tests**
  * Extended automated tests to cover the new modes’ icons and input behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->