### PR TITLE
docs(website): document Stream Deck profiles, Switch Profile action, and Race Admin workflow (#788)

### DIFF
--- a/.claude/rules/profiles-and-devices.md
+++ b/.claude/rules/profiles-and-devices.md
@@ -43,9 +43,9 @@ The manifest `Profiles[].DeviceType` field and the runtime `device.type` use the
 
 `PROFILE_TARGET_DEVICES` is the ordered `target` list. When a device graduates from `candidate` to `target`, update `DEVICE_SUPPORT` **and** `PROFILE_TARGET_DEVICES` together (the test enforces they match).
 
-## The three bundled templates
+## The bundled templates
 
-`PROFILE_NAMES`: **iRaceDeck Default**, **iRaceDeck Pit Actions**, **iRaceDeck Replay**. Each target device needs its **own** profile file (one `Profiles[]` entry carries exactly one `DeviceType`), so the full set is 3 templates × 3 devices — one device-suffixed file each, per the naming scheme below.
+Four templates are registered and shipped: **iRaceDeck Default**, **iRaceDeck Replay**, **iRaceDeck Race Admin Cars**, **iRaceDeck Race Admin Per Car** — currently for the classic Stream Deck and the XL only (8 `Profiles[]` entries; the `+ XL` target device has no registered profiles yet). `PROFILE_NAMES` additionally defines **iRaceDeck Pit Actions**, which is not registered or shipped. Each target device needs its **own** profile file (one `Profiles[]` entry carries exactly one `DeviceType`) — one device-suffixed file each, per the naming scheme below.
 
 ## Profile naming — device-suffixed files, clean user-facing names (#753)
 

--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -137,7 +137,7 @@ Mode counts reflect the PI Mode/Setting dropdown choices documented in each acti
 
 | Action | Modes | Mode values |
 |--------|-------|-------------|
-| Switch Profile | 1 | single behavior, no Mode dropdown (#736) — the Profile setting picks a bundled profile to switch to (default iRaceDeck Default) or "Back to previous" (walks the per-device history of visited iRaceDeck profiles, ending at the device's Default); a "Placed in profile" marker setting (#762) keeps the back-history correct for keys inside bundled profiles. Elgato-only, keypad-only, no iRacing command; forward switches land on page 1. |
+| Switch Profile | 1 | single behavior, no Mode dropdown (#736) — the Profile setting picks a bundled profile to switch to (default iRaceDeck Default) or "Back to previous" (walks the per-device history of visited iRaceDeck profiles, ending at the device's Default); a "Placed in profile" marker setting (#762) keeps the back-history correct for keys inside bundled profiles. Elgato-only, keypad-only, no iRacing command; forward switches land on the first page (page index 0). |
 
 ## Control Patterns
 

--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -9,7 +9,7 @@ description: Use when looking up Stream Deck actions, sub-actions, modes, catego
 
 Complete action definitions: `docs/reference/actions.json`
 
-This skill file documents **31 actions with 297 modes** using a detailed per-mode count (the totals in the category table below). The user-facing website (`packages/website/src/content/docs/`) uses a coarser counting convention and shows a lower total (**257 modes**) — treat the website as the source of truth for user-facing copy and this skill file as the detailed inventory. `docs/reference/actions.json` has not yet been re-synced to the per-mode counting convention; treat it as a detailed inventory of individual mode values that is occasionally out of date.
+This skill file documents **32 actions with 298 modes** using a detailed per-mode count (the totals in the category table below). The user-facing website (`packages/website/src/content/docs/`) uses a coarser counting convention and shows a lower total (**266 modes**) — treat the website as the source of truth for user-facing copy and this skill file as the detailed inventory. `docs/reference/actions.json` has not yet been re-synced to the per-mode counting convention; treat it as a detailed inventory of individual mode values that is occasionally out of date.
 
 Each action entry:
 ```json
@@ -55,7 +55,8 @@ When asked about actions or controls:
 | Pit Service | 3 | 15 | Fuel, tires, compounds, tearoff, fast repair |
 | Car Setup | 7 | 73 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control — adjustment modes plus live-display "View …" sub-modes; each View sub-mode also supports dual-press (tap = configured direction, long-press = opposite) so one key both shows the value and adjusts it (#540) |
 | Communication | 2 | 35 | Chat, macros (15), whisper, toggle, reply, race admin commands, car selector |
-| **Total** | **31** | **297** | |
+| Stream Deck | 1 | 1 | Switch Profile — switch to a bundled iRaceDeck profile or back to the previous one (Elgato-only, no iRacing command) |
+| **Total** | **32** | **298** | |
 
 Mode counts reflect the PI Mode/Setting dropdown choices documented in each action page. Directional variants (Increase/Decrease) are treated as a single mode with a Direction sub-setting, matching the per-mode website format. Legacy replay actions (Replay Transport, Replay Speed, Replay Navigation) and Camera Cycle (Legacy) still exist in the plugin manifest for backward compatibility but are not counted as documented actions.
 
@@ -131,6 +132,12 @@ Mode counts reflect the PI Mode/Setting dropdown choices documented in each acti
 |--------|-------|-------------|
 | Chat | 7 | send-message, macro (1-15), reply, whisper (keyboard), toggle (keyboard), open-chat, cancel (`respond-pm` is a hidden alias of `reply` retained for backward compatibility — not exposed in the PI dropdown) |
 | Race Admin | 28 | yellow, black-flag, dq-driver, show-dqs-field, show-dqs-driver, clear-penalties, clear-all, wave-around, eol, pit-close, pit-open, pace-laps, single/double-file-restart, advance-session, grid-set, grid-start, track-state, grant/revoke-admin, remove-driver, enable/disable-chat (all/driver), message-all, rc-message, select-car (Elgato-only car selector: auto-fills a car per key, stores the shared admin target). Driver Target adds a `selected-car` option that acts on that shared target. |
+
+### Stream Deck
+
+| Action | Modes | Mode values |
+|--------|-------|-------------|
+| Switch Profile | 1 | single behavior, no Mode dropdown (#736) — the Profile setting picks a bundled profile to switch to (default iRaceDeck Default) or "Back to previous" (walks the per-device history of visited iRaceDeck profiles, ending at the device's Default); a "Placed in profile" marker setting (#762) keeps the back-history correct for keys inside bundled profiles. Elgato-only, keypad-only, no iRacing command; forward switches land on page 1. |
 
 ## Control Patterns
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## Features
 
-**31 actions** with **263+ modes** across 8 categories, with Stream Deck+ dial rotation support on most modes:
+**32 actions** with **264+ modes** across 9 categories, with Stream Deck+ dial rotation support on most modes:
 
 | Category                | Actions | Modes | Examples                                                              |
 | ----------------------- | ------- | ----- | --------------------------------------------------------------------- |
@@ -38,6 +38,7 @@
 | **Pit Service**         | 3       | 15    | Fuel, tires, compounds, tearoff, fast repair                          |
 | **Car Setup**           | 7       | 44    | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction control |
 | **Communication**       | 2       | 34    | Chat, macros, whisper, reply, race admin commands                     |
+| **Stream Deck**         | 1       | 1     | Switch to bundled iRaceDeck profiles (Elgato only)                    |
 
 **Key highlights:**
 

--- a/docs/reference/actions.json
+++ b/docs/reference/actions.json
@@ -919,6 +919,30 @@
           ]
         }
       ]
+    },
+    {
+      "name": "Stream Deck",
+      "actions": [
+        {
+          "id": "com.iracedeck.sd.core.switch-profile",
+          "name": "Switch Profile",
+          "file": "switch-profile.ts",
+          "encoder": false,
+          "settingsKey": "profile",
+          "modes": [
+            {
+              "value": "(profile name)",
+              "label": "Switch to a bundled profile",
+              "description": "The dropdown is populated with the bundled iRaceDeck profiles available for this device; defaults to iRaceDeck Default. Elgato Stream Deck only."
+            },
+            {
+              "value": "__previous",
+              "label": "Back to previous",
+              "description": "Return to the profile you came from, walking back through visited iRaceDeck profiles and ending at iRaceDeck Default"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/packages/iracing-actions/src/actions/data/docs-urls.json
+++ b/packages/iracing-actions/src/actions/data/docs-urls.json
@@ -25,6 +25,7 @@
   "setup-hybrid": "https://iracedeck.com/docs/actions/car-setup/setup-hybrid/",
   "setup-traction": "https://iracedeck.com/docs/actions/car-setup/setup-traction/",
   "splits-delta-cycle": "https://iracedeck.com/docs/actions/cockpit/splits-delta-cycle/",
+  "switch-profile": "https://iracedeck.com/docs/actions/stream-deck/switch-profile/",
   "telemetry-control": "https://iracedeck.com/docs/actions/cockpit/telemetry-control/",
   "telemetry-display": "https://iracedeck.com/docs/actions/display-session/telemetry-display/",
   "tire-service": "https://iracedeck.com/docs/actions/pit-service/tire-service/",

--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -115,6 +115,7 @@ export default defineConfig({
           items: [
             { slug: "docs/features/communication-methods" },
             { slug: "docs/features/key-bindings" },
+            { slug: "docs/features/stream-deck-profiles" },
             { slug: "docs/features/flags-overlay" },
             { slug: "docs/features/focus-iracing-window" },
             { slug: "docs/features/icon-colors" },
@@ -201,6 +202,10 @@ export default defineConfig({
                 { slug: "docs/actions/communication/chat" },
                 { slug: "docs/actions/communication/race-admin" },
               ],
+            },
+            {
+              label: "Stream Deck",
+              items: [{ slug: "docs/actions/stream-deck/switch-profile" }],
             },
           ],
         },

--- a/packages/website/src/content/docs/docs/actions/communication/race-admin.md
+++ b/packages/website/src/content/docs/docs/actions/communication/race-admin.md
@@ -520,7 +520,7 @@ Required. Supports template variables.
 
 ### Select Car (Admin Target)
 
-**Elgato Stream Deck only.** Turns a key into a self-populating car button for a race-control car selector. It auto-fills with one car from the live session and, when pressed, remembers that car as the shared **admin target** and switches to your per-car commands profile. Combine it with the bundled **iRaceDeck Race Admin Cars** selector profile and any command mode set to the **Selected Car** target (see **Shared settings**) so a whole page of admin commands acts on the car you picked — instead of hand-building a page per car number. The selection is per-session: when a new session starts (car numbers reshuffle), a stale selection is voided rather than silently pointing at a different driver.
+**Elgato Stream Deck only.** Turns a key into a self-populating car button for a race-control car selector. It auto-fills with one car from the live session and, when pressed, remembers that car as the shared **admin target** and switches to your per-car commands profile. Combine it with the bundled [**iRaceDeck Race Admin Cars**](/docs/features/stream-deck-profiles/) selector profile and any command mode set to the **Selected Car** target (see **Shared settings**) so a whole page of admin commands acts on the car you picked — instead of hand-building a page per car number. The selection is per-session: when a new session starts (car numbers reshuffle), a stale selection is voided rather than silently pointing at a different driver.
 
 This mode sends no iRacing command itself; it's navigation plus shared state.
 
@@ -543,7 +543,7 @@ On a multi-page selector, the plugin learns how many car keys each page holds as
 
 #### Setting: Target Profile
 
-The bundled profile to switch to after a car is picked, chosen from the profiles available for this device. Leaving it unset uses the bundled **iRaceDeck Race Admin Per Car** profile for this device.
+The bundled profile to switch to after a car is picked, chosen from the [profiles available for this device](/docs/features/stream-deck-profiles/). Leaving it unset uses the bundled **iRaceDeck Race Admin Per Car** profile for this device.
 
 ## Shared settings
 
@@ -592,3 +592,10 @@ Every `[message]` parameter supports [template variables](/docs/features/templat
 
 1. Set up two buttons: one for **Close Pit Entrance**, one for **Open Pit Entrance**
 2. Press to toggle pit status during green flag racing
+
+**Run race control on one car at a time (Elgato Stream Deck only):**
+
+1. Switch your Stream Deck to the bundled **iRaceDeck Race Admin Cars** profile — from the [Stream Deck Profiles](/docs/features/stream-deck-profiles/) section in any action's settings, or with a [Switch Profile](/docs/actions/stream-deck/switch-profile/) key. The Stream Deck app asks to install the profile the first time you switch to it.
+2. The selector fills its keys with the cars in the session, sorted by car number — one big car number per key with the driver's name below. Use the page keys to reach larger fields. Press the car you need to act on.
+3. Your Stream Deck switches to the **iRaceDeck Race Admin Per Car** profile, where every command key — black flag, end-of-line, disqualify, clear penalties, wave around, and the rest — uses the **Selected Car** target and acts on the car you picked.
+4. When you're done with that car, the profile's back key (a [Switch Profile](/docs/actions/stream-deck/switch-profile/) key set to **Back to previous**) returns you to the car selector to pick the next one.

--- a/packages/website/src/content/docs/docs/actions/overview.md
+++ b/packages/website/src/content/docs/docs/actions/overview.md
@@ -3,7 +3,7 @@ title: Actions Overview
 description: All iRaceDeck actions organized by category
 ---
 
-iRaceDeck provides 31 actions with 265 modes for iRacing, organized into 9 categories.
+iRaceDeck provides 32 actions with 266 modes for iRacing, organized into 10 categories.
 
 ## Categories
 
@@ -18,6 +18,7 @@ iRaceDeck provides 31 actions with 265 modes for iRacing, organized into 9 categ
 | [Pit Service](/docs/actions/pit-service/pit-quick-actions/) | 3 | 15 | Fuel, tires, compounds, tearoff, fast repair |
 | [Car Setup](/docs/actions/car-setup/setup-aero/) | 7 | 44 | Brakes, chassis, aero, engine, fuel mix, hybrid/ERS, traction |
 | [Communication](/docs/actions/communication/chat/) | 2 | 35 | Chat, macros, whisper, reply, race admin commands and car selector |
+| [Stream Deck](/docs/actions/stream-deck/switch-profile/) | 1 | 1 | Switch between bundled iRaceDeck profiles (Elgato Stream Deck only) |
 
 ## How Actions Work
 

--- a/packages/website/src/content/docs/docs/actions/stream-deck/switch-profile.md
+++ b/packages/website/src/content/docs/docs/actions/stream-deck/switch-profile.md
@@ -1,0 +1,42 @@
+---
+title: Switch Profile
+description: Put a Stream Deck profile switch on any key — jump to a bundled iRaceDeck profile or back to the previous one.
+sidebar:
+  badge:
+    text: "Elgato only"
+    variant: note
+---
+
+Puts a profile switch on any key. Pressing the key switches your Stream Deck to a bundled [iRaceDeck profile](/docs/features/stream-deck-profiles/) — **iRaceDeck Default** unless you pick another — or walks back to the profile you came from. This action is only available on Elgato Stream Deck devices, and only does something on models that ship bundled profiles (see [supported devices](/docs/features/stream-deck-profiles/#supported-devices)).
+
+This action sends no iRacing command — it's pure Stream Deck navigation.
+
+## Details
+
+- **Method:** Navigation (switches the Stream Deck profile) — no iRacing command
+- **Dial:** No rotation support (keypad only)
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No — the icon reflects the selected profile
+
+## Pressing the key
+
+- With a profile selected, the key switches your Stream Deck to it, always landing on the profile's first page. If the profile isn't installed yet, the Stream Deck app asks to install it first.
+- With **Back to previous** selected, the key returns to the profile you came from — restoring the page you left — walking back through the iRaceDeck profiles you visited and ending at **iRaceDeck Default** when there's nowhere further back.
+- A key with no profile selected behaves as **iRaceDeck Default**, so a Switch Profile key is never a dead key.
+
+## Settings
+
+### Profile
+
+Which profile the key switches to. The dropdown lists the bundled profiles available for this device, plus **Back to previous**. Defaults to **iRaceDeck Default**.
+
+### Placed in profile
+
+Only needed when a Switch Profile key lives **inside** a bundled iRaceDeck profile: set it to the profile the key is placed in. It tells the plugin which profile is on screen so **Back to previous** can find its way back — the Stream Deck app offers the plugin no other way to tell. Leave it unset for keys in your own profiles. The keys inside the bundled profiles ship with this already configured.
+
+## Key icon
+
+- **iRaceDeck Default** shows a clean, title-less iRaceDeck logo.
+- Other profiles show their own artwork with the profile name as the key label (the `iRaceDeck` prefix is dropped — e.g. `REPLAY`, `RACE ADMIN CARS`).
+- **Back to previous** shows a back chevron with no label.
+- Switch Profile keys stay border-less even when plugin-wide [borders](/docs/features/border-indicator/) are enabled; a per-key border override in this key's settings still applies.

--- a/packages/website/src/content/docs/docs/actions/stream-deck/switch-profile.md
+++ b/packages/website/src/content/docs/docs/actions/stream-deck/switch-profile.md
@@ -22,7 +22,7 @@ This action sends no iRacing command — it's pure Stream Deck navigation.
 
 - With a profile selected, the key switches your Stream Deck to it, always landing on the profile's first page. If the profile isn't installed yet, the Stream Deck app asks to install it first.
 - With **Back to previous** selected, the key returns to the profile you came from — restoring the page you left — walking back through the iRaceDeck profiles you visited and ending at **iRaceDeck Default** when there's nowhere further back.
-- A key with no profile selected behaves as **iRaceDeck Default**, so a Switch Profile key is never a dead key.
+- On devices with bundled profiles, a key with no profile selected behaves as **iRaceDeck Default**, so a Switch Profile key is never a dead key.
 
 ## Settings
 

--- a/packages/website/src/content/docs/docs/features/stream-deck-profiles.md
+++ b/packages/website/src/content/docs/docs/features/stream-deck-profiles.md
@@ -14,7 +14,7 @@ Profiles are built separately for each Stream Deck model, and not every model ha
 - **Stream Deck** — the classic 15-key model
 - **Stream Deck XL** — the 32-key model
 
-On other Stream Deck models, iRaceDeck and all of its actions work normally — there are just no bundled profiles to switch to yet. A [Switch Profile](/docs/actions/stream-deck/switch-profile/) key or a **Switch** press in the settings does nothing on those devices.
+On other Stream Deck models, iRaceDeck's other actions work normally — there are just no bundled profiles to switch to yet. A [Switch Profile](/docs/actions/stream-deck/switch-profile/) key or a **Switch** press in the settings does nothing on those devices.
 
 ## The bundled profiles
 

--- a/packages/website/src/content/docs/docs/features/stream-deck-profiles.md
+++ b/packages/website/src/content/docs/docs/features/stream-deck-profiles.md
@@ -1,0 +1,45 @@
+---
+title: Stream Deck Profiles
+description: Ready-made iRaceDeck button layouts for Elgato Stream Deck devices — installed and switched with a single press.
+---
+
+iRaceDeck bundles ready-made Stream Deck profiles — complete button layouts built from iRaceDeck actions — so you get a full iRacing deck without arranging every key yourself. Switch to one and your Stream Deck shows a curated iRacing layout; your own profiles stay untouched, and you can return to them at any time.
+
+Bundled profiles are an **Elgato Stream Deck feature**. Mirabox and Ulanzi hosts have no profile system, so nothing on this page applies to those devices.
+
+## Supported devices
+
+Profiles are built separately for each Stream Deck model, and not every model has them yet. Bundled profiles are currently provided for:
+
+- **Stream Deck** — the classic 15-key model
+- **Stream Deck XL** — the 32-key model
+
+On other Stream Deck models, iRaceDeck and all of its actions work normally — there are just no bundled profiles to switch to yet. A [Switch Profile](/docs/actions/stream-deck/switch-profile/) key or a **Switch** press in the settings does nothing on those devices.
+
+## The bundled profiles
+
+- **iRaceDeck Default** — the everyday racing layout: pit service (fuel, tires, quick actions), chat macros, black box selection, the Race Engineer, and folders leading to more. It is the profile a fresh [Switch Profile](/docs/actions/stream-deck/switch-profile/) key targets, and the hub the other profiles come back to.
+- **iRaceDeck Replay** — built for watching replays and broadcasts: replay playback controls and camera-focus keys across multiple pages.
+- **iRaceDeck Race Admin Cars** — the race-control car selector: pages of [Select Car](/docs/actions/communication/race-admin/#select-car-admin-target) keys that fill themselves with the cars in the current session.
+- **iRaceDeck Race Admin Per Car** — the admin command page the car selector switches to: [Race Admin](/docs/actions/communication/race-admin/) commands set to the **Selected Car** target, so every key acts on the car you picked.
+
+## Installing a profile
+
+There is nothing to import by hand. The first time you switch to a bundled profile, the Stream Deck app asks to install it — confirm, and the profile is added to your device's profile list. Updates work the same way: after an iRaceDeck update, switching to a profile installs its latest version.
+
+## Switching from any action's settings
+
+Every iRaceDeck action's settings include a **Stream Deck Profiles** section, so you can switch profiles without dedicating a key to it:
+
+1. Select any iRaceDeck key on your Stream Deck to open its settings (the Property Inspector).
+2. Scroll down past the action's own settings to the **Global Settings** area and expand the **Stream Deck Profiles** section.
+3. The section lists every bundled profile with a **Switch** button next to it.
+4. Press **Switch** — your Stream Deck changes to that profile immediately. If the profile isn't installed yet, the Stream Deck app asks to install it first.
+
+## Switching with a key
+
+The [Switch Profile](/docs/actions/stream-deck/switch-profile/) action puts a profile switch on any key — on your own layout to jump into an iRaceDeck profile, or inside the bundled profiles, where it powers the navigation between them. Its **Back to previous** option walks back through the iRaceDeck profiles you visited, ending at **iRaceDeck Default** when there's nowhere further back.
+
+## Returning to your own layout
+
+iRaceDeck can only switch between the profiles it ships — it has no access to profiles you built yourself. To get back to one of your own layouts, switch profiles in the Stream Deck app as usual, by picking your profile from the device's profile list.

--- a/packages/website/src/content/docs/docs/getting-started/installation.md
+++ b/packages/website/src/content/docs/docs/getting-started/installation.md
@@ -84,6 +84,8 @@ You can also install iRaceDeck directly from within UlanziStudio via the [iRaceD
 
 ## After Installation
 
-Drag any iRaceDeck action onto your device profile. Most actions have a **mode** dropdown in the Property Inspector (the settings panel on the right) that lets you choose what the button does.
+On Elgato Stream Deck devices, the fastest way to a full iRacing layout is switching to one of the bundled [Stream Deck Profiles](/docs/features/stream-deck-profiles/) — ready-made pages of iRaceDeck actions for supported devices.
+
+Or build your own: drag any iRaceDeck action onto your device profile. Most actions have a **mode** dropdown in the Property Inspector (the settings panel on the right) that lets you choose what the button does.
 
 For actions that use keyboard shortcuts (like black box selection or camera controls), you can customize the key bindings in each action's Property Inspector to match your iRacing configuration. See [Key Bindings](/docs/features/key-bindings/) for more details.

--- a/packages/website/src/content/docs/index.mdx
+++ b/packages/website/src/content/docs/index.mdx
@@ -24,17 +24,17 @@ hero:
 
 <div class="stats-row">
   <div class="stat">
-    <span class="stat-value">30</span>
+    <span class="stat-value">32</span>
     <span class="stat-label">Actions</span>
   </div>
   <div class="stat-divider" />
   <div class="stat">
-    <span class="stat-value">257</span>
+    <span class="stat-value">266</span>
     <span class="stat-label">Modes</span>
   </div>
   <div class="stat-divider" />
   <div class="stat">
-    <span class="stat-value">8</span>
+    <span class="stat-value">10</span>
     <span class="stat-label">Categories</span>
   </div>
   <div class="stat-divider" />
@@ -87,6 +87,10 @@ hero:
   <a class="category-card" href="/docs/actions/communication/chat/">
     <span class="category-title">Communication</span>
     <span class="category-desc">Open chat, 15 macros, reply, whisper, and more.</span>
+  </a>
+  <a class="category-card" href="/docs/actions/stream-deck/switch-profile/">
+    <span class="category-title">Stream Deck</span>
+    <span class="category-desc">Ready-made iRaceDeck profiles and a Switch Profile key to move between them (Elgato only).</span>
   </a>
 </div>
 


### PR DESCRIPTION
## Related Issue

Fixes #788

## What changed?

The 1.24.0 profiles feature was undocumented on the website outside the changelog entry. This PR adds a **Stream Deck Profiles** features page (what the bundled profiles are, which devices have them — classic Stream Deck and XL only —, the Elgato-only scope, install-on-first-switch, and a guided walkthrough of the Stream Deck Profiles section in every action's settings) and a **Switch Profile** action page under a new "Stream Deck" sidebar category with an Elgato-only badge (press behavior, the Profile and Placed in profile settings, Back to previous semantics, key icon behavior).

It also adds the missing end-to-end car-selector workflow to the Race Admin page (Race Admin Cars → pick a car → Per Car profile → Selected Car commands → Back to previous), points the installation guide at profiles as the fastest way to a full layout, and gives the Switch Profile Property Inspector its documentation link via `docs-urls.json`.

Finally, it syncs Switch Profile into every action-count surface — actions overview (32 actions / 266 modes / 10 categories), homepage stats and category cards (fixing the stale 30/8 values), README table, the `iracedeck-actions` skill, and `docs/reference/actions.json` — and fixes the stale "three bundled templates" list in `.claude/rules/profiles-and-devices.md`.

No changelog line: the 1.24.0 feature entry already covers the profiles capability and these docs ship in the same unreleased version.

## How to test

1. `pnpm --filter @iracedeck/website build` (passes; also covered by the full `pnpm build`)
2. `pnpm --filter @iracedeck/website dev` and check `/docs/features/stream-deck-profiles/`, `/docs/actions/stream-deck/switch-profile/`, the new workflow at the bottom of `/docs/actions/communication/race-admin/`, and the sidebar entries
3. Verify count consistency: the overview table sums to its prose (32/266/10), the homepage stats match, and the README table sums to its counts line

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests (N/A — documentation and data-file change, no new code)
- [x] Changes registered in all applicable plugins (`docs-urls.json` is shared by all plugin builds; the Switch Profile action itself is deliberately Elgato-only, #736)
- [x] No unrelated changes included

https://claude.ai/code/session_01JV9rvKy7Cct6m6BDLFQWoD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Stream Deck **Switch Profile** to move between bundled iRaceDeck profiles and return to the previously used one.
  * Published bundled **Stream Deck Profiles** support and navigation for Elgato Stream Deck.

* **Documentation**
  * Added new pages for **Switch Profile** and **Stream Deck Profiles**, plus updates to action/reference documentation and navigation.
  * Refreshed installation, Race Admin workflow guidance, and landing/overview stats to reflect the latest totals (**32 actions**, **266 modes**, **10 categories**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->