### PR TITLE
docs(website): document the Telemetry Control Take Snapshot mode (#961)

### DIFF
--- a/.claude/skills/iracedeck-actions/SKILL.md
+++ b/.claude/skills/iracedeck-actions/SKILL.md
@@ -9,7 +9,7 @@ description: Use when looking up Stream Deck actions, sub-actions, modes, catego
 
 Complete action definitions: `docs/reference/actions.json`
 
-This skill file documents **32 actions with 299 modes** using a detailed per-mode count (the totals in the category table below). The user-facing website (`packages/website/src/content/docs/`) uses a coarser counting convention and shows a lower total (**268 modes**) — treat the website as the source of truth for user-facing copy and this skill file as the detailed inventory. `docs/reference/actions.json` has not yet been re-synced to the per-mode counting convention; treat it as a detailed inventory of individual mode values that is occasionally out of date.
+This skill file documents **32 actions with 299 modes** using a detailed per-mode count (the totals in the category table below). The user-facing website (`packages/website/src/content/docs/`) uses a coarser counting convention and shows a lower total (**269 modes**) — treat the website as the source of truth for user-facing copy and this skill file as the detailed inventory. `docs/reference/actions.json` has not yet been re-synced to the per-mode counting convention; treat it as a detailed inventory of individual mode values that is occasionally out of date.
 
 Each action entry:
 ```json

--- a/packages/website/src/content/docs/changelog.mdx
+++ b/packages/website/src/content/docs/changelog.mdx
@@ -17,6 +17,10 @@ _Unreleased_
 
 - The Setup Chassis spring controls now show what you've dialed in: the modes are named LR Spring / RR Spring to match iRacing's pit-stop rows, the Stream Deck+ dial strip and two new View key modes display the pending next-pit-stop spring offset live (in whole millimeters or three-decimal inches — following the sim's display units, or forced metric/imperial per key and per dial) with lit left/right arrows showing which side you're editing, the spring keys support the paired +/− key styles, new dial gestures can bring up the Pit Stop black box or switch the dial between the two springs, and every Setup Chassis key gains a Show Black Box option that opens the box the adjusted value lives in (In-Car or Pit Stop) as you press it. Existing spring key bindings and placed keys carry over automatically.
 
+**Maintenance**
+
+- The Telemetry Control page on iracedeck.com now documents the Take Snapshot mode (shipped in 1.21.0 but missing from the action page): what the JSON and Markdown files contain, where they go, and how the Output Folder setting is resolved.
+
 ## 2.4.0
 
 _2026-08-12_

--- a/packages/website/src/content/docs/docs/actions/cockpit/telemetry-control.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/telemetry-control.md
@@ -1,17 +1,17 @@
 ---
 title: Telemetry Control
-description: Control telemetry logging and recording in iRacing.
+description: Control telemetry logging and recording in iRacing, and save telemetry snapshots to disk.
 sidebar:
   badge:
-    text: "5 modes"
+    text: "6 modes"
     variant: tip
 ---
 
-Manage iRacing's telemetry logging and recording features. Toggle logging, mark events of interest for later review, and start / stop / restart recording sessions.
+Manage iRacing's telemetry logging and recording features. Toggle logging, mark events of interest for later review, start / stop / restart recording sessions, and save a snapshot of the live telemetry and session info to disk for diagnostics.
 
 ## Modes
 
-Select the mode from the **Action** dropdown in the Property Inspector.
+Select the mode from the **Mode** dropdown in the Property Inspector.
 
 ### Toggle Logging
 
@@ -95,3 +95,24 @@ Stop and immediately restart telemetry recording via the iRacing SDK.
 #### Settings
 
 - No additional settings
+
+---
+
+### Take Snapshot
+
+Save everything iRaceDeck currently sees from iRacing — the full live telemetry and the session info — to disk. Each press writes two timestamped files to the Output Folder: a `.json` file holding every telemetry variable plus the session info (the raw data), and a companion `.md` report you can read at a glance — the session identification, the running order and the on-track order with each driver's car number, laps completed, and location, and the player's own telemetry. It is a developer / diagnostic tool: attach the files to a bug report, or use them to check what iRacing was reporting at a given moment.
+
+The mode only reads data the plugin already has and sends nothing to iRacing, so it never affects the sim. A press while iRacing isn't running (no telemetry available) is skipped with a warning in the plugin log; a successful save is logged as well, including the file paths. There is no feedback on the key itself.
+
+#### Details
+
+- **Method:** Local file write (saves telemetry to disk) — no iRacing command
+- **Dial:** No rotation support
+- **Default binding:** No keyboard binding
+- **Telemetry-aware icon:** No
+
+#### Setting: Output Folder
+
+The folder the snapshot files are written to. Leave it blank to use the default — an `iRaceDeck\telemetry-snapshots` folder in your user home folder (for example `C:\Users\<you>\iRaceDeck\telemetry-snapshots`). Any folder path works: environment variables such as `%USERPROFILE%` and a leading `~` are expanded, and a relative path is resolved against your home folder rather than the plugin's own folder. The folder is created if it doesn't exist.
+
+Files are named `telemetry-snapshot-YYYYMMDD-HHMMSS-mmm.json` and `.md` — local time, with milliseconds, so two presses in quick succession never overwrite each other.

--- a/packages/website/src/content/docs/docs/actions/cockpit/telemetry-control.md
+++ b/packages/website/src/content/docs/docs/actions/cockpit/telemetry-control.md
@@ -115,4 +115,4 @@ The mode only reads data the plugin already has and sends nothing to iRacing, so
 
 The folder the snapshot files are written to. Leave it blank to use the default — an `iRaceDeck\telemetry-snapshots` folder in your user home folder (for example `C:\Users\<you>\iRaceDeck\telemetry-snapshots`). Any folder path works: environment variables such as `%USERPROFILE%` and a leading `~` are expanded, and a relative path is resolved against your home folder rather than the plugin's own folder. The folder is created if it doesn't exist.
 
-Files are named `telemetry-snapshot-YYYYMMDD-HHMMSS-mmm.json` and `.md` — local time, with milliseconds, so two presses in quick succession never overwrite each other.
+Files are named `telemetry-snapshot-YYYYMMDD-HHMMSS-mmm.json` and `.md` — local time with millisecond resolution, so presses in quick succession normally get their own files rather than overwriting the previous one.

--- a/packages/website/src/content/docs/docs/actions/overview.md
+++ b/packages/website/src/content/docs/docs/actions/overview.md
@@ -3,7 +3,7 @@ title: Actions Overview
 description: All iRaceDeck actions organized by category
 ---
 
-iRaceDeck provides 32 actions with 268 modes for iRacing, organized into 10 categories.
+iRaceDeck provides 32 actions with 269 modes for iRacing, organized into 10 categories.
 
 ## Categories
 
@@ -12,7 +12,7 @@ iRaceDeck provides 32 actions with 268 modes for iRacing, organized into 10 cate
 | [Audio & Voice](/docs/actions/audio-voice/ai-spotter-controls/) | 3 | 15 | AI spotter, audio controls (incl. Race Engineer & Radar volume), race engineer, radar & corner names |
 | [Display & Session](/docs/actions/display-session/session-info/) | 2 | 11 | Live session data: incidents, time remaining, laps, position, estimated iRating gain/loss, gaps, fuel, laps to empty, flags, track wetness, wind |
 | [Driving Controls](/docs/actions/driving/black-box-selector/) | 3 | 21 | Black boxes, look direction, car control |
-| [Cockpit & Interface](/docs/actions/cockpit/cockpit-misc/) | 5 | 30 | Wipers, force feedback, splits & reference, telemetry, UI toggles |
+| [Cockpit & Interface](/docs/actions/cockpit/cockpit-misc/) | 5 | 31 | Wipers, force feedback, splits & reference, telemetry, UI toggles |
 | [View & Camera](/docs/actions/view-camera/view-adjustment/) | 5 | 89 | FOV, replay, camera controls, broadcast tools |
 | [Media](/docs/actions/media/media-capture/) | 1 | 7 | Video recording, screenshots, texture management |
 | [Pit Service](/docs/actions/pit-service/pit-quick-actions/) | 3 | 15 | Fuel (button and dial), tires, compounds, tearoff, fast repair |

--- a/packages/website/src/content/docs/index.mdx
+++ b/packages/website/src/content/docs/index.mdx
@@ -29,7 +29,7 @@ hero:
   </div>
   <div class="stat-divider" />
   <div class="stat">
-    <span class="stat-value">268</span>
+    <span class="stat-value">269</span>
     <span class="stat-label">Modes</span>
   </div>
   <div class="stat-divider" />


### PR DESCRIPTION
## Related Issue

Fixes #961

## What changed?

The Telemetry Control action page on the website documented five modes; the **Take Snapshot** mode (shipped in 1.21.0) was never added. This PR:

- Adds a `### Take Snapshot` section to `docs/actions/cockpit/telemetry-control.md` in the per-mode format: what the timestamped `.json` (full telemetry + session info) and companion `.md` report contain, that the mode sends nothing to iRacing (log-only feedback; skipped with a warning when the sim isn't running), Method "Local file write (saves telemetry to disk) — no iRacing command", and a **Setting: Output Folder** block covering the default `iRaceDeck\telemetry-snapshots` home-folder location, `%VAR%` / `~` expansion, relative-path-against-home resolution, on-demand folder creation, and the `telemetry-snapshot-YYYYMMDD-HHMMSS-mmm` file naming.
- Bumps the page badge to "6 modes", extends the description/intro to mention snapshots, and corrects "**Action** dropdown" to "**Mode** dropdown" (the PI already labels it Mode).
- Rolls the website mode totals for the new dropdown mode: Cockpit & Interface 30 → 31 and the overall total 268 → 269 on `docs/actions/overview.md` and the landing page `index.mdx`; syncs the `iracedeck-actions` skill note that mirrors the website total.
- Adds a **Maintenance** line to the 2.5.0 `_Unreleased_` changelog section (folded under the section #963 opened).

No plugin code changes.

## How to test

1. `pnpm --filter @iracedeck/website build` then `pnpm --filter @iracedeck/website preview`.
2. Open `/docs/actions/cockpit/telemetry-control/` — sidebar badge reads "6 modes", the page intro names the Mode dropdown, and a Take Snapshot section follows Restart Recording with a Details block and a Setting: Output Folder block.
3. Open `/docs/actions/overview/` (Cockpit & Interface 31, total 269) and `/` (269 modes stat), and `/changelog/` (2.5.0 section has the Maintenance line under Features).
4. Cross-check the described behaviour against `packages/iracing-actions/src/actions/telemetry-control/telemetry-control.ts` (`captureSnapshot`, `resolveSnapshotDir`) and `packages/iracing-sdk/src/snapshot.ts` (`snapshotBaseName`, `buildSnapshotEnvelope`, `generateMarkdown`).

## Checklist

- [x] Linked to an approved issue
- [ ] New code has unit tests (documentation-only change — no code)
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — not applicable, website + docs only
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documented the new **Take Snapshot** telemetry mode, including JSON and Markdown output, timestamped filenames, destination settings, and unavailable-telemetry behavior.

* **Documentation**
  * Updated the website to reflect 269 available modes, including 31 Cockpit & Interface modes.
  * Added version 2.5.0 maintenance notes covering the Telemetry Control page updates.
  * Clarified output-folder configuration, path expansion, folder creation, logging, and collision-safe file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->