### PR TITLE
refactor(audio-scenarios): derive Race Engineer callout pools per-voice from the manifest (#664)

### DIFF
--- a/.claude/rules/race-engineer-callouts.md
+++ b/.claude/rules/race-engineer-callouts.md
@@ -41,7 +41,7 @@ voice scenario as the outermost short-circuit.
 
 | Concern | File |
 |---|---|
-| **Voice lines (source of truth)** | `packages/audio-assets/configs/<voice-id>.voice.json` — canonical: `default.voice.json`; key parity across voices enforced by `voice-parity.test.ts` |
+| **Voice lines (source of truth)** | `packages/audio-assets/configs/<voice-id>.voice.json` — canonical: `default.voice.json`; voices may differ in variant counts and omit callouts (issue #664), `voice-parity.test.ts` only guards against `<group>/<base>` keys unknown to default |
 | **Generated clips** | `packages/audio-assets/voice/<voice>/<group>/<name>.mp3` (gitignored locally; committed once stable) |
 | **Generator cache** | `packages/audio-assets/generate.manifest.json` |
 | **Runtime manifest** | `packages/audio-assets/manifest.json` (rebuilt by `generate:manifest`) |
@@ -49,7 +49,7 @@ voice scenario as the outermost short-circuit.
 | **Bus public exports** | `packages/event-bus/src/index.ts` (export new enums as values, not just types) |
 | **iRacing translator** | `packages/sim-events-iracing/src/diff/<name>.ts` + wired into `translator.ts` |
 | **Translator state** | `packages/sim-events-iracing/src/state.ts` (TranslatorState type AND createInitialState — keep them in sync) |
-| **Audio pools** | `packages/audio-scenarios/src/catalog/pit-crew/pools.ts` |
+| **Audio pools** | `packages/audio-scenarios/src/catalog/pit-crew/pools.ts` — `POOL_REGISTRY` maps pool name → manifest `(group, base)`; members (`<base>-NN.mp3`) derive per-voice from the manifest at fire time (issue #664) |
 | **Audio scenarios** | `packages/audio-scenarios/src/catalog/pit-crew/<family>.ts` |
 | **Family wiring (id type, key map, scenario id map, registerPitCrew param)** | `packages/audio-scenarios/src/catalog/pit-crew/index.ts` |
 | **Per-callout opt-in (Zod field)** | `packages/deck-core/src/global-settings.ts` |
@@ -62,7 +62,7 @@ voice scenario as the outermost short-circuit.
 
 - **Per-callout opt-in setting key:** `callout<Polarity><Family><Subject>` (`.claude/rules/global-settings.md` is the canonical reference). Polarity is always `Enabled`; the schema field's *default* encodes the family's natural baseline (callouts default `true`). Examples: `calloutEnabledFlagYellowLocal`, `calloutEnabledTrackWetness`.
 - **Scenario id:** `pit-crew.<family>-<subject>` — `pit-crew.flag-yellow-local`, `pit-crew.pit-status-too-far-left`, `pit-crew.track-conditions-worsening-mostly-dry`.
-- **Pool name:** `<family>-<subject>` — matches the scenario subject. One pool per scenario; arrays of clip paths so future variants append cleanly.
+- **Pool name:** `<family>-<subject>` — matches the scenario subject. One pool per scenario. A pool's members are all clips sharing its `(group, base)` — `voice/<voice>/<group>/<base>-NN.mp3` — so future variants are clip-file additions with no code change (issue #664). The pool name need not equal `<group>/<base>` (`flag-blue` → `flags`/`blue`); `POOL_REGISTRY` carries the mapping.
 - **Voice clip path:** `voice/{voice}/<group>/<name>.mp3` — group keys the `groups` map in the voice config; name keys the entry inside the group.
 - **Family identifier (for preemption):** matches the directory naming: `flag`, `damage`, `pit-status`, `track-conditions`. All scenarios in a family share the same `family:` value, so a newer fire supersedes an in-flight one cleanly.
 
@@ -86,7 +86,7 @@ In `packages/event-bus/src/event-catalog.ts`:
 
 ### 3. Voice lines
 
-In `packages/audio-assets/configs/default.voice.json` (and every other voice file — `voice-parity.test.ts` enforces matching `<group>/<entry-name>` sets across voices, even though text can differ):
+In `packages/audio-assets/configs/default.voice.json` (other voices *may* add the same entries with their own wording, but don't have to — a voice without a clip skips that callout; `voice-parity.test.ts` only rejects `<group>/<base>` keys unknown to default, issue #664):
 - Add (or extend) a group with one entry per `(direction × subject)` combination.
 - Each entry: `name` (kebab-case, suffix `-01` so future variants append as `-02`), `text`, optionally `seed` (omit it on new entries — the generator defaults an omitted seed to `1` — or set `"seed": 1` explicitly; NEVER an arbitrary/random value, since the seed only selects which take ElevenLabs produces. Bump it deliberately for a different take when the generated clip doesn't sound right — the seed feeds the hash, so the change re-cuts only that clip), optional `previous_request_ids` to bias prosody continuity.
 - Use `<break time="0.3s" />` for natural pauses inside a single line.
@@ -104,7 +104,7 @@ Each `configs/<voice-id>.voice.json` is the per-voice source of truth — voices
 
 ### 4. Audio pools + scenario
 
-- Add one pool per `(direction × subject)` to `packages/audio-scenarios/src/catalog/pit-crew/pools.ts`. Single-element pools are deterministic; multi-element pools are sampled uniform-random with a per-pool no-immediate-repeat guard (the interpreter's `pickFromPool` — not a sequential rotation).
+- Add one `POOL_REGISTRY` entry per `(direction × subject)` to `packages/audio-scenarios/src/catalog/pit-crew/pools.ts` — pool name → `(group, base)`, no clip lists. The pool's members are derived per-voice from the manifest (`voice/<voice>/<group>/<base>-NN.mp3`) at fire time, so adding a *variant* later is a clip-file change only. Single-member pools are deterministic; multi-member pools are sampled uniform-random with a per-pool no-immediate-repeat guard (the interpreter's `pickFromPool` — not a sequential rotation; the tracker resets on voice change).
 - Write a scenario file under `packages/audio-scenarios/src/catalog/pit-crew/<family>.ts`. Mirror `flag-alerts.ts` / `pit-status.ts` / `track-conditions.ts`. Each scenario has:
   - `id: "pit-crew.<family>-<subject>"`
   - `family: "<family>"` (shared across the whole family — a newer same-family fire replaces the in-flight family-mate wholesale, regardless of weight)

--- a/packages/audio-assets/CLAUDE.md
+++ b/packages/audio-assets/CLAUDE.md
@@ -31,9 +31,9 @@ Consumer surface (`package.json` exports): `./build` (`processAndCopyAudioAssets
 
 `sfx/` holds the non-voice assets: the walkie-talkie tick-open/close pair, the ambient pit loop, and the radar proximity tones (`sfx/radar/`). They're consumed by `@iracedeck/audio-scenarios` — the radio frame (`radio-frame.ts`), the PI background-volume test (`background-test.ts`), and the radar engine (`radar-engine.ts`). Deliberately **not** radio-filtered at build time: everything outside `voice/` is copied into the plugin output unchanged (see `src/presets.mjs`), so the ticks and tones stay clean.
 
-## Key parity across voices
+## Voices may diverge — the relaxed parity check (issue #664)
 
-The test `src/generate/voice-parity.test.ts` enforces that every voice config defines the **same set of `<group>/<entry-name>` keys** as `default.voice.json`. The wording can vary per voice (different engineer personalities), but the *set of clips offered* must match — otherwise pools and scenarios resolve inconsistently for one voice and not another. CI fails with a diff (missing / extra) on any mismatch.
+Pools are derived per-voice from the clips that actually exist (see the `@iracedeck/audio-scenarios` `POOL_REGISTRY`), so voices do **not** need identical clip sets: a voice may record fewer or more `-NN` variants of a line, or omit a callout entirely — that voice simply doesn't play it. The test `src/generate/voice-parity.test.ts` keeps only a **soft typo guard**: a non-default voice must not define a `<group>/<base>` key (entry name with the `-NN` suffix stripped) that `default.voice.json` doesn't know — such a base is referenced by nothing and would never play, so it's almost certainly a misspelling. Missing keys are allowed; wording can vary per voice (different engineer personalities).
 
 ## Manifests
 
@@ -67,7 +67,7 @@ See `README.md` for the full CLI flag reference.
 
 The most common case — a new callout in an existing family (e.g. another flag):
 
-1. Add the entry to the group in `configs/default.voice.json`, and the same `<group>/<entry-name>` key to every other voice config (the parity test enforces it; wording may differ per voice). Omit `seed` (or set `"seed": 1`) — never an arbitrary value.
+1. Add the entry to the group in `configs/default.voice.json`. Other voice configs *may* add the same `<group>/<entry-name>` key (wording may differ per voice) but don't have to — a voice without the clip just skips that callout (issue #664). Omit `seed` (or set `"seed": 1`) — never an arbitrary value.
 2. Preview: `pnpm --filter @iracedeck/audio-assets generate:dry-run --group <group>` — it must report exactly the new entries as "WOULD GENERATE" and everything else as cache hits.
 3. Generate scoped: `pnpm --filter @iracedeck/audio-assets generate --group <group>`.
 4. Rebuild the runtime manifest: `pnpm --filter @iracedeck/audio-assets generate:manifest`.
@@ -75,23 +75,23 @@ The most common case — a new callout in an existing family (e.g. another flag)
 
 ## Adding a new group
 
-1. Add the new top-level key under `groups` in `configs/default.voice.json` (the canonical voice; the parity test enforces that every other voice gets the same key set).
+1. Add the new top-level key under `groups` in `configs/default.voice.json` (the canonical voice; other voices may adopt the group later — parity is not required, issue #664).
 2. Author the entries (text, no `seed` — or `"seed": 1` — by default, optional `previous_request_ids`).
 3. Generate (scoped by `--group`), after a dry-run preview.
 4. Rebuild the runtime manifest.
-5. Reference the new clips from a pool in `@iracedeck/audio-scenarios` (`packages/audio-scenarios/src/catalog/pit-crew/pools.ts`).
+5. Register the pool in `@iracedeck/audio-scenarios` — a `POOL_REGISTRY` entry mapping the pool name to `(group, base)` in `packages/audio-scenarios/src/catalog/pit-crew/pools.ts`.
 
 ## Adding a new voice
 
-1. Create `configs/<voice-id>.voice.json` with its own `id` (ElevenLabs voice id), `label`, `model_id`, `voice_settings`, and `groups`. The groups must contain the same `<group>/<entry-name>` set as `default.voice.json` — the parity test enforces this.
+1. Create `configs/<voice-id>.voice.json` with its own `id` (ElevenLabs voice id), `label`, `model_id`, `voice_settings`, and `groups`. The groups do **not** need to match `default.voice.json` — a partial voice ships fine and simply skips the callouts it lacks (issue #664). The only constraint is the typo guard: don't invent `<group>/<base>` keys that `default.voice.json` doesn't have.
 2. Run `pnpm --filter @iracedeck/audio-assets generate --voice <voice-id>` to render its clips into `voice/<voice-id>/...`.
 3. Rebuild the runtime manifest. The runtime auto-discovers voices from the manifest's `voice/<id>/...` paths, so the new voice appears in the PI dropdown automatically.
 
 ## Conventions
 
 - One group per callout family (flags, pit-actions, pit-status, track-conditions, …). Mixing families in one group makes the cost-scoping flag `--group` less useful.
-- File names are stable identifiers — pools reference them by exact path. Renaming an entry's `name` is a breaking change for any pool that references it.
-- Variants use a `-NN` suffix (`flag-blue-01.mp3`, `flag-blue-02.mp3`). Playback picks from the pool uniform-random with a no-immediate-repeat guard (not in array order).
+- Variants use a `-NN` suffix (`blue-01.mp3`, `blue-02.mp3`). A pool is *all clips sharing a base name* — `voice/<voice>/<group>/<base>-NN.mp3` — derived per-voice from the runtime manifest (issue #664), so **adding or removing a variant is just adding or removing an entry + clip**: no pool edit, no code change. Playback picks uniform-random with a no-immediate-repeat guard (not in numeric order).
+- The `<group>/<base>` pair is the stable identifier — the audio-scenarios `POOL_REGISTRY` references pools by it, so renaming a base is a breaking change for the pool that references it. (The acknowledgment clips are the exception until #837: they don't follow `-NN` yet and are referenced by exact path.)
 
 ## Known re-render triggers
 

--- a/packages/audio-assets/src/generate/voice-parity.test.ts
+++ b/packages/audio-assets/src/generate/voice-parity.test.ts
@@ -10,28 +10,28 @@ const CONFIGS_DIR = path.join(PACKAGE_ROOT, "configs");
 
 const DEFAULT_VOICE_ID = "default";
 
+/** Strip the `-NN` variant suffix from an entry name (`blue-01` → `blue`). */
+function stripVariantSuffix(name: string): string {
+  return name.replace(/-\d{2}$/, "");
+}
+
 /**
- * Collect the set of `<group>/<entry-name>` keys for a voice. This is the
- * unit of parity: every voice pack must offer the same set of clips, even
- * if the wording differs between voices.
+ * Collect the set of `<group>/<base>` keys for a voice, where `base` is the
+ * entry name with any `-NN` variant suffix stripped. This is the unit of the
+ * relaxed parity check (issue #664): pools are derived per-voice from the
+ * clips that actually exist, so a voice may carry a different number of
+ * variants of a line, or omit a callout entirely — neither is an error.
  */
-function clipKeys(voice: VoiceConfig): Set<string> {
+function baseKeys(voice: VoiceConfig): Set<string> {
   const keys = new Set<string>();
 
   for (const [groupName, entries] of Object.entries(voice.groups)) {
     for (const entry of entries) {
-      keys.add(`${groupName}/${entry.name}`);
+      keys.add(`${groupName}/${stripVariantSuffix(entry.name)}`);
     }
   }
 
   return keys;
-}
-
-function diff(reference: Set<string>, other: Set<string>): { missing: string[]; extra: string[] } {
-  const missing = [...reference].filter((k) => !other.has(k)).sort();
-  const extra = [...other].filter((k) => !reference.has(k)).sort();
-
-  return { missing, extra };
 }
 
 describe("voice-parity", () => {
@@ -45,23 +45,19 @@ describe("voice-parity", () => {
 
   if (!defaultVoice) return;
 
-  const defaultKeys = clipKeys(defaultVoice);
+  const defaultBases = baseKeys(defaultVoice);
 
+  // Soft typo guard: a base the canonical default voice doesn't know is
+  // referenced by no pool, so it would never play — almost certainly a
+  // misspelling (`blu-01` for `blue-01`). MISSING bases are deliberately
+  // allowed: a voice that omits a callout simply doesn't play it.
   for (const [voiceId, voice] of voiceConfigs) {
     if (voiceId === DEFAULT_VOICE_ID) continue;
 
-    it(`voice "${voiceId}" has the same <group>/<entry> keys as default`, () => {
-      const keys = clipKeys(voice);
-      const { missing, extra } = diff(defaultKeys, keys);
+    it(`voice "${voiceId}" has no <group>/<base> keys unknown to default (typo guard)`, () => {
+      const extra = [...baseKeys(voice)].filter((k) => !defaultBases.has(k)).sort();
 
-      // Build a single message so the test failure shows both gaps at once.
-      const parts: string[] = [];
-
-      if (missing.length > 0) parts.push(`missing in "${voiceId}":\n  ${missing.join("\n  ")}`);
-
-      if (extra.length > 0) parts.push(`extra in "${voiceId}" (not in default):\n  ${extra.join("\n  ")}`);
-
-      expect(parts, parts.join("\n\n")).toEqual([]);
+      expect(extra, `extra in "${voiceId}" (not in default — probable typo):\n  ${extra.join("\n  ")}`).toEqual([]);
     });
   }
 });

--- a/packages/audio-scenarios/CLAUDE.md
+++ b/packages/audio-scenarios/CLAUDE.md
@@ -11,15 +11,15 @@ below cover the audio-scenarios-only mechanics.
 ## Engine modules (`src/`)
 
 - `dsl.ts` — the `Scenario` / step types, the `WEIGHT` bands, and step-shorthand resolution.
-- `interpreter.ts` — the scenario engine: subscribes scenarios to the bus, expands sequences at fire time (`pickFromPool` with per-pool no-immediate-repeat, `{voice}` substitution, include/var/conditional resolution), and runs the weight/interrupt/queueable scheduler with per-bus focus floors and the single pending slot.
-- `validation.ts` — load-time scenario validation on `defineScenario` (clip/pool/var/include existence per voice, include-cycle detection, scheduling-metadata checks — e.g. `resumable` requires `queueable`).
-- `manifest.ts` — deliberate leaf module breaking the interpreter ↔ validation circular import; defines the `AudioAssetsManifest` shape (`{ clips, ambientLoop, ticks }`) plus the voice / driver-name scanners.
+- `interpreter.ts` — the scenario engine: subscribes scenarios to the bus, expands sequences at fire time (`pickFromPool` with per-pool no-immediate-repeat, `{voice}` substitution, include/var/conditional resolution), and runs the weight/interrupt/queueable scheduler with per-bus focus floors and the single pending slot. Pools register either as manifest-derived (`definePoolFromManifest(name, group, base)` — members are every `voice/<voice>/<group>/<base>-NN.mp3` in the manifest, resolved per active voice at fire time; issue #664) or as explicit clip lists (`definePool`).
+- `validation.ts` — load-time scenario validation on `defineScenario` (clip/pool/var/include existence, include-cycle detection, scheduling-metadata checks — e.g. `resumable` requires `queueable`). Errors disable the scenario; `{voice}`-templated paths are checked against the **reference voice** only (`referenceVoice()` — `default` when present) and a miss just **warns**, since per-voice clip sets may legitimately diverge (issue #664).
+- `manifest.ts` — deliberate leaf module breaking the interpreter ↔ validation circular import; defines the `AudioAssetsManifest` shape (`{ clips, ambientLoop, ticks }`) plus the voice / driver-name scanners and `referenceVoice()`.
 
 ## Catalog layout
 
 `src/catalog/pit-crew/` — one file per scenario family, plus wiring, shared helpers, two imperative engines, and three non-family singles (tests, where present, are sibling `*.test.ts` files — not every family has one).
 
-- **Wiring & shared:** `index.ts` (id types, setting-key maps, scenario-id maps, `registerPitCrew()`), `pools.ts` (every pool name → clip paths), `radio-frame.ts` (the shared `@pit-crew.radio-open` / `@pit-crew.radio-close` include scenarios).
+- **Wiring & shared:** `index.ts` (id types, setting-key maps, scenario-id maps, `registerPitCrew()`), `pools.ts` (`POOL_REGISTRY`: pool name → manifest `(group, base)` source, plus the enumerated acknowledgment pools and `registerPools()`), `radio-frame.ts` (the shared `@pit-crew.radio-open` / `@pit-crew.radio-close` include scenarios).
 - **Flags & race flow:** `flag-alerts.ts`, `start-lights.ts`, `rolling-start.ts`, `session-start.ts`, `race-start.ts`, `race-status.ts`, `race-end.ts`, `qualifying-invalidation.ts`.
 - **Pit:** `pit-approach.ts`, `pit-box.ts`, `pit-exit.ts`, `pit-limiter.ts`, `pit-status.ts`, `pit-window.ts`, `readback.ts`, `service-reminder.ts`, `stall-departure.ts`, `toggle-confirmations.ts`.
 - **Position & pace:** `position.ts`, `overtake.ts`, `lap-time.ts` — plus the shared helpers `position-readout.ts` (the cross-trigger "We're currently P[n]" readout + cooldown), `position-range.ts`, and `overtake-gate.ts` (leaf modules, not families).
@@ -45,18 +45,32 @@ Per-family issue history lives in `.claude/rules/race-engineer-callout-examples.
 
 ## Pools
 
-Defined once in `pools.ts` as `Record<string, readonly string[]>`. Scenarios
-reference them by name — `"pool:<name>"` in a sequence step, or `{ pool: "<name>" }`
-in a step object.
+Pools are **config-driven** (issue #664): a pool is *all clips sharing a base
+name* — `voice/<voice>/<group>/<base>-NN.mp3` — derived per-voice from the
+runtime audio-asset manifest. `POOL_REGISTRY` in `pools.ts` maps each logical
+pool name to its `(group, base)` source and carries **no clip lists and no
+counts**; adding or removing a variant (or bringing up a partial voice) is a
+clip-file change in `@iracedeck/audio-assets` with no code edit. Scenarios
+reference pools by name — `"pool:<name>"` in a sequence step, or
+`{ pool: "<name>" }` in a step object — exactly as before.
 
-- Single-element pools resolve deterministically.
-- Multi-element pools are **sampled uniform-random** with a per-pool
-  no-immediate-repeat guard (`pickFromPool`), shared across every scenario
-  that draws from the pool. So a callout family that reuses a pool (e.g., the
-  acknowledgment pool used by every pit-action confirmation) never plays the
-  same clip back-to-back across the whole family.
-- Voice substitution: `{voice}` in a path is replaced at playback time with
-  the active Race Engineer voice setting. Always use `voice/{voice}/…` paths.
+- Members resolve **at fire time for the active voice**. Voices may carry
+  different variant counts or omit a pool entirely — an empty pool skips its
+  step (debug log, not an error). Until the whole-callout skip rule lands
+  (#835), the rest of the sequence still plays.
+- Single-member pools resolve deterministically; multi-member pools are
+  **sampled uniform-random** with a per-pool no-immediate-repeat guard
+  (`pickFromPool`), shared across every scenario that draws from the pool.
+  The tracker resets when the active voice changes, since variant counts
+  differ across voices.
+- Typo guard: a registry entry whose `(group, base)` matches no clip for the
+  **reference voice** (`default`) warns at registration without disabling
+  anything.
+- The two acknowledgment pools (`acknowledgment`, `pit-action-acknowledgment`)
+  are still explicit clip lists in `ENUMERATED_POOLS` — their curated clips
+  don't follow `<base>-NN` yet. They move into the registry with the rename
+  migration (#837). For these `{voice}` paths, substitution happens at
+  playback time from the active Race Engineer voice setting.
 
 ## Scenarios
 
@@ -105,7 +119,7 @@ Both engines reuse the existing `radar.changed` bus event (no new event, no tran
 Adding one more callout to a family that already exists (e.g. another flag colour, or a paired `*-cleared`) needs **no `registerPitCrew` signature change and no plugin change** — the per-family `get<Family>CalloutEnabled` closure is generic over the family's id type, so a new union member routes through it automatically:
 
 1. Add the scenario to the family file and append it to the `<FAMILY>_ALERTS` array.
-2. Add its pool to `pools.ts` (clip path `voice/{voice}/<group>/<name>.mp3` — the clip itself is authored/generated in `@iracedeck/audio-assets`).
+2. Add its pool to `POOL_REGISTRY` in `pools.ts` — one line mapping the pool name to its `(group, base)`; the clips themselves (`voice/<voice>/<group>/<base>-NN.mp3`) are authored/generated in `@iracedeck/audio-assets`. Adding a *variant* of an existing callout needs no `pools.ts` change at all.
 3. In `index.ts`, extend three places: the `<Family>CalloutId` union, `<FAMILY>_CALLOUT_SETTING_KEYS` (key: `callout<Polarity><Family><Subject>`), and `SCENARIO_ID_TO_<FAMILY>_ID`.
 4. Cross-package companions: the Zod field in `deck-core/src/global-settings.ts` (default `true`), the PI checkbox row in `pit-crew.ejs`, BOTH exhaustive literals in `deck-core/src/simhub-service.test.ts`, and this package's test fixtures (`<family>.test.ts` + `register-pit-crew.test.ts` — clip-name lists, id lists, fire matrices).
 5. If the triggering bus event is new, also add the `scenario-harness` event template (`event-names.ts`, enforced by a compile-time completeness check) and a shortcut button (`scenario-shortcuts.ts`).
@@ -116,7 +130,7 @@ This is the consumer-side checklist; see the rule
 (`.claude/rules/race-engineer-callouts.md`) for the full cross-package flow.
 
 1. New file under `src/catalog/pit-crew/<family>.ts` — scenarios, pool names, scenario-id list.
-2. Add the pool entries to `pools.ts`.
+2. Add the family's `POOL_REGISTRY` entries to `pools.ts` (pool name → `(group, base)`).
 3. In `index.ts`:
    - Add `<Family>CalloutId` (type union of subject ids).
    - Add `<FAMILY>_CALLOUT_SETTING_KEYS: Record<<Family>CalloutId, string>` — exported so plugins can read it.
@@ -127,7 +141,7 @@ This is the consumer-side checklist; see the rule
 ## Conventions
 
 - **Scenario id:** `pit-crew.<family>-<subject>`. The translator does NOT see this id; it's the audio-side convention. The compile-time completeness check in `<FAMILY>_SCENARIO_IDS` catches typos.
-- **Pool name:** `<family>-<subject>`. Mirrors the scenario naming so a grep on the family prefix finds both halves.
+- **Pool name:** `<family>-<subject>`. Mirrors the scenario naming so a grep on the family prefix finds both halves. The name does **not** have to equal the manifest `<group>/<base>` (`flag-blue` → `flags`/`blue`; `start-light-ready` → `start-lights`/`start-ready`) — `POOL_REGISTRY` carries the mapping.
 - **Family identifier (`family:` field):** matches the file/scenario prefix without the `pit-crew.` namespace. So `flag-yellow-local` has `family: "flag"`, `track-conditions-worsening-mostly-dry` has `family: "track-conditions"`.
 
 ## Testing

--- a/packages/audio-scenarios/src/catalog/pit-crew/flag-alerts.test.ts
+++ b/packages/audio-scenarios/src/catalog/pit-crew/flag-alerts.test.ts
@@ -14,7 +14,7 @@ import {
   FLAG_SCENARIO_IDS,
   WAVING_FLAG_COOLDOWN_MS,
 } from "./flag-alerts.js";
-import { POOLS } from "./pools.js";
+import { POOL_REGISTRY } from "./pools.js";
 import { RADIO_CLOSE, RADIO_OPEN } from "./radio-frame.js";
 
 const mockSessionType = vi.fn(() => "Race");
@@ -215,7 +215,10 @@ beforeEach(() => {
   audio = createFakeAudio();
   engine = initializeAudioScenarios(bus, audio, manifest, mockLogger as never, () => activeVoice);
 
-  for (const name of FLAG_POOL_NAMES) engine.definePool(name, [...POOLS[name]]);
+  for (const name of FLAG_POOL_NAMES) {
+    const { group, base } = POOL_REGISTRY[name];
+    engine.definePoolFromManifest(name, group, base);
+  }
 
   engine.defineScenario(RADIO_OPEN);
   engine.defineScenario(RADIO_CLOSE);
@@ -788,10 +791,11 @@ describe("FLAG_POOL_NAMES", () => {
     ]);
   });
 
-  it("every name has a non-empty pool entry in POOLS", () => {
+  it("every name has a POOL_REGISTRY entry sourced from the flags group", () => {
     for (const name of FLAG_POOL_NAMES) {
-      expect(POOLS[name]).toBeDefined();
-      expect(POOLS[name].length).toBeGreaterThan(0);
+      expect(POOL_REGISTRY[name]).toBeDefined();
+      expect(POOL_REGISTRY[name].group).toBe("flags");
+      expect(POOL_REGISTRY[name].base.length).toBeGreaterThan(0);
     }
   });
 });

--- a/packages/audio-scenarios/src/catalog/pit-crew/flag-alerts.ts
+++ b/packages/audio-scenarios/src/catalog/pit-crew/flag-alerts.ts
@@ -47,7 +47,7 @@ import { getLatestTelemetry, getSessionType, getStandingStart } from "@iracedeck
 
 import type { Scenario, Step } from "../../dsl.js";
 import { WEIGHT } from "../../dsl.js";
-import { POOLS } from "./pools.js";
+import { POOL_REGISTRY } from "./pools.js";
 import { isRaceSession } from "./race-start.js";
 
 // Race-progression / formation flags (one-pace-lap-to-go, green-held, ten-to-go,
@@ -444,4 +444,4 @@ export const FLAG_SCENARIO_IDS: readonly string[] = FLAG_ALERTS.map((s) => s.id)
  * flows through `registerPitCrew()` without a parallel list to keep
  * in sync.
  */
-export const FLAG_POOL_NAMES: readonly string[] = Object.keys(POOLS).filter((name) => name.startsWith("flag-"));
+export const FLAG_POOL_NAMES: readonly string[] = Object.keys(POOL_REGISTRY).filter((name) => name.startsWith("flag-"));

--- a/packages/audio-scenarios/src/catalog/pit-crew/index.ts
+++ b/packages/audio-scenarios/src/catalog/pit-crew/index.ts
@@ -5,8 +5,8 @@
  *   - The directional radar (state-driven tick loop, not expressible in the
  *     scenario DSL)
  *   - All pools defined in `pools.ts`, registered en masse via
- *     `Object.entries(POOLS)` (acknowledgment, pit-action acknowledgment,
- *     per-action pit-action callouts, flag callouts)
+ *     `registerPools(engine)` — manifest-derived registry pools plus the
+ *     enumerated acknowledgment pools (issue #664)
  *   - The radio-frame include scenarios (`@pit-crew.radio-open` / `…close`)
  *   - Fuel toggle scenarios (on/off via `pitService.toggled`)
  *   - Tire toggle scenarios (every meaningful tire-set selection, including
@@ -72,7 +72,7 @@ import {
 import { PIT_BOX_ALERTS } from "./pit-box.js";
 import { PIT_STATUS_ALERTS } from "./pit-status.js";
 import { PIT_WINDOW_ALERTS } from "./pit-window.js";
-import { POOLS } from "./pools.js";
+import { registerPools } from "./pools.js";
 import {
   buildOvertakeGainedPositionScenario,
   buildOvertakeLostPositionScenario,
@@ -865,9 +865,7 @@ export function registerPitCrew(
 
   const engine = getScenarioEngine();
 
-  Object.entries(POOLS).forEach(([key, value]) => {
-    engine.definePool(key, value as string[]);
-  });
+  registerPools(engine);
 
   engine.defineScenario(RADIO_OPEN);
   engine.defineScenario(RADIO_CLOSE);
@@ -920,7 +918,7 @@ export function registerPitCrew(
   }
 
   // Start-light family (issue #480). The `start-light-*` pools are already
-  // registered en masse above via `Object.entries(POOLS)` (same as the flag
+  // registered en masse above via `registerPools(engine)` (same as the flag
   // pools), so no explicit pool loop is needed here — `START_LIGHT_POOL_NAMES`
   // exists for the catalog tests to register pools in isolation. Two grouped
   // opt-ins (`lights`, `countdown`) gate the five scenarios via
@@ -940,7 +938,7 @@ export function registerPitCrew(
   }
 
   // Pit-window family (issue #655). The `pit-window-*` pools are already
-  // registered en masse above via `Object.entries(POOLS)`, so no explicit pool
+  // registered en masse above via `registerPools(engine)`, so no explicit pool
   // loop is needed here — `PIT_WINDOW_POOL_NAMES` exists for the catalog tests
   // to register pools in isolation. Single subject (`pit-open-closed`) gates
   // both directional scenarios via `SCENARIO_ID_TO_PIT_WINDOW_ID`.
@@ -953,7 +951,7 @@ export function registerPitCrew(
   }
 
   // Rolling-start family (issue #660). The `rolling-start-*` pool is already
-  // registered en masse above via `Object.entries(POOLS)`, so no explicit pool
+  // registered en masse above via `registerPools(engine)`, so no explicit pool
   // loop is needed here — `ROLLING_START_POOL_NAMES` exists for the catalog
   // tests to register pools in isolation. Single subject (`pace-car`) gates the
   // scenario via `SCENARIO_ID_TO_ROLLING_START_ID`.

--- a/packages/audio-scenarios/src/catalog/pit-crew/pit-status.test.ts
+++ b/packages/audio-scenarios/src/catalog/pit-crew/pit-status.test.ts
@@ -22,7 +22,7 @@ import type { AudioAssetsManifest, IScenarioEngine } from "../../interpreter.js"
 import { _resetAudioScenarios, initializeAudioScenarios } from "../../interpreter.js";
 import { type PitStatusCalloutId, registerPitCrew } from "./index.js";
 import { PIT_STATUS_ALERTS, PIT_STATUS_POOL_NAMES, PIT_STATUS_SCENARIO_IDS } from "./pit-status.js";
-import { POOLS } from "./pools.js";
+import { POOL_REGISTRY } from "./pools.js";
 import { _resetRadarEngine } from "./radar-engine.js";
 import { RADIO_CLOSE, RADIO_OPEN } from "./radio-frame.js";
 import { _resetSpotterEngine } from "./spotter-engine.js";
@@ -203,10 +203,11 @@ describe("PIT_STATUS_ALERTS structure", () => {
     }
   });
 
-  it("every pool name has a non-empty pool entry in POOLS", () => {
+  it("every pool name has a POOL_REGISTRY entry sourced from the pit-status group", () => {
     for (const name of PIT_STATUS_POOL_NAMES) {
-      expect(POOLS[name]).toBeDefined();
-      expect(POOLS[name].length).toBeGreaterThan(0);
+      expect(POOL_REGISTRY[name]).toBeDefined();
+      expect(POOL_REGISTRY[name].group).toBe("pit-status");
+      expect(POOL_REGISTRY[name].base.length).toBeGreaterThan(0);
     }
   });
 });
@@ -217,7 +218,10 @@ describe("PIT_STATUS_ALERTS triggers (engine-level, no opt-out gating)", () => {
     audio = createFakeAudio();
     engine = initializeAudioScenarios(bus, audio, manifest, mockLogger as never, () => VOICE);
 
-    for (const name of PIT_STATUS_POOL_NAMES) engine.definePool(name, [...POOLS[name]]);
+    for (const name of PIT_STATUS_POOL_NAMES) {
+      const { group, base } = POOL_REGISTRY[name];
+      engine.definePoolFromManifest(name, group, base);
+    }
 
     engine.defineScenario(RADIO_OPEN);
     engine.defineScenario(RADIO_CLOSE);

--- a/packages/audio-scenarios/src/catalog/pit-crew/pools.ts
+++ b/packages/audio-scenarios/src/catalog/pit-crew/pools.ts
@@ -1,19 +1,172 @@
 /**
- * Pool definitions for the pit-crew scenario catalog.
+ * Pool registry for the pit-crew scenario catalog (issue #664).
  *
- * Each pool name maps to a list of clip paths relative to the
- * `@iracedeck/audio-assets` package root. Pools are registered with the
- * scenario engine at catalog load time; scenarios then reference them as
- * `"pool:<name>"` and `{ pool: "<name>" }`.
+ * Pools are config-driven: a pool is *all clips sharing a base name*
+ * (`voice/<voice>/<group>/<base>-NN.mp3`), derived per-voice from the
+ * runtime audio-asset manifest. `POOL_REGISTRY` maps each logical pool name
+ * to its `(group, base)` source — it carries **no clip lists and no
+ * counts**. Adding or removing a variant (or an entire voice) is a
+ * clip-file change in `@iracedeck/audio-assets`; this file only changes
+ * when a *new callout* (a new base) is introduced.
  *
- * Selection is RANDOM — every pick is a uniform-random clip from the pool
- * (`Math.random`), never a fixed order. The only constraint is no immediate
- * repeat: the same clip is never played twice in a row. That "last index"
- * tracker is shared per-pool, so the no-repeat guard holds even across two
- * scenarios that draw from the same pool.
+ * Registered with the scenario engine at catalog load time via
+ * `engine.definePoolFromManifest(name, group, base)`; scenarios reference
+ * pools as `"pool:<name>"` and `{ pool: "<name>" }` exactly as before.
+ *
+ * Selection is RANDOM — every pick is a uniform-random clip from the active
+ * voice's members (`Math.random`), never a fixed order. The only constraint
+ * is no immediate repeat: the same clip is never played twice in a row.
+ * That "last index" tracker is shared per-pool (and reset when the active
+ * voice changes, since variant counts differ across voices), so the
+ * no-repeat guard holds even across two scenarios drawing from one pool.
+ * Voices may carry different variant counts or omit a pool entirely — an
+ * empty pool skips its step at fire time.
  */
 
-export const POOLS: Readonly<Record<string, readonly string[]>> = {
+/** Where a pool's members live in the manifest: `voice/<voice>/<group>/<base>-NN.mp3`. */
+export type PoolSource = { group: string; base: string };
+
+export const POOL_REGISTRY: Readonly<Record<string, PoolSource>> = {
+  // Pit-action callouts. One pool per action; `pit-action-acknowledgment`
+  // stays enumerated below until the acknowledgment rename migration (#837).
+  "pit-action-fuel-on": { group: "pit-actions", base: "fuel-on" },
+  "pit-action-fuel-off": { group: "pit-actions", base: "fuel-off" },
+  "pit-action-tires-off": { group: "pit-actions", base: "tires-off" },
+
+  // Flag callout pools. Every flag scenario draws from a pool — even the
+  // single-clip flags. Green, white and checkered branch on getSessionType()
+  // at fire time so each session type gets its own pool. Auto-picked by
+  // `FLAG_POOL_NAMES` (the `flag-` prefix).
+  "flag-yellow-local": { group: "flags", base: "yellow-local" },
+  "flag-yellow-full": { group: "flags", base: "yellow-full" },
+  "flag-yellow-cleared": { group: "flags", base: "yellow-cleared" },
+  "flag-blue": { group: "flags", base: "blue" },
+  "flag-red": { group: "flags", base: "red" },
+  "flag-black": { group: "flags", base: "black" },
+  "flag-debris": { group: "flags", base: "debris" },
+  "flag-meatball": { group: "flags", base: "meatball" },
+  "flag-green-practice": { group: "flags", base: "green-practice" },
+  "flag-green-qualifying": { group: "flags", base: "green-qualifying" },
+  "flag-green-race": { group: "flags", base: "green-race" },
+  "flag-white-practice": { group: "flags", base: "white-practice" },
+  "flag-white-qualifying": { group: "flags", base: "white-qualifying" },
+  "flag-white-race": { group: "flags", base: "white-race" },
+  // Stage 2 of the two-stage white (issue #772) — the player crosses S/F
+  // under the white flag and starts THEIR last lap.
+  "flag-white-last-lap": { group: "flags", base: "white-last-lap" },
+  "flag-checkered-practice": { group: "flags", base: "checkered-practice" },
+  "flag-checkered-qualifying": { group: "flags", base: "checkered-qualifying" },
+  "flag-checkered-race": { group: "flags", base: "checkered-race" },
+  // Missing-session-flag callouts (issue #480): driver-black splits,
+  // race-progression flags, and the caution-waving variants (#657).
+  "flag-disqualify": { group: "flags", base: "disqualify" },
+  "flag-furled": { group: "flags", base: "furled" },
+  "flag-furled-cleared": { group: "flags", base: "furled-cleared" },
+  "flag-dq-scoring-invalid": { group: "flags", base: "dq-scoring-invalid" },
+  "flag-crossed": { group: "flags", base: "crossed" },
+  "flag-one-pace-lap-to-go": { group: "flags", base: "one-pace-lap-to-go" },
+  "flag-green-held": { group: "flags", base: "green-held" },
+  "flag-ten-to-go": { group: "flags", base: "ten-to-go" },
+  "flag-five-to-go": { group: "flags", base: "five-to-go" },
+  "flag-yellow-waving": { group: "flags", base: "yellow-waving" },
+  "flag-caution-waving": { group: "flags", base: "caution-waving" },
+
+  // Start-light family pools (issues #480 / #673): two gantry lines plus
+  // the four numeric countdown marks. Auto-picked by the `start-light-`
+  // prefix (see `start-lights.ts` `START_LIGHT_POOL_NAMES`).
+  "start-light-ready": { group: "start-lights", base: "start-ready" },
+  "start-light-go": { group: "start-lights", base: "start-go" },
+  "start-light-countdown-90": { group: "start-lights", base: "countdown-90" },
+  "start-light-countdown-60": { group: "start-lights", base: "countdown-60" },
+  "start-light-countdown-30": { group: "start-lights", base: "countdown-30" },
+  "start-light-countdown-10": { group: "start-lights", base: "countdown-10" },
+
+  // Rolling-start family pool (issue #660): the "pace car is moving" call
+  // at the start of a rolling-start formation lap.
+  "rolling-start-pace-car": { group: "rolling-start", base: "pace-car-moving" },
+
+  // Pit-window callout pools (issue #655): pit road opened / closed for the
+  // player.
+  "pit-window-opened": { group: "pit-window", base: "opened" },
+  "pit-window-closed": { group: "pit-window", base: "closed" },
+
+  // Damage callout pool (issue #489).
+  "damage-repair-needed": { group: "damage", base: "repair-needed" },
+
+  // Pit-service status callout pools (issue #479). One pool per non-`None`
+  // PitSvStatus target. Closing transitions (`* → None`) are suppressed by
+  // the sim translator, so there's no `pit-status-none` pool.
+  "pit-status-in-progress": { group: "pit-status", base: "in-progress" },
+  "pit-status-complete": { group: "pit-status", base: "complete" },
+  "pit-status-too-far-left": { group: "pit-status", base: "too-far-left" },
+  "pit-status-too-far-right": { group: "pit-status", base: "too-far-right" },
+  "pit-status-too-far-forward": { group: "pit-status", base: "too-far-forward" },
+  "pit-status-too-far-back": { group: "pit-status", base: "too-far-back" },
+  "pit-status-bad-angle": { group: "pit-status", base: "bad-angle" },
+  "pit-status-cant-fix-that": { group: "pit-status", base: "cant-fix-that" },
+
+  // Incident callout pools (issue #530). One pool per IncidentType
+  // discriminator. Collision lines mention the deterministic penalty point
+  // count inline (CollisionWithWorld is always 2x, CollisionWithCar is
+  // always 4x per iRacing's `irsdk_IncidentFlags` enum), so no separate
+  // penalty follow-on pool is needed.
+  "incident-off-track": { group: "incidents", base: "off-track" },
+  "incident-out-of-control": { group: "incidents", base: "out-of-control" },
+  "incident-contact-world": { group: "incidents", base: "contact-world" },
+  "incident-collision-world": { group: "incidents", base: "collision-world" },
+  "incident-contact-car": { group: "incidents", base: "contact-car" },
+  "incident-collision-car": { group: "incidents", base: "collision-car" },
+
+  // Track-conditions callout pools (issue #526). One pool per
+  // (direction, target-state) combination — six worsening + six drying.
+  "track-conditions-worsening-mostly-dry": { group: "track-conditions", base: "worsening-mostly-dry" },
+  "track-conditions-worsening-very-lightly-wet": { group: "track-conditions", base: "worsening-very-lightly-wet" },
+  "track-conditions-worsening-lightly-wet": { group: "track-conditions", base: "worsening-lightly-wet" },
+  "track-conditions-worsening-moderately-wet": { group: "track-conditions", base: "worsening-moderately-wet" },
+  "track-conditions-worsening-very-wet": { group: "track-conditions", base: "worsening-very-wet" },
+  "track-conditions-worsening-extremely-wet": { group: "track-conditions", base: "worsening-extremely-wet" },
+  "track-conditions-drying-dry": { group: "track-conditions", base: "drying-dry" },
+  "track-conditions-drying-mostly-dry": { group: "track-conditions", base: "drying-mostly-dry" },
+  "track-conditions-drying-very-lightly-wet": { group: "track-conditions", base: "drying-very-lightly-wet" },
+  "track-conditions-drying-lightly-wet": { group: "track-conditions", base: "drying-lightly-wet" },
+  "track-conditions-drying-moderately-wet": { group: "track-conditions", base: "drying-moderately-wet" },
+  "track-conditions-drying-very-wet": { group: "track-conditions", base: "drying-very-wet" },
+
+  // Qualifying lap-invalidation pools (issue #567). The core "invalidated"
+  // line always fires; the tail picks one of these branches based on the
+  // snapshot's `lapsRemaining`:
+  //   0      → qualifying-out-of-laps
+  //   1..5   → qualifying-N-laps-left  (each clip carries its own unique
+  //            motivational line, so the scenario is just a pool lookup)
+  //   6+     → qualifying-plenty-of-laps
+  // Time-limited qualifying is gated upstream (no `lapLimited` snapshot field
+  // → tail skipped, core line only).
+  "qualifying-invalidated": { group: "qualifying-invalidation", base: "invalidated" },
+  "qualifying-out-of-laps": { group: "qualifying-invalidation", base: "out-of-laps" },
+  "qualifying-plenty-of-laps": { group: "qualifying-invalidation", base: "plenty-of-laps" },
+  "qualifying-1-lap-left": { group: "qualifying-invalidation", base: "1-lap-left" },
+  "qualifying-2-laps-left": { group: "qualifying-invalidation", base: "2-laps-left" },
+  "qualifying-3-laps-left": { group: "qualifying-invalidation", base: "3-laps-left" },
+  "qualifying-4-laps-left": { group: "qualifying-invalidation", base: "4-laps-left" },
+  "qualifying-5-laps-left": { group: "qualifying-invalidation", base: "5-laps-left" },
+
+  // Pit-box count-in pools (issue #600). One pool per distance mark. Terse
+  // delivery — no radio frame around the countdown (see `pit-box.ts`).
+  "pit-box-five": { group: "pit-box", base: "five" },
+  "pit-box-four": { group: "pit-box", base: "four" },
+  "pit-box-three": { group: "pit-box", base: "three" },
+  "pit-box-two": { group: "pit-box", base: "two" },
+  "pit-box-one": { group: "pit-box", base: "one" },
+  "pit-box-pit-now": { group: "pit-box", base: "pit-now" },
+};
+
+/**
+ * The two acknowledgment pools still enumerate explicit clip paths: their
+ * curated clips don't follow the `<base>-NN` convention yet (`okay.mp3`,
+ * `got-it.mp3`, …), so they can't be derived from the manifest. They move
+ * into `POOL_REGISTRY` with the acknowledgment rename migration (#837).
+ */
+export const ENUMERATED_POOLS: Readonly<Record<string, readonly string[]>> = {
   // Acknowledgments that open toggle callouts ("copy that", "got it", ...).
   // Voice-scoped via `{voice}` substitution — resolved at playback time from
   // the active Race Engineer voice setting.
@@ -37,230 +190,22 @@ export const POOLS: Readonly<Record<string, readonly string[]>> = {
     "voice/{voice}/pit-actions/roger-that.mp3",
     "voice/{voice}/pit-actions/copy-that.mp3",
   ],
-
-  // Pit-action callouts. One pool per action — single-clip today, named
-  // `-NN` so future variants append cleanly (mirrors the flag pools).
-  "pit-action-fuel-on": ["voice/{voice}/pit-actions/fuel-on-01.mp3"],
-  "pit-action-fuel-off": ["voice/{voice}/pit-actions/fuel-off-01.mp3"],
-  "pit-action-tires-off": ["voice/{voice}/pit-actions/tires-off-01.mp3"],
-
-  // Flag callout pools. Every flag scenario draws from a pool — even the
-  // single-clip flags — so adding a variant later becomes a one-line
-  // append here instead of restructuring the scenario. Multi-element
-  // pools pick at random (no immediate repeat, shared per-pool);
-  // single-element pools are deterministic. All voice-scoped via `{voice}`.
-  "flag-yellow-local": ["voice/{voice}/flags/yellow-local-01.mp3"],
-  "flag-yellow-full": ["voice/{voice}/flags/yellow-full-01.mp3"],
-  "flag-yellow-cleared": ["voice/{voice}/flags/yellow-cleared-01.mp3"],
-  "flag-blue": [
-    "voice/{voice}/flags/blue-01.mp3",
-    "voice/{voice}/flags/blue-02.mp3",
-  ],
-  "flag-red": ["voice/{voice}/flags/red-01.mp3"],
-  "flag-black": ["voice/{voice}/flags/black-01.mp3"],
-  "flag-debris": [
-    "voice/{voice}/flags/debris-01.mp3",
-    "voice/{voice}/flags/debris-02.mp3",
-    "voice/{voice}/flags/debris-03.mp3",
-  ],
-  "flag-meatball": ["voice/{voice}/flags/meatball-01.mp3"],
-  // Green, white and checkered all branch on getSessionType() at fire time
-  // so each session type gets its own pool. Future variants for any single
-  // session type append to that pool only.
-  "flag-green-practice": ["voice/{voice}/flags/green-practice-01.mp3"],
-  "flag-green-qualifying": ["voice/{voice}/flags/green-qualifying-01.mp3"],
-  "flag-green-race": [
-    "voice/{voice}/flags/green-race-01.mp3",
-    "voice/{voice}/flags/green-race-02.mp3",
-  ],
-  "flag-white-practice": ["voice/{voice}/flags/white-practice-01.mp3"],
-  "flag-white-qualifying": ["voice/{voice}/flags/white-qualifying-01.mp3"],
-  "flag-white-race": [
-    "voice/{voice}/flags/white-race-01.mp3",
-    "voice/{voice}/flags/white-race-02.mp3",
-  ],
-  // Stage 2 of the two-stage white (issue #772) — the player crosses S/F
-  // under the white flag and starts THEIR last lap.
-  "flag-white-last-lap": [
-    "voice/{voice}/flags/white-last-lap-01.mp3",
-    "voice/{voice}/flags/white-last-lap-02.mp3",
-  ],
-  "flag-checkered-practice": ["voice/{voice}/flags/checkered-practice-01.mp3"],
-  "flag-checkered-qualifying": ["voice/{voice}/flags/checkered-qualifying-01.mp3"],
-  "flag-checkered-race": ["voice/{voice}/flags/checkered-race-01.mp3"],
-
-  // Missing-session-flag callout pools (issue #480). Driver-black splits
-  // (disqualify / furled / dq-scoring-invalid), race-progression flags
-  // (crossed / one-pace-lap-to-go / green-held / ten-to-go / five-to-go), and
-  // the caution-waving variants (yellow-waving / caution-waving). Mostly
-  // single-clip; `one-pace-lap-to-go` and `green-held` have five variants each
-  // (#657). Auto-picked by `FLAG_POOL_NAMES` (the `flag-` prefix).
-  "flag-disqualify": ["voice/{voice}/flags/disqualify-01.mp3"],
-  "flag-furled": ["voice/{voice}/flags/furled-01.mp3"],
-  "flag-furled-cleared": ["voice/{voice}/flags/furled-cleared-01.mp3"],
-  "flag-dq-scoring-invalid": ["voice/{voice}/flags/dq-scoring-invalid-01.mp3"],
-  "flag-crossed": ["voice/{voice}/flags/crossed-01.mp3"],
-  "flag-one-pace-lap-to-go": [
-    "voice/{voice}/flags/one-pace-lap-to-go-01.mp3",
-    "voice/{voice}/flags/one-pace-lap-to-go-02.mp3",
-    "voice/{voice}/flags/one-pace-lap-to-go-03.mp3",
-    "voice/{voice}/flags/one-pace-lap-to-go-04.mp3",
-    "voice/{voice}/flags/one-pace-lap-to-go-05.mp3",
-  ],
-  "flag-green-held": [
-    "voice/{voice}/flags/green-held-01.mp3",
-    "voice/{voice}/flags/green-held-02.mp3",
-    "voice/{voice}/flags/green-held-03.mp3",
-    "voice/{voice}/flags/green-held-04.mp3",
-    "voice/{voice}/flags/green-held-05.mp3",
-  ],
-  "flag-ten-to-go": ["voice/{voice}/flags/ten-to-go-01.mp3"],
-  "flag-five-to-go": ["voice/{voice}/flags/five-to-go-01.mp3"],
-  "flag-yellow-waving": ["voice/{voice}/flags/yellow-waving-01.mp3"],
-  "flag-caution-waving": ["voice/{voice}/flags/caution-waving-01.mp3"],
-
-  // Start-light family pools (issues #480 / #673). Two gantry lines (ready /
-  // go — the heads-up line moved from StartSet to StartReady in #673) plus the
-  // four numeric countdown marks (90 added in #673; 15/5 dropped in #666).
-  // Auto-picked for the start-light catalog by the `start-light-` prefix (see
-  // `start-lights.ts` `START_LIGHT_POOL_NAMES`). Single-clip today; voice-scoped
-  // via `{voice}`.
-  "start-light-ready": ["voice/{voice}/start-lights/start-ready-01.mp3"],
-  "start-light-go": ["voice/{voice}/start-lights/start-go-01.mp3"],
-  "start-light-countdown-90": ["voice/{voice}/start-lights/countdown-90-01.mp3"],
-  "start-light-countdown-60": ["voice/{voice}/start-lights/countdown-60-01.mp3"],
-  "start-light-countdown-30": ["voice/{voice}/start-lights/countdown-30-01.mp3"],
-  "start-light-countdown-10": ["voice/{voice}/start-lights/countdown-10-01.mp3"],
-
-  // Rolling-start family pool (issue #660). Five random-pick variants for the
-  // "pace car is moving" call at the start of a rolling-start formation lap.
-  "rolling-start-pace-car": [
-    "voice/{voice}/rolling-start/pace-car-moving-01.mp3",
-    "voice/{voice}/rolling-start/pace-car-moving-02.mp3",
-    "voice/{voice}/rolling-start/pace-car-moving-03.mp3",
-    "voice/{voice}/rolling-start/pace-car-moving-04.mp3",
-    "voice/{voice}/rolling-start/pace-car-moving-05.mp3",
-  ],
-
-  // Pit-window callout pools (issue #655). Pit road opened / closed for the
-  // player. Two multi-element pools (five variants each) so the engineer doesn't
-  // repeat himself across a caution's open→closed→open flurry; random pick with
-  // the shared no-immediate-repeat guard. Voice-scoped via `{voice}`.
-  "pit-window-opened": [
-    "voice/{voice}/pit-window/opened-01.mp3",
-    "voice/{voice}/pit-window/opened-02.mp3",
-    "voice/{voice}/pit-window/opened-03.mp3",
-    "voice/{voice}/pit-window/opened-04.mp3",
-    "voice/{voice}/pit-window/opened-05.mp3",
-  ],
-  "pit-window-closed": [
-    "voice/{voice}/pit-window/closed-01.mp3",
-    "voice/{voice}/pit-window/closed-02.mp3",
-    "voice/{voice}/pit-window/closed-03.mp3",
-    "voice/{voice}/pit-window/closed-04.mp3",
-    "voice/{voice}/pit-window/closed-05.mp3",
-  ],
-
-  // Damage callout pool (issue #489). Single pool today; multi-clip random
-  // selection works the same way as the flag pools above.
-  "damage-repair-needed": [
-    "voice/{voice}/damage/repair-needed-01.mp3",
-    "voice/{voice}/damage/repair-needed-02.mp3",
-    "voice/{voice}/damage/repair-needed-03.mp3",
-  ],
-
-  // Pit-service status callout pools (issue #479). One pool per non-`None`
-  // PitSvStatus target. Single-clip today; future variants append cleanly
-  // here without scenario changes. Closing transitions (`* → None`) are
-  // suppressed by the sim translator, so there's no `pit-status-none` pool.
-  "pit-status-in-progress": ["voice/{voice}/pit-status/in-progress-01.mp3"],
-  "pit-status-complete": ["voice/{voice}/pit-status/complete-01.mp3"],
-  "pit-status-too-far-left": ["voice/{voice}/pit-status/too-far-left-01.mp3"],
-  "pit-status-too-far-right": ["voice/{voice}/pit-status/too-far-right-01.mp3"],
-  "pit-status-too-far-forward": ["voice/{voice}/pit-status/too-far-forward-01.mp3"],
-  "pit-status-too-far-back": ["voice/{voice}/pit-status/too-far-back-01.mp3"],
-  "pit-status-bad-angle": ["voice/{voice}/pit-status/bad-angle-01.mp3"],
-  "pit-status-cant-fix-that": ["voice/{voice}/pit-status/cant-fix-that-01.mp3"],
-
-  // Incident callout pools (issue #530). One pool per IncidentType
-  // discriminator. Three alternating lines per pool — the first two are
-  // calm coaching (off-track / out-of-control / contact = no penalty),
-  // the third adds variety. Collision lines mention the deterministic
-  // penalty point count inline (CollisionWithWorld is always 2x,
-  // CollisionWithCar is always 4x per iRacing's `irsdk_IncidentFlags`
-  // enum), so no separate penalty follow-on pool is needed.
-  "incident-off-track": [
-    "voice/{voice}/incidents/off-track-01.mp3",
-    "voice/{voice}/incidents/off-track-02.mp3",
-    "voice/{voice}/incidents/off-track-03.mp3",
-  ],
-  "incident-out-of-control": [
-    "voice/{voice}/incidents/out-of-control-01.mp3",
-    "voice/{voice}/incidents/out-of-control-02.mp3",
-    "voice/{voice}/incidents/out-of-control-03.mp3",
-  ],
-  "incident-contact-world": [
-    "voice/{voice}/incidents/contact-world-01.mp3",
-    "voice/{voice}/incidents/contact-world-02.mp3",
-    "voice/{voice}/incidents/contact-world-03.mp3",
-  ],
-  "incident-collision-world": [
-    "voice/{voice}/incidents/collision-world-01.mp3",
-    "voice/{voice}/incidents/collision-world-02.mp3",
-    "voice/{voice}/incidents/collision-world-03.mp3",
-  ],
-  "incident-contact-car": [
-    "voice/{voice}/incidents/contact-car-01.mp3",
-    "voice/{voice}/incidents/contact-car-02.mp3",
-    "voice/{voice}/incidents/contact-car-03.mp3",
-  ],
-  "incident-collision-car": [
-    "voice/{voice}/incidents/collision-car-01.mp3",
-    "voice/{voice}/incidents/collision-car-02.mp3",
-    "voice/{voice}/incidents/collision-car-03.mp3",
-  ],
-
-  // Track-conditions callout pools (issue #526). One pool per
-  // (direction, target-state) combination — six worsening + six drying.
-  // Single-clip today; future variants append cleanly here.
-  "track-conditions-worsening-mostly-dry": ["voice/{voice}/track-conditions/worsening-mostly-dry-01.mp3"],
-  "track-conditions-worsening-very-lightly-wet": ["voice/{voice}/track-conditions/worsening-very-lightly-wet-01.mp3"],
-  "track-conditions-worsening-lightly-wet": ["voice/{voice}/track-conditions/worsening-lightly-wet-01.mp3"],
-  "track-conditions-worsening-moderately-wet": ["voice/{voice}/track-conditions/worsening-moderately-wet-01.mp3"],
-  "track-conditions-worsening-very-wet": ["voice/{voice}/track-conditions/worsening-very-wet-01.mp3"],
-  "track-conditions-worsening-extremely-wet": ["voice/{voice}/track-conditions/worsening-extremely-wet-01.mp3"],
-  "track-conditions-drying-dry": ["voice/{voice}/track-conditions/drying-dry-01.mp3"],
-  "track-conditions-drying-mostly-dry": ["voice/{voice}/track-conditions/drying-mostly-dry-01.mp3"],
-  "track-conditions-drying-very-lightly-wet": ["voice/{voice}/track-conditions/drying-very-lightly-wet-01.mp3"],
-  "track-conditions-drying-lightly-wet": ["voice/{voice}/track-conditions/drying-lightly-wet-01.mp3"],
-  "track-conditions-drying-moderately-wet": ["voice/{voice}/track-conditions/drying-moderately-wet-01.mp3"],
-  "track-conditions-drying-very-wet": ["voice/{voice}/track-conditions/drying-very-wet-01.mp3"],
-
-  // Qualifying lap-invalidation pools (issue #567). The core "invalidated"
-  // line always fires; the tail picks one of these branches based on the
-  // snapshot's `lapsRemaining`:
-  //   0      → qualifying-out-of-laps
-  //   1..5   → qualifying-N-laps-left  (each clip carries its own unique
-  //            motivational line, so the scenario is just a pool lookup)
-  //   6+     → qualifying-plenty-of-laps
-  // Time-limited qualifying is gated upstream (no `lapLimited` snapshot field
-  // → tail skipped, core line only).
-  "qualifying-invalidated": ["voice/{voice}/qualifying-invalidation/invalidated-01.mp3"],
-  "qualifying-out-of-laps": ["voice/{voice}/qualifying-invalidation/out-of-laps-01.mp3"],
-  "qualifying-plenty-of-laps": ["voice/{voice}/qualifying-invalidation/plenty-of-laps-01.mp3"],
-  "qualifying-1-lap-left": ["voice/{voice}/qualifying-invalidation/1-lap-left-01.mp3"],
-  "qualifying-2-laps-left": ["voice/{voice}/qualifying-invalidation/2-laps-left-01.mp3"],
-  "qualifying-3-laps-left": ["voice/{voice}/qualifying-invalidation/3-laps-left-01.mp3"],
-  "qualifying-4-laps-left": ["voice/{voice}/qualifying-invalidation/4-laps-left-01.mp3"],
-  "qualifying-5-laps-left": ["voice/{voice}/qualifying-invalidation/5-laps-left-01.mp3"],
-
-  // Pit-box count-in pools (issue #600). One pool per distance mark; single-clip
-  // today, named `-NN` so future variants append cleanly. Terse delivery — no
-  // radio frame around the countdown (see `pit-box.ts`).
-  "pit-box-five": ["voice/{voice}/pit-box/five-01.mp3"],
-  "pit-box-four": ["voice/{voice}/pit-box/four-01.mp3"],
-  "pit-box-three": ["voice/{voice}/pit-box/three-01.mp3"],
-  "pit-box-two": ["voice/{voice}/pit-box/two-01.mp3"],
-  "pit-box-one": ["voice/{voice}/pit-box/one-01.mp3"],
-  "pit-box-pit-now": ["voice/{voice}/pit-box/pit-now-01.mp3"],
 };
+
+/**
+ * Register every catalog pool with the engine: registry pools derive their
+ * members from the manifest per voice; the enumerated remainder registers
+ * as explicit clip lists (until #837).
+ */
+export function registerPools(engine: {
+  definePool(name: string, clips: string[]): void;
+  definePoolFromManifest(name: string, group: string, base: string): void;
+}): void {
+  for (const [name, { group, base }] of Object.entries(POOL_REGISTRY)) {
+    engine.definePoolFromManifest(name, group, base);
+  }
+
+  for (const [name, clips] of Object.entries(ENUMERATED_POOLS)) {
+    engine.definePool(name, [...clips]);
+  }
+}

--- a/packages/audio-scenarios/src/catalog/pit-crew/rolling-start.test.ts
+++ b/packages/audio-scenarios/src/catalog/pit-crew/rolling-start.test.ts
@@ -19,7 +19,7 @@ import { WEIGHT } from "../../dsl.js";
 import type { AudioAssetsManifest, IScenarioEngine } from "../../interpreter.js";
 import { _resetAudioScenarios, initializeAudioScenarios } from "../../interpreter.js";
 import { registerPitCrew, type RollingStartCalloutId } from "./index.js";
-import { POOLS } from "./pools.js";
+import { POOL_REGISTRY } from "./pools.js";
 import { _resetRadarEngine } from "./radar-engine.js";
 import { RADIO_CLOSE, RADIO_OPEN } from "./radio-frame.js";
 import { ROLLING_START_ALERTS, ROLLING_START_POOL_NAMES, ROLLING_START_SCENARIO_IDS } from "./rolling-start.js";
@@ -177,7 +177,10 @@ beforeEach(() => {
   audio = createFakeAudio();
   engine = initializeAudioScenarios(bus, audio, manifest, mockLogger as never, () => activeVoice);
 
-  for (const name of ROLLING_START_POOL_NAMES) engine.definePool(name, [...POOLS[name]]);
+  for (const name of ROLLING_START_POOL_NAMES) {
+    const { group, base } = POOL_REGISTRY[name];
+    engine.definePoolFromManifest(name, group, base);
+  }
 
   engine.defineScenario(RADIO_OPEN);
   engine.defineScenario(RADIO_CLOSE);

--- a/packages/audio-scenarios/src/catalog/pit-crew/rolling-start.ts
+++ b/packages/audio-scenarios/src/catalog/pit-crew/rolling-start.ts
@@ -28,7 +28,7 @@ import { getSessionType } from "@iracedeck/sim-events-iracing";
 
 import type { Scenario } from "../../dsl.js";
 import { WEIGHT } from "../../dsl.js";
-import { POOLS } from "./pools.js";
+import { POOL_REGISTRY } from "./pools.js";
 import { isRaceSession } from "./race-start.js";
 
 // Rolling-start callouts are a race-only concept spoken to a driver in the car.
@@ -61,6 +61,6 @@ export const ROLLING_START_SCENARIO_IDS: readonly string[] = ROLLING_START_ALERT
  * prefix, so adding or renaming a pool there automatically flows through
  * `registerPitCrew()` without a parallel list to keep in sync.
  */
-export const ROLLING_START_POOL_NAMES: readonly string[] = Object.keys(POOLS).filter((name) =>
+export const ROLLING_START_POOL_NAMES: readonly string[] = Object.keys(POOL_REGISTRY).filter((name) =>
   name.startsWith("rolling-start-"),
 );

--- a/packages/audio-scenarios/src/catalog/pit-crew/start-lights.test.ts
+++ b/packages/audio-scenarios/src/catalog/pit-crew/start-lights.test.ts
@@ -20,7 +20,7 @@ import { WEIGHT } from "../../dsl.js";
 import type { AudioAssetsManifest, IScenarioEngine } from "../../interpreter.js";
 import { _resetAudioScenarios, initializeAudioScenarios } from "../../interpreter.js";
 import { registerPitCrew, type StartLightCalloutId } from "./index.js";
-import { POOLS } from "./pools.js";
+import { POOL_REGISTRY } from "./pools.js";
 import { _resetRadarEngine } from "./radar-engine.js";
 import { RADIO_CLOSE, RADIO_OPEN } from "./radio-frame.js";
 import { _resetSpotterEngine } from "./spotter-engine.js";
@@ -181,7 +181,10 @@ beforeEach(() => {
   audio = createFakeAudio();
   engine = initializeAudioScenarios(bus, audio, manifest, mockLogger as never, () => activeVoice);
 
-  for (const name of START_LIGHT_POOL_NAMES) engine.definePool(name, [...POOLS[name]]);
+  for (const name of START_LIGHT_POOL_NAMES) {
+    const { group, base } = POOL_REGISTRY[name];
+    engine.definePoolFromManifest(name, group, base);
+  }
 
   engine.defineScenario(RADIO_OPEN);
   engine.defineScenario(RADIO_CLOSE);

--- a/packages/audio-scenarios/src/catalog/pit-crew/start-lights.ts
+++ b/packages/audio-scenarios/src/catalog/pit-crew/start-lights.ts
@@ -40,7 +40,7 @@ import { getSessionType } from "@iracedeck/sim-events-iracing";
 
 import type { Scenario, Step } from "../../dsl.js";
 import { WEIGHT } from "../../dsl.js";
-import { POOLS } from "./pools.js";
+import { POOL_REGISTRY } from "./pools.js";
 import { isRaceSession } from "./race-start.js";
 
 function startLightSequence(steps: Step[]): Step[] {
@@ -131,6 +131,6 @@ export const START_LIGHT_SCENARIO_IDS: readonly string[] = START_LIGHT_ALERTS.ma
  * prefix, so adding or renaming a pool there automatically flows through
  * `registerPitCrew()` without a parallel list to keep in sync.
  */
-export const START_LIGHT_POOL_NAMES: readonly string[] = Object.keys(POOLS).filter((name) =>
+export const START_LIGHT_POOL_NAMES: readonly string[] = Object.keys(POOL_REGISTRY).filter((name) =>
   name.startsWith("start-light-"),
 );

--- a/packages/audio-scenarios/src/catalog/pit-crew/toggle-confirmations.test.ts
+++ b/packages/audio-scenarios/src/catalog/pit-crew/toggle-confirmations.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AudioAssetsManifest, IScenarioEngine } from "../../interpreter.js";
 import { _resetAudioScenarios, initializeAudioScenarios } from "../../interpreter.js";
-import { POOLS } from "./pools.js";
+import { ENUMERATED_POOLS, POOL_REGISTRY } from "./pools.js";
 import { RADIO_CLOSE, RADIO_OPEN } from "./radio-frame.js";
 import {
   FAST_REPAIR_TOGGLE_SCENARIOS,
@@ -178,10 +178,13 @@ beforeEach(() => {
   audio = createFakeAudio();
   engine = initializeAudioScenarios(bus, audio, manifest, mockLogger as never, () => activeVoice);
 
-  engine.definePool("pit-action-acknowledgment", [...POOLS["pit-action-acknowledgment"]]);
-  engine.definePool("pit-action-fuel-on", [...POOLS["pit-action-fuel-on"]]);
-  engine.definePool("pit-action-fuel-off", [...POOLS["pit-action-fuel-off"]]);
-  engine.definePool("pit-action-tires-off", [...POOLS["pit-action-tires-off"]]);
+  engine.definePool("pit-action-acknowledgment", [...ENUMERATED_POOLS["pit-action-acknowledgment"]]);
+
+  for (const name of ["pit-action-fuel-on", "pit-action-fuel-off", "pit-action-tires-off"]) {
+    const { group, base } = POOL_REGISTRY[name];
+    engine.definePoolFromManifest(name, group, base);
+  }
+
   engine.defineScenario(RADIO_OPEN);
   engine.defineScenario(RADIO_CLOSE);
 

--- a/packages/audio-scenarios/src/interpreter.test.ts
+++ b/packages/audio-scenarios/src/interpreter.test.ts
@@ -240,6 +240,193 @@ describe("pools", () => {
   });
 });
 
+// ─── Manifest-derived pools (issue #664) ────────────────────────────────────
+
+describe("manifest-derived pools (definePoolFromManifest)", () => {
+  /**
+   * Voiced manifest: `default` is the reference voice with two `blue`
+   * variants (plus a near-miss `blue-cleared` base that must not leak into
+   * the `blue` pool); `luca` carries an extra third variant; `titan` omits
+   * the blue callout entirely.
+   */
+  const voicedManifest: AudioAssetsManifest = {
+    clips: [
+      "sfx/IRD-tick-open.mp3",
+      "sfx/IRD-tick-close.mp3",
+      "sfx/IRD-ambient-pit.mp3",
+      "voice/default/flags/blue-01.mp3",
+      "voice/default/flags/blue-02.mp3",
+      "voice/default/flags/blue-cleared-01.mp3",
+      "voice/luca/flags/blue-01.mp3",
+      "voice/luca/flags/blue-02.mp3",
+      "voice/luca/flags/blue-03.mp3",
+      "voice/titan/flags/red-01.mp3",
+    ],
+    ambientLoop: "sfx/IRD-ambient-pit.mp3",
+    ticks: { open: "sfx/IRD-tick-open.mp3", close: "sfx/IRD-tick-close.mp3" },
+  };
+
+  let activeVoice: string | null;
+
+  beforeEach(() => {
+    _resetAudioScenarios();
+    activeVoice = "default";
+    bus = createMockBus();
+    audio = createFakeAudio();
+    engine = initializeAudioScenarios(bus, audio, voicedManifest, mockLogger as never, () => activeVoice);
+  });
+
+  function defineBluePoolScenario(): void {
+    engine.definePoolFromManifest("flag-blue", "flags", "blue");
+    engine.defineScenario({
+      id: "test.blue",
+      channel: AudioChannel.Voice,
+      bus: AudioBus.Voice,
+      sequence: ["pool:flag-blue"],
+    });
+  }
+
+  function voicePaths(): string[] {
+    return audio._played.filter((p) => p.channel === AudioChannel.Voice).map((p) => p.path);
+  }
+
+  it("resolves pool members from the manifest for the active voice at fire time", () => {
+    const stub = vi.spyOn(Math, "random").mockReturnValue(0);
+    defineBluePoolScenario();
+
+    engine.fire("test.blue");
+    flushVoiceAndSfx(audio);
+
+    activeVoice = "luca";
+    engine.fire("test.blue");
+    flushVoiceAndSfx(audio);
+
+    expect(voicePaths()[0]).toBe("voice/default/flags/blue-01.mp3");
+    expect(voicePaths()[1]).toMatch(/^voice\/luca\/flags\/blue-0\d\.mp3$/);
+
+    stub.mockRestore();
+  });
+
+  it("draws only from the active voice's own variants (counts may differ per voice)", () => {
+    const stub = vi.spyOn(Math, "random").mockReturnValue(0.99);
+    defineBluePoolScenario();
+
+    activeVoice = "luca";
+    engine.fire("test.blue");
+    flushVoiceAndSfx(audio);
+
+    activeVoice = "default";
+    engine.fire("test.blue");
+    flushVoiceAndSfx(audio);
+
+    // luca has three variants (0.99 → index 2); default has two (0.99 → index 1).
+    expect(voicePaths()).toEqual(["voice/luca/flags/blue-03.mp3", "voice/default/flags/blue-02.mp3"]);
+
+    stub.mockRestore();
+  });
+
+  it("matches only exact <base>-NN members, not longer bases sharing the prefix", () => {
+    // If the scan treated `base` as a prefix, sorted members would be
+    // [blue-01, blue-02, blue-cleared-01] and 0.9 would pick blue-cleared-01.
+    const stub = vi.spyOn(Math, "random").mockReturnValue(0.9);
+    defineBluePoolScenario();
+
+    engine.fire("test.blue");
+    flushVoiceAndSfx(audio);
+
+    expect(voicePaths()).toEqual(["voice/default/flags/blue-02.mp3"]);
+
+    stub.mockRestore();
+  });
+
+  it("resets the no-repeat tracker when the active voice changes", () => {
+    const stub = vi.spyOn(Math, "random").mockReturnValue(0);
+    defineBluePoolScenario();
+
+    engine.fire("test.blue");
+    flushVoiceAndSfx(audio);
+
+    // Without the reset, the stale lastIndex (0) would bump the luca pick to
+    // blue-02; with it, index 0 is a fresh pick.
+    activeVoice = "luca";
+    engine.fire("test.blue");
+    flushVoiceAndSfx(audio);
+
+    expect(voicePaths()).toEqual(["voice/default/flags/blue-01.mp3", "voice/luca/flags/blue-01.mp3"]);
+
+    stub.mockRestore();
+  });
+
+  it("skips the pool step when the active voice has no clips for it (debug, not error)", () => {
+    engine.definePoolFromManifest("flag-blue", "flags", "blue");
+    engine.defineScenario({
+      id: "test.blue-then-tick",
+      channel: AudioChannel.Voice,
+      bus: AudioBus.Voice,
+      sequence: ["pool:flag-blue", "sfx/IRD-tick-close.mp3"],
+    });
+
+    activeVoice = "titan";
+    engine.fire("test.blue-then-tick");
+    flushVoiceAndSfx(audio);
+
+    expect(voicePaths()).toEqual([]);
+    expect(audio._played.map((p) => p.path)).toEqual(["sfx/IRD-tick-close.mp3"]);
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it("skips the pool step when no voice is selected", () => {
+    defineBluePoolScenario();
+
+    activeVoice = null;
+    engine.fire("test.blue");
+    flushVoiceAndSfx(audio);
+
+    expect(voicePaths()).toEqual([]);
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it("warns at define time when the reference voice has no clips for the base (typo guard), without disabling", () => {
+    engine.definePoolFromManifest("flag-purple", "flags", "purple");
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("flag-purple"));
+
+    // The pool is still registered — a scenario referencing it validates clean.
+    engine.defineScenario({
+      id: "test.purple",
+      channel: AudioChannel.Voice,
+      bus: AudioBus.Voice,
+      sequence: ["pool:flag-purple"],
+    });
+
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it("registers a {voice}-templated static pool when the reference voice has the clip, even if another voice lacks it", () => {
+    engine.definePool("static-blue", ["voice/{voice}/flags/blue-01.mp3"]);
+
+    expect(mockLogger.error).not.toHaveBeenCalled();
+
+    engine.defineScenario({
+      id: "test.static-blue",
+      channel: AudioChannel.Voice,
+      bus: AudioBus.Voice,
+      sequence: ["pool:static-blue"],
+    });
+    engine.fire("test.static-blue");
+    flushVoiceAndSfx(audio);
+
+    expect(voicePaths()).toEqual(["voice/default/flags/blue-01.mp3"]);
+  });
+
+  it("warns (not rejects) when a {voice}-templated static-pool clip is missing for the reference voice", () => {
+    engine.definePool("static-purple", ["voice/{voice}/flags/purple-01.mp3"]);
+
+    expect(mockLogger.error).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("static-purple"));
+  });
+});
+
 // ─── Variables ──────────────────────────────────────────────────────────────
 
 describe("variables", () => {

--- a/packages/audio-scenarios/src/interpreter.ts
+++ b/packages/audio-scenarios/src/interpreter.ts
@@ -43,8 +43,8 @@ import { silentLogger } from "@iracedeck/logger";
 import type { ResolvedStep, Scenario, ScenarioContext } from "./dsl.js";
 import { applyBase, DEFAULT_WEIGHT, resolveStep } from "./dsl.js";
 // Manifest types + helpers live in `./manifest.js` to break a circular
-// import with `./validation.js`, which also needs `manifestVoices`.
-import { type AudioAssetsManifest, manifestVoices } from "./manifest.js";
+// import with `./validation.js`, which also needs `referenceVoice`.
+import { type AudioAssetsManifest, referenceVoice } from "./manifest.js";
 import { validateScenario } from "./validation.js";
 
 // Re-export so existing consumers of `interpreter.js` keep their import paths.
@@ -53,6 +53,14 @@ export { type AudioAssetsManifest, manifestVoices } from "./manifest.js";
 export interface IScenarioEngine {
   defineScenario(s: Scenario): void;
   definePool(name: string, clips: string[]): void;
+  /**
+   * Register a pool whose members are derived from the audio-asset manifest
+   * (issue #664): every clip matching `voice/<voice>/<group>/<base>-NN.mp3`,
+   * resolved at fire time for the active voice. Voices may carry different
+   * variant counts or omit the pool entirely — an empty pool skips the step.
+   * No clip list is enumerated in code.
+   */
+  definePoolFromManifest(name: string, group: string, base: string): void;
   defineVar(name: string, resolver: () => string | null): void;
   setEnabled(scenarioId: string, enabled: boolean): void;
   fire(scenarioId: string): void;
@@ -70,7 +78,22 @@ export interface IScenarioEngine {
   releaseFocus(bus: AudioBus, ownerId: string): void;
 }
 
-type PoolState = { clips: string[]; lastIndex: number };
+/**
+ * A pool is either an explicit clip list (`static`) or derived from the
+ * manifest per voice at fire time (`manifest`, issue #664). Both share the
+ * no-immediate-repeat `lastIndex`; manifest pools also track the voice the
+ * index belongs to, since variant counts differ across voices.
+ */
+type PoolState =
+  | { kind: "static"; clips: string[]; lastIndex: number }
+  | {
+      kind: "manifest";
+      group: string;
+      base: string;
+      byVoice: Map<string, string[]>;
+      lastIndex: number;
+      lastVoice: string | null;
+    };
 
 type CompiledScenario = {
   raw: Scenario;
@@ -263,7 +286,18 @@ class ScenarioEngine implements IScenarioEngine {
 
     this.scenarios.set(s.id, entry);
 
-    const errors = validateScenario(s, resolvedSequence, this.scenarios, this.pools, this.vars, this.manifest);
+    const { errors, warnings } = validateScenario(
+      s,
+      resolvedSequence,
+      this.scenarios,
+      this.pools,
+      this.vars,
+      this.manifest,
+    );
+
+    if (warnings.length > 0) {
+      this.logger.warn(`Scenario "${s.id}" has validation warnings:\n  - ${warnings.join("\n  - ")}`);
+    }
 
     if (errors.length > 0) {
       this.logger.error(`Scenario "${s.id}" has validation errors and is disabled:\n  - ${errors.join("\n  - ")}`);
@@ -282,18 +316,21 @@ class ScenarioEngine implements IScenarioEngine {
       this.logger.warn(`Pool "${name}" redefined`);
     }
 
-    // For `{voice}`-templated clips we expand against every voice present in
-    // the manifest and require all variants to exist; this catches typos
-    // (`{voce}`) and missing-voice gaps at definition time, not at fire time.
-    const voices = manifestVoices(this.manifest);
+    // A `{voice}`-templated clip is checked against the REFERENCE voice only
+    // (issue #664): per-voice clip sets may legitimately diverge, so a gap in
+    // another voice is not an error. A miss for the reference voice is a
+    // probable typo and warns without rejecting the pool. Non-templated
+    // clips must exist verbatim.
+    const reference = referenceVoice(this.manifest);
     const missing: string[] = [];
+    const suspect: string[] = [];
 
     for (const clip of clips) {
       if (clip.includes("{voice}")) {
-        for (const voice of voices) {
-          const resolved = clip.replace(/\{voice\}/g, voice);
+        if (reference !== null) {
+          const resolved = clip.replace(/\{voice\}/g, reference);
 
-          if (!this.manifest.clips.includes(resolved)) missing.push(resolved);
+          if (!this.manifest.clips.includes(resolved)) suspect.push(resolved);
         }
       } else if (!this.manifest.clips.includes(clip)) {
         missing.push(clip);
@@ -306,7 +343,52 @@ class ScenarioEngine implements IScenarioEngine {
       return;
     }
 
-    this.pools.set(name, { clips: [...clips], lastIndex: -1 });
+    if (suspect.length > 0) {
+      this.logger.warn(
+        `Pool "${name}": no clip for reference voice "${reference}" (possible typo):\n  - ${suspect.join("\n  - ")}`,
+      );
+    }
+
+    this.pools.set(name, { kind: "static", clips: [...clips], lastIndex: -1 });
+  }
+
+  definePoolFromManifest(name: string, group: string, base: string): void {
+    if (this.pools.has(name)) {
+      this.logger.warn(`Pool "${name}" redefined`);
+    }
+
+    const pattern = new RegExp(`^voice/([^/]+)/${escapeRegExp(group)}/${escapeRegExp(base)}-\\d{2}\\.mp3$`);
+    const byVoice = new Map<string, string[]>();
+
+    for (const clip of this.manifest.clips) {
+      const match = pattern.exec(clip);
+
+      if (!match) continue;
+
+      let members = byVoice.get(match[1]);
+
+      if (!members) {
+        members = [];
+        byVoice.set(match[1], members);
+      }
+
+      members.push(clip);
+    }
+
+    for (const members of byVoice.values()) members.sort();
+
+    // Typo guard: only the reference voice is checked — other voices may
+    // legitimately omit the callout. Warn, never reject: a pool that is
+    // empty for the active voice just skips at fire time.
+    const reference = referenceVoice(this.manifest);
+
+    if (reference !== null && !byVoice.has(reference)) {
+      this.logger.warn(
+        `Pool "${name}": no "${group}/${base}-NN" clips for reference voice "${reference}" (possible typo)`,
+      );
+    }
+
+    this.pools.set(name, { kind: "manifest", group, base, byVoice, lastIndex: -1, lastVoice: null });
   }
 
   defineVar(name: string, resolver: () => string | null): void {
@@ -965,21 +1047,47 @@ class ScenarioEngine implements IScenarioEngine {
       return null;
     }
 
-    if (pool.clips.length === 0) {
-      this.logger.error(`pickFromPool: pool "${name}" is empty — step skipped, clip will not play`);
+    let clips: string[];
+
+    if (pool.kind === "manifest") {
+      const voice = this.getActiveVoice();
+
+      if (!voice) {
+        this.logger.debug(`pickFromPool: pool "${name}" skipped — no active voice selected`);
+
+        return null;
+      }
+
+      // Variant counts differ across voices, so a stale lastIndex from
+      // another voice would skew the no-repeat guard — reset it on voice
+      // change (issue #664).
+      if (voice !== pool.lastVoice) {
+        pool.lastVoice = voice;
+        pool.lastIndex = -1;
+      }
+
+      clips = pool.byVoice.get(voice) ?? [];
+    } else {
+      clips = pool.clips;
+    }
+
+    if (clips.length === 0) {
+      // Not an error: a voice may legitimately omit a callout (issue #664) —
+      // the step skips silently.
+      this.logger.debug(`pickFromPool: pool "${name}" is empty for the active voice — step skipped`);
 
       return null;
     }
 
-    let idx = Math.floor(Math.random() * pool.clips.length);
+    let idx = Math.floor(Math.random() * clips.length);
 
-    if (noRepeat && pool.clips.length > 1 && idx === pool.lastIndex) {
-      idx = (idx + 1) % pool.clips.length;
+    if (noRepeat && clips.length > 1 && idx === pool.lastIndex) {
+      idx = (idx + 1) % clips.length;
     }
 
     pool.lastIndex = idx;
 
-    return pool.clips[idx];
+    return clips[idx];
   }
 }
 
@@ -997,6 +1105,11 @@ function buildResumeState(active: ActiveFire): ResumeState | undefined {
   if (sourceIndex >= active.sourceOps.length) return undefined;
 
   return { ops: active.sourceOps, index: sourceIndex };
+}
+
+/** Escape a literal string for embedding in a RegExp source. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /** Element-wise equality of two expanded op lists (plain data, no functions). */

--- a/packages/audio-scenarios/src/interpreter.ts
+++ b/packages/audio-scenarios/src/interpreter.ts
@@ -59,6 +59,14 @@ export interface IScenarioEngine {
    * resolved at fire time for the active voice. Voices may carry different
    * variant counts or omit the pool entirely — an empty pool skips the step.
    * No clip list is enumerated in code.
+   *
+   * `(group, base)` is the pool's STABLE IDENTIFIER: renaming a base — in
+   * the registry or on disk — silently changes (or empties) what the pool
+   * resolves to, so treat it as a breaking change for the pool. The
+   * reference-voice typo guard warns at registration; it deliberately never
+   * rejects, because an empty pool is indistinguishable from a legitimate
+   * per-voice omission (and tests register the full catalog against minimal
+   * manifests).
    */
   definePoolFromManifest(name: string, group: string, base: string): void;
   defineVar(name: string, resolver: () => string | null): void;

--- a/packages/audio-scenarios/src/manifest.test.ts
+++ b/packages/audio-scenarios/src/manifest.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { type AudioAssetsManifest, manifestVoices, scanDriverNames, scanRaceEngineerVoices } from "./manifest.js";
+import {
+  type AudioAssetsManifest,
+  manifestVoices,
+  referenceVoice,
+  scanDriverNames,
+  scanRaceEngineerVoices,
+} from "./manifest.js";
 
 const manifest: AudioAssetsManifest = {
   clips: [
@@ -34,6 +40,24 @@ describe("scanRaceEngineerVoices", () => {
 
   it("returns an empty array when no voice clips are present", () => {
     expect(scanRaceEngineerVoices({ ...manifest, clips: [] })).toEqual([]);
+  });
+});
+
+describe("referenceVoice", () => {
+  it("prefers the canonical 'default' voice when present", () => {
+    const m: AudioAssetsManifest = {
+      ...manifest,
+      clips: ["voice/luca/welcome.mp3", "voice/default/welcome.mp3", "voice/titan/welcome.mp3"],
+    };
+    expect(referenceVoice(m)).toBe("default");
+  });
+
+  it("falls back to the first sorted voice when 'default' is absent", () => {
+    expect(referenceVoice(manifest)).toBe("luca");
+  });
+
+  it("returns null when the manifest has no voices", () => {
+    expect(referenceVoice({ ...manifest, clips: ["sfx/IRD-tick-open.mp3"] })).toBeNull();
   });
 });
 

--- a/packages/audio-scenarios/src/manifest.ts
+++ b/packages/audio-scenarios/src/manifest.ts
@@ -40,6 +40,22 @@ export function scanRaceEngineerVoices(manifest: AudioAssetsManifest): string[] 
 }
 
 /**
+ * The voice used for load-time typo guards (issue #664): the canonical
+ * `default` voice when present, else the first sorted voice, else `null`.
+ * Per-voice clip sets may legitimately diverge — voices can carry different
+ * variant counts or omit a callout — so validation checks `{voice}`-templated
+ * paths against this single reference voice instead of requiring parity
+ * across all voices.
+ */
+export function referenceVoice(manifest: AudioAssetsManifest): string | null {
+  const voices = scanRaceEngineerVoices(manifest);
+
+  if (voices.length === 0) return null;
+
+  return voices.includes("default") ? "default" : voices[0];
+}
+
+/**
  * Sorted array of available driver-name keys (the names the engineer can
  * address the user as) derived from `voice/<voice>/names/<name>.mp3`
  * paths. The set is the union across voices — a name only present for one

--- a/packages/audio-scenarios/src/validation.test.ts
+++ b/packages/audio-scenarios/src/validation.test.ts
@@ -12,14 +12,14 @@ const manifest = {
 
 let engine: IScenarioEngine;
 let errorLogs: string[];
+let warnLogs: string[];
 
-beforeEach(() => {
-  errorLogs = [];
+function initEngine(m: typeof manifest): void {
   const logger = {
     trace: vi.fn(),
     debug: vi.fn(),
     info: vi.fn(),
-    warn: vi.fn(),
+    warn: vi.fn((msg: string) => warnLogs.push(msg)),
     error: vi.fn((msg: string) => errorLogs.push(msg)),
     createScope: vi.fn(),
     withLevel: vi.fn(),
@@ -28,9 +28,15 @@ beforeEach(() => {
   engine = initializeAudioScenarios(
     { publish: vi.fn(), subscribe: vi.fn(() => () => {}), unsubscribe: vi.fn() } as never,
     {} as never,
-    manifest,
+    m,
     logger as never,
   );
+}
+
+beforeEach(() => {
+  errorLogs = [];
+  warnLogs = [];
+  initEngine(manifest);
 });
 
 afterEach(() => {
@@ -180,5 +186,44 @@ describe("validateScenario", () => {
     });
 
     expect(errorLogs).toEqual([]);
+  });
+});
+
+describe("voice-templated clip steps (issue #664)", () => {
+  // `default` is the reference voice; `titan` deliberately lacks the toggle clip.
+  const voicedManifest = {
+    clips: ["voice/default/toggle/fuel-on-01.mp3", "voice/titan/flags/red-01.mp3"],
+    ambientLoop: "sfx/IRD-ambient-pit.mp3",
+    ticks: { open: "sfx/IRD-tick-open.mp3", close: "sfx/IRD-tick-close.mp3" },
+  };
+
+  beforeEach(() => {
+    _resetAudioScenarios();
+    initEngine(voicedManifest);
+  });
+
+  it("does not disable a scenario whose templated clip is missing for a non-reference voice", () => {
+    engine.defineScenario({
+      id: "toggle",
+      channel: AudioChannel.Voice,
+      bus: AudioBus.Voice,
+      base: "voice/{voice}",
+      sequence: ["toggle/fuel-on-01.mp3"],
+    });
+
+    expect(errorLogs).toEqual([]);
+  });
+
+  it("warns without disabling when the templated clip is missing for the reference voice", () => {
+    engine.defineScenario({
+      id: "typo",
+      channel: AudioChannel.Voice,
+      bus: AudioBus.Voice,
+      base: "voice/{voice}",
+      sequence: ["toggle/feul-on-01.mp3"],
+    });
+
+    expect(errorLogs).toEqual([]);
+    expect(warnLogs.join("\n")).toContain("voice/default/toggle/feul-on-01.mp3");
   });
 });

--- a/packages/audio-scenarios/src/validation.ts
+++ b/packages/audio-scenarios/src/validation.ts
@@ -2,8 +2,9 @@
  * Load-time validation for scenarios.
  *
  * Runs on `defineScenario` against the already-loaded scenarios, pools,
- * variables, and audio-asset manifest. Returns a list of human-readable
- * errors — empty means the scenario is ready to play.
+ * variables, and audio-asset manifest. Returns human-readable `errors`
+ * (non-empty disables the scenario) and `warnings` (logged, scenario stays
+ * enabled — e.g. a probable typo in a `{voice}`-templated path).
  *
  * Include-cycle detection is performed here (at load time) *in addition* to
  * the runtime guard in the interpreter's expansion code, so broken graphs
@@ -11,21 +12,24 @@
  */
 import type { ResolvedStep, Scenario } from "./dsl.js";
 import { applyBase } from "./dsl.js";
-import { type AudioAssetsManifest, manifestVoices } from "./manifest.js";
+import { type AudioAssetsManifest, referenceVoice } from "./manifest.js";
 
 type CompiledEntry = { raw: Scenario; resolvedSequence: ResolvedStep[] };
+
+export type ScenarioValidationResult = { errors: string[]; warnings: string[] };
 
 export function validateScenario(
   s: Scenario,
   resolved: ResolvedStep[],
   scenarios: Map<string, CompiledEntry>,
-  pools: Map<string, { clips: string[] }>,
+  pools: Map<string, unknown>,
   vars: Map<string, () => string | null>,
   manifest: AudioAssetsManifest,
-): string[] {
+): ScenarioValidationResult {
   const errors: string[] = [];
+  const warnings: string[] = [];
   const clipSet = new Set(manifest.clips);
-  const voices = manifestVoices(manifest);
+  const reference = referenceVoice(manifest);
 
   // Scheduling metadata (issue #652): `weight` must be a finite number when
   // present so a typo (e.g. an undefined `WEIGHT.x`) surfaces at load rather
@@ -47,7 +51,7 @@ export function validateScenario(
 
   walk(resolved, s.base, new Set([s.id]));
 
-  return errors;
+  return { errors, warnings };
 
   function walk(steps: ResolvedStep[], base: string | undefined, visited: Set<string>): void {
     for (const step of steps) {
@@ -56,13 +60,17 @@ export function validateScenario(
           const abs = applyBase(base, step.path);
 
           if (abs.includes("{voice}")) {
-            // Templated — every voice in the manifest must have the resolved
-            // clip; if even one is missing this scenario can't safely run
-            // when the user picks that voice.
-            for (const voice of voices) {
-              const resolved = abs.replace(/\{voice\}/g, voice);
+            // Templated — checked against the REFERENCE voice only (issue
+            // #664): per-voice clip sets may legitimately diverge, so a gap
+            // in another voice is not an error. A miss for the reference
+            // voice is a probable typo and only warns — the scenario stays
+            // enabled and the step skips at fire time.
+            if (reference !== null) {
+              const resolved = abs.replace(/\{voice\}/g, reference);
 
-              if (!clipSet.has(resolved)) errors.push(`unknown clip: ${resolved} (template: ${abs})`);
+              if (!clipSet.has(resolved)) {
+                warnings.push(`unknown clip for reference voice: ${resolved} (template: ${abs})`);
+              }
             }
           } else if (!clipSet.has(abs)) {
             errors.push(`unknown clip: ${abs}`);


### PR DESCRIPTION
## Related Issue

Fixes #664

## What changed?

Phase 1 of #664: Race Engineer callout pools are now **config-driven**, derived per-voice from the clips that exist in the audio-asset manifest, instead of hand-enumerated in code.

- `pools.ts` no longer lists any clips: `POOL_REGISTRY` maps each logical pool name (`flag-blue`) to its manifest `(group, base)` (`flags`/`blue`) and carries no clip lists or counts. Scenario reference strings (`"pool:flag-blue"`) are unchanged.
- New engine API `definePoolFromManifest(name, group, base)`: a pool's members are every `voice/<voice>/<group>/<base>-NN.mp3` in the manifest, resolved for the **active voice at fire time**. Voices may carry different variant counts or omit a callout entirely — an empty pool skips its step (debug, not error), and the no-repeat tracker resets on voice change since counts differ across voices.
- The all-voices parity coupling is deleted: `definePool` and scenario validation now check `{voice}`-templated paths against the **reference voice** only (`default`, else the first sorted voice) and **warn instead of rejecting/disabling** — a probable-typo guard without blocking per-voice divergence.
- The two acknowledgment pools (`acknowledgment`, `pit-action-acknowledgment`) stay enumerated in `ENUMERATED_POOLS` until the `-NN` rename migration (#837).
- `voice-parity.test.ts` relaxed to a base-level soft typo guard: a non-default voice may have fewer/more variants and omit callouts; only `<group>/<base>` keys unknown to the default voice fail (they'd never play — almost certainly a misspelling).
- Docs updated to the derive-from-manifest model: `packages/audio-scenarios/CLAUDE.md`, `packages/audio-assets/CLAUDE.md`, `.claude/rules/race-engineer-callouts.md`.

Follow-up phases split out of #664: #835 (missing clip → skip whole callout), #836 (value-indexed clips as pools), #837 (acknowledgment rename migration).

No changelog entry: internal architecture, nothing user-visible changes with the single shipped voice.

## How to test

1. `pnpm install && pnpm build && pnpm test` — full suite passes (6515 tests; new coverage for per-voice resolution, exact `<base>-NN` matching, voice-change no-repeat reset, empty-pool skip, and the reference-voice typo guards).
2. Audition without iRacing: `pnpm --filter @iracedeck/scenario-harness dev`, open `127.0.0.1:5750`, fire flag / pit-status / incident / start-light shortcuts — callouts play exactly as before (same clips, same random-variant behavior).
3. In iRacing: trigger a flag callout and a pit-service toggle; behavior is unchanged for the `default` voice.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — no plugin changes needed; the pool registration path is internal to `@iracedeck/audio-scenarios`
- [x] No unrelated changes included

https://claude.ai/code/session_01NxubR68fSJmc7LpKLVC8Wn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio callout and pit-crew pools are now manifest-derived and resolve members for the active voice at playback time.
  * Voice clip parity is relaxed using `<group>/<base>` matching (variant `-NN` stripping), enabling differing clip sets per voice.
* **Bug Fixes**
  * Missing clips for non-reference voices no longer disable scenarios; issues now surface as warnings.
* **Documentation**
  * Updated audio asset and scenario guidance to reflect the new manifest-based pooling and flexible voice coverage rules.
* **Tests**
  * Expanded coverage for manifest-derived pools, active-voice behavior, and relaxed parity “typo guard” checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->