### PR TITLE
improve(icons): redesign Toggle Wipers and Trigger Wipers icons around a windshield (#813)

### DIFF
--- a/packages/icons/cockpit-misc/toggle-wipers.svg
+++ b/packages/icons/cockpit-misc/toggle-wipers.svg
@@ -1,15 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 90 63" stroke-width="0.5" stroke="#fff" fill="#fff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 72" stroke-width="0.5" stroke="#fff" fill="#fff">
   <desc>{"colors":{"backgroundColor":"#2a2a3a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TOGGLE\nWIPERS"},"border":{"color":"#5a5a6a"}}</desc>
   
 
-    <path d="M5,55A44,44,0,0,1,85,55" fill="none" stroke="#888888" stroke-width="3"/>
+    <path d="M18,64 Q8,64 9,55 L14,17 Q15,7 25,7 L75,7 Q85,7 86,17 L91,55 Q92,64 82,64 Z" fill="none" stroke="#888888" stroke-width="4" stroke-linejoin="round"/>
 
-    <line x1="45" y1="55" x2="17" y2="15" stroke="{{graphic1Color}}" stroke-width="5" stroke-linecap="round"/>
+    <line x1="43" y1="61" x2="29" y2="20" stroke="{{graphic1Color}}" stroke-width="3" stroke-linecap="round"/>
+    <line x1="36.7" y1="42.55" x2="29" y2="20" stroke="{{graphic1Color}}" stroke-width="7" stroke-linecap="round"/>
 
-    <line x1="45" y1="55" x2="73" y2="15" stroke="{{graphic1Color}}" stroke-width="5" stroke-linecap="round" opacity="0.4"/>
+    <line x1="61" y1="61" x2="47" y2="20" stroke="{{graphic1Color}}" stroke-width="3" stroke-linecap="round"/>
+    <line x1="54.7" y1="42.55" x2="47" y2="20" stroke="{{graphic1Color}}" stroke-width="7" stroke-linecap="round"/>
 
-    <circle cx="45" cy="55" r="5" fill="{{graphic1Color}}" stroke="none"/>
+    <circle cx="43" cy="61" r="3.5" fill="{{graphic1Color}}" stroke="none"/>
+    <circle cx="61" cy="61" r="3.5" fill="{{graphic1Color}}" stroke="none"/>
 
-    <path d="M17,15A40,40,0,0,1,73,15" fill="none" stroke="#2ecc71" stroke-width="3" stroke-linecap="round"/>
+    <circle cx="78" cy="53" r="4.5" fill="#2ecc71" stroke="none"/>
 
 </svg>

--- a/packages/icons/cockpit-misc/trigger-wipers.svg
+++ b/packages/icons/cockpit-misc/trigger-wipers.svg
@@ -1,10 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 90 59" stroke-width="0.5" stroke="#fff" fill="#fff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 72" stroke-width="0.5" stroke="#fff" fill="#fff">
   <desc>{"colors":{"backgroundColor":"#2a2a3a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"TRIGGER\nWIPERS"},"border":{"color":"#5a5a6a"}}</desc>
   
 
-    <path d="M5,52A44,44,0,0,1,85,52" fill="none" stroke="#888888" stroke-width="3"/>
-    <line x1="45" y1="52" x2="17" y2="12" stroke="{{graphic1Color}}" stroke-width="5" stroke-linecap="round"/>
-    <circle cx="45" cy="52" r="5" fill="{{graphic1Color}}" stroke="none"/>
-    <path d="M17,12A40,40,0,0,1,61,8" fill="none" stroke="{{graphic1Color}}" stroke-width="3" stroke-linecap="round" stroke-dasharray="6,4"/>
+    <path d="M18,64 Q8,64 9,55 L14,17 Q15,7 25,7 L75,7 Q85,7 86,17 L91,55 Q92,64 82,64 Z" fill="none" stroke="#888888" stroke-width="4" stroke-linejoin="round"/>
+    <line x1="50" y1="61" x2="33" y2="20" stroke="{{graphic1Color}}" stroke-width="3" stroke-linecap="round"/>
+    <line x1="42.35" y1="42.55" x2="33" y2="20" stroke="{{graphic1Color}}" stroke-width="7" stroke-linecap="round"/>
+    <circle cx="50" cy="61" r="3.5" fill="{{graphic1Color}}" stroke="none"/>
+    <circle cx="60" cy="25" r="3" fill="{{graphic1Color}}" stroke="none"/>
+    <circle cx="70" cy="36" r="3" fill="{{graphic1Color}}" stroke="none"/>
+    <circle cx="58" cy="42" r="3" fill="{{graphic1Color}}" stroke="none"/>
+    <path d="M40,19 Q52,15 61,23" fill="none" stroke="{{graphic1Color}}" stroke-width="2.5" stroke-linecap="round" opacity="0.7"/>
 
 </svg>

--- a/packages/icons/preview/cockpit-misc/toggle-wipers.svg
+++ b/packages/icons/preview/cockpit-misc/toggle-wipers.svg
@@ -1,15 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 90 63" stroke-width="0.5" stroke="#fff" fill="#fff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 72" stroke-width="0.5" stroke="#fff" fill="#fff">
   <desc>{"colors":{"backgroundColor":"#2a2a3a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TOGGLE\nWIPERS"},"border":{"color":"#5a5a6a"}}</desc>
   
 
-    <path d="M5,55A44,44,0,0,1,85,55" fill="none" stroke="#888888" stroke-width="3"/>
+    <path d="M18,64 Q8,64 9,55 L14,17 Q15,7 25,7 L75,7 Q85,7 86,17 L91,55 Q92,64 82,64 Z" fill="none" stroke="#888888" stroke-width="4" stroke-linejoin="round"/>
 
-    <line x1="45" y1="55" x2="17" y2="15" stroke="#ffffff" stroke-width="5" stroke-linecap="round"/>
+    <line x1="43" y1="61" x2="29" y2="20" stroke="#ffffff" stroke-width="3" stroke-linecap="round"/>
+    <line x1="36.7" y1="42.55" x2="29" y2="20" stroke="#ffffff" stroke-width="7" stroke-linecap="round"/>
 
-    <line x1="45" y1="55" x2="73" y2="15" stroke="#ffffff" stroke-width="5" stroke-linecap="round" opacity="0.4"/>
+    <line x1="61" y1="61" x2="47" y2="20" stroke="#ffffff" stroke-width="3" stroke-linecap="round"/>
+    <line x1="54.7" y1="42.55" x2="47" y2="20" stroke="#ffffff" stroke-width="7" stroke-linecap="round"/>
 
-    <circle cx="45" cy="55" r="5" fill="#ffffff" stroke="none"/>
+    <circle cx="43" cy="61" r="3.5" fill="#ffffff" stroke="none"/>
+    <circle cx="61" cy="61" r="3.5" fill="#ffffff" stroke="none"/>
 
-    <path d="M17,15A40,40,0,0,1,73,15" fill="none" stroke="#2ecc71" stroke-width="3" stroke-linecap="round"/>
+    <circle cx="78" cy="53" r="4.5" fill="#2ecc71" stroke="none"/>
 
 </svg>

--- a/packages/icons/preview/cockpit-misc/trigger-wipers.svg
+++ b/packages/icons/preview/cockpit-misc/trigger-wipers.svg
@@ -1,10 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 90 59" stroke-width="0.5" stroke="#fff" fill="#fff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 72" stroke-width="0.5" stroke="#fff" fill="#fff">
   <desc>{"colors":{"backgroundColor":"#2a2a3a","textColor":"#ffffff","graphic1Color":"#ffffff"},"title":{"text":"TRIGGER\nWIPERS"},"border":{"color":"#5a5a6a"}}</desc>
   
 
-    <path d="M5,52A44,44,0,0,1,85,52" fill="none" stroke="#888888" stroke-width="3"/>
-    <line x1="45" y1="52" x2="17" y2="12" stroke="#ffffff" stroke-width="5" stroke-linecap="round"/>
-    <circle cx="45" cy="52" r="5" fill="#ffffff" stroke="none"/>
-    <path d="M17,12A40,40,0,0,1,61,8" fill="none" stroke="#ffffff" stroke-width="3" stroke-linecap="round" stroke-dasharray="6,4"/>
+    <path d="M18,64 Q8,64 9,55 L14,17 Q15,7 25,7 L75,7 Q85,7 86,17 L91,55 Q92,64 82,64 Z" fill="none" stroke="#888888" stroke-width="4" stroke-linejoin="round"/>
+    <line x1="50" y1="61" x2="33" y2="20" stroke="#ffffff" stroke-width="3" stroke-linecap="round"/>
+    <line x1="42.35" y1="42.55" x2="33" y2="20" stroke="#ffffff" stroke-width="7" stroke-linecap="round"/>
+    <circle cx="50" cy="61" r="3.5" fill="#ffffff" stroke="none"/>
+    <circle cx="60" cy="25" r="3" fill="#ffffff" stroke="none"/>
+    <circle cx="70" cy="36" r="3" fill="#ffffff" stroke="none"/>
+    <circle cx="58" cy="42" r="3" fill="#ffffff" stroke="none"/>
+    <path d="M40,19 Q52,15 61,23" fill="none" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round" opacity="0.7"/>
 
 </svg>

--- a/packages/website/src/content/docs/changelog.mdx
+++ b/packages/website/src/content/docs/changelog.mdx
@@ -9,6 +9,14 @@ import ChangelogLeadIn from "../../components/ChangelogLeadIn.astro";
 
 Release notes for each version of iRaceDeck. The newest release is listed first. For installation help, see the [installation guide](/docs/getting-started/installation/); to grab the latest build, head to the [downloads page](/downloads/).
 
+## 2.1.0
+
+_Unreleased_
+
+**Improvements**
+
+- Redesigned the Toggle Wipers and Trigger Wipers key icons around a windshield, so the two keys are clearly distinct from each other and read unmistakably as wipers at deck size.
+
 ## 2.0.0
 
 _2026-07-08_


### PR DESCRIPTION
## Related Issue

Fixes #813

## What changed?

Replaced the abstract "fan of arcs" wiper marks with a windshield-anchored design so the two **Cockpit Misc** keys are distinct and read as wipers at deck size:

- **Toggle Wipers** — windshield + a pair of blades + a locked green ON light (persistent on/off state). `graphic1Color` stays in the icon's `locked` slots so a global color preset can't clash with the green.
- **Trigger Wipers** — the same windshield + a single blade clearing rain droplets (one momentary wipe); stays fully color-overridable.

Artwork-only swap for two existing icons. Both SVGs retrimmed to `viewBox="0 0 100 72"`; `<desc>` metadata (colors, title, border) is unchanged. Only SVG Tiny 1.2 shapes (paths, lines, circles) are used, so the icons stay QT5-safe for Mirabox/Ulanzi. Previews regenerated via `scripts/generate-icon-previews.mjs`; the derived icon defaults are unchanged. A new in-development `2.1.0` changelog section records the improvement.

## How to test

1. Build/link the Stream Deck plugin and add two **Cockpit Misc** keys, set to **Toggle Wipers** and **Trigger Wipers**.
2. Confirm the two keys are clearly distinguishable at deck size and read unmistakably as wipers.
3. Preview the resolved artwork at `packages/icons/preview/cockpit-misc/{toggle,trigger}-wipers.svg`.
4. (Optional) Verify on a Mirabox/Ulanzi (QT5) device that the artwork renders correctly.

## Checklist

- [x] Linked to an approved issue
- [x] ~~New code has unit tests~~ — N/A (artwork-only; guarded by the existing icon preview-freshness test)
- [x] Changes registered in all applicable plugins — N/A (icons are shared via `@iracedeck/icons`; consumed by every plugin, no per-plugin registration)
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the changelog with a new unreleased 2.1.0 entry.
  * Improved the key icon layout for Toggle Wipers and Trigger Wipers so the two controls are easier to tell apart at deck size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->