### PR TITLE
fix(website): name every supported Elgato device in the canonical list (#983)

### DIFF
--- a/.claude/skills/website/SKILL.md
+++ b/.claude/skills/website/SKILL.md
@@ -132,7 +132,7 @@ Domain: **iracedeck.com** (Firebase Hosting with custom domain).
 
 **Update action count on landing page**: Edit the stats row and category cards in `src/content/docs/index.mdx`
 **Add an action page**: Create `.md` in the right category folder, add slug to sidebar in `astro.config.mjs`, update `docs/reference/actions.json`, and update `.claude/skills/iracedeck-actions/SKILL.md`
-**Add a supported hardware brand or device**: Edit `src/data/brands.ts` — one entry propagates to the landing page strip, the download cards, and the installation guide. Optional logo assets go in `src/assets/brands/` (see that folder's `README.md`); a brand without one renders as a wordmark tile.
+**Add a supported hardware brand or device**: Edit `src/data/brands.ts` — one entry propagates to the landing page strip, the download cards, and the installation guide. Optional logo assets go in `src/assets/brands/` (see that folder's `README.md`); a brand without one renders as a wordmark tile. The Elgato `devices` string is pinned to deck-core's `DEVICE_SUPPORT` matrix by `scripts/website-device-list.test.mjs` (#983): every supported device must be named and no unsupported one may be, so a device added to that matrix fails the test until this string names it.
 **Change brand color**: Update `--sl-color-accent` in `src/styles/custom.css`
 **Update favicon**: Replace files in `public/`, source from `assets/favicon/`
 **Add sidebar section**: Edit `sidebar` array in `astro.config.mjs`

--- a/.claude/skills/website/SKILL.md
+++ b/.claude/skills/website/SKILL.md
@@ -132,7 +132,7 @@ Domain: **iracedeck.com** (Firebase Hosting with custom domain).
 
 **Update action count on landing page**: Edit the stats row and category cards in `src/content/docs/index.mdx`
 **Add an action page**: Create `.md` in the right category folder, add slug to sidebar in `astro.config.mjs`, update `docs/reference/actions.json`, and update `.claude/skills/iracedeck-actions/SKILL.md`
-**Add a supported hardware brand or device**: Edit `src/data/brands.ts` — one entry propagates to the landing page strip, the download cards, and the installation guide. Optional logo assets go in `src/assets/brands/` (see that folder's `README.md`); a brand without one renders as a wordmark tile. The Elgato `devices` string is pinned to deck-core's `DEVICE_SUPPORT` matrix by `scripts/website-device-list.test.mjs` (#983): every supported device must be named and no unsupported one may be, so a device added to that matrix fails the test until this string names it.
+**Add a supported hardware brand or device**: Edit `src/data/brands.ts` — one entry propagates to the landing page strip, the download cards, and the installation guide. Optional logo assets go in `src/assets/brands/` (see that folder's `README.md`); a brand without one renders as a wordmark tile. The Elgato `devices` string is pinned to deck-core's `DEVICE_SUPPORT` matrix by `scripts/website-device-list.test.mjs` (#983): every supported device must be named and no unsupported one may be, so a supported device added to that matrix fails the test until this string names it.
 **Change brand color**: Update `--sl-color-accent` in `src/styles/custom.css`
 **Update favicon**: Replace files in `public/`, source from `assets/favicon/`
 **Add sidebar section**: Edit `sidebar` array in `astro.config.mjs`

--- a/docs/reference/store-descriptions.md
+++ b/docs/reference/store-descriptions.md
@@ -2,7 +2,7 @@
 
 Canonical copies of the iRaceDeck product descriptions published on the **Elgato Marketplace** and **Mirabox Space** store listings. The live texts exist only in the store dashboards — nothing in the repo or CI forces an update when the product changes, so these descriptions rot silently unless checked deliberately (the pre-2026-08 text predated the Race Engineer entirely).
 
-**Last synced: 2026-08-12 (v2.4.0).** Update this file whenever a new text is published, and keep the "Last synced" line current.
+**Last synced: 2026-08-23 (v3.0.0).** Update this file whenever a new text is published, and keep the "Last synced" line current.
 
 ## When to update
 
@@ -13,8 +13,8 @@ Check these descriptions for drift as part of **every release's** release-notes 
 | Action count (Elgato) | 32 | `packages/website/src/content/docs/index.mdx` stats row |
 | Action count (Mirabox) | 31 (no Switch Profile) | Mirabox manifest `Actions` |
 | Dial-capable actions (Elgato only) | 16 | `iracedeck-actions` skill / actions with `encoder: true` |
-| Headline features | Race Engineer, live data on keys, template variables, dials, profiles | changelog / website |
-| Supported Elgato devices | Stream Deck, Mini, XL, + | `packages/website/src/data/brands.ts` (`ECOSYSTEMS.elgato.devices`) |
+| Headline features | Settings window, Race Engineer, live data on keys, template variables, dials, profiles | changelog / website |
+| Supported Elgato devices | every device DEVICE_SUPPORT marks supported (#983) | `packages/website/src/data/brands.ts` (`ECOSYSTEMS.elgato.devices`) |
 | Supported Mirabox brands | Mirabox, Stream Dock, SOOMFON, VAPOURD, KILOGOGRAPH, HALCONTORNO, VSDinside, Nouvolo (list is open-ended) | `packages/website/src/data/brands.ts` (`BRANDS` for the names; `ECOSYSTEMS.mirabox.listIsComplete` for the open-ended marker) |
 | Elgato requirements | Stream Deck software 7.1+, Windows 10+ | Elgato manifest `Software`/`OS` |
 | Mirabox requirements | Stream Dock software 3.10.188+, Windows 10+ | Mirabox manifest `Software`/`OS` |
@@ -62,13 +62,17 @@ Switch cameras, follow different cars, and control replay playback directly from
 
 Send predefined chat messages with a single press — 15 configurable macros with live-data templating — plus reply, whisper, and quick chat toggles. League admins get a full race-control panel: black flags, penalties, wave-arounds, pace laps, session advance, and more.
 
+**Everything in One Settings Window**
+
+Every plugin-wide setting lives in one full-size window instead of being repeated inside every key’s panel: all 236 key bindings in one searchable table, appearance defaults, the Race Engineer, ready-made profiles, SimHub, and diagnostics — opened with the cog button under any key’s own settings. Your settings live in a file iRaceDeck owns, so they survive plugin updates and reinstalls, and each release’s notes ship inside the plugin so you can read what an update changes before taking it.
+
 **Made for Stream Deck +**
 
 16 actions come with full dial support on Stream Deck+: spin a dial for fuel amounts, brake bias and other setup values, audio volumes, camera focus, FFB strength, black boxes, and more — with live readouts on the touch strip.
 
 **Built for Every Stream Deck**
 
-iRaceDeck supports Stream Deck, Stream Deck Mini, Stream Deck XL, and Stream Deck+ — and ships ready-made profiles so you can start from a full layout instead of an empty grid.
+iRaceDeck supports Stream Deck, Stream Deck Mini, Stream Deck XL, Stream Deck Neo, Stream Deck Studio, Stream Deck +, Stream Deck + XL, Galleon 100 SD, Stream Deck Mobile, and the Virtual Stream Deck — and ships ready-made profiles so you can start from a full layout instead of an empty grid.
 
 **Free & Open Source**
 
@@ -115,6 +119,10 @@ Switch cameras, follow different cars, and control replay playback directly from
 Chat & Race Admin
 
 Send predefined chat messages with a single press — 15 configurable macros with live-data templating — plus reply, whisper, and quick chat toggles. League admins get a full race-control panel: black flags, penalties, wave-arounds, pace laps, session advance, and more.
+
+Everything in One Settings Window
+
+Every plugin-wide setting lives in one full-size window instead of being repeated inside every key’s panel: all 236 key bindings in one searchable table, appearance defaults, the Race Engineer, SimHub, and diagnostics — opened with the cog button under any key’s own settings. Your settings live in a file iRaceDeck owns, so they survive plugin updates and reinstalls, and each release’s notes ship inside the plugin so you can read what an update changes before taking it.
 
 Built for the Mirabox Ecosystem
 

--- a/docs/reference/store-descriptions.md
+++ b/docs/reference/store-descriptions.md
@@ -72,7 +72,7 @@ Every plugin-wide setting lives in one full-size window instead of being repeate
 
 **Built for Every Stream Deck**
 
-iRaceDeck supports Stream Deck, Stream Deck Mini, Stream Deck XL, Stream Deck Neo, Stream Deck Studio, Stream Deck +, Stream Deck + XL, Galleon 100 SD, Stream Deck Mobile, and the Virtual Stream Deck — and ships ready-made profiles so you can start from a full layout instead of an empty grid.
+iRaceDeck supports Stream Deck, Stream Deck Mini, Stream Deck XL, Stream Deck Neo, Stream Deck Studio, Stream Deck +, Stream Deck + XL, Galleon 100 SD, Stream Deck Mobile, and the Virtual Stream Deck. Ready-made profiles ship for Stream Deck, Stream Deck XL and Stream Deck + XL, so on those you start from a full layout instead of an empty grid.
 
 **Free & Open Source**
 

--- a/packages/iracing-actions/src/actions/data/changelog.json
+++ b/packages/iracing-actions/src/actions/data/changelog.json
@@ -6,6 +6,18 @@
   },
   "releases": [
     {
+      "version": "3.0.1",
+      "date": null,
+      "categories": [
+        {
+          "title": "Maintenance",
+          "items": [
+            "The website now names every Stream Deck device iRaceDeck runs on. Stream Deck Neo, Stream Deck Studio, Stream Deck + XL, Galleon 100 SD, Stream Deck Mobile and the Virtual Stream Deck are all supported, but the download card and the installation guide listed only the original four models — so owners of the others read that their device was not covered."
+          ]
+        }
+      ]
+    },
+    {
       "version": "3.0.0",
       "date": "2026-08-23",
       "categories": [

--- a/packages/website/src/content/docs/changelog.mdx
+++ b/packages/website/src/content/docs/changelog.mdx
@@ -9,6 +9,14 @@ import ChangelogLeadIn from "../../components/ChangelogLeadIn.astro";
 
 Release notes for each version of iRaceDeck. The newest release is listed first. For installation help, see the [installation guide](/docs/getting-started/installation/); to grab the latest build, head to the [downloads page](/downloads/).
 
+## 3.0.1
+
+_Unreleased_
+
+**Maintenance**
+
+- The website now names every Stream Deck device iRaceDeck runs on. Stream Deck Neo, Stream Deck Studio, Stream Deck + XL, Galleon 100 SD, Stream Deck Mobile and the Virtual Stream Deck are all supported, but the download card and the installation guide listed only the original four models — so owners of the others read that their device was not covered.
+
 ## 3.0.0
 
 _2026-08-23_

--- a/packages/website/src/data/brands.ts
+++ b/packages/website/src/data/brands.ts
@@ -62,7 +62,16 @@ export const BRAND_LOGO_EXTENSIONS = [".svg", ".png", ".webp", ".avif"] as const
 export const ECOSYSTEMS: Record<Ecosystem, EcosystemInfo> = {
   elgato: {
     label: "Elgato Stream Deck",
-    devices: "Stream Deck, Stream Deck Mini, Stream Deck XL, and Stream Deck+",
+    /*
+     * Every device `DEVICE_SUPPORT` (deck-core) marks as supported, hardware
+     * first and the two software surfaces last. It omitted Neo, Studio, + XL,
+     * Galleon and the software decks until #983, so their owners read on the
+     * download card and in the installation guide that their device was not
+     * covered. `scripts/website-device-list.test.mjs` now fails if the two
+     * lists drift apart in either direction.
+     */
+    devices:
+      "Stream Deck, Stream Deck Mini, Stream Deck XL, Stream Deck Neo, Stream Deck Studio, Stream Deck +, Stream Deck + XL, Galleon 100 SD, Stream Deck Mobile, and the Virtual Stream Deck",
     listIsComplete: true,
   },
   mirabox: {

--- a/scripts/website-device-list.test.mjs
+++ b/scripts/website-device-list.test.mjs
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { DEVICE_SPECS, DEVICE_SUPPORT } from "../packages/deck-core/src/device-profiles.ts";
+import { ECOSYSTEMS } from "../packages/website/src/data/brands.ts";
+
+/**
+ * The website's Elgato device list vs. the canonical support matrix (#983).
+ *
+ * `DEVICE_SUPPORT` in deck-core decides which devices iRaceDeck actually runs
+ * on; `ECOSYSTEMS.elgato.devices` is the single string the download card and
+ * the installation guide both render. Nothing connected the two, and they had
+ * drifted: Neo, Studio, + XL, Galleon 100 SD, Stream Deck Mobile and the
+ * Virtual Stream Deck were all supported and none of them was named, so their
+ * owners read that iRaceDeck did not cover their device.
+ *
+ * Both directions matter. A supported device missing from the prose costs us a
+ * user who owns one; an unsupported device named in it is a promise the plugin
+ * cannot keep.
+ */
+const elgatoDevices = ECOSYSTEMS.elgato.devices;
+
+/** `[name, controls]` for every entry in the matrix, e.g. `["Stream Deck Neo", "keys"]`. */
+const devices = Object.entries(DEVICE_SUPPORT).map(([type, support]) => [
+  DEVICE_SPECS[Number(type)].name,
+  support.controls,
+]);
+
+const supported = devices.filter(([, controls]) => controls !== "unsupported");
+const unsupported = devices.filter(([, controls]) => controls === "unsupported");
+
+/**
+ * Supported devices deliberately left out of the public prose. Empty since
+ * #983 — every supported device is named, including the two software surfaces.
+ * Add a name here (with the reason) rather than deleting the assertion.
+ */
+const DELIBERATELY_UNNAMED = [];
+
+describe("website Elgato device list (#983)", () => {
+  it("reads the matrix at all", () => {
+    // Guards the parsing itself: an empty list would make every other
+    // assertion below pass vacuously.
+    expect(supported.length).toBeGreaterThan(5);
+    expect(unsupported.length).toBeGreaterThan(0);
+  });
+
+  it.each(supported.filter(([name]) => !DELIBERATELY_UNNAMED.includes(name)))(
+    "names %s, which iRaceDeck supports (%s)",
+    (name) => {
+      expect(elgatoDevices).toContain(name);
+    },
+  );
+
+  it.each(unsupported)("does not claim %s, which is unsupported (%s)", (name) => {
+    expect(elgatoDevices).not.toContain(name);
+  });
+
+  it("keeps every deliberately unnamed device out of the prose", () => {
+    // Otherwise the allow-list quietly becomes a list of things that ARE named.
+    for (const name of DELIBERATELY_UNNAMED) {
+      expect(elgatoDevices).not.toContain(name);
+    }
+  });
+});

--- a/scripts/website-device-list.test.mjs
+++ b/scripts/website-device-list.test.mjs
@@ -17,7 +17,20 @@ import { ECOSYSTEMS } from "../packages/website/src/data/brands.ts";
  * user who owns one; an unsupported device named in it is a promise the plugin
  * cannot keep.
  */
-const elgatoDevices = ECOSYSTEMS.elgato.devices;
+/**
+ * The prose list split back into exact device names.
+ *
+ * Substring matching would leave holes precisely where they hurt: "Stream Deck"
+ * occurs inside every other name, and "Stream Deck +" inside "Stream Deck + XL",
+ * so dropping either of those two from the prose would still satisfy a
+ * `toContain` on the raw string. Comparing parsed entries makes each assertion
+ * exact. The leading article is stripped here rather than dropped from the copy,
+ * so the sentence can still read "…, and the Virtual Stream Deck".
+ */
+const namedDevices = ECOSYSTEMS.elgato.devices
+  .split(",")
+  .map((entry) => entry.trim().replace(/^and\s+/i, "").replace(/^the\s+/i, ""))
+  .filter(Boolean);
 
 /** `[name, controls]` for every entry in the matrix, e.g. `["Stream Deck Neo", "keys"]`. */
 const devices = Object.entries(DEVICE_SUPPORT).map(([type, support]) => [
@@ -36,28 +49,38 @@ const unsupported = devices.filter(([, controls]) => controls === "unsupported")
 const DELIBERATELY_UNNAMED = [];
 
 describe("website Elgato device list (#983)", () => {
-  it("reads the matrix at all", () => {
-    // Guards the parsing itself: an empty list would make every other
+  it("reads both sides at all", () => {
+    // Guards the parsing itself: an empty list on either side would make every
     // assertion below pass vacuously.
     expect(supported.length).toBeGreaterThan(5);
     expect(unsupported.length).toBeGreaterThan(0);
+    expect(namedDevices.length).toBe(supported.length - DELIBERATELY_UNNAMED.length);
   });
 
   it.each(supported.filter(([name]) => !DELIBERATELY_UNNAMED.includes(name)))(
     "names %s, which iRaceDeck supports (%s)",
     (name) => {
-      expect(elgatoDevices).toContain(name);
+      expect(namedDevices).toContain(name);
     },
   );
 
   it.each(unsupported)("does not claim %s, which is unsupported (%s)", (name) => {
-    expect(elgatoDevices).not.toContain(name);
+    expect(namedDevices).not.toContain(name);
   });
 
   it("keeps every deliberately unnamed device out of the prose", () => {
     // Otherwise the allow-list quietly becomes a list of things that ARE named.
     for (const name of DELIBERATELY_UNNAMED) {
-      expect(elgatoDevices).not.toContain(name);
+      expect(namedDevices).not.toContain(name);
     }
+  });
+
+  it("names nothing the matrix has never heard of", () => {
+    // The other direction of the same drift: a device renamed in deck-core
+    // leaves its old name stranded in the prose, where nothing else would
+    // catch it.
+    const known = devices.map(([name]) => name);
+
+    expect(namedDevices.filter((name) => !known.includes(name))).toEqual([]);
   });
 });


### PR DESCRIPTION
## Related Issue

Fixes #983

## What changed?

`ECOSYSTEMS.elgato.devices` named four models — Stream Deck, Mini, XL, + — while deck-core's `DEVICE_SUPPORT` matrix marks **ten** devices as supported. Since #946 that single string feeds the download card *and* the installation guide, so an owner of a Neo, Studio, + XL, Galleon 100 SD, Stream Deck Mobile or the Virtual Stream Deck read on two separate pages that their device wasn't covered — while the profiles page already listed + XL as a device we ship profiles for.

The list now names every device the matrix supports, hardware first and the two software surfaces last:

> Stream Deck, Stream Deck Mini, Stream Deck XL, Stream Deck Neo, Stream Deck Studio, Stream Deck +, Stream Deck + XL, Galleon 100 SD, Stream Deck Mobile, and the Virtual Stream Deck

**The guard test is the point of the change.** `scripts/website-device-list.test.mjs` pins the prose to the matrix in *both* directions: every supported device must be named (a missing one costs a user who owns that device), and no unsupported device may be (a named one is a promise the plugin can't keep — Corsair G-Keys, Stream Deck Pedal, Corsair Voyager and SCUF Controller are all `unsupported`). A device added to `DEVICE_SUPPORT` now fails the suite until the website names it.

Also folded in, from the 3.0.0 release-notes pass:

- `docs/reference/store-descriptions.md` gains an **Everything in One Settings Window** section for both listings — the headline feature of 3.0 was missing from both product descriptions. The Mirabox copy withholds profiles as that listing must (#786), and the Elgato copy carries the corrected device list. Elgato text is 3913 characters against its 4000 cap.
- The drift-check facts table and its *Last synced* line move to v3.0.0.
- `.claude/skills/website/SKILL.md` notes that the Elgato device string is now test-pinned.
- Changelog: a new `## 3.0.1` section under **Maintenance** (see "notes for the reviewer" below).

## How to test

1. `pnpm build && pnpm --filter @iracedeck/website build`
2. `packages/website/dist/downloads/index.html` — the Elgato card reads "For Stream Deck, … and the Virtual Stream Deck. Requires Stream Deck software version 7.1 or newer."
3. `packages/website/dist/docs/getting-started/installation/index.html` — the requirements bullet names the same set.
4. `pnpm exec vitest run scripts/website-device-list.test.mjs` — 16 assertions.
5. Mutation check (already done, restore afterwards): revert the string to the old four names → 8 failures; add "Stream Deck Pedal" → 1 more.

Full run: `pnpm build` 22/22, `pnpm lint`, `pnpm format`, `pnpm test` 310 files / 8832 tests.

## Notes for the reviewer

**Galleon 100 SD is named on the maintainer's explicit call.** It's `keys-and-dials` in the matrix, but it isn't a name in Elgato's public product line — it may be an unreleased or codenamed entry in the SDK's device enum, so this names a device we might not be able to point a buyer at. Raised before implementing and confirmed; the matrix is what decides support. Same reasoning covers Stream Deck Mobile and the Virtual Stream Deck, which are software surfaces rather than hardware.

**The changelog section is `## 3.0.1`, and that number is a guess.** 3.0.0 is released and dated, so this change needed a new section, and a website-copy correction reads as a patch. If the next release turns out to be 3.1.0, the heading needs renaming before the release tooling can stamp it — the stamp matches the section to the release version and silently no-ops otherwise.

**The issue says three consumer surfaces; there are two.** The landing page's "Works with" strip renders brand *logos* via `BrandStrip` and links to the installation guide — it never reads the `devices` string. Only the download card and the installation guide do.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — n/a, website and docs only
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support messaging for additional Stream Deck devices, including Neo, Studio, Stream Deck + XL, Galleon 100 SD, Stream Deck Mobile, and Virtual Stream Deck.
  * Added Settings Window details to Elgato and Mirabox product descriptions.
* **Documentation**
  * Updated website content, download cards, installation guidance, and store descriptions.
  * Added a 3.0.1 maintenance entry documenting expanded device support.
* **Bug Fixes**
  * Improved validation to keep listed supported devices aligned with actual compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->