### PR TITLE
fix(template): treat blank driver string fields as empty strings in expressions (#869)

### DIFF
--- a/packages/iracing-sdk/src/session-utils.test.ts
+++ b/packages/iracing-sdk/src/session-utils.test.ts
@@ -79,6 +79,20 @@ describe("classifyCarNumberTarget", () => {
     expect(classifyCarNumberTarget(null, "42")).toBe("unknown");
     expect(classifyCarNumberTarget({}, "42")).toBe("unknown");
   });
+
+  it("tolerates roster entries with null or unquoted-numeric CarNumber (#869)", () => {
+    const info = {
+      DriverInfo: {
+        Drivers: [
+          { CarIdx: 0, CarNumber: null, CarNumberRaw: 0 },
+          { CarIdx: 1, CarNumber: 42, CarNumberRaw: 42, UserName: "Jane Doe", CarIsAI: 0 },
+        ],
+      },
+    };
+
+    expect(classifyCarNumberTarget(info, "42")).toBe("user");
+    expect(classifyCarNumberTarget(info, "7")).toBe("unknown");
+  });
 });
 
 describe("getCarNumberFromSessionInfo", () => {
@@ -122,6 +136,26 @@ describe("getCarNumberFromSessionInfo", () => {
     };
 
     expect(getCarNumberFromSessionInfo(info, 0)).toBe("042");
+  });
+
+  it("should return null when the entry's CarNumber is null (blank in YAML, #869)", () => {
+    const info = {
+      DriverInfo: {
+        Drivers: [{ CarIdx: 0, CarNumber: null, CarNumberRaw: 0 }],
+      },
+    };
+
+    expect(getCarNumberFromSessionInfo(info, 0)).toBeNull();
+  });
+
+  it("should handle an unquoted numeric CarNumber (#869)", () => {
+    const info = {
+      DriverInfo: {
+        Drivers: [{ CarIdx: 0, CarNumber: 42, CarNumberRaw: 42 }],
+      },
+    };
+
+    expect(getCarNumberFromSessionInfo(info, 0)).toBe("42");
   });
 
   it("should return null for unknown car index", () => {
@@ -199,6 +233,19 @@ describe("getAllCarNumbers", () => {
       ],
     },
   };
+
+  it("should skip entries whose CarNumber is null (blank in YAML, #869)", () => {
+    const info = {
+      DriverInfo: {
+        Drivers: [
+          { CarIdx: 0, CarNumber: null, CarNumberRaw: 0 },
+          { CarIdx: 1, CarNumber: "42", CarNumberRaw: 42 },
+        ],
+      },
+    };
+
+    expect(getAllCarNumbers(info)).toEqual([{ carIdx: 1, carNumber: "42", carNumberRaw: 42, userName: "" }]);
+  });
 
   it("should return all car numbers sorted ascending by numeric value", () => {
     const result = getAllCarNumbers(sessionInfo);

--- a/packages/iracing-sdk/src/session-utils.ts
+++ b/packages/iracing-sdk/src/session-utils.ts
@@ -6,12 +6,18 @@
 
 interface DriverEntry {
   CarIdx: number;
-  CarNumber: string;
+  /** Session YAML can leave this blank (null) or emit it unquoted (number) — see #869. */
+  CarNumber: string | number | null;
   CarNumberRaw: number;
   CarIsPaceCar?: number;
   IsSpectator?: number;
   UserName?: string;
   CarIsAI?: number;
+}
+
+/** Digit-cleaned car number for a roster entry; "" when the YAML left it blank. */
+function cleanCarNumber(carNumber: DriverEntry["CarNumber"]): string {
+  return String(carNumber ?? "").replace(/[^0-9]/g, "");
 }
 
 /**
@@ -56,7 +62,7 @@ export function classifyCarNumberTarget(sessionInfo: unknown, carNumber: string)
 
   const driverInfo = (sessionInfo as Record<string, unknown>)?.DriverInfo as Record<string, unknown> | undefined;
   const drivers = driverInfo?.Drivers as DriverEntry[] | undefined;
-  const driver = drivers?.find((d) => d.CarNumber?.replace(/[^0-9]/g, "") === target);
+  const driver = drivers?.find((d) => cleanCarNumber(d.CarNumber) === target);
 
   if (!driver) return "unknown";
 
@@ -78,7 +84,7 @@ export function getCarNumberFromSessionInfo(sessionInfo: unknown, carIdx: number
 
   if (!driver) return null;
 
-  const cleaned = driver.CarNumber.replace(/[^0-9]/g, "");
+  const cleaned = cleanCarNumber(driver.CarNumber);
 
   return cleaned.length > 0 ? cleaned : null;
 }
@@ -127,7 +133,7 @@ export function getAllCarNumbers(
 
     if (excludeSpectators && driver.IsSpectator === 1) continue;
 
-    const cleaned = driver.CarNumber.replace(/[^0-9]/g, "");
+    const cleaned = cleanCarNumber(driver.CarNumber);
 
     if (cleaned.length === 0) continue;
 

--- a/packages/iracing-sdk/src/snapshot.test.ts
+++ b/packages/iracing-sdk/src/snapshot.test.ts
@@ -159,6 +159,19 @@ describe("buildPlayerTelemetry", () => {
     expect(table).toContain("180.0 km/h"); // 50 m/s * 3.6
     expect(table).toContain("32.6 L");
   });
+
+  it("should render blank instead of 'null' for a blank UserName/CarNumber (#869)", () => {
+    const sessionInfo = {
+      DriverInfo: {
+        Drivers: [{ CarIdx: 1, UserName: null, CarNumber: null, CarScreenName: "Mazda MX-5" }],
+      },
+    } as Record<string, unknown>;
+
+    const table = buildPlayerTelemetry({ PlayerCarIdx: 1 }, sessionInfo);
+
+    expect(table).not.toContain("null");
+    expect(table).toContain("Mazda MX-5 (#)");
+  });
 });
 
 describe("generateMarkdown", () => {

--- a/packages/iracing-sdk/src/snapshot.ts
+++ b/packages/iracing-sdk/src/snapshot.ts
@@ -259,8 +259,11 @@ export function buildPlayerTelemetry(
 
   // Player identity
   if (player) {
-    posRows.push(["Driver", String(player.UserName)]);
-    posRows.push(["Car", `${player.CarScreenName ?? player.CarScreenNameShort ?? "Unknown"} (#${player.CarNumber})`]);
+    posRows.push(["Driver", String(player.UserName ?? "")]);
+    posRows.push([
+      "Car",
+      `${player.CarScreenName ?? player.CarScreenNameShort ?? "Unknown"} (#${player.CarNumber ?? ""})`,
+    ]);
 
     if (player.TeamName) posRows.push(["Team", String(player.TeamName)]);
 

--- a/packages/iracing-sdk/src/template-context.test.ts
+++ b/packages/iracing-sdk/src/template-context.test.ts
@@ -1052,6 +1052,26 @@ describe("buildTemplateContextFromData raw map", () => {
     expect(ctx.raw["self.last_name"]).toBe("");
     expect(ctx.display["self.name"]).toBe("");
   });
+
+  it("should keep a null LicString as an empty string in raw", () => {
+    const sessionInfo = makeSessionInfo([makeDriver({ CarIdx: 0, LicString: null })], 0);
+
+    const ctx = buildTemplateContextFromData(makeTelemetry(), sessionInfo);
+
+    expect(ctx.raw["self.license"]).toBe("");
+    expect(ctx.display["self.license"]).toBe("");
+  });
+
+  it("should coerce unquoted-numeric YAML string fields instead of crashing (#869)", () => {
+    const sessionInfo = makeSessionInfo([makeDriver({ CarIdx: 0, UserName: 88, AbbrevName: 88, CarNumber: 88 })], 0);
+
+    const ctx = buildTemplateContextFromData(makeTelemetry(), sessionInfo);
+
+    expect(ctx.raw["self.name"]).toBe("88");
+    expect(ctx.raw["self.first_name"]).toBe("88");
+    expect(ctx.raw["self.abbrev_name"]).toBe("88");
+    expect(ctx.raw["self.car_number"]).toBe("88");
+  });
 });
 
 describe("flattenContext display map", () => {

--- a/packages/iracing-sdk/src/template-context.test.ts
+++ b/packages/iracing-sdk/src/template-context.test.ts
@@ -1008,6 +1008,50 @@ describe("buildTemplateContextFromData raw map", () => {
     expect(ctx.raw["focused.irating"]).toBe(4200);
     expect(resolveTemplate("{{= focused.irating + 100 }}", ctx)).toBe("4300");
   });
+
+  it("should keep a null AbbrevName as an empty string in raw (AI drivers, #869)", () => {
+    const sessionInfo = makeSessionInfo([makeDriver({ CarIdx: 0, AbbrevName: null })], 0);
+
+    const ctx = buildTemplateContextFromData(makeTelemetry(), sessionInfo);
+
+    expect(ctx.raw["self.abbrev_name"]).toBe("");
+    expect(ctx.display["self.abbrev_name"]).toBe("");
+  });
+
+  it("should let a ternary fall back to name when abbrev_name is null (#869)", () => {
+    const drivers = [
+      makeDriver({ CarIdx: 0, UserName: "Player" }),
+      makeDriver({ CarIdx: 1, UserName: "Ahead Driver", AbbrevName: null }),
+    ];
+
+    // Default telemetry places CarIdx 1 physically ahead of the player.
+    const ctx = buildTemplateContextFromData(makeTelemetry(), makeSessionInfo(drivers, 0));
+
+    expect(resolveTemplate("{{= track_ahead.abbrev_name ? track_ahead.abbrev_name : track_ahead.name }}", ctx)).toBe(
+      "Ahead Driver",
+    );
+    expect(resolveTemplate('{{= track_ahead.abbrev_name == "" ? "1" : "2" }}3', ctx)).toBe("13");
+  });
+
+  it("should keep a null CarNumber as an empty string in raw", () => {
+    const sessionInfo = makeSessionInfo([makeDriver({ CarIdx: 0, CarNumber: null })], 0);
+
+    const ctx = buildTemplateContextFromData(makeTelemetry(), sessionInfo);
+
+    expect(ctx.raw["self.car_number"]).toBe("");
+    expect(ctx.display["self.car_number"]).toBe("");
+  });
+
+  it("should not crash on a null UserName and keep name fields as empty strings", () => {
+    const sessionInfo = makeSessionInfo([makeDriver({ CarIdx: 0, UserName: null })], 0);
+
+    const ctx = buildTemplateContextFromData(makeTelemetry(), sessionInfo);
+
+    expect(ctx.raw["self.name"]).toBe("");
+    expect(ctx.raw["self.first_name"]).toBe("");
+    expect(ctx.raw["self.last_name"]).toBe("");
+    expect(ctx.display["self.name"]).toBe("");
+  });
 });
 
 describe("flattenContext display map", () => {

--- a/packages/iracing-sdk/src/template-context.ts
+++ b/packages/iracing-sdk/src/template-context.ts
@@ -71,18 +71,24 @@ type SelfDriverFields = DriverFields & {
 
 /**
  * One entry from the session YAML's driver roster. String fields iRacing can
- * leave blank (parsed to null) — e.g. AbbrevName for AI drivers (#869) — are
- * typed nullable so consumers must coalesce.
+ * leave blank (parsed to null) — e.g. AbbrevName for AI drivers — or emit as
+ * unquoted numeric scalars (parsed to number), so consumers must normalize
+ * through `yamlString` (#869).
  */
 interface DriverEntry {
   CarIdx: number;
-  UserName: string | null;
-  AbbrevName: string | null;
-  CarNumber: string | null;
+  UserName: string | number | null;
+  AbbrevName: string | number | null;
+  CarNumber: string | number | null;
   IRating: number;
-  LicString: string | null;
+  LicString: string | number | null;
   IsSpectator: number;
   CarIsPaceCar: number;
+}
+
+/** Normalizes a YAML scalar to a string: blank (null/undefined) → "", numbers → digits. */
+function yamlString(value: string | number | null | undefined): string {
+  return value == null ? "" : String(value);
 }
 
 const EMPTY_DRIVER_FIELDS: DriverFields = {
@@ -521,11 +527,10 @@ function buildDriverFields(
   playerCarIdx?: number,
   estimates?: IRatingEstimates,
 ): DriverFields {
-  // iRacing's session YAML can send string fields blank (→ null) — e.g.
-  // AbbrevName for AI drivers (#869). Coalesce to "" so the raw map keeps the
-  // key and expressions like `{{= x.abbrev_name ? … : … }}` can branch on it
-  // instead of dying on an unknown variable.
-  const userName = driver.UserName ?? "";
+  // Normalize the YAML string fields (#869) so the raw map keeps the key and
+  // expressions like `{{= x.abbrev_name ? … : … }}` can branch on it instead
+  // of dying on an unknown variable.
+  const userName = yamlString(driver.UserName);
   const { firstName, lastName } = splitDriverName(userName);
   const carIdx = driver.CarIdx;
   const isPlayer = playerCarIdx !== undefined && carIdx === playerCarIdx;
@@ -541,8 +546,8 @@ function buildDriverFields(
     name: userName,
     first_name: firstName,
     last_name: lastName,
-    abbrev_name: driver.AbbrevName ?? "",
-    car_number: driver.CarNumber ?? "",
+    abbrev_name: yamlString(driver.AbbrevName),
+    car_number: yamlString(driver.CarNumber),
     // Single source: the canonical live order. When it exists it's authoritative
     // (a car not in it stays blank); only with no live order at all do we fall
     // back to iRacing's official CarIdxPosition. No pit-road / PlayerCar* overlay —
@@ -559,7 +564,7 @@ function buildDriverFields(
     irating_change: iratingChange ?? undefined,
     // Projected post-race rating — integer, like the reference implementation.
     irating_new: iratingChange != null && driver.IRating > 0 ? Math.round(driver.IRating + iratingChange) : undefined,
-    license: driver.LicString ?? "",
+    license: yamlString(driver.LicString),
   };
 }
 

--- a/packages/iracing-sdk/src/template-context.ts
+++ b/packages/iracing-sdk/src/template-context.ts
@@ -69,13 +69,18 @@ type SelfDriverFields = DriverFields & {
   incidents: number | undefined;
 };
 
+/**
+ * One entry from the session YAML's driver roster. String fields iRacing can
+ * leave blank (parsed to null) — e.g. AbbrevName for AI drivers (#869) — are
+ * typed nullable so consumers must coalesce.
+ */
 interface DriverEntry {
   CarIdx: number;
-  UserName: string;
-  AbbrevName: string;
-  CarNumber: string;
+  UserName: string | null;
+  AbbrevName: string | null;
+  CarNumber: string | null;
   IRating: number;
-  LicString: string;
+  LicString: string | null;
   IsSpectator: number;
   CarIsPaceCar: number;
 }
@@ -516,7 +521,12 @@ function buildDriverFields(
   playerCarIdx?: number,
   estimates?: IRatingEstimates,
 ): DriverFields {
-  const { firstName, lastName } = splitDriverName(driver.UserName);
+  // iRacing's session YAML can send string fields blank (→ null) — e.g.
+  // AbbrevName for AI drivers (#869). Coalesce to "" so the raw map keeps the
+  // key and expressions like `{{= x.abbrev_name ? … : … }}` can branch on it
+  // instead of dying on an unknown variable.
+  const userName = driver.UserName ?? "";
+  const { firstName, lastName } = splitDriverName(userName);
   const carIdx = driver.CarIdx;
   const isPlayer = playerCarIdx !== undefined && carIdx === playerCarIdx;
   // The pace car and spectators have no race position. The relative prefixes
@@ -528,11 +538,11 @@ function buildDriverFields(
   const iratingChange = isCompetitor ? (estimates?.changes[carIdx] ?? null) : null;
 
   return {
-    name: driver.UserName,
+    name: userName,
     first_name: firstName,
     last_name: lastName,
-    abbrev_name: driver.AbbrevName,
-    car_number: driver.CarNumber,
+    abbrev_name: driver.AbbrevName ?? "",
+    car_number: driver.CarNumber ?? "",
     // Single source: the canonical live order. When it exists it's authoritative
     // (a car not in it stays blank); only with no live order at all do we fall
     // back to iRacing's official CarIdxPosition. No pit-road / PlayerCar* overlay —

--- a/packages/website/src/content/docs/changelog.mdx
+++ b/packages/website/src/content/docs/changelog.mdx
@@ -9,6 +9,14 @@ import ChangelogLeadIn from "../../components/ChangelogLeadIn.astro";
 
 Release notes for each version of iRaceDeck. The newest release is listed first. For installation help, see the [installation guide](/docs/getting-started/installation/); to grab the latest build, head to the [downloads page](/downloads/).
 
+## 2.3.0
+
+_Unreleased_
+
+**Bug Fixes**
+
+- Template expressions no longer render as empty text when they reference a driver text field iRacing left blank — such as `abbrev_name` for AI drivers. Blank fields now count as empty strings in expressions, so fallback patterns like `{{= track_ahead.abbrev_name ? track_ahead.abbrev_name : track_ahead.name }}` work as expected.
+
 ## 2.2.0
 
 _2026-07-16_

--- a/packages/website/src/content/docs/docs/features/template-variables.md
+++ b/packages/website/src/content/docs/docs/features/template-variables.md
@@ -98,6 +98,12 @@ In race sessions, `position` and `class_position` follow the **live race order**
 
 `irating_change` and `irating_new` are **estimates** computed from the live running order and the field's iRatings (per car class, exactly like iRacing scores them) — not official post-race values. They render blank outside race sessions, before a live order exists, and for cars excluded from scoring (the pace car, spectators, cars without a valid iRating, or a class with fewer than two cars). In expressions, `irating_change` is the unrounded value — wrap it in `round(...)` to match the displayed number.
 
+The text fields (`name`, `abbrev_name`, `car_number`, `license`) are always available in expressions — when iRacing doesn't provide one (for example, AI drivers have no `abbrev_name`), it's an empty string rather than an unknown variable. That makes fallback patterns work:
+
+```text
+{{= track_ahead.abbrev_name ? track_ahead.abbrev_name : track_ahead.name }}
+```
+
 | Variable | Description |
 |----------|-------------|
 | `{{self.name}}` | Full driver name |

--- a/packages/website/src/content/docs/docs/features/template-variables.md
+++ b/packages/website/src/content/docs/docs/features/template-variables.md
@@ -98,7 +98,7 @@ In race sessions, `position` and `class_position` follow the **live race order**
 
 `irating_change` and `irating_new` are **estimates** computed from the live running order and the field's iRatings (per car class, exactly like iRacing scores them) — not official post-race values. They render blank outside race sessions, before a live order exists, and for cars excluded from scoring (the pace car, spectators, cars without a valid iRating, or a class with fewer than two cars). In expressions, `irating_change` is the unrounded value — wrap it in `round(...)` to match the displayed number.
 
-The text fields (`name`, `abbrev_name`, `car_number`, `license`) are always available in expressions — when iRacing doesn't provide one (for example, AI drivers have no `abbrev_name`), it's an empty string rather than an unknown variable. That makes fallback patterns work:
+The text fields (`name`, `first_name`, `last_name`, `abbrev_name`, `car_number`, `license`) are always available in expressions — when iRacing doesn't provide one (for example, AI drivers have no `abbrev_name`), it's an empty string rather than an unknown variable. That makes fallback patterns work:
 
 ```text
 {{= track_ahead.abbrev_name ? track_ahead.abbrev_name : track_ahead.name }}


### PR DESCRIPTION
## Related Issue

Fixes #869

## What changed?

For AI drivers, iRacing's session YAML sends `AbbrevName:` blank (parsed to `null`). The template context omitted such fields from the raw map, so any `{{= ... }}` expression referencing them threw "Unknown variable" internally and rendered the **whole expression** as empty text — making the natural fallback `{{= track_ahead.abbrev_name ? track_ahead.abbrev_name : track_ahead.name }}` impossible.

- `buildDriverFields` now normalizes the YAML string fields (`name`, `abbrev_name`, `car_number`, `license`) through a `yamlString()` helper: blank → `""`, unquoted numeric scalar → its digits. The raw map always keeps these keys, so expressions can branch on them.
- `DriverEntry` (template-context) is typed `string | number | null` for those fields to match what the YAML parser actually delivers; a null `UserName` no longer crashes `splitDriverName`.
- Hardening from code review: `session-utils.ts` car-number readers (`getCarNumberFromSessionInfo`, `getAllCarNumbers`, `classifyCarNumberTarget`) share a `cleanCarNumber()` helper and tolerate null/numeric `CarNumber` instead of throwing; the session-snapshot diagnostic renders blanks instead of literal `null`/`#null`.
- Website: changelog entry under 2.3.0, and the template-variables page documents the always-available text fields plus the fallback pattern.

## How to test

1. Start an AI race session.
2. Put `{{= track_ahead.abbrev_name ? track_ahead.abbrev_name : track_ahead.name }}` on a Telemetry Display key.
3. With an AI car ahead, the key shows the AI driver's full name (previously: empty text).
4. `1{{track_ahead.abbrev_name}}2` still renders "12" and `{{= track_ahead.name ? "1" : "2" }}3` still renders "13" — unchanged behavior for available fields.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — shared `@iracedeck/iracing-sdk` change, no plugin registration needed
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of blank, null, and numeric driver and car-number data.
  - Template expressions now treat missing driver fields as empty strings, enabling reliable fallbacks.
  - Telemetry displays no longer show “null” for missing driver or car information.
  - Session car-number lists and lookups now handle incomplete roster entries consistently.

- **Documentation**
  - Clarified driver-field behavior in templates and added a fallback example.
  - Added a changelog entry for the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->