### PR TITLE
improve(tire-service): redesign Change Compound badge, Change All & Clear icons (#815)

### DIFF
--- a/docs/superpowers/specs/2026-07-08-tire-service-icon-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-08-tire-service-icon-redesign-design.md
@@ -1,0 +1,47 @@
+# Tire Service Icon Redesign — Design
+
+_2026-07-08 · #815 · approved in brainstorming_
+
+## Scope
+
+Visual-only redesign of three Tire Service modes: **Change Compound**, **Change All Tires**, **Clear Tires**. Behavior (the iRacing commands each sends) is unchanged. The `toggle-tires` mode is **out of scope** and untouched. Background stays the existing tire-service brown `#3a2a2a` (kept so all four modes remain consistent).
+
+## Change Compound (dynamic, telemetry-driven)
+
+Replace the two-concentric-circles tire glyph with an **F1 compound badge**: a bold colored ring + the compound's initial letter, name spelled below.
+
+- **Colors** (`getCompoundColor`, unchanged): soft = `#e74c3c`, medium = `#f1c40f`, hard = `#ffffff`, intermediate = `#2ecc71`, wet = `#3498db`, **anything else (incl. dry) = `#888888` gray** — deliberately distinct from hard's white so Dry and Hard are never confused. This is already the fallback; no color-map change.
+- **Initial** = first character of the display name (`getCompoundName`), uppercased: SOFT→S, MEDIUM→M, HARD→H, INTER→I, WET→W, DRY→D.
+- **Badge geometry** (144 canvas): ring `circle cx=72 cy=54 r=33 stroke-width=9`; letter centered in the ring via baseline math (`y = 54 + round(0.36·fontSize)`, no `dominant-baseline` — Qt ignores it), font-size ~40 bold, both in the compound color.
+- **Two states** (from `isChanging = player ≠ pitSv`):
+  - **Changing** — vivid badge; label two lines `CHANGE TO` (muted) + `<NAME>` (compound color).
+  - **Staying on** — badge dimmed (`opacity 0.55`) + a small green ✓ badge top-right; label `STAYING ON` (muted) + `<NAME>` (muted gray). Reads "settled, nothing pending."
+- Rendered through the existing dynamic template `icons/tire-service.svg` (`iconContent` = badge, `textElement` = labels). Telemetry subscription / state-key memoization unchanged.
+
+## Change All Tires & Clear Tires (static)
+
+A matched **four-corner tire set** (the car's four corners as rounded rects):
+
+- **Change All** — four corners filled green `#2ecc71`, a small change ↻ in a center hub; title `TIRES / CHANGE ALL`.
+- **Clear** — four corners empty (grey outline), a bold red `#e74c3c` diagonal wipe across; title `TIRES / CLEAR`.
+
+Authored as trimmed-viewBox graphic-snippet SVGs (`packages/icons/tire-service/{change-all-tires,clear-tires}.svg`) with `<desc>` metadata, assembled via `assembleIcon` exactly as today (background/title/border/graphic slots colorizable; the semantic green/red action colors are fixed). Regenerate previews + icon-defaults.
+
+## Files
+
+- `packages/iracing-actions/src/actions/tire-service/tire-service.ts` — rewrite `generateTireIcon` to emit the badge; update the `change-compound` case for the change/stay treatment and `CHANGE TO`/`STAYING ON` wording.
+- `packages/iracing-actions/src/actions/tire-service/tire-service.test.ts` — update compound-icon + change/stay assertions (wording `STAYING ON`; badge contains the compound color + initial); keep `getCompoundColor`/`getCompoundName` tests.
+- `packages/icons/tire-service/change-all-tires.svg`, `clear-tires.svg` — new artwork; then `node scripts/generate-icon-previews.mjs` + `node scripts/generate-icon-defaults.mjs`.
+- Docs: `packages/website/src/content/docs/docs/actions/pit-service/tire-service.md` (icon descriptions) + `changelog.mdx` (2.1.0, Improvements). Action-doc icon table if present.
+
+## Out of scope
+
+- `toggle-tires` mode, the compound cycle logic, the color map itself, any behavior. No manifest / registration changes.
+
+## Decisions log
+
+- Dry = gray (user), distinct from hard's white.
+- Wording: `CHANGE TO` / `STAYING ON` (uppercase, matching the approved mockup).
+- No ↻ badge on the compound key (its yellow clashed with the Medium compound; vivid/dim + wording carry the state).
+- Background stays `#3a2a2a` (toggle-tires consistency; not requested to change).
+- Change All / Clear = four-corner "Set 1" (user pick).

--- a/packages/icons/preview/tire-service/change-all-tires.svg
+++ b/packages/icons/preview/tire-service/change-all-tires.svg
@@ -1,9 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 44 44" stroke-width="0.5" stroke="#fff" fill="#fff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 84" fill="none">
   <desc>{"colors":{"backgroundColor":"#3a2a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TIRES\nCHANGE ALL"},"border":{"color":"#6a5a5a"}}</desc>
-  
 
-    <circle cx="22" cy="22" r="20" fill="none" stroke="#ffffff" stroke-width="3"/>
-    <circle cx="22" cy="22" r="8" fill="none" stroke="#888888" stroke-width="2"/>
-    <polyline points="10,22 18,32 34,12" fill="none" stroke="#2ecc71" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+    <g fill="#2ecc71">
+      <rect x="10" y="8" width="18" height="26" rx="4"/>
+      <rect x="56" y="8" width="18" height="26" rx="4"/>
+      <rect x="10" y="50" width="18" height="26" rx="4"/>
+      <rect x="56" y="50" width="18" height="26" rx="4"/>
+    </g>
+    <g transform="translate(34.8,32.8) scale(0.6)" fill="none" stroke="#2ecc71" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="23 4 23 10 17 10"/>
+      <polyline points="1 20 1 14 7 14"/>
+      <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/>
+    </g>
 
 </svg>

--- a/packages/icons/preview/tire-service/clear-tires.svg
+++ b/packages/icons/preview/tire-service/clear-tires.svg
@@ -1,10 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 44 44" stroke-width="0.5" stroke="#fff" fill="#fff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 84" fill="none">
   <desc>{"colors":{"backgroundColor":"#3a2a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TIRES\nCLEAR"},"border":{"color":"#6a5a5a"}}</desc>
-  
 
-    <circle cx="22" cy="22" r="20" fill="none" stroke="#ffffff" stroke-width="3"/>
-    <circle cx="22" cy="22" r="8" fill="none" stroke="#888888" stroke-width="2"/>
-    <line x1="8" y1="8" x2="36" y2="36" stroke="#e74c3c" stroke-width="5" stroke-linecap="round"/>
-    <line x1="36" y1="8" x2="8" y2="36" stroke="#e74c3c" stroke-width="5" stroke-linecap="round"/>
+    <g fill="none" stroke="#888888" stroke-width="3">
+      <rect x="10" y="8" width="18" height="26" rx="4"/>
+      <rect x="56" y="8" width="18" height="26" rx="4"/>
+      <rect x="10" y="50" width="18" height="26" rx="4"/>
+      <rect x="56" y="50" width="18" height="26" rx="4"/>
+    </g>
+    <line x1="8" y1="76" x2="76" y2="8" stroke="#e74c3c" stroke-width="8" stroke-linecap="round"/>
 
 </svg>

--- a/packages/icons/tire-service/change-all-tires.svg
+++ b/packages/icons/tire-service/change-all-tires.svg
@@ -1,9 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 44 44" stroke-width="0.5" stroke="#fff" fill="#fff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 84" fill="none">
   <desc>{"colors":{"backgroundColor":"#3a2a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TIRES\nCHANGE ALL"},"border":{"color":"#6a5a5a"}}</desc>
-  
 
-    <circle cx="22" cy="22" r="20" fill="none" stroke="{{graphic1Color}}" stroke-width="3"/>
-    <circle cx="22" cy="22" r="8" fill="none" stroke="#888888" stroke-width="2"/>
-    <polyline points="10,22 18,32 34,12" fill="none" stroke="#2ecc71" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+    <g fill="#2ecc71">
+      <rect x="10" y="8" width="18" height="26" rx="4"/>
+      <rect x="56" y="8" width="18" height="26" rx="4"/>
+      <rect x="10" y="50" width="18" height="26" rx="4"/>
+      <rect x="56" y="50" width="18" height="26" rx="4"/>
+    </g>
+    <g transform="translate(34.8,32.8) scale(0.6)" fill="none" stroke="#2ecc71" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="23 4 23 10 17 10"/>
+      <polyline points="1 20 1 14 7 14"/>
+      <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/>
+    </g>
 
 </svg>

--- a/packages/icons/tire-service/clear-tires.svg
+++ b/packages/icons/tire-service/clear-tires.svg
@@ -1,10 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 44 44" stroke-width="0.5" stroke="#fff" fill="#fff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 84" fill="none">
   <desc>{"colors":{"backgroundColor":"#3a2a2a","textColor":"#ffffff","graphic1Color":"#ffffff"},"locked":["graphic1Color"],"title":{"text":"TIRES\nCLEAR"},"border":{"color":"#6a5a5a"}}</desc>
-  
 
-    <circle cx="22" cy="22" r="20" fill="none" stroke="{{graphic1Color}}" stroke-width="3"/>
-    <circle cx="22" cy="22" r="8" fill="none" stroke="#888888" stroke-width="2"/>
-    <line x1="8" y1="8" x2="36" y2="36" stroke="#e74c3c" stroke-width="5" stroke-linecap="round"/>
-    <line x1="36" y1="8" x2="8" y2="36" stroke="#e74c3c" stroke-width="5" stroke-linecap="round"/>
+    <g fill="none" stroke="#888888" stroke-width="3">
+      <rect x="10" y="8" width="18" height="26" rx="4"/>
+      <rect x="56" y="8" width="18" height="26" rx="4"/>
+      <rect x="10" y="50" width="18" height="26" rx="4"/>
+      <rect x="56" y="50" width="18" height="26" rx="4"/>
+    </g>
+    <line x1="8" y1="76" x2="76" y2="8" stroke="#e74c3c" stroke-width="8" stroke-linecap="round"/>
 
 </svg>

--- a/packages/iracing-actions/src/actions/tire-service/tire-service.test.ts
+++ b/packages/iracing-actions/src/actions/tire-service/tire-service.test.ts
@@ -331,6 +331,12 @@ describe("TireService", () => {
       const icon = generateTireIcon("Unknown");
       expect(icon).toContain("#888888");
     });
+
+    it("should render the compound initial letter inside the badge", () => {
+      expect(generateTireIcon("Soft")).toContain(">S</text>");
+      expect(generateTireIcon("Wet")).toContain(">W</text>");
+      expect(generateTireIcon("Dry")).toContain(">D</text>");
+    });
   });
 
   describe("areAllTiresOn", () => {
@@ -633,35 +639,44 @@ describe("TireService", () => {
       it("should show Stay on DRY when player and pit service are both dry", () => {
         const result = generateTireServiceSvg(compoundSettings, noTires, { player: 0, pitSv: 0 });
         const decoded = decodeURIComponent(result);
-        expect(decoded).toContain("Stay on");
+        expect(decoded).toContain("STAYING ON");
         expect(decoded).toContain("DRY");
       });
 
       it("should show Change to WET when player is dry but pit service is wet", () => {
         const result = generateTireServiceSvg(compoundSettings, noTires, { player: 0, pitSv: 1 });
         const decoded = decodeURIComponent(result);
-        expect(decoded).toContain("Change to");
+        expect(decoded).toContain("CHANGE TO");
         expect(decoded).toContain("WET");
+      });
+
+      it("dims the badge and adds a green confirm mark only when staying on the same compound", () => {
+        const staying = decodeURIComponent(generateTireServiceSvg(compoundSettings, noTires, { player: 1, pitSv: 1 }));
+        expect(staying).toContain('opacity="0.55"'); // badge dimmed when nothing will change
+        expect(staying).toContain("#2ecc71"); // green confirm badge
+
+        const changing = decodeURIComponent(generateTireServiceSvg(compoundSettings, noTires, { player: 0, pitSv: 1 }));
+        expect(changing).not.toContain('opacity="0.55"'); // vivid when a change is pending
       });
 
       it("should show Stay on WET when player and pit service are both wet", () => {
         const result = generateTireServiceSvg(compoundSettings, noTires, { player: 1, pitSv: 1 });
         const decoded = decodeURIComponent(result);
-        expect(decoded).toContain("Stay on");
+        expect(decoded).toContain("STAYING ON");
         expect(decoded).toContain("WET");
       });
 
       it("should show Change to DRY when player is wet but pit service is dry", () => {
         const result = generateTireServiceSvg(compoundSettings, noTires, { player: 1, pitSv: 0 });
         const decoded = decodeURIComponent(result);
-        expect(decoded).toContain("Change to");
+        expect(decoded).toContain("CHANGE TO");
         expect(decoded).toContain("DRY");
       });
 
       it("should default to Stay on DRY when compound is not provided", () => {
         const result = generateTireServiceSvg(compoundSettings, noTires);
         const decoded = decodeURIComponent(result);
-        expect(decoded).toContain("Stay on");
+        expect(decoded).toContain("STAYING ON");
         expect(decoded).toContain("DRY");
       });
 

--- a/packages/iracing-actions/src/actions/tire-service/tire-service.ts
+++ b/packages/iracing-actions/src/actions/tire-service/tire-service.ts
@@ -198,14 +198,31 @@ export function getCompoundName(compound: number): string {
 /**
  * @internal Exported for testing
  *
- * Generate a simple colored tire icon for a compound type.
+ * First character of a compound display name, uppercased (SOFT→S, DRY→D, WET→W).
+ * Used as the letter inside the compound badge ring.
+ */
+export function compoundInitial(name: string): string {
+  return name.trim().charAt(0).toUpperCase() || "?";
+}
+
+/**
+ * @internal Exported for testing
+ *
+ * F1-style compound badge: a bold ring in the compound colour with the
+ * compound initial centred inside. The colour carries the meaning (soft red,
+ * medium yellow, hard white, inter green, wet blue, everything else — incl.
+ * dry — gray). The letter is placed by baseline maths (`54 + 0.36·fontSize`)
+ * rather than `dominant-baseline`, which the Stream Deck / Mirabox Qt renderer
+ * ignores.
  */
 export function generateTireIcon(compoundType: string): string {
   const color = getCompoundColor(compoundType);
+  const initial = compoundInitial(compoundType);
+  const letterY = 54 + Math.round(0.36 * 40);
 
   return `
-    <circle cx="72" cy="44" r="24" fill="${color}" fill-opacity="0.25" stroke="${color}" stroke-width="4"/>
-    <circle cx="72" cy="44" r="10" fill="${GRAY}" stroke="${GRAY}" stroke-width="2"/>`;
+    <circle cx="72" cy="54" r="33" fill="none" stroke="${color}" stroke-width="9"/>
+    <text x="72" y="${letterY}" text-anchor="middle" fill="${color}" font-family="Arial, sans-serif" font-size="40" font-weight="bold">${initial}</text>`;
 }
 
 /**
@@ -390,18 +407,24 @@ export function generateTireServiceSvg(
       let textElement: string;
       const compoundType = getCompoundName(compoundState.pitSv);
       const isChanging = compoundState.player !== compoundState.pitSv;
-
-      iconContent = generateTireIcon(compoundType);
+      const compoundColor = getCompoundColor(compoundType);
+      const badge = generateTireIcon(compoundType);
 
       if (isChanging) {
+        // Something WILL change on the next stop: vivid badge, name in the compound colour.
+        iconContent = badge;
         textElement = [
-          generateIconText({ text: `Change to`, fontSize: 18, fill: YELLOW, baseY: 112, centerX: 72 }),
-          generateIconText({ text: compoundType, fontSize: 24, fill: YELLOW, baseY: 138, centerX: 72 }),
+          generateIconText({ text: `CHANGE TO`, fontSize: 18, fill: "#bbbbbb", baseY: 112, centerX: 72 }),
+          generateIconText({ text: compoundType, fontSize: 24, fill: compoundColor, baseY: 138, centerX: 72 }),
         ].join("\n");
       } else {
+        // Keeping the same compound: settled, nothing pending — dim the badge and add a green ✓.
+        iconContent = `<g opacity="0.55">${badge}</g>
+    <circle cx="110" cy="24" r="14" fill="${GREEN}"/>
+    <polyline points="103,24 108,30 118,17" fill="none" stroke="#1a1a1a" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>`;
         textElement = [
-          generateIconText({ text: `Stay on`, fontSize: 18, fill: "#ffffff", baseY: 112, centerX: 72 }),
-          generateIconText({ text: compoundType, fontSize: 24, fill: "#ffffff", baseY: 138, centerX: 72 }),
+          generateIconText({ text: `STAYING ON`, fontSize: 18, fill: "#8a8a8a", baseY: 112, centerX: 72 }),
+          generateIconText({ text: compoundType, fontSize: 24, fill: "#c9c9c9", baseY: 138, centerX: 72 }),
         ].join("\n");
       }
 

--- a/packages/website/src/content/docs/changelog.mdx
+++ b/packages/website/src/content/docs/changelog.mdx
@@ -19,6 +19,7 @@ _Unreleased_
 
 **Improvements**
 
+- Redesigned the Tire Service icons: Change Compound now shows the compound as a bold colour-coded badge (F1 style — soft red, medium yellow, hard white, inter green, wet blue, dry grey) with the compound initial, and says whether the next stop will change to it or stay on the fitted one; Change All Tires and Clear Tires became a matching four-corner tire set.
 - Redesigned the Toggle Wipers and Trigger Wipers key icons around a windshield, so the two keys are clearly distinct from each other and read unmistakably as wipers at deck size.
 
 ## 2.0.0

--- a/packages/website/src/content/docs/docs/actions/pit-service/tire-service.md
+++ b/packages/website/src/content/docs/docs/actions/pit-service/tire-service.md
@@ -87,6 +87,8 @@ Cycle through available tire compounds. Each press advances to the next compound
 
 The available compounds depend on the car — most cars have DRY and WET, while some have additional options like Soft, Medium, and Hard.
 
+The key shows the selected compound as a colour-coded badge (F1 style — soft red, medium yellow, hard white, intermediate green, wet blue, and dry grey so it never reads as hard), and tells you whether the next stop will **change to** that compound or **stay on** the one already fitted.
+
 #### Details
 
 - **Method:** iRacing API


### PR DESCRIPTION
## Related Issue

Fixes #815

## What changed?

Visual redesign of three Tire Service modes — behavior is unchanged, and the `toggle-tires` mode is untouched. Background stays the existing tire-service brown for consistency across all four modes.

- **Change Compound** (dynamic) — now leads with a bold **F1 compound badge**: a colored ring + the compound initial, name below. Colors: soft red, medium yellow, hard white, intermediate green, wet blue, and **dry gray** (deliberately distinct from hard's white so Dry and Hard are never confused). Two states from live telemetry: **`CHANGE TO <NAME>`** — vivid, name in the compound colour — when the selected compound differs from what's fitted; **`STAYING ON <NAME>`** — dimmed badge + a small green ✓ — when they match.
- **Change All Tires** and **Clear Tires** (static) — a matched **four-corner tire set**: Change All lights all four corners green with a change ↻; Clear shows the four corners empty (grey) with a red diagonal wipe.

The compound letter is placed by baseline maths rather than `dominant-baseline` (which the Qt renderer ignores). Icon previews regenerated; the shared `getCompoundColor` map is unchanged (dry already falls back to gray).

## How to test

1. Place a Tire Service key, set **Mode → Change Compound**. With iRacing running, cycle the compound: the badge shows the F1 colour + initial, and the label flips between **CHANGE TO** (when it differs from the fitted compound) and **STAYING ON** (when it matches).
2. Try a 2-compound car (Dry/Wet) — Dry renders grey, Wet blue.
3. Place **Change All Tires** and **Clear Tires** — confirm the four-corner set (green + ↻ vs empty + red wipe).

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — no registration/manifest change; visual-only, ships to all three plugins via the shared action + icon source
- [x] No unrelated changes included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2jj37zj1w6cdD8uVDNy5e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tire Service icons now use clearer visual badges for compound choices, making it easier to see the selected tire type at a glance.
  * The interface now distinguishes whether the next stop will switch compounds or keep the current set.
  * Change All Tires and Clear Tires now share a more consistent tire-set icon style.

* **Bug Fixes**
  * Updated icon rendering and labels to match the new tire-service visuals more accurately.

* **Documentation**
  * Added updated release notes and user-facing guidance for the redesigned Tire Service icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->