### PR TITLE
fix(ulanzi): show plugin icon and open PI links in Ulanzi Studio (#845)

### DIFF
--- a/.claude/rules/pi-templates.md
+++ b/.claude/rules/pi-templates.md
@@ -146,7 +146,7 @@ External links in a PI otherwise open in the deck app's small built-in browser, 
 <a href="https://iracedeck.com/downloads/" target="_blank" rel="noopener noreferrer">Downloads</a>
 ```
 
-That event reaches the OS default browser on every host: Elgato handles it natively, the VSD (Mirabox) host receives it directly, and the Ulanzi PI bridge translates it to its `openurl` cmd (`src/ulanzi-bridge/translate.ts`). No plugin-side code is needed. The handler resolves the anchor's normalized `.href` and only reroutes `http(s)` (the SDK can't open other schemes, e.g. `mailto:`/`app://`, and in-PI/relative targets are left alone). It only intercepts when sdpi-components is loaded, so a load failure falls back to the link's default behavior; the `openUrl` send is fire-and-forget (rejections swallowed) and the listener installs once per document.
+That event reaches the OS default browser on every host: Elgato handles it natively, the VSD (Mirabox) host receives it directly, and the Ulanzi PI bridge relays it as a `sendToPlugin` openUrl marker (`src/ulanzi-bridge/translate.ts`) that the Ulanzi adapter re-sends as `openurl` from the **plugin** socket — UlanziStudio ignores `openurl` sent on the PI socket (#845). No per-action plugin code is needed on any host. The handler resolves the anchor's normalized `.href` and only reroutes `http(s)` (the SDK can't open other schemes, e.g. `mailto:`/`app://`, and in-PI/relative targets are left alone). It only intercepts when sdpi-components is loaded, so a load failure falls back to the link's default behavior; the `openUrl` send is fire-and-forget (rejections swallowed) and the listener installs once per document.
 
 ## Title Overrides Partial
 

--- a/packages/deck-adapter-ulanzi/CLAUDE.md
+++ b/packages/deck-adapter-ulanzi/CLAUDE.md
@@ -52,7 +52,7 @@ Ulanzi only carries settings on `add` / `paramfromapp`; `keydown` / `keyup` / `d
 
 UlanziStudio has no host-generated "PI appeared" event. The Ulanzi PI bridge (in `@iracedeck/pi-components`) sends a `sendToPlugin` marker (`payload.event === "propertyInspectorDidAppear"`) on connect; the client normalizes that into the `propertyInspectorDidAppear` global event so `onPropertyInspectorDidAppear` (e.g. audio-device re-enumeration) works.
 
-External PI links use the same relay (#845): UlanziStudio ignores `openurl` sent on the PI socket but honours it from the plugin socket, so the bridge translates sdpi's `openUrl` event into a `sendToPlugin` openUrl marker, the client normalizes it to an `openUrl` global event, and the adapter constructor forwards the url via `client.openUrl`. Any other `sendToPlugin` payload normalizes to nothing.
+External PI links use the same relay (#845): UlanziStudio ignores `openurl` sent on the PI socket but honours it from the plugin socket, so the bridge translates sdpi's `openUrl` event into a `sendToPlugin` openUrl marker, the client normalizes it to an `openUrl` global event (string urls only — no coercion), and the adapter constructor forwards the url via `client.openUrl` after validating it parses as `http:`/`https:` (matching the PI external-link contract, #243; the debug log redacts to origin + path). Any other `sendToPlugin` payload normalizes to nothing.
 
 ### Outbound icons
 

--- a/packages/deck-adapter-ulanzi/CLAUDE.md
+++ b/packages/deck-adapter-ulanzi/CLAUDE.md
@@ -10,7 +10,7 @@ Mirrors `@iracedeck/deck-adapter-mirabox`. The key difference: VSD Craft speaks 
 - **`UlanziPlatformAdapter`** (`adapter.ts`) — wraps the client, translating normalized events into deck-core events (`IDeckWillAppearEvent`, `IDeckKeyDownEvent`, …) via `UlanziActionContext`. Near-identical to `VSDPlatformAdapter`.
 - **Controller type defaults to Keypad (gotcha for the #786 dial re-enable)** — Ulanzi `add` frames carry no controller hint (`normalizeFrame("add")` emits only settings), so every context falls back to `Keypad` in `registerAction` and `isDial()` is effectively never true on Ulanzi today. Also, `ControllerType` here is `"Keypad" | "Encoder" | "Information"` — no `"Knob"` (unlike Mirabox).
 - **`switchToProfile` is a no-op** — UlanziStudio has no profile system. The PI "Stream Deck Profiles" accordion is hidden on this platform via the `profiles` feature flag (`packages/iracing-plugin-ulanzi/platform-features.json`), so the method exists only to satisfy `IDeckPlatformAdapter`.
-- **`openUrl(url)`** — the adapter's own method sends the `openurl` cmd best-effort (harmless if the host ignores it). Distinct from the PI bridge, which separately translates PI link clicks to the same cmd.
+- **`openUrl(url)`** — the adapter's own method sends the `openurl` cmd best-effort (harmless if the host ignores it). PI link clicks route through here too: UlanziStudio ignores `openurl` sent on the **PI** socket, so the PI bridge relays link clicks as a `sendToPlugin` openUrl marker and the adapter constructor forwards them out the plugin socket via `client.openUrl` (#845).
 - **`UlanziActionContext.setTitle` is a no-op** — Ulanzi has no native title API (labels travel as the `text` field of the icon setter). iRaceDeck bakes the title into the icon SVG and every action only ever calls `setTitle("")` to clear the native title, which Ulanzi never draws (`setImage` sends `showtext:false`).
 - **`createLogger(scope)`** — `createConsoleLogger()` teed to `<plugin>/log/<YYYY.M.D>.log` (`file-logger.ts`) when a log dir is passed to the constructor (issue #609). The UlanziStudio host discards plugin stdout, same as Mirabox's Stream Dock host. Console + file share the live `logLevel` (`setLogLevel`).
 - **Broadcast callbacks** — `onKeyDown`, `onDialDown`, `onDialRotate` fire before per-action handlers (for window focus).
@@ -39,6 +39,7 @@ On open the client sends the handshake `{ code: 0, cmd: "connected", uuid }` (no
 | `didReceiveSettings` / `paramfromapp` / `paramfromplugin` | `didReceiveSettings`         | settings in `param`                                        |
 | `didReceiveGlobalSettings`                                | global event                 | settings in `settings`                                     |
 | `sendToPlugin` (PI-appear marker)                         | `propertyInspectorDidAppear` | see below                                                  |
+| `sendToPlugin` (openUrl marker)                           | `openUrl` (global event)     | url in `payload.url` — see below                           |
 | `run` / `setactive` / acks                                | (ignored)                    |                                                            |
 
 Frames with `code` set and no `cmdType === "REQUEST"` are ack/responses and are dropped.
@@ -47,9 +48,11 @@ Frames with `code` set and no `cmdType === "REQUEST"` are ack/responses and are 
 
 Ulanzi only carries settings on `add` / `paramfromapp`; `keydown` / `keyup` / `dial*` frames omit them. The client caches the latest settings per context and **backfills** press/dial events before routing — otherwise actions would fire with empty settings. The cache is dropped on `clear`.
 
-### PI-appear (synthesized)
+### PI markers (synthesized)
 
 UlanziStudio has no host-generated "PI appeared" event. The Ulanzi PI bridge (in `@iracedeck/pi-components`) sends a `sendToPlugin` marker (`payload.event === "propertyInspectorDidAppear"`) on connect; the client normalizes that into the `propertyInspectorDidAppear` global event so `onPropertyInspectorDidAppear` (e.g. audio-device re-enumeration) works.
+
+External PI links use the same relay (#845): UlanziStudio ignores `openurl` sent on the PI socket but honours it from the plugin socket, so the bridge translates sdpi's `openUrl` event into a `sendToPlugin` openUrl marker, the client normalizes it to an `openUrl` global event, and the adapter constructor forwards the url via `client.openUrl`. Any other `sendToPlugin` payload normalizes to nothing.
 
 ### Outbound icons
 

--- a/packages/deck-adapter-ulanzi/src/adapter.test.ts
+++ b/packages/deck-adapter-ulanzi/src/adapter.test.ts
@@ -92,6 +92,14 @@ describe("UlanziPlatformAdapter", () => {
 
       expect(client.openUrl).not.toHaveBeenCalled();
     });
+
+    it("forwards only http(s) urls — other schemes and malformed urls are dropped", () => {
+      for (const url of ["javascript:alert(1)", "file:///C:/Windows/system.ini", "app://open", "not a url", "   "]) {
+        openUrlHandler()({ event: "openUrl", action: "u", context: "u___5___a", payload: { url } });
+      }
+
+      expect(client.openUrl).not.toHaveBeenCalled();
+    });
   });
 
   describe("onDidReceiveGlobalSettings", () => {

--- a/packages/deck-adapter-ulanzi/src/adapter.test.ts
+++ b/packages/deck-adapter-ulanzi/src/adapter.test.ts
@@ -71,6 +71,29 @@ describe("UlanziPlatformAdapter", () => {
     });
   });
 
+  // The Ulanzi PI bridge relays external-link clicks as a `sendToPlugin` openUrl
+  // marker (the host ignores `openurl` sent on the PI socket, #845); the adapter
+  // forwards them out the plugin socket, which the host honours.
+  describe("PI openUrl relay", () => {
+    const openUrlHandler = () => client.onGlobalEvent.mock.calls.find((call) => call[0] === "openUrl")?.[1];
+
+    it("registers a global openUrl handler on construction", () => {
+      expect(client.onGlobalEvent).toHaveBeenCalledWith("openUrl", expect.any(Function));
+    });
+
+    it("forwards the relayed url out the plugin socket via client.openUrl", () => {
+      openUrlHandler()({ event: "openUrl", action: "u", context: "u___5___a", payload: { url: "https://x/" } });
+
+      expect(client.openUrl).toHaveBeenCalledWith("https://x/");
+    });
+
+    it("ignores a relay without a usable url", () => {
+      openUrlHandler()({ event: "openUrl", action: "u", context: "u___5___a", payload: {} });
+
+      expect(client.openUrl).not.toHaveBeenCalled();
+    });
+  });
+
   describe("onDidReceiveGlobalSettings", () => {
     it("should register a global event handler for didReceiveGlobalSettings", () => {
       const callback = vi.fn();
@@ -83,7 +106,7 @@ describe("UlanziPlatformAdapter", () => {
       const callback = vi.fn();
       adapter.onDidReceiveGlobalSettings(callback);
 
-      const handler = client.onGlobalEvent.mock.calls[0][1];
+      const handler = client.onGlobalEvent.mock.calls.find((call) => call[0] === "didReceiveGlobalSettings")?.[1];
       handler({ event: "didReceiveGlobalSettings", payload: { settings: { key: "value" } } });
 
       expect(callback).toHaveBeenCalledWith({ key: "value" });
@@ -102,7 +125,7 @@ describe("UlanziPlatformAdapter", () => {
       const callback = vi.fn();
       adapter.onApplicationDidLaunch(callback);
 
-      const handler = client.onGlobalEvent.mock.calls[0][1];
+      const handler = client.onGlobalEvent.mock.calls.find((call) => call[0] === "applicationDidLaunch")?.[1];
       handler({ event: "applicationDidLaunch", payload: { application: "iRacingSim64DX11.exe" } });
 
       expect(callback).toHaveBeenCalledWith("iRacingSim64DX11.exe");
@@ -130,7 +153,7 @@ describe("UlanziPlatformAdapter", () => {
       const callback = vi.fn();
       adapter.onPropertyInspectorDidAppear(callback);
 
-      const handler = client.onGlobalEvent.mock.calls[0][1];
+      const handler = client.onGlobalEvent.mock.calls.find((call) => call[0] === "propertyInspectorDidAppear")?.[1];
       handler({ event: "propertyInspectorDidAppear", action: "com.test.action", context: "abc" });
 
       expect(callback).toHaveBeenCalledTimes(1);

--- a/packages/deck-adapter-ulanzi/src/adapter.ts
+++ b/packages/deck-adapter-ulanzi/src/adapter.ts
@@ -184,6 +184,19 @@ export class UlanziPlatformAdapter implements IDeckPlatformAdapter {
     this.fileSink = logDir ? new FileSink(logDir) : null;
     const log = logger ?? this.buildLogger("Ulanzi");
     this.client = new UlanziClient(parseConnectionParams(), log.createScope("WebSocket"));
+
+    // The Ulanzi PI bridge relays external-link clicks as a `sendToPlugin`
+    // openUrl marker — UlanziStudio ignores `openurl` sent on the PI socket but
+    // honours it from the plugin socket, so forward it from here (#845).
+    this.client.onGlobalEvent("openUrl", (data) => {
+      const url = data.payload?.url;
+
+      if (typeof url === "string" && url) {
+        log.info("Opening URL relayed from Property Inspector");
+        log.debug(`URL: ${url}`);
+        this.client.openUrl(url);
+      }
+    });
   }
 
   /**

--- a/packages/deck-adapter-ulanzi/src/adapter.ts
+++ b/packages/deck-adapter-ulanzi/src/adapter.ts
@@ -187,15 +187,35 @@ export class UlanziPlatformAdapter implements IDeckPlatformAdapter {
 
     // The Ulanzi PI bridge relays external-link clicks as a `sendToPlugin`
     // openUrl marker — UlanziStudio ignores `openurl` sent on the PI socket but
-    // honours it from the plugin socket, so forward it from here (#845).
+    // honours it from the plugin socket, so forward it from here (#845). Only
+    // http(s) URLs are forwarded, matching the PI external-link contract (#243)
+    // and the Elgato host's own behavior.
     this.client.onGlobalEvent("openUrl", (data) => {
       const url = data.payload?.url;
 
-      if (typeof url === "string" && url) {
-        log.info("Opening URL relayed from Property Inspector");
-        log.debug(`URL: ${url}`);
-        this.client.openUrl(url);
+      if (typeof url !== "string") return;
+
+      let parsed: URL;
+
+      try {
+        parsed = new URL(url);
+      } catch {
+        log.warn("Ignoring relayed PI URL: not a valid URL");
+
+        return;
       }
+
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        log.warn("Ignoring relayed PI URL: unsupported scheme");
+
+        return;
+      }
+
+      log.info("Opening URL relayed from Property Inspector");
+      // Redacted to origin + path: query/fragment could carry identifiers that
+      // don't belong in console or file logs.
+      log.debug(`URL: ${parsed.origin}${parsed.pathname}`);
+      this.client.openUrl(url);
     });
   }
 

--- a/packages/deck-adapter-ulanzi/src/ulanzi-client.test.ts
+++ b/packages/deck-adapter-ulanzi/src/ulanzi-client.test.ts
@@ -171,7 +171,7 @@ describe("normalizeFrame", () => {
     expect(ev).toEqual({ event: "didReceiveGlobalSettings", payload: { settings: { debugLogging: true } } });
   });
 
-  it("surfaces `sendToPlugin` only for the PI-appear marker", () => {
+  it("surfaces `sendToPlugin` only for known PI markers", () => {
     const marker = normalizeFrame({
       cmd: "sendToPlugin",
       uuid: "u",
@@ -183,6 +183,20 @@ describe("normalizeFrame", () => {
 
     const other = normalizeFrame({ cmd: "sendToPlugin", uuid: "u", key: "5", actionid: "a", payload: { foo: 1 } });
     expect(other).toEqual([]);
+  });
+
+  it("surfaces the `sendToPlugin` openUrl marker as a global openUrl event carrying the url", () => {
+    const events = normalizeFrame({
+      cmd: "sendToPlugin",
+      uuid: "u",
+      key: "5",
+      actionid: "a",
+      payload: { event: "openUrl", url: "https://iracedeck.com/docs/" },
+    });
+
+    expect(events).toEqual([
+      { event: "openUrl", action: "u", context: "u___5___a", payload: { url: "https://iracedeck.com/docs/" } },
+    ]);
   });
 
   it("ignores unused frames (`run`, `setactive`, acks)", () => {

--- a/packages/deck-adapter-ulanzi/src/ulanzi-client.test.ts
+++ b/packages/deck-adapter-ulanzi/src/ulanzi-client.test.ts
@@ -199,6 +199,14 @@ describe("normalizeFrame", () => {
     ]);
   });
 
+  it("drops an openUrl marker whose url is not a string", () => {
+    for (const url of [42, null, undefined, { nested: true }]) {
+      expect(
+        normalizeFrame({ cmd: "sendToPlugin", uuid: "u", key: "5", actionid: "a", payload: { event: "openUrl", url } }),
+      ).toEqual([]);
+    }
+  });
+
   it("ignores unused frames (`run`, `setactive`, acks)", () => {
     expect(normalizeFrame({ cmd: "run", uuid: "u", key: "5", actionid: "a" })).toEqual([]);
     expect(normalizeFrame({ cmd: "setactive", uuid: "u", key: "5", actionid: "a", active: true })).toEqual([]);

--- a/packages/deck-adapter-ulanzi/src/ulanzi-client.ts
+++ b/packages/deck-adapter-ulanzi/src/ulanzi-client.ts
@@ -73,6 +73,13 @@ const WS_OPEN = 1;
 /** Marker a Ulanzi PI bridge sends (via `sendToPlugin`) to signal it opened. */
 const PI_APPEAR_MARKER = "propertyInspectorDidAppear";
 
+/**
+ * Marker the Ulanzi PI bridge sends (via `sendToPlugin`) to relay an external
+ * link click. UlanziStudio ignores `openurl` sent on the PI socket but honours
+ * it from the plugin socket, so the adapter re-sends the url from there (#845).
+ */
+const PI_OPEN_URL_MARKER = "openUrl";
+
 /** Parse UlanziStudio connection parameters from process.argv. */
 export function parseConnectionParams(): UlanziConnectionParams {
   return {
@@ -137,8 +144,8 @@ function pressedFromRotate(rotateEvent: unknown): boolean {
  * Normalize a raw Ulanzi wire frame (keyed by `cmd`) into zero or more
  * Elgato-style {@link UlanziEvent}s. Most frames map 1:1; `clear` fans out to
  * one disappear event per item in its `param` array; `sendToPlugin` is surfaced
- * only for the PI-appear marker; unused frames (`run`, `setactive`, command
- * acks) normalize to nothing.
+ * only for the known PI markers (PI-appear, openUrl); unused frames (`run`,
+ * `setactive`, command acks) normalize to nothing.
  *
  * Pure and side-effect-free: settings backfill for press/dial events (which
  * carry no `param` on the wire) is the stateful client's responsibility.
@@ -179,10 +186,17 @@ export function normalizeFrame(frame: Record<string, unknown>): UlanziEvent[] {
       return normalizeClear(frame);
     case "didReceiveGlobalSettings":
       return [{ event: "didReceiveGlobalSettings", payload: { settings: settingsOf(frame) } }];
-    case "sendToPlugin":
-      return asRecord(frame.payload)?.event === PI_APPEAR_MARKER
-        ? [{ event: "propertyInspectorDidAppear", action, context }]
-        : [];
+    case "sendToPlugin": {
+      const payload = asRecord(frame.payload);
+
+      if (payload?.event === PI_APPEAR_MARKER) return [{ event: "propertyInspectorDidAppear", action, context }];
+
+      if (payload?.event === PI_OPEN_URL_MARKER) {
+        return [{ event: "openUrl", action, context, payload: { url: String(payload.url ?? "") } }];
+      }
+
+      return [];
+    }
     default:
       return [];
   }

--- a/packages/deck-adapter-ulanzi/src/ulanzi-client.ts
+++ b/packages/deck-adapter-ulanzi/src/ulanzi-client.ts
@@ -191,8 +191,10 @@ export function normalizeFrame(frame: Record<string, unknown>): UlanziEvent[] {
 
       if (payload?.event === PI_APPEAR_MARKER) return [{ event: "propertyInspectorDidAppear", action, context }];
 
-      if (payload?.event === PI_OPEN_URL_MARKER) {
-        return [{ event: "openUrl", action, context, payload: { url: String(payload.url ?? "") } }];
+      // Pass the url through only when it is already a string — no coercion, so
+      // a malformed marker normalizes to nothing (the adapter validates further).
+      if (payload?.event === PI_OPEN_URL_MARKER && typeof payload.url === "string") {
+        return [{ event: "openUrl", action, context, payload: { url: payload.url } }];
       }
 
       return [];

--- a/packages/iracing-plugin-ulanzi/CLAUDE.md
+++ b/packages/iracing-plugin-ulanzi/CLAUDE.md
@@ -22,6 +22,8 @@ PI framework (web components, EJS partials, compile plugin, `sdpi-components.js`
 
 `com.ulanzi.iracedeck.ulanziPlugin/manifest.json` is committed and hand-maintained, mirroring the Mirabox action set with the Ulanzi transform above. When adding/removing an action, update this manifest alongside the Elgato and Mirabox manifests, keeping the `Actions` array alphabetical by display `Name` (the host renders them in array order). `scripts/manifest-actions-order.test.mjs` discovers every plugin manifest dynamically and enforces sorted order, name uniqueness, and cross-manifest action-set parity — ecosystem-specific actions (`ECOSYSTEM_SPECIFIC_ACTIONS`, currently the Elgato-only "Switch Profile") are exempt from the parity check only. (A throwaway transform script — `scripts/local/gen-ulanzi-manifest.mjs`, gitignored — bootstrapped the initial file from the Mirabox manifest.)
 
+**Image paths carry explicit file extensions** (`imgs/plugin/marketplace.png`, `imgs/actions/<name>/icon.svg`, `imgs/actions/<name>/key.svg`) — unlike the Elgato manifest convention, UlanziStudio resolves image paths literally and does not probe for `.png`/`.svg`/`@2x` variants, so an extensionless reference shows no icon (e.g. in the Settings > Plugins list, #845). `scripts/ulanzi-manifest-images.test.mjs` enforces the extension and that every reference resolves to its committed source (per-action icons in `@iracedeck/iracing-actions`, plugin branding in the Elgato plugin's `imgs/plugin/` — the rollup copy sources).
+
 ## Build
 
 ```bash
@@ -43,6 +45,8 @@ There is no `link:ulanzi` script — the root `package.json` only has `*:stream-
 Validated live in UlanziDeck (the desktop host): the plugin loads, the WebSocket connects (handshake + argv layout `address port language`), the global-settings read/write round-trips, the PI bridge drives `sdpi-components`, the **SVG data-URI icons render**, and key presses dispatch to actions. The earlier known-unknowns (manifest format, the 4-segment UUID, the wire protocol, the PI bridge, SVG passthrough) are therefore confirmed, not deferred.
 
 Still to exercise on a physical device: dial input end-to-end (the manifest declares no `Encoder` controllers until this is verified — #786), D200X dial custom feedback layouts (no SDK `setFeedback` method — rich dial-slot display is deferred), Keypad-vs-Encoder detection at `add` (defaults to Keypad), and per-device behaviour across the four supported device models. None block the build.
+
+Still to verify in the UlanziStudio host (no device needed): the #845 fixes — the plugin-list icon (manifest image paths now carry explicit extensions) and PI external links (relayed out the plugin socket via the `sendToPlugin` openUrl marker). Both were authored blind against first-party plugin conventions and the observed working plugin-socket `openurl` path.
 
 ## Window Focus
 

--- a/packages/iracing-plugin-ulanzi/com.ulanzi.iracedeck.ulanziPlugin/manifest.json
+++ b/packages/iracing-plugin-ulanzi/com.ulanzi.iracedeck.ulanziPlugin/manifest.json
@@ -3,9 +3,9 @@
   "Name": "iRaceDeck",
   "Version": "2.2.0.1887",
   "Description": "Complete iRacing controls for Ulanzi Deck.",
-  "Icon": "imgs/plugin/marketplace",
+  "Icon": "imgs/plugin/marketplace.png",
   "Category": "iRaceDeck",
-  "CategoryIcon": "imgs/plugin/category-icon",
+  "CategoryIcon": "imgs/plugin/category-icon.png",
   "CodePath": "bin/plugin.js",
   "Type": "JavaScript",
   "UUID": "com.iracedeck.sd.core",
@@ -27,7 +27,7 @@
     {
       "Name": "AI Spotter Controls",
       "UUID": "com.iracedeck.sd.core.ai-spotter-controls",
-      "Icon": "imgs/actions/ai-spotter-controls/icon",
+      "Icon": "imgs/actions/ai-spotter-controls/icon.svg",
       "Tooltip": "AI spotter controls (damage/weather reports, lap reporting, volume, silence)",
       "PropertyInspectorPath": "ui/ai-spotter-controls.html",
       "Controllers": [
@@ -35,14 +35,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/ai-spotter-controls/key"
+          "Image": "imgs/actions/ai-spotter-controls/key.svg"
         }
       ]
     },
     {
       "Name": "Audio Controls",
       "UUID": "com.iracedeck.sd.core.audio-controls",
-      "Icon": "imgs/actions/audio-controls/icon",
+      "Icon": "imgs/actions/audio-controls/icon.svg",
       "Tooltip": "Audio volume and mute controls (iRacing voice chat & master; iRaceDeck Race Engineer & Radar)",
       "PropertyInspectorPath": "ui/audio-controls.html",
       "Controllers": [
@@ -50,14 +50,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/audio-controls/key"
+          "Image": "imgs/actions/audio-controls/key.svg"
         }
       ]
     },
     {
       "Name": "Black Box Selector",
       "UUID": "com.iracedeck.sd.core.black-box-selector",
-      "Icon": "imgs/actions/black-box-selector/icon",
+      "Icon": "imgs/actions/black-box-selector/icon.svg",
       "Tooltip": "Cycle through or select iRacing black boxes",
       "PropertyInspectorPath": "ui/black-box-selector.html",
       "Controllers": [
@@ -65,14 +65,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/black-box-selector/key"
+          "Image": "imgs/actions/black-box-selector/key.svg"
         }
       ]
     },
     {
       "Name": "Camera Controls",
       "UUID": "com.iracedeck.sd.core.camera-focus",
-      "Icon": "imgs/actions/camera-focus/icon",
+      "Icon": "imgs/actions/camera-focus/icon.svg",
       "Tooltip": "Cycle through cameras and focus on targets (your car, leader, incidents, positions)",
       "PropertyInspectorPath": "ui/camera-focus.html",
       "Controllers": [
@@ -80,14 +80,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/camera-focus/key"
+          "Image": "imgs/actions/camera-focus/key.svg"
         }
       ]
     },
     {
       "Name": "Camera Cycle (Legacy)",
       "UUID": "com.iracedeck.sd.core.camera-cycle",
-      "Icon": "imgs/actions/camera-focus/icon",
+      "Icon": "imgs/actions/camera-focus/icon.svg",
       "Tooltip": "Legacy action — use Camera Controls instead",
       "PropertyInspectorPath": "ui/camera-focus.html",
       "Controllers": [
@@ -95,7 +95,7 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/camera-focus/key"
+          "Image": "imgs/actions/camera-focus/key.svg"
         }
       ],
       "VisibleInActionsList": false
@@ -103,7 +103,7 @@
     {
       "Name": "Camera Editor Adjustments",
       "UUID": "com.iracedeck.sd.core.camera-editor-adjustments",
-      "Icon": "imgs/actions/camera-editor-adjustments/icon",
+      "Icon": "imgs/actions/camera-editor-adjustments/icon.svg",
       "Tooltip": "Camera editor adjustments for position, rotation, zoom, and other parameters",
       "PropertyInspectorPath": "ui/camera-editor-adjustments.html",
       "Controllers": [
@@ -111,14 +111,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/camera-editor-adjustments/key"
+          "Image": "imgs/actions/camera-editor-adjustments/key.svg"
         }
       ]
     },
     {
       "Name": "Camera Editor Controls",
       "UUID": "com.iracedeck.sd.core.camera-editor-controls",
-      "Icon": "imgs/actions/camera-editor-controls/icon",
+      "Icon": "imgs/actions/camera-editor-controls/icon.svg",
       "Tooltip": "Camera editor toggles and management controls for broadcasters and content creators",
       "PropertyInspectorPath": "ui/camera-editor-controls.html",
       "Controllers": [
@@ -126,14 +126,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/camera-editor-controls/key"
+          "Image": "imgs/actions/camera-editor-controls/key.svg"
         }
       ]
     },
     {
       "Name": "Car Control",
       "UUID": "com.iracedeck.sd.core.car-control",
-      "Icon": "imgs/actions/car-control/icon",
+      "Icon": "imgs/actions/car-control/icon.svg",
       "Tooltip": "Control car operations (starter, ignition, pit limiter, and more)",
       "PropertyInspectorPath": "ui/car-control.html",
       "Controllers": [
@@ -141,14 +141,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/car-control/key"
+          "Image": "imgs/actions/car-control/key.svg"
         }
       ]
     },
     {
       "Name": "Chat",
       "UUID": "com.iracedeck.sd.core.chat",
-      "Icon": "imgs/actions/chat/icon",
+      "Icon": "imgs/actions/chat/icon.svg",
       "Tooltip": "Text chat operations (open, reply, whisper, send message, macros)",
       "PropertyInspectorPath": "ui/chat.html",
       "Controllers": [
@@ -156,14 +156,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/chat/key"
+          "Image": "imgs/actions/chat/key.svg"
         }
       ]
     },
     {
       "Name": "Cockpit Misc",
       "UUID": "com.iracedeck.sd.core.cockpit-misc",
-      "Icon": "imgs/actions/cockpit-misc/icon",
+      "Icon": "imgs/actions/cockpit-misc/icon.svg",
       "Tooltip": "Miscellaneous cockpit controls (toggle/trigger wipers, FFB, latency, dash pages, in-lap mode)",
       "PropertyInspectorPath": "ui/cockpit-misc.html",
       "Controllers": [
@@ -171,14 +171,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/cockpit-misc/key"
+          "Image": "imgs/actions/cockpit-misc/key.svg"
         }
       ]
     },
     {
       "Name": "Force Feedback",
       "UUID": "com.iracedeck.sd.core.force-feedback",
-      "Icon": "imgs/actions/force-feedback/icon",
+      "Icon": "imgs/actions/force-feedback/icon.svg",
       "Tooltip": "Force feedback controls (FFB force, wheel LFE, bass shaker, haptic intensity)",
       "PropertyInspectorPath": "ui/force-feedback.html",
       "Controllers": [
@@ -186,14 +186,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/force-feedback/key"
+          "Image": "imgs/actions/force-feedback/key.svg"
         }
       ]
     },
     {
       "Name": "Fuel Service",
       "UUID": "com.iracedeck.sd.core.fuel-service",
-      "Icon": "imgs/actions/fuel-service/icon",
+      "Icon": "imgs/actions/fuel-service/icon.svg",
       "Tooltip": "Fuel management for pit stops (add/reduce fuel, autofuel, lap margin)",
       "PropertyInspectorPath": "ui/fuel-service.html",
       "Controllers": [
@@ -201,14 +201,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/fuel-service/key"
+          "Image": "imgs/actions/fuel-service/key.svg"
         }
       ]
     },
     {
       "Name": "Look Direction",
       "UUID": "com.iracedeck.sd.core.look-direction",
-      "Icon": "imgs/actions/look-direction/icon",
+      "Icon": "imgs/actions/look-direction/icon.svg",
       "Tooltip": "Change the driver's view direction",
       "PropertyInspectorPath": "ui/look-direction.html",
       "Controllers": [
@@ -216,14 +216,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/look-direction/key"
+          "Image": "imgs/actions/look-direction/key.svg"
         }
       ]
     },
     {
       "Name": "Media Capture",
       "UUID": "com.iracedeck.sd.core.media-capture",
-      "Icon": "imgs/actions/media-capture/icon",
+      "Icon": "imgs/actions/media-capture/icon.svg",
       "Tooltip": "Video recording, screenshots, and texture management",
       "PropertyInspectorPath": "ui/media-capture.html",
       "Controllers": [
@@ -231,14 +231,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/media-capture/key"
+          "Image": "imgs/actions/media-capture/key.svg"
         }
       ]
     },
     {
       "Name": "Pit Crew",
       "UUID": "com.iracedeck.sd.core.pit-crew",
-      "Icon": "imgs/actions/pit-crew/icon",
+      "Icon": "imgs/actions/pit-crew/icon.svg",
       "Tooltip": "Race Engineer voice and Radar controls",
       "PropertyInspectorPath": "ui/pit-crew.html",
       "Controllers": [
@@ -246,14 +246,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/pit-crew/key"
+          "Image": "imgs/actions/pit-crew/key.svg"
         }
       ]
     },
     {
       "Name": "Pit Quick Actions",
       "UUID": "com.iracedeck.sd.core.pit-quick-actions",
-      "Icon": "imgs/actions/pit-quick-actions/icon",
+      "Icon": "imgs/actions/pit-quick-actions/icon.svg",
       "Tooltip": "Quick pit stop controls (clear all, windshield tearoff, fast repair)",
       "PropertyInspectorPath": "ui/pit-quick-actions.html",
       "Controllers": [
@@ -261,14 +261,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/pit-quick-actions/key"
+          "Image": "imgs/actions/pit-quick-actions/key.svg"
         }
       ]
     },
     {
       "Name": "Race Admin",
       "UUID": "com.iracedeck.sd.core.race-admin",
-      "Icon": "imgs/actions/race-admin/icon",
+      "Icon": "imgs/actions/race-admin/icon.svg",
       "Tooltip": "Session admin commands for race directors (yellows, penalties, pit control, chat)",
       "PropertyInspectorPath": "ui/race-admin.html",
       "Controllers": [
@@ -276,14 +276,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/race-admin/key"
+          "Image": "imgs/actions/race-admin/key.svg"
         }
       ]
     },
     {
       "Name": "Replay Control",
       "UUID": "com.iracedeck.sd.core.replay-control",
-      "Icon": "imgs/actions/replay-control/icon",
+      "Icon": "imgs/actions/replay-control/icon.svg",
       "Tooltip": "Unified replay controls: transport, speed, and navigation",
       "PropertyInspectorPath": "ui/replay-control.html",
       "Controllers": [
@@ -291,14 +291,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/replay-control/key"
+          "Image": "imgs/actions/replay-control/key.svg"
         }
       ]
     },
     {
       "Name": "Replay Navigation",
       "UUID": "com.iracedeck.sd.core.replay-navigation",
-      "Icon": "imgs/actions/replay-navigation/icon",
+      "Icon": "imgs/actions/replay-navigation/icon.svg",
       "Tooltip": "Jump to sessions, laps, incidents, or specific positions in replay",
       "PropertyInspectorPath": "ui/replay-navigation.html",
       "Controllers": [
@@ -306,7 +306,7 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/replay-navigation/key"
+          "Image": "imgs/actions/replay-navigation/key.svg"
         }
       ],
       "VisibleInActionsList": false
@@ -314,7 +314,7 @@
     {
       "Name": "Replay Speed",
       "UUID": "com.iracedeck.sd.core.replay-speed",
-      "Icon": "imgs/actions/replay-speed/icon",
+      "Icon": "imgs/actions/replay-speed/icon.svg",
       "Tooltip": "Increase or decrease replay playback speed",
       "PropertyInspectorPath": "ui/replay-speed.html",
       "Controllers": [
@@ -322,7 +322,7 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/replay-speed/key"
+          "Image": "imgs/actions/replay-speed/key.svg"
         }
       ],
       "VisibleInActionsList": false
@@ -330,7 +330,7 @@
     {
       "Name": "Replay Transport",
       "UUID": "com.iracedeck.sd.core.replay-transport",
-      "Icon": "imgs/actions/replay-transport/icon",
+      "Icon": "imgs/actions/replay-transport/icon.svg",
       "Tooltip": "Replay playback controls (play, pause, fast forward, rewind, slow motion, frame step)",
       "PropertyInspectorPath": "ui/replay-transport.html",
       "Controllers": [
@@ -338,7 +338,7 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/replay-transport/key"
+          "Image": "imgs/actions/replay-transport/key.svg"
         }
       ],
       "VisibleInActionsList": false
@@ -346,7 +346,7 @@
     {
       "Name": "Session Info",
       "UUID": "com.iracedeck.sd.core.session-info",
-      "Icon": "imgs/actions/session-info/icon",
+      "Icon": "imgs/actions/session-info/icon.svg",
       "Tooltip": "Display live session data (incidents, time, laps, position, fuel, flags)",
       "PropertyInspectorPath": "ui/session-info.html",
       "Controllers": [
@@ -354,14 +354,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/session-info/key"
+          "Image": "imgs/actions/session-info/key.svg"
         }
       ]
     },
     {
       "Name": "Setup Aero",
       "UUID": "com.iracedeck.sd.core.setup-aero",
-      "Icon": "imgs/actions/setup-aero/icon",
+      "Icon": "imgs/actions/setup-aero/icon.svg",
       "Tooltip": "Aerodynamic adjustments (front wing, rear wing, qualifying tape, RF brake)",
       "PropertyInspectorPath": "ui/setup-aero.html",
       "Controllers": [
@@ -369,14 +369,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/setup-aero/key"
+          "Image": "imgs/actions/setup-aero/key.svg"
         }
       ]
     },
     {
       "Name": "Setup Brakes",
       "UUID": "com.iracedeck.sd.core.setup-brakes",
-      "Icon": "imgs/actions/setup-brakes/icon",
+      "Icon": "imgs/actions/setup-brakes/icon.svg",
       "Tooltip": "Brake adjustments (ABS, brake bias, peak bias, engine braking)",
       "PropertyInspectorPath": "ui/setup-brakes.html",
       "Controllers": [
@@ -384,14 +384,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/setup-brakes/key"
+          "Image": "imgs/actions/setup-brakes/key.svg"
         }
       ]
     },
     {
       "Name": "Setup Chassis",
       "UUID": "com.iracedeck.sd.core.setup-chassis",
-      "Icon": "imgs/actions/setup-chassis/icon",
+      "Icon": "imgs/actions/setup-chassis/icon.svg",
       "Tooltip": "Chassis adjustments (differential, ARB, springs, shocks, power steering)",
       "PropertyInspectorPath": "ui/setup-chassis.html",
       "Controllers": [
@@ -399,14 +399,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/setup-chassis/key"
+          "Image": "imgs/actions/setup-chassis/key.svg"
         }
       ]
     },
     {
       "Name": "Setup Engine",
       "UUID": "com.iracedeck.sd.core.setup-engine",
-      "Icon": "imgs/actions/setup-engine/icon",
+      "Icon": "imgs/actions/setup-engine/icon.svg",
       "Tooltip": "Engine adjustments (power, throttle shaping, boost, launch RPM)",
       "PropertyInspectorPath": "ui/setup-engine.html",
       "Controllers": [
@@ -414,14 +414,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/setup-engine/key"
+          "Image": "imgs/actions/setup-engine/key.svg"
         }
       ]
     },
     {
       "Name": "Setup Fuel",
       "UUID": "com.iracedeck.sd.core.setup-fuel",
-      "Icon": "imgs/actions/setup-fuel/icon",
+      "Icon": "imgs/actions/setup-fuel/icon.svg",
       "Tooltip": "Fuel adjustments (mixture, fuel cut, low fuel, FCY mode)",
       "PropertyInspectorPath": "ui/setup-fuel.html",
       "Controllers": [
@@ -429,14 +429,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/setup-fuel/key"
+          "Image": "imgs/actions/setup-fuel/key.svg"
         }
       ]
     },
     {
       "Name": "Setup Hybrid",
       "UUID": "com.iracedeck.sd.core.setup-hybrid",
-      "Icon": "imgs/actions/setup-hybrid/icon",
+      "Icon": "imgs/actions/setup-hybrid/icon.svg",
       "Tooltip": "Hybrid/ERS adjustments (MGU-K regen, deploy modes, HYS boost/regen)",
       "PropertyInspectorPath": "ui/setup-hybrid.html",
       "Controllers": [
@@ -444,14 +444,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/setup-hybrid/key"
+          "Image": "imgs/actions/setup-hybrid/key.svg"
         }
       ]
     },
     {
       "Name": "Setup Traction",
       "UUID": "com.iracedeck.sd.core.setup-traction",
-      "Icon": "imgs/actions/setup-traction/icon",
+      "Icon": "imgs/actions/setup-traction/icon.svg",
       "Tooltip": "Traction control adjustments (TC Toggle, TC Slots 1-4)",
       "PropertyInspectorPath": "ui/setup-traction.html",
       "Controllers": [
@@ -459,14 +459,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/setup-traction/key"
+          "Image": "imgs/actions/setup-traction/key.svg"
         }
       ]
     },
     {
       "Name": "Splits & Reference",
       "UUID": "com.iracedeck.sd.core.splits-delta-cycle",
-      "Icon": "imgs/actions/splits-delta-cycle/icon",
+      "Icon": "imgs/actions/splits-delta-cycle/icon.svg",
       "Tooltip": "Cycle splits delta display modes or toggle reference car",
       "PropertyInspectorPath": "ui/splits-delta-cycle.html",
       "Controllers": [
@@ -474,14 +474,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/splits-delta-cycle/key"
+          "Image": "imgs/actions/splits-delta-cycle/key.svg"
         }
       ]
     },
     {
       "Name": "Telemetry Control",
       "UUID": "com.iracedeck.sd.core.telemetry-control",
-      "Icon": "imgs/actions/telemetry-control/icon",
+      "Icon": "imgs/actions/telemetry-control/icon.svg",
       "Tooltip": "Telemetry logging and recording controls",
       "PropertyInspectorPath": "ui/telemetry-control.html",
       "Controllers": [
@@ -489,14 +489,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/telemetry-control/key"
+          "Image": "imgs/actions/telemetry-control/key.svg"
         }
       ]
     },
     {
       "Name": "Telemetry Display",
       "UUID": "com.iracedeck.sd.core.telemetry-display",
-      "Icon": "imgs/actions/telemetry-display/icon",
+      "Icon": "imgs/actions/telemetry-display/icon.svg",
       "Tooltip": "Display live telemetry values using custom templates",
       "PropertyInspectorPath": "ui/telemetry-display.html",
       "Controllers": [
@@ -504,14 +504,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/telemetry-display/key"
+          "Image": "imgs/actions/telemetry-display/key.svg"
         }
       ]
     },
     {
       "Name": "Tire Service",
       "UUID": "com.iracedeck.sd.core.tire-service",
-      "Icon": "imgs/actions/tire-service/icon",
+      "Icon": "imgs/actions/tire-service/icon.svg",
       "Tooltip": "Tire management for pit stops (toggle tires, change compound, clear)",
       "PropertyInspectorPath": "ui/tire-service.html",
       "Controllers": [
@@ -519,14 +519,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/tire-service/key"
+          "Image": "imgs/actions/tire-service/key.svg"
         }
       ]
     },
     {
       "Name": "Toggle UI Elements",
       "UUID": "com.iracedeck.sd.core.toggle-ui-elements",
-      "Icon": "imgs/actions/toggle-ui-elements/icon",
+      "Icon": "imgs/actions/toggle-ui-elements/icon.svg",
       "Tooltip": "Toggle iRacing UI elements on or off",
       "PropertyInspectorPath": "ui/toggle-ui-elements.html",
       "Controllers": [
@@ -534,14 +534,14 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/toggle-ui-elements/key"
+          "Image": "imgs/actions/toggle-ui-elements/key.svg"
         }
       ]
     },
     {
       "Name": "View Adjustment",
       "UUID": "com.iracedeck.sd.core.view-adjustment",
-      "Icon": "imgs/actions/view-adjustment/icon",
+      "Icon": "imgs/actions/view-adjustment/icon.svg",
       "Tooltip": "Adjust camera and view settings (FOV, horizon, driver height, VR recenter, UI size)",
       "PropertyInspectorPath": "ui/view-adjustment.html",
       "Controllers": [
@@ -549,7 +549,7 @@
       ],
       "States": [
         {
-          "Image": "imgs/actions/view-adjustment/key"
+          "Image": "imgs/actions/view-adjustment/key.svg"
         }
       ]
     }

--- a/packages/pi-components/src/ulanzi-bridge/translate.test.ts
+++ b/packages/pi-components/src/ulanzi-bridge/translate.test.ts
@@ -55,11 +55,14 @@ describe("elgatoToUlanzi", () => {
       payload: { foo: 1 },
     });
 
+    // openUrl relays through the plugin socket (sendToPlugin marker): the host
+    // ignores `openurl` sent on the PI socket, so the plugin re-sends it (#845).
     expect(elgatoToUlanzi({ event: "openUrl", payload: { url: "https://x/" } }, identity)).toEqual({
-      cmd: "openurl",
-      url: "https://x/",
-      local: false,
-      param: "",
+      cmd: "sendToPlugin",
+      uuid: identity.uuid,
+      key: "5",
+      actionid: "abc",
+      payload: { event: "openUrl", url: "https://x/" },
     });
 
     expect(elgatoToUlanzi({ event: "logMessage", payload: { message: "hi" } }, identity)).toEqual({

--- a/packages/pi-components/src/ulanzi-bridge/translate.ts
+++ b/packages/pi-components/src/ulanzi-bridge/translate.ts
@@ -54,7 +54,14 @@ export function elgatoToUlanzi(
     case "sendToPlugin":
       return { cmd: "sendToPlugin", ...base, payload: asRecord(frame.payload) ?? {} };
     case "openUrl":
-      return { cmd: "openurl", url: String(asRecord(frame.payload)?.url ?? ""), local: false, param: "" };
+      // Relayed out the plugin socket as a sendToPlugin marker: UlanziStudio
+      // ignores `openurl` sent on the PI socket but honours it from the plugin
+      // socket, so the Ulanzi adapter re-sends it from there (#845).
+      return {
+        cmd: "sendToPlugin",
+        ...base,
+        payload: { event: "openUrl", url: String(asRecord(frame.payload)?.url ?? "") },
+      };
     case "logMessage":
       return { cmd: "logMessage", message: String(asRecord(frame.payload)?.message ?? ""), level: "info" };
     default:

--- a/packages/website/src/content/docs/changelog.mdx
+++ b/packages/website/src/content/docs/changelog.mdx
@@ -17,6 +17,11 @@ _Unreleased_
 
 - The Race Engineer now estimates how many laps of fuel you have left and calls the count out mid-lap — *"We're estimating that we have about 3 laps of fuel left after completing this lap."* — ending in a dedicated *"Box this lap for fuel."* call when the tank won't cover another full lap. Each count from 10 down to 1 plus the box call has its own checkbox (5, 3, 2, 1 and Box on by default), and a safety-margin slider (0–3 laps, default 0.3) makes the spoken estimate deliberately conservative relative to Session Info's Laps to Empty display. Counts announce once per stint on the way down — saving fuel never repeats a higher count — and a refuel re-arms them all.
 
+**Bug Fixes**
+
+- The plugin now shows its icon in Ulanzi Studio's Settings > Plugins list.
+- The documentation and Downloads links at the bottom of an action's settings now open in the browser on Ulanzi Deck.
+
 **Maintenance**
 
 - Reworked the Race Engineer's voice-clip catalog to be fully config-driven: which lines, variants, and values the engineer can speak now derives from the audio clips that actually ship instead of lists in code, a callout missing any required clip skips cleanly as a whole (never a half-sentence), and voices may carry different variant counts or omit lines entirely — groundwork for additional Race Engineer voices.

--- a/scripts/ulanzi-manifest-images.test.mjs
+++ b/scripts/ulanzi-manifest-images.test.mjs
@@ -28,7 +28,9 @@ function imageRefs() {
     }
   }
 
-  return refs.filter(([, ref]) => typeof ref === "string");
+  // No filtering: a missing Icon / States[n].Image must fail the assertions
+  // below, not silently shrink the case list.
+  return refs;
 }
 
 /**
@@ -55,11 +57,14 @@ describe("ulanzi manifest image references", () => {
   // host it does not probe for .png/.svg/@2x variants, so an extensionless
   // reference (the Elgato manifest convention) renders no icon. Every
   // first-party Ulanzi plugin declares explicit extensions (issue #845).
-  it.each(imageRefs())("declares an explicit file extension: %s", (_label, ref) => {
+  it.each(imageRefs())("declares an explicit file extension: %s", (label, ref) => {
+    expect(ref, `${label}: image reference must be a string`).toBeTypeOf("string");
     expect(ref).toMatch(/\.(png|svg)$/);
   });
 
-  it.each(imageRefs())("resolves to a committed source file: %s", (_label, ref) => {
+  it.each(imageRefs())("resolves to a committed source file: %s", (label, ref) => {
+    expect(ref, `${label}: image reference must be a string`).toBeTypeOf("string");
+
     const source = committedSource(ref);
 
     expect(source, `unrecognized image path shape: ${ref}`).not.toBeNull();

--- a/scripts/ulanzi-manifest-images.test.mjs
+++ b/scripts/ulanzi-manifest-images.test.mjs
@@ -1,0 +1,68 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// scripts/ulanzi-manifest-images.test.mjs lives in scripts/, so the repo root is one up.
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const manifest = JSON.parse(
+  readFileSync(
+    join(repoRoot, "packages/iracing-plugin-ulanzi/com.ulanzi.iracedeck.ulanziPlugin/manifest.json"),
+    "utf-8",
+  ),
+);
+
+/** Collect every image reference in the Ulanzi manifest as [label, ref] pairs. */
+function imageRefs() {
+  const refs = [
+    ["Icon", manifest.Icon],
+    ["CategoryIcon", manifest.CategoryIcon],
+  ];
+
+  for (const action of manifest.Actions) {
+    refs.push([`${action.Name} Icon`, action.Icon]);
+
+    for (const [i, state] of (action.States ?? []).entries()) {
+      refs.push([`${action.Name} States[${i}].Image`, state.Image]);
+    }
+  }
+
+  return refs.filter(([, ref]) => typeof ref === "string");
+}
+
+/**
+ * Map a manifest image reference to its committed source file. The plugin's own
+ * `imgs/` tree is build output (gitignored): per-action icons are copied from
+ * `@iracedeck/iracing-actions` and plugin-level branding from the Elgato plugin
+ * (see the Ulanzi plugin's rollup `copy-assets` step), so existence is checked
+ * against those committed sources.
+ */
+function committedSource(ref) {
+  const action = ref.match(/^imgs\/actions\/([^/]+)\/(.+)$/);
+  if (action) return join(repoRoot, "packages/iracing-actions/src/actions", action[1], action[2]);
+
+  const plugin = ref.match(/^imgs\/plugin\/(.+)$/);
+  if (plugin) {
+    return join(repoRoot, "packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/imgs/plugin", plugin[1]);
+  }
+
+  return null;
+}
+
+describe("ulanzi manifest image references", () => {
+  // UlanziStudio resolves manifest image paths literally — unlike the Elgato
+  // host it does not probe for .png/.svg/@2x variants, so an extensionless
+  // reference (the Elgato manifest convention) renders no icon. Every
+  // first-party Ulanzi plugin declares explicit extensions (issue #845).
+  it.each(imageRefs())("declares an explicit file extension: %s", (_label, ref) => {
+    expect(ref).toMatch(/\.(png|svg)$/);
+  });
+
+  it.each(imageRefs())("resolves to a committed source file: %s", (_label, ref) => {
+    const source = committedSource(ref);
+
+    expect(source, `unrecognized image path shape: ${ref}`).not.toBeNull();
+    expect(existsSync(source), `missing source for ${ref}: ${source}`).toBe(true);
+  });
+});


### PR DESCRIPTION
## Related Issue

Fixes #845

## What changed?

Two Ulanzi Studio compatibility fixes from Ulanzi QA feedback, authored blind (no device) against first-party plugin conventions and the observed working plugin-socket `openurl` path:

- **Plugin icon missing in Settings > Plugins:** every image reference in the Ulanzi manifest now carries an explicit file extension (`imgs/plugin/marketplace.png`, `imgs/actions/<name>/icon.svg`, `imgs/actions/<name>/key.svg`). UlanziStudio resolves image paths literally — no Elgato-style `.png`/`@2x` probing (all three first-party plugins declare explicit extensions) — so the extensionless references rendered no icon. A new `scripts/ulanzi-manifest-images.test.mjs` enforces the extension convention and that every reference resolves to its committed copy source.
- **PI documentation/Downloads links unresponsive:** UlanziStudio ignores `openurl` sent on the PI socket, so the PI bridge now relays external-link clicks as a `sendToPlugin` openUrl marker; the Ulanzi client normalizes it to an `openUrl` global event and the adapter re-sends the URL out the plugin socket via `client.openUrl` — the path proven to work by the version-check changelog opening in the tester's browser (issue #845, their report #3).

Docs kept in sync: `deck-adapter-ulanzi/CLAUDE.md` (marker table + relay), `iracing-plugin-ulanzi/CLAUDE.md` (manifest image-extension convention, validation status), `.claude/rules/pi-templates.md` (External Links), and two Bug Fixes entries under 2.2.0 in `changelog.mdx`.

## How to test

No deck hardware needed — both fixes are host-app-level:

1. Quit UlanziStudio, copy the built `com.ulanzi.iracedeck.ulanziPlugin` folder over `%APPDATA%\Ulanzi\UlanziDeck\Plugins\com.ulanzi.iracedeck.ulanziPlugin`, restart UlanziStudio.
2. Settings > Plugins: the iRaceDeck entry should show the plugin icon.
3. Open any action's Property Inspector, scroll to the bottom: "See documentation for this action" and "Downloads" should open in the default browser.
4. `pnpm test` covers the translation, normalization, adapter relay, and manifest-reference guards (6715 tests green; full `pnpm build` + website build pass).

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Ulanzi-only by design — Elgato/Mirabox hosts handle `openUrl` natively and keep the extensionless manifest convention)
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - External links from action settings now open in the browser on Ulanzi Deck.
  - Fixed plugin icon rendering in Ulanzi Studio’s Settings → Plugins list.
  - Improved external-link relay from the Property Inspector to Ulanzi Deck, forwarding only valid `http(s)` URLs.
- **Documentation**
  - Clarified external-link handling and how Deck routing works between the Property Inspector, plugin, and PI-safe targets.
- **Tests**
  - Added/expanded coverage for external-link relays and Ulanzi manifest image reference validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->