### PR TITLE
chore(build): ship project LICENSE and aggregated third-party notices in all plugin artifacts (#905)

### DIFF
--- a/.claude/rules/plugin-structure.md
+++ b/.claude/rules/plugin-structure.md
@@ -50,6 +50,8 @@ packages/iracing-plugin-stream-deck-{name}/
 ├── icons/                                 # SVG icon templates
 └── com.iracedeck.sd.{name}.sdPlugin/
     ├── manifest.json                      # Plugin metadata
+    ├── LICENSE                            # Copied at build time from the repo root (#905)
+    ├── THIRD-PARTY-LICENSES.md            # Copied at build time from the repo root (#905)
     ├── imgs/
     │   ├── plugin/                        # category-icon.png, marketplace.png (@1x and @2x)
     │   └── actions/{action-name}/         # icon.svg, key.svg for each action
@@ -125,6 +127,12 @@ const pkg = {
 4. **Bundle the rasterizer's fonts** - `@iracedeck/rasterizer` ships bundled Arimo font files (`packages/rasterizer/fonts/`) that must be copied into `{sdPlugin}/assets/fonts/` at build time (a dedicated `generateBundle` copy step, same pattern as the per-action icon copy) so `createSvgRasterizer({ fontsDir })` can find them at runtime.
 
 Reference `iracing-plugin-stream-deck/rollup.config.mjs` for the correct configuration.
+
+### License and Third-Party Notices
+
+Every plugin artifact must ship the project `LICENSE` and the aggregated `THIRD-PARTY-LICENSES.md` at the sdPlugin root (issue #905): LICENSE §3/§5/§7 require the license text in every distributed copy, and several shipped components carry notice obligations of their own (the iRacing SDK's BSD-3-Clause notice, the MPL-2.0 source pointer for `@resvg/resvg-js`, the Lovely Sim Racing corner-data attribution). Both files are copied from the repo root by the `copy-license-files` `generateBundle` step in each plugin's `rollup.config.mjs` (same pattern as the rasterizer-fonts copy), and the copies are gitignored in each plugin package — new plugins must add both the copy step and the `.gitignore` entries.
+
+When a shipped third-party dependency or vendored component is added or removed, update the repo-root `THIRD-PARTY-LICENSES.md` in the same change. `scripts/third-party-licenses.test.mjs` guards the wiring: every non-workspace rollup `external` must have an entry in the file, every plugin config must contain the copy step, and no `.sdignore` pattern may exclude the two files from the packed plugin.
 
 ### Application Monitoring
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ iRaceDeck is source-available and licensed under the [iRaceDeck Non-Commercial L
 
 Free for personal and non-commercial use, including use in sim racing events and competitions.
 
+Plugin downloads ship the license alongside [THIRD-PARTY-LICENSES.md](THIRD-PARTY-LICENSES.md), which aggregates the license notices of every bundled third-party component.
+
 For full details, see [USAGE.md](USAGE.md).
 
 The name “iRaceDeck” and associated branding are not included in the license and may not be used for derived versions without permission.

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -1,0 +1,334 @@
+# Third-Party Licenses
+
+iRaceDeck itself is distributed under the iRaceDeck Non-Commercial License — see the `LICENSE` file next to this document. The plugin additionally ships the third-party components listed below. This document aggregates their license notices; where a component's full license text also ships elsewhere in the plugin folder, its entry points there.
+
+Not every component is present in every plugin build (Elgato Stream Deck, Mirabox, Ulanzi) — the table notes the differences. Versions of the npm packages are pinned in the plugin's `bin/package.json`.
+
+| Component | License | Where it ships |
+| --- | --- | --- |
+| [iRacing SDK](https://forums.iracing.com/discussion/15068/official-iracing-sdk) | BSD-3-Clause | compiled into `iracing_native.node` |
+| [miniaudio](https://miniaud.io) | Public domain / MIT-0 (dual) | compiled into `audio_native.node` |
+| [@resvg/resvg-js](https://github.com/yisibl/resvg-js) | MPL-2.0 | `bin/node_modules/@resvg/resvg-js` |
+| [keysender](https://github.com/Krombik/keysender) | MIT | `bin/node_modules/keysender` (Windows only) |
+| [yaml](https://github.com/eemeli/yaml) | ISC | `bin/node_modules/yaml` |
+| [ws](https://github.com/websockets/ws) | MIT | `bin/node_modules/ws` (Mirabox and Ulanzi builds) |
+| [node-addon-api](https://github.com/nodejs/node-addon-api) | MIT | `bin/node_modules/node-addon-api` |
+| [zod](https://github.com/colinhacks/zod) | MIT | bundled into `bin/plugin.js` |
+| [semver](https://github.com/npm/node-semver) | ISC | bundled into `bin/plugin.js` |
+| [@elgato/streamdeck](https://github.com/elgatosf/streamdeck) | MIT | bundled into `bin/plugin.js` (Elgato build) |
+| [sdpi-components](https://sdpi-components.dev) | MIT | `ui/sdpi-components.js` |
+| [Lit](https://lit.dev) | BSD-3-Clause | bundled into `ui/sdpi-components.js` |
+| [Arimo fonts](https://github.com/googlefonts/Arimo) | SIL Open Font License 1.1 | `assets/fonts/` |
+| [lovely-track-data](https://github.com/Lovely-Sim-Racing/lovely-track-data) corner data | CC BY-NC-SA 4.0 | bundled into `bin/plugin.js` |
+
+## iRacing SDK
+
+The iRacing SDK (telemetry access headers and utilities) is compiled into the `@iracedeck/iracing-native` addon.
+
+```text
+Copyright (c) 2013, iRacing.com Motorsport Simulations, LLC.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of iRacing.com Motorsport Simulations nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+## miniaudio
+
+miniaudio by David Reid (https://miniaud.io, https://github.com/mackron/miniaudio) is compiled into the `@iracedeck/audio-native` addon. Upstream offers it as a choice of public domain ([Unlicense](https://unlicense.org)) or MIT No Attribution; iRaceDeck uses it under the MIT No Attribution license:
+
+```text
+MIT No Attribution
+
+Copyright 2026 David Reid
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## @resvg/resvg-js
+
+resvg-js is licensed under the Mozilla Public License 2.0. The full MPL-2.0 text ships in this plugin at `bin/node_modules/@resvg/resvg-js/LICENSE` (also available at https://www.mozilla.org/en-US/MPL/2.0/). Per MPL-2.0 §3.2, the source code of the covered software is available at https://github.com/yisibl/resvg-js; it embeds the resvg SVG rendering library, also MPL-2.0, whose source is available at https://github.com/linebender/resvg.
+
+## keysender
+
+Ships in Windows builds at `bin/node_modules/keysender` (its `LICENSE` file included).
+
+```text
+MIT License
+
+Copyright (c) 2020 Andrey
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## yaml
+
+Ships at `bin/node_modules/yaml` (its `LICENSE` file included).
+
+```text
+Copyright Eemeli Aro <eemeli@gmail.com>
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+```
+
+## ws
+
+Ships in the Mirabox and Ulanzi builds at `bin/node_modules/ws`.
+
+```text
+Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
+Copyright (c) 2013 Arnout Kazemier and contributors
+Copyright (c) 2016 Luigi Pinca and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
+## node-addon-api
+
+Ships at `bin/node_modules/node-addon-api` (its `LICENSE.md` file included) as a dependency of the `@iracedeck/audio-native` and `@iracedeck/iracing-native` addons.
+
+```text
+The MIT License (MIT)
+
+Copyright (c) 2017 Node.js API collaborators
+(https://github.com/nodejs/node-addon-api#collaborators)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
+## zod
+
+Bundled into `bin/plugin.js`.
+
+```text
+MIT License
+
+Copyright (c) 2025 Colin McDonnell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## semver
+
+Bundled into `bin/plugin.js`.
+
+```text
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+```
+
+## @elgato/streamdeck
+
+Bundled into `bin/plugin.js` in the Elgato Stream Deck build.
+
+```text
+MIT License
+
+Copyright (c) Corsair Memory Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## sdpi-components
+
+Ships at `ui/sdpi-components.js` (vendored from https://github.com/GeekyEggo/sdpi-components). The bundle includes Lit — see the next entry.
+
+```text
+MIT License
+
+Copyright (c) 2024 Corsair Memory Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## Lit
+
+Bundled inside `ui/sdpi-components.js`.
+
+```text
+BSD 3-Clause License
+
+Copyright (c) 2017 Google LLC. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+## Arimo fonts
+
+Copyright 2026 The Arimo Project Authors (https://github.com/googlefonts/Arimo). Licensed under the SIL Open Font License, Version 1.1 — the full license text ships in this plugin at `assets/fonts/OFL.txt` and is available with an FAQ at https://openfontlicense.org.
+
+## Lovely Sim Racing corner data
+
+Corner data © 2025 [Lovely Sim Racing](https://github.com/Lovely-Sim-Racing/lovely-track-data) (lovely-track-data, modified: pruned and normalized for iRaceDeck), corner names by Racing Circuits — [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/), used with permission.

--- a/packages/iracing-plugin-mirabox/.gitignore
+++ b/packages/iracing-plugin-mirabox/.gitignore
@@ -8,5 +8,9 @@ node_modules/
 *.sdPlugin/ui
 *.sdPlugin/assets
 
+# License files copied from the repo root at build time (#905)
+*.sdPlugin/LICENSE
+*.sdPlugin/THIRD-PARTY-LICENSES.md
+
 # Build artifacts
 *.streamDeckPlugin

--- a/packages/iracing-plugin-mirabox/rollup.config.mjs
+++ b/packages/iracing-plugin-mirabox/rollup.config.mjs
@@ -268,6 +268,15 @@ const config = {
 				}
 			},
 		},
+		// Ship the project license and aggregated third-party notices at the plugin root (#905)
+		{
+			name: "copy-license-files",
+			generateBundle() {
+				for (const file of ["LICENSE", "THIRD-PARTY-LICENSES.md"]) {
+					copyFileSync(path.resolve(__dirname, "../..", file), path.join(sdPlugin, file));
+				}
+			},
+		},
 		{
 			name: "watch-externals",
 			buildStart: function () {

--- a/packages/iracing-plugin-stream-deck/.gitignore
+++ b/packages/iracing-plugin-stream-deck/.gitignore
@@ -20,6 +20,10 @@ node_modules/
 # Font assets (rasterized at build time)
 *.sdPlugin/assets/fonts
 
+# License files copied from the repo root at build time (#905)
+*.sdPlugin/LICENSE
+*.sdPlugin/THIRD-PARTY-LICENSES.md
+
 # Packaged plugin artifacts (streamdeck pack output / manual zips)
 *.streamDeckPlugin
 *.zip

--- a/packages/iracing-plugin-stream-deck/rollup.config.mjs
+++ b/packages/iracing-plugin-stream-deck/rollup.config.mjs
@@ -211,6 +211,15 @@ const config = {
 				}
 			},
 		},
+		// Ship the project license and aggregated third-party notices at the plugin root (#905)
+		{
+			name: "copy-license-files",
+			generateBundle() {
+				for (const file of ["LICENSE", "THIRD-PARTY-LICENSES.md"]) {
+					copyFileSync(path.resolve(__dirname, "../..", file), path.join(sdPlugin, file));
+				}
+			},
+		},
 		// Copy vendored sdpi-components.js and built pi-components.js from @iracedeck/pi-components
 		{
 			name: "copy-pi-browser-assets",

--- a/packages/iracing-plugin-ulanzi/.gitignore
+++ b/packages/iracing-plugin-ulanzi/.gitignore
@@ -9,3 +9,7 @@ node_modules/
 *.ulanziPlugin/imgs
 *.ulanziPlugin/ui
 *.ulanziPlugin/assets
+
+# License files copied from the repo root at build time (#905)
+*.ulanziPlugin/LICENSE
+*.ulanziPlugin/THIRD-PARTY-LICENSES.md

--- a/packages/iracing-plugin-ulanzi/rollup.config.mjs
+++ b/packages/iracing-plugin-ulanzi/rollup.config.mjs
@@ -282,6 +282,15 @@ const config = {
         }
       },
     },
+    // Ship the project license and aggregated third-party notices at the plugin root (#905)
+    {
+      name: "copy-license-files",
+      generateBundle() {
+        for (const file of ["LICENSE", "THIRD-PARTY-LICENSES.md"]) {
+          copyFileSync(path.resolve(__dirname, "../..", file), path.join(sdPlugin, file));
+        }
+      },
+    },
     {
       name: "watch-externals",
       buildStart: function () {

--- a/packages/website/src/content/docs/changelog.mdx
+++ b/packages/website/src/content/docs/changelog.mdx
@@ -41,6 +41,7 @@ _Unreleased_
 **Maintenance**
 
 - The Mirabox and Ulanzi plugins now clean up their own log files — logs older than 14 days are deleted automatically, so the log folder no longer grows forever — and packed plugin downloads can no longer accidentally include log files.
+- Plugin downloads now include the iRaceDeck license and a `THIRD-PARTY-LICENSES.md` collecting every third-party license notice — the iRacing SDK, the audio and rendering libraries, the bundled Arimo fonts, and the Lovely Sim Racing corner-data attribution.
 
 ## 2.2.0
 

--- a/scripts/third-party-licenses.test.mjs
+++ b/scripts/third-party-licenses.test.mjs
@@ -21,27 +21,33 @@ const PLUGINS = allPluginManifestRelPaths(repoRoot).map((relPath) => {
 });
 
 /**
- * Third-party components that ship inside plugin artifacts without a license
- * text of their own in the artifact (vendored sources compiled into the native
- * addons, dependencies bundled into bin/plugin.js, vendored browser assets,
- * fonts, and data). Not every entry ships in every artifact (e.g.
- * @elgato/streamdeck is Elgato-only), but each must have a section in
- * THIRD-PARTY-LICENSES.md. The list is hand-maintained: when a new third-party
- * component is bundled (rather than added to a rollup `external` array, which
- * is checked automatically below), add it here and to the notices file.
+ * Every third-party component shipped in the plugin artifacts → a distinctive
+ * phrase from its license notice that must appear inside the component's
+ * `## <name>` section of THIRD-PARTY-LICENSES.md, so an empty or mislabeled
+ * section fails the guard, not just a missing heading. Covers the rollup
+ * `external` dependencies (cross-checked against this map below) and the
+ * vendored/bundled components (sources compiled into the native addons,
+ * dependencies bundled into bin/plugin.js, vendored browser assets, fonts, and
+ * data). Not every entry ships in every artifact (e.g. @elgato/streamdeck is
+ * Elgato-only). The map is hand-maintained: when a new third-party component
+ * is shipped, add it here and to the notices file.
  */
-const VENDORED_COMPONENTS = [
-  "iRacing SDK",
-  "miniaudio",
-  "node-addon-api",
-  "sdpi-components",
-  "Lit",
-  "zod",
-  "semver",
-  "@elgato/streamdeck",
-  "Arimo",
-  "Lovely Sim Racing",
-];
+const COMPONENT_LICENSE_MARKERS = {
+  "iRacing SDK": "Redistribution and use in source and binary forms",
+  miniaudio: "MIT No Attribution",
+  "@resvg/resvg-js": "Mozilla Public License",
+  keysender: "MIT License",
+  yaml: "Permission to use, copy, modify, and/or distribute this software",
+  ws: "Permission is hereby granted, free of charge",
+  "node-addon-api": "The MIT License (MIT)",
+  zod: "MIT License",
+  semver: "The ISC License",
+  "@elgato/streamdeck": "MIT License",
+  "sdpi-components": "MIT License",
+  Lit: "BSD 3-Clause License",
+  Arimo: "SIL Open Font License",
+  "Lovely Sim Racing": "CC BY-NC-SA 4.0",
+};
 
 const notices = readFileSync(join(repoRoot, NOTICES_FILE), "utf-8");
 
@@ -62,18 +68,13 @@ function noticesSectionPattern(name) {
   return new RegExp(`^## ${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "m");
 }
 
-/**
- * Whether a single .sdignore pattern line matches a file at the artifact root.
- * Supports the pattern shapes the .sdignore files actually use: exact names,
- * `*.ext` globs, an optional leading double-star-slash prefix, and directory
- * patterns (trailing `/`, which can never match a file).
- */
-function sdignorePatternMatchesRootFile(pattern, fileName) {
-  if (pattern.endsWith("/")) return false; // directory pattern
-  const stripped = pattern.replace(/^\*\*\//, "");
-  if (stripped.includes("/")) return false; // nested path — cannot match a root-level file
-  const regex = new RegExp(`^${stripped.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, "[^/]*")}$`);
-  return regex.test(fileName);
+/** The body of a component's `## <name>` section (up to the next `## `), or null. */
+function noticesSection(name) {
+  const match = notices.match(noticesSectionPattern(name));
+  if (!match) return null;
+  const start = match.index + match[0].length;
+  const nextHeading = notices.slice(start).search(/^## /m);
+  return nextHeading === -1 ? notices.slice(start) : notices.slice(start, start + nextHeading);
 }
 
 describe("shipped license files (#905)", () => {
@@ -86,28 +87,41 @@ describe("shipped license files (#905)", () => {
     expect(PLUGINS.length).toBeGreaterThanOrEqual(3);
   });
 
-  it.each(VENDORED_COMPONENTS)("THIRD-PARTY-LICENSES.md covers vendored/bundled component: %s", (component) => {
-    expect(notices).toMatch(noticesSectionPattern(component));
-  });
+  it.each(Object.keys(COMPONENT_LICENSE_MARKERS))(
+    "THIRD-PARTY-LICENSES.md has a substantive section for: %s",
+    (component) => {
+      const section = noticesSection(component);
+      expect(section, `missing "## ${component}" section in ${NOTICES_FILE}`).not.toBeNull();
+      expect(section, `"## ${component}" section must carry its license notice`).toContain(
+        COMPONENT_LICENSE_MARKERS[component],
+      );
+    },
+  );
 
   describe.each(PLUGINS)("%s", (pkg, artifact) => {
     const configPath = join(repoRoot, "packages", pkg, "rollup.config.mjs");
     const configSource = readFileSync(configPath, "utf-8");
 
-    it("every non-workspace rollup external has an entry in THIRD-PARTY-LICENSES.md", () => {
+    it("every non-workspace rollup external is a guarded component", () => {
       const thirdParty = rollupExternals(configSource).filter((name) => !name.startsWith("@iracedeck/"));
       expect(thirdParty.length).toBeGreaterThan(0);
       for (const name of thirdParty) {
-        expect(notices, `missing ${NOTICES_FILE} section for rollup external "${name}" (${pkg})`).toMatch(
-          noticesSectionPattern(name),
-        );
+        expect(
+          Object.keys(COMPONENT_LICENSE_MARKERS),
+          `rollup external "${name}" (${pkg}) must be added to COMPONENT_LICENSE_MARKERS and ${NOTICES_FILE}`,
+        ).toContain(name);
       }
     });
 
-    it("the rollup config copies LICENSE and THIRD-PARTY-LICENSES.md into the artifact", () => {
-      expect(configSource).toContain("copy-license-files");
-      expect(configSource).toContain(`"${NOTICES_FILE}"`);
-      expect(configSource).toContain('"LICENSE"');
+    it("the rollup config copies LICENSE and THIRD-PARTY-LICENSES.md from the repo root to the artifact root", () => {
+      expect(configSource).toContain('name: "copy-license-files"');
+      // Assert the actual copy invocation — source anchored to the repo root,
+      // destination to the artifact root — not just the filenames appearing
+      // somewhere in the config.
+      expect(configSource).toMatch(/for \(const file of \["LICENSE", "THIRD-PARTY-LICENSES\.md"\]\)/);
+      expect(configSource).toMatch(
+        /copyFileSync\(path\.resolve\(__dirname, "\.\.\/\.\.", file\), path\.join\(sdPlugin, file\)\)/,
+      );
     });
 
     it(".sdignore does not strip the license files from the packed plugin", () => {
@@ -127,3 +141,17 @@ describe("shipped license files (#905)", () => {
     });
   });
 });
+
+/**
+ * Whether a single .sdignore pattern line matches a file at the artifact root.
+ * Supports the pattern shapes the .sdignore files actually use: exact names,
+ * `*.ext` globs, an optional leading double-star-slash prefix, and directory
+ * patterns (trailing `/`, which can never match a file).
+ */
+function sdignorePatternMatchesRootFile(pattern, fileName) {
+  if (pattern.endsWith("/")) return false; // directory pattern
+  const stripped = pattern.replace(/^\*\*\//, "");
+  if (stripped.includes("/")) return false; // nested path — cannot match a root-level file
+  const regex = new RegExp(`^${stripped.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, "[^/]*")}$`);
+  return regex.test(fileName);
+}

--- a/scripts/third-party-licenses.test.mjs
+++ b/scripts/third-party-licenses.test.mjs
@@ -2,24 +2,33 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { allPluginManifestRelPaths } from "./lib/version-discovery.mjs";
 
 // scripts/third-party-licenses.test.mjs lives in scripts/, so the repo root is one up.
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
 const NOTICES_FILE = "THIRD-PARTY-LICENSES.md";
 
-/** Plugin package dir → shipped artifact folder name. */
-const PLUGINS = [
-  ["iracing-plugin-stream-deck", "com.iracedeck.sd.core.sdPlugin"],
-  ["iracing-plugin-mirabox", "com.iracedeck.sd.core.sdPlugin"],
-  ["iracing-plugin-ulanzi", "com.ulanzi.iracedeck.ulanziPlugin"],
-];
+/**
+ * [plugin package dir, shipped artifact folder name] pairs, discovered from the
+ * committed plugin manifests (the same source the release bump uses) so a new
+ * deck ecosystem is covered automatically instead of needing to be added to a
+ * parallel hardcoded list here.
+ */
+const PLUGINS = allPluginManifestRelPaths(repoRoot).map((relPath) => {
+  const [, pkg, artifact] = relPath.split("/");
+  return [pkg, artifact];
+});
 
 /**
- * Third-party components that ship inside every artifact without carrying a
- * license text of their own (vendored sources compiled into the native addons,
- * dependencies bundled into bin/plugin.js, vendored browser assets, fonts, and
- * data). Each must have an entry in THIRD-PARTY-LICENSES.md.
+ * Third-party components that ship inside plugin artifacts without a license
+ * text of their own in the artifact (vendored sources compiled into the native
+ * addons, dependencies bundled into bin/plugin.js, vendored browser assets,
+ * fonts, and data). Not every entry ships in every artifact (e.g.
+ * @elgato/streamdeck is Elgato-only), but each must have a section in
+ * THIRD-PARTY-LICENSES.md. The list is hand-maintained: when a new third-party
+ * component is bundled (rather than added to a rollup `external` array, which
+ * is checked automatically below), add it here and to the notices file.
  */
 const VENDORED_COMPONENTS = [
   "iRacing SDK",
@@ -44,6 +53,16 @@ function rollupExternals(configSource) {
 }
 
 /**
+ * A `## <name>` section heading in the notices file, anchored so incidental
+ * substrings elsewhere in the document (e.g. "ws" inside "Windows") can never
+ * satisfy the check. `\b` (not `$`) so descriptive heading suffixes like
+ * "## Arimo fonts" still match their component name.
+ */
+function noticesSectionPattern(name) {
+  return new RegExp(`^## ${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "m");
+}
+
+/**
  * Whether a single .sdignore pattern line matches a file at the artifact root.
  * Supports the pattern shapes the .sdignore files actually use: exact names,
  * `*.ext` globs, an optional leading double-star-slash prefix, and directory
@@ -63,8 +82,12 @@ describe("shipped license files (#905)", () => {
     expect(existsSync(join(repoRoot, NOTICES_FILE))).toBe(true);
   });
 
+  it("discovers every plugin artifact (an empty list would silently skip all per-plugin checks)", () => {
+    expect(PLUGINS.length).toBeGreaterThanOrEqual(3);
+  });
+
   it.each(VENDORED_COMPONENTS)("THIRD-PARTY-LICENSES.md covers vendored/bundled component: %s", (component) => {
-    expect(notices).toContain(component);
+    expect(notices).toMatch(noticesSectionPattern(component));
   });
 
   describe.each(PLUGINS)("%s", (pkg, artifact) => {
@@ -75,7 +98,9 @@ describe("shipped license files (#905)", () => {
       const thirdParty = rollupExternals(configSource).filter((name) => !name.startsWith("@iracedeck/"));
       expect(thirdParty.length).toBeGreaterThan(0);
       for (const name of thirdParty) {
-        expect(notices, `missing ${NOTICES_FILE} entry for rollup external "${name}" (${pkg})`).toContain(name);
+        expect(notices, `missing ${NOTICES_FILE} section for rollup external "${name}" (${pkg})`).toMatch(
+          noticesSectionPattern(name),
+        );
       }
     });
 

--- a/scripts/third-party-licenses.test.mjs
+++ b/scripts/third-party-licenses.test.mjs
@@ -1,0 +1,104 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// scripts/third-party-licenses.test.mjs lives in scripts/, so the repo root is one up.
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const NOTICES_FILE = "THIRD-PARTY-LICENSES.md";
+
+/** Plugin package dir → shipped artifact folder name. */
+const PLUGINS = [
+  ["iracing-plugin-stream-deck", "com.iracedeck.sd.core.sdPlugin"],
+  ["iracing-plugin-mirabox", "com.iracedeck.sd.core.sdPlugin"],
+  ["iracing-plugin-ulanzi", "com.ulanzi.iracedeck.ulanziPlugin"],
+];
+
+/**
+ * Third-party components that ship inside every artifact without carrying a
+ * license text of their own (vendored sources compiled into the native addons,
+ * dependencies bundled into bin/plugin.js, vendored browser assets, fonts, and
+ * data). Each must have an entry in THIRD-PARTY-LICENSES.md.
+ */
+const VENDORED_COMPONENTS = [
+  "iRacing SDK",
+  "miniaudio",
+  "node-addon-api",
+  "sdpi-components",
+  "Lit",
+  "zod",
+  "semver",
+  "@elgato/streamdeck",
+  "Arimo",
+  "Lovely Sim Racing",
+];
+
+const notices = readFileSync(join(repoRoot, NOTICES_FILE), "utf-8");
+
+/** Extract the package names from a rollup config's `external: [...]` array. */
+function rollupExternals(configSource) {
+  const match = configSource.match(/external:\s*\[([^\]]*)\]/);
+  expect(match, "rollup config must declare an external array").not.toBeNull();
+  return [...match[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+}
+
+/**
+ * Whether a single .sdignore pattern line matches a file at the artifact root.
+ * Supports the pattern shapes the .sdignore files actually use: exact names,
+ * `*.ext` globs, an optional leading double-star-slash prefix, and directory
+ * patterns (trailing `/`, which can never match a file).
+ */
+function sdignorePatternMatchesRootFile(pattern, fileName) {
+  if (pattern.endsWith("/")) return false; // directory pattern
+  const stripped = pattern.replace(/^\*\*\//, "");
+  if (stripped.includes("/")) return false; // nested path — cannot match a root-level file
+  const regex = new RegExp(`^${stripped.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, "[^/]*")}$`);
+  return regex.test(fileName);
+}
+
+describe("shipped license files (#905)", () => {
+  it("the repo root has LICENSE and THIRD-PARTY-LICENSES.md", () => {
+    expect(existsSync(join(repoRoot, "LICENSE"))).toBe(true);
+    expect(existsSync(join(repoRoot, NOTICES_FILE))).toBe(true);
+  });
+
+  it.each(VENDORED_COMPONENTS)("THIRD-PARTY-LICENSES.md covers vendored/bundled component: %s", (component) => {
+    expect(notices).toContain(component);
+  });
+
+  describe.each(PLUGINS)("%s", (pkg, artifact) => {
+    const configPath = join(repoRoot, "packages", pkg, "rollup.config.mjs");
+    const configSource = readFileSync(configPath, "utf-8");
+
+    it("every non-workspace rollup external has an entry in THIRD-PARTY-LICENSES.md", () => {
+      const thirdParty = rollupExternals(configSource).filter((name) => !name.startsWith("@iracedeck/"));
+      expect(thirdParty.length).toBeGreaterThan(0);
+      for (const name of thirdParty) {
+        expect(notices, `missing ${NOTICES_FILE} entry for rollup external "${name}" (${pkg})`).toContain(name);
+      }
+    });
+
+    it("the rollup config copies LICENSE and THIRD-PARTY-LICENSES.md into the artifact", () => {
+      expect(configSource).toContain("copy-license-files");
+      expect(configSource).toContain(`"${NOTICES_FILE}"`);
+      expect(configSource).toContain('"LICENSE"');
+    });
+
+    it(".sdignore does not strip the license files from the packed plugin", () => {
+      const sdignore = readFileSync(join(repoRoot, "packages", pkg, artifact, ".sdignore"), "utf-8");
+      const patterns = sdignore
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => line && !line.startsWith("#"));
+      for (const pattern of patterns) {
+        for (const file of ["LICENSE", NOTICES_FILE]) {
+          expect(
+            sdignorePatternMatchesRootFile(pattern, file),
+            `.sdignore pattern "${pattern}" (${pkg}) would exclude ${file}`,
+          ).toBe(false);
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Related Issue

Fixes #905

## What changed?

- Added `THIRD-PARTY-LICENSES.md` at the repo root: a hand-maintained aggregation of every third-party license notice shipped in the plugin artifacts — the iRacing SDK (BSD-3-Clause, whose notice the packed artifacts previously stripped via `.sdignore`), miniaudio, @resvg/resvg-js (MPL-2.0 with source URLs), keysender, yaml, ws, node-addon-api, zod, semver, @elgato/streamdeck, sdpi-components + Lit, the Arimo fonts (OFL 1.1), and the Lovely Sim Racing corner data (CC BY-NC-SA 4.0).
- Each of the three plugin `rollup.config.mjs` files gained a `copy-license-files` `generateBundle` step (same pattern as the rasterizer-fonts copy) that copies the project `LICENSE` and `THIRD-PARTY-LICENSES.md` from the repo root into the artifact root; the copies are gitignored in each plugin package.
- New guard test `scripts/third-party-licenses.test.mjs` (21 tests): plugin artifacts are discovered dynamically via `allPluginManifestRelPaths`, every non-workspace rollup `external` must have a `## <name>` section in the notices file (heading-anchored so incidental substrings can never satisfy the check), every vendored/bundled component must have its section, every config must contain the copy step, and no `.sdignore` pattern may exclude the two files from a packed plugin. `.sdignore` itself needed no changes — verified rather than modified.
- Docs kept in sync: new "License and Third-Party Notices" section in `.claude/rules/plugin-structure.md`, a Maintenance line in the website changelog (2.3.0), and a README note.

## How to test

1. `pnpm install && pnpm build`
2. Verify `LICENSE` and `THIRD-PARTY-LICENSES.md` exist at the root of all three artifact folders (`packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/`, `packages/iracing-plugin-mirabox/com.iracedeck.sd.core.sdPlugin/`, `packages/iracing-plugin-ulanzi/com.ulanzi.iracedeck.ulanziPlugin/`) and are byte-identical to the repo-root files.
3. `pnpm exec vitest run scripts/third-party-licenses.test.mjs` — 21/21 pass.
4. Optionally pack a plugin and confirm the packed artifact retains both files (no `.sdignore` pattern matches them).

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin downloads now include the project license and a comprehensive third-party license notice file.
  * License information covers bundled libraries, fonts, SDKs, and other included components.

* **Documentation**
  * Updated usage, licensing, and changelog documentation to explain the included notices.

* **Bug Fixes**
  * Added validation to ensure license files are consistently included in generated plugin packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->