### PR TITLE
improve(stream-deck): drop the macOS support claim from the plugin manifest (#994)

### DIFF
--- a/.claude/rules/plugin-structure.md
+++ b/.claude/rules/plugin-structure.md
@@ -134,6 +134,18 @@ Every plugin artifact must ship the project `LICENSE` and the aggregated `THIRD-
 
 When a shipped third-party dependency or vendored component is added or removed, update the repo-root `THIRD-PARTY-LICENSES.md` in the same change. `scripts/third-party-licenses.test.mjs` guards the wiring: every non-workspace rollup `external` must have an entry in the file, every plugin config must contain the copy step, and no `.sdignore` pattern may exclude the two files from the packed plugin.
 
+### Supported Operating Systems
+
+Every plugin manifest declares **Windows and nothing else** (issue #994):
+
+```json
+{
+  "OS": [{ "Platform": "windows", "MinimumVersion": "10" }]
+}
+```
+
+iRaceDeck exists to control iRacing, which has no macOS build, and the keyboard/window/audio addons are Windows-native. The `@iracedeck/iracing-native` / `@iracedeck/audio-native` mocks exist so the repo can be installed, built, and tested on a Mac or Linux machine (see the `cross-platform-development` skill) — they are **not** a reason to add a `mac` entry, which would only offer host users an install that can do nothing. `scripts/manifest-platform.test.mjs` guards this across every discovered plugin manifest (plugin-level `OS` and per-action `OS` alike), so a new plugin folder is covered automatically.
+
 ### Application Monitoring
 
 To enable app monitoring (for features like conditional reconnection that pauses when iRacing isn't running), add to manifest.json:

--- a/.claude/skills/cross-platform-development/SKILL.md
+++ b/.claude/skills/cross-platform-development/SKILL.md
@@ -7,7 +7,7 @@ description: Use when working with native dependencies, handling platform differ
 
 ## Why the mock exists
 
-**The mock is development tooling, not a support claim.** iRaceDeck ships Windows-only — all three plugin manifests declare `windows` and nothing else (#994) — because every action depends on iRacing, which has no macOS build. The mock exists so the repo can still be installed, built, and tested on a Mac or Linux machine; it is not there to make the plugin usable off Windows, and it is not a reason to re-add a `mac` entry to a manifest.
+**The mock is development tooling, not a support claim.** iRaceDeck ships Windows-only — all three plugin manifests declare `windows` and nothing else (#994) — because iRaceDeck exists to control iRacing, which has no macOS build. The mock exists so the repo can still be installed, built, and tested on a Mac or Linux machine; it is not there to make the plugin usable off Windows, and it is not a reason to re-add a `mac` entry to a manifest. `scripts/manifest-platform.test.mjs` fails the build if one comes back.
 
 `@iracedeck/iracing-native` wraps the iRacing SDK (Windows-only C++ N-API addon). Without the mock layer, `pnpm install`, `pnpm build`, and `pnpm test` all fail on macOS/Linux because:
 - `node-gyp` can't compile the Windows-specific C++ code

--- a/.claude/skills/cross-platform-development/SKILL.md
+++ b/.claude/skills/cross-platform-development/SKILL.md
@@ -7,6 +7,8 @@ description: Use when working with native dependencies, handling platform differ
 
 ## Why the mock exists
 
+**The mock is development tooling, not a support claim.** iRaceDeck ships Windows-only — all three plugin manifests declare `windows` and nothing else (#994) — because every action depends on iRacing, which has no macOS build. The mock exists so the repo can still be installed, built, and tested on a Mac or Linux machine; it is not there to make the plugin usable off Windows, and it is not a reason to re-add a `mac` entry to a manifest.
+
 `@iracedeck/iracing-native` wraps the iRacing SDK (Windows-only C++ N-API addon). Without the mock layer, `pnpm install`, `pnpm build`, and `pnpm test` all fail on macOS/Linux because:
 - `node-gyp` can't compile the Windows-specific C++ code
 - `keysender` (native keyboard module) is Windows-only

--- a/packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/manifest.json
+++ b/packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/manifest.json
@@ -790,10 +790,6 @@
     {
       "Platform": "windows",
       "MinimumVersion": "10"
-    },
-    {
-      "Platform": "mac",
-      "MinimumVersion": "15"
     }
   ],
   "Nodejs": {

--- a/packages/website/src/content/docs/changelog.mdx
+++ b/packages/website/src/content/docs/changelog.mdx
@@ -39,7 +39,7 @@ _Unreleased_
 **Breaking changes**
 
 - The Camera Controls dial's Cycle by Car # mode now counts *down* when turned clockwise — `#94` to `#77` instead of the other way around — so the two modes that cycle *by* a number follow one rule: clockwise makes that number go down, matching Cycle by Race Position (which has worked that way since 2.3.0). Cycle by Track Order is ordered by the road rather than by a number, so it keeps taking you to the car physically ahead. Every existing Cycle by Car # dial changes direction with this update — including one that already has **Reverse rotation** ticked — so flip that checkbox in the dial settings, whichever way it is set today, to get the old feel back. The touch-strip previews follow whichever direction is in effect.
-- The Stream Deck plugin no longer declares macOS support: it is offered and installable on Windows only, matching what the Mirabox and Ulanzi plugins already declared. Nothing changes for Windows users — the macOS entry only ever existed so the plugin could be built on a Mac, and every action depends on iRacing, which does not run on macOS.
+- The Stream Deck plugin no longer declares macOS support: from this version it is offered and installable on Windows only, matching what the Mirabox and Ulanzi plugins already declared. Nothing changes for Windows users — the macOS entry only ever told the Stream Deck software it was allowed to install the plugin on a Mac, where it could do nothing useful, because iRaceDeck controls iRacing and iRacing has no macOS build.
 
 **Maintenance**
 

--- a/packages/website/src/content/docs/changelog.mdx
+++ b/packages/website/src/content/docs/changelog.mdx
@@ -39,6 +39,7 @@ _Unreleased_
 **Breaking changes**
 
 - The Camera Controls dial's Cycle by Car # mode now counts *down* when turned clockwise — `#94` to `#77` instead of the other way around — so the two modes that cycle *by* a number follow one rule: clockwise makes that number go down, matching Cycle by Race Position (which has worked that way since 2.3.0). Cycle by Track Order is ordered by the road rather than by a number, so it keeps taking you to the car physically ahead. Every existing Cycle by Car # dial changes direction with this update — including one that already has **Reverse rotation** ticked — so flip that checkbox in the dial settings, whichever way it is set today, to get the old feel back. The touch-strip previews follow whichever direction is in effect.
+- The Stream Deck plugin no longer declares macOS support: it is offered and installable on Windows only, matching what the Mirabox and Ulanzi plugins already declared. Nothing changes for Windows users — the macOS entry only ever existed so the plugin could be built on a Mac, and every action depends on iRacing, which does not run on macOS.
 
 **Maintenance**
 

--- a/packages/website/src/content/docs/docs/getting-started/installation.mdx
+++ b/packages/website/src/content/docs/docs/getting-started/installation.mdx
@@ -12,6 +12,7 @@ iRaceDeck is available for **Elgato Stream Deck**, **Mirabox**, and **Ulanzi Dec
 
 ### Requirements
 
+- **Windows 10 or newer** — iRacing is Windows-only, so iRaceDeck is too
 - **Stream Deck software** version 7.1 or newer
 - A supported Stream Deck device — {ECOSYSTEMS.elgato.devices}
 
@@ -55,6 +56,7 @@ The Mirabox ecosystem covers devices from brands including <BrandNames ecosystem
 
 ### Requirements
 
+- **Windows 10 or newer** — iRacing is Windows-only, so iRaceDeck is too
 - A Mirabox ecosystem device with the Mirabox Space app installed
 
 ### Install from Mirabox Space
@@ -73,6 +75,7 @@ iRaceDeck runs on **{ECOSYSTEMS.ulanzi.devices}** through the UlanziStudio app.
 
 ### Requirements
 
+- **Windows 10 or newer** — iRacing is Windows-only, so iRaceDeck is too
 - A Ulanzi Deck device with the **UlanziStudio** app installed
 
 ### Install from iRaceDeck

--- a/packages/website/src/content/docs/downloads.mdx
+++ b/packages/website/src/content/docs/downloads.mdx
@@ -17,6 +17,8 @@ export const version = import.meta.env.PUBLIC_IRACEDECK_VERSION;
 
 {version && <p class="version-badge">Latest release: <strong>{version}</strong></p>}
 
+<p class="download-help">Requires <strong>Windows 10 or newer</strong> — iRacing is Windows-only, so iRaceDeck is too.</p>
+
 <div class="download-grid not-content">
   <div class="download-card">
     <span class="download-title">{ECOSYSTEMS.elgato.label}</span>

--- a/scripts/manifest-platform.test.mjs
+++ b/scripts/manifest-platform.test.mjs
@@ -29,8 +29,12 @@ describe("plugin manifest supported operating systems", () => {
     expect(manifests.length).toBeGreaterThan(0);
   });
 
-  it.each(manifests)("declares Windows and nothing else: %s", (manifestRelPath) => {
-    expect(readManifest(manifestRelPath).OS.map((os) => os.Platform)).toEqual(["windows"]);
+  // One assertion covers both halves of the invariant: the only platform is
+  // Windows, and the floor stays at 10. Pinning the version means a bump to
+  // Windows 11 has to be a deliberate edit here rather than a silent narrowing
+  // of who is offered the plugin.
+  it.each(manifests)("declares Windows 10 and nothing else: %s", (manifestRelPath) => {
+    expect(readManifest(manifestRelPath).OS).toEqual([{ Platform: "windows", MinimumVersion: "10" }]);
   });
 
   // The Elgato schema also allows a per-action `OS` list, which could re-introduce

--- a/scripts/manifest-platform.test.mjs
+++ b/scripts/manifest-platform.test.mjs
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { allPluginManifestRelPaths } from "./lib/version-discovery.mjs";
+
+// scripts/manifest-platform.test.mjs lives in scripts/, so the repo root is one up.
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// Discover every plugin folder's manifest dynamically (the same source the
+// release bump uses), so a new deck ecosystem is covered automatically instead
+// of needing to be added to a parallel hardcoded list here.
+const manifests = allPluginManifestRelPaths(repoRoot);
+
+function readManifest(manifestRelPath) {
+  return JSON.parse(readFileSync(join(repoRoot, manifestRelPath), "utf-8"));
+}
+
+// iRaceDeck ships Windows-only (#994): every control ultimately drives iRacing,
+// which has no macOS build, and the keyboard/window/audio addons are
+// Windows-native. The `@iracedeck/iracing-native` / `@iracedeck/audio-native`
+// mocks exist so the repo can be installed, built, and tested on a Mac or Linux
+// machine (see the `cross-platform-development` skill) — they are NOT a reason
+// to advertise the plugin there. A `mac` entry would offer host users an install
+// that can do nothing, so guard the claim mechanically rather than by prose.
+describe("plugin manifest supported operating systems", () => {
+  it("discovers every plugin manifest", () => {
+    expect(manifests.length).toBeGreaterThan(0);
+  });
+
+  it.each(manifests)("declares Windows and nothing else: %s", (manifestRelPath) => {
+    expect(readManifest(manifestRelPath).OS.map((os) => os.Platform)).toEqual(["windows"]);
+  });
+
+  // The Elgato schema also allows a per-action `OS` list, which could re-introduce
+  // the same claim one action at a time without touching the plugin-level array.
+  it.each(manifests)("declares no non-Windows action platforms: %s", (manifestRelPath) => {
+    const offenders = readManifest(manifestRelPath)
+      .Actions.filter((action) => Array.isArray(action.OS) && action.OS.some((os) => os !== "windows"))
+      .map((action) => action.Name);
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Related Issue

Fixes #994

## What changed?

The Elgato manifest's `OS` array no longer declares `mac`. All three plugin manifests now declare Windows 10 and nothing else, which is what the Mirabox and Ulanzi manifests already said. The array is what the Elgato Marketplace reads to decide who is offered the plugin, so until now a Mac user could be shown — and could install — a plugin whose every control drives a simulator that does not run on their machine.

`scripts/manifest-platform.test.mjs` guards the invariant mechanically, following the existing `manifest-actions-order.test.mjs` pattern: every discovered plugin manifest must declare exactly `["windows"]`, and no action may re-introduce the claim through the per-action `OS` list the Elgato schema allows. Manifests are discovered via `allPluginManifestRelPaths`, so a future deck ecosystem is covered without editing a parallel hardcoded list.

**Consistency check requested by the issue:** the three `Software` minimum versions are deliberately left alone. They name three different host applications — Stream Deck `7.1`, Mirabox `3.10.188.226`, UlanziStudio `2.1.0` (under Ulanzi's own `MinVersion` key) — and are not comparable to one another. The Stream Deck `7.1` already matches what the installation page tells users.

**The non-Windows native mocks are untouched**, per the issue. `plugin-structure.md` gains a Supported Operating Systems section and the `cross-platform-development` skill now states outright that the mocks are development tooling rather than a support claim, so the manifest entry does not get restored on their account.

Website: the installation page's three Requirements lists and the downloads page now state the Windows requirement, which none of them did before — a Mac visitor was previously told nothing either way.

**Open question for the release, not for this PR:** Elgato does not document how the Marketplace treats an update that narrows the `OS` array for users who already have the plugin installed. The manifest reference defines `OS` only as "Collection of operating systems, and their minimum required versions, that the plugin supports" and is silent on the rest. The changelog entry therefore claims only what is certain — that the plugin is offered and installable on Windows only from this version — and makes no promise about existing Mac installs. The Marketplace listing's own platform metadata lives outside this repo and is worth a manual check at release.

## How to test

1. `pnpm install && pnpm build && pnpm test` — 284 test files, 8344 tests.
2. `npx vitest run scripts/manifest-platform.test.mjs` — 7 tests. Temporarily re-add a `mac` entry to any manifest, or an `"OS": ["mac"]` to any action, and confirm the run fails.
3. `streamdeck validate ./packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin` — Validation successful.
4. Link the plugin and start the Stream Deck app: the iRaceDeck category and all its actions appear as before (verified manually on Windows).
5. `pnpm --filter @iracedeck/website build` — the Windows requirement renders on `/docs/getting-started/installation/` (three times) and `/downloads/`.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox)
- [x] No unrelated changes included

https://claude.ai/code/session_013DfEgcdKE8JrdCP1ReYc7X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that iRaceDeck supports Windows only.
  * Added a Windows 10 or newer requirement to installation and download guidance.
  * Updated the changelog to note the removal of macOS support and documented the platform requirements.

* **Bug Fixes**
  * Updated plugin platform declarations to prevent unsupported macOS installations.

* **Tests**
  * Added validation ensuring all plugin and action declarations target Windows 10 or newer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->