### PR TITLE
improve(mirabox): log the global-settings read dropped before the socket opens (#1046)

### DIFF
--- a/packages/deck-adapter-mirabox/src/adapter.ts
+++ b/packages/deck-adapter-mirabox/src/adapter.ts
@@ -211,6 +211,13 @@ export class VSDPlatformAdapter implements IDeckPlatformAdapter {
     });
   }
 
+  /**
+   * Read the deck host's global settings. deck-core calls this once per start,
+   * for the one-time migration, as soon as it finds no settings file — usually
+   * before the host socket is open, in which case the client's connect-time
+   * read asks in its place and the skipped read is logged rather than dropped
+   * silently (#1046); see `VSDClient.requestGlobalSettings`.
+   */
   getGlobalSettings(): void {
     this.client.requestGlobalSettings();
   }

--- a/packages/deck-adapter-mirabox/src/vsd-client.test.ts
+++ b/packages/deck-adapter-mirabox/src/vsd-client.test.ts
@@ -145,3 +145,75 @@ describe("VSDClient.setGlobalSettings before the socket is open (#993)", () => {
     });
   });
 });
+
+describe("VSDClient.requestGlobalSettings before the socket is open (#1046)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports the skipped read at INFO, so it survives a log from a user without debug logging", () => {
+    // The point of the line is that a Mirabox support log showed nothing at
+    // all for this sequence. `debugLogging` is applied from the schema-DEFAULT
+    // cache at startup and the persisted value only arrives once the store is
+    // ready — strictly after this read — so a debug line would be suppressed
+    // for exactly the user whose log we would need. This is the only
+    // observable difference between the guard and send()'s own readyState
+    // check, so without this assertion the guard has no coverage.
+    const info = vi.fn();
+    const debug = vi.fn();
+    const logger = { info, warn: vi.fn(), error: vi.fn(), debug, createScope: vi.fn() };
+    const client = new VSDClient(params, logger as never, () => {});
+
+    client.requestGlobalSettings();
+
+    expect(info).toHaveBeenCalledOnce();
+    expect(debug).not.toHaveBeenCalled();
+  });
+
+  it("sends nothing when no socket exists yet, and does not throw", async () => {
+    // deck-core's one-time migration read fires as soon as the missing
+    // settings file resolves, which is before connect() has opened the socket.
+    const client = new VSDClient(params, undefined, () => {});
+
+    client.requestGlobalSettings();
+
+    await client.connect();
+    expect(lastSocket.sent).toEqual([]);
+  });
+
+  it("does not stash the read — the connect-time read asks in its place, exactly once", async () => {
+    // A stash like setGlobalSettings' would put a duplicate frame on the wire:
+    // the open handler already issues this same read. (deck-core's own read is
+    // a separate frame and deliberately kept — it is what completes the
+    // migration in the ordering where the socket opens first, since deck-core
+    // ignores any reply that arrives before it asked.)
+    const client = new VSDClient(params, undefined, () => {});
+
+    client.requestGlobalSettings();
+    client.requestGlobalSettings();
+
+    await client.connect();
+    lastSocket.emit("open");
+
+    expect(sentMessages().filter((m) => m.event === "getGlobalSettings")).toEqual([
+      { event: "getGlobalSettings", context: params.pluginUuid },
+    ]);
+  });
+
+  it("sends nothing while the socket is CONNECTING, then the read lands once open", async () => {
+    const client = new VSDClient(params, undefined, () => {});
+    await client.connect();
+    lastSocket.readyState = 0; // CONNECTING — a socket exists, but not an open one
+
+    client.requestGlobalSettings();
+
+    expect(lastSocket.sent).toEqual([]);
+
+    lastSocket.readyState = WS_OPEN;
+    lastSocket.emit("open");
+
+    expect(sentMessages().filter((m) => m.event === "getGlobalSettings")).toEqual([
+      { event: "getGlobalSettings", context: params.pluginUuid },
+    ]);
+  });
+});

--- a/packages/deck-adapter-mirabox/src/vsd-client.test.ts
+++ b/packages/deck-adapter-mirabox/src/vsd-client.test.ts
@@ -168,6 +168,12 @@ describe("VSDClient.requestGlobalSettings before the socket is open (#1046)", ()
 
     expect(info).toHaveBeenCalledOnce();
     expect(debug).not.toHaveBeenCalled();
+    // The whole message, not just that something was logged: the line has to
+    // tell a support reader the dropped read was COVERED, or it reports a
+    // problem where there is none (#1046 review).
+    expect(info).toHaveBeenCalledWith(
+      "Global-settings read requested while the host socket was not open; the connect-time read will ask in its place",
+    );
   });
 
   it("sends nothing when no socket exists yet, and does not throw", async () => {

--- a/packages/deck-adapter-mirabox/src/vsd-client.ts
+++ b/packages/deck-adapter-mirabox/src/vsd-client.ts
@@ -226,7 +226,53 @@ export class VSDClient {
     });
   }
 
+  /**
+   * Read the deck host's global settings.
+   *
+   * deck-core issues this once per start for the one-time settings migration,
+   * as soon as it finds no settings file. `initGlobalSettings` runs before
+   * `adapter.connect()` and the read fires when the store's file load resolves
+   * — an `ENOENT` a tick or two later — so it usually arrives here before the
+   * socket is open, and `send()` discards anything written while it is not.
+   *
+   * Nothing misbehaves: the `open` handler in {@link connect} reissues this
+   * same read. What was missing is any trace that a read had been attempted at
+   * all — no frame, no line — which on the migration path is an hour of a
+   * support thread before anyone thinks to check (#1046). Unlike Ulanzi there
+   * is no addressing hazard alongside it: the VSD protocol's
+   * `getGlobalSettings` carries only `context`, so there is no scope to get
+   * wrong (#1041 was Ulanzi-only).
+   */
   requestGlobalSettings(): void {
+    if (this.ws?.readyState !== WS_OPEN) {
+      // Say so rather than dropping the frame silently, which is what left a
+      // Mirabox support log with no evidence either way — and at INFO, not
+      // debug. `debugLogging` is applied from the schema-DEFAULT
+      // cache at startup and the persisted value only arrives once the store
+      // is ready — strictly after this read — so a debug line would be
+      // suppressed for exactly the user whose log we would need. That is the
+      // only observable difference between this guard and the readyState check
+      // inside `send()`, and it is the whole point of the change.
+      //
+      // No stash, unlike `setGlobalSettings` below: the `open` handler issues
+      // this same read unconditionally, so it asks the question this call could
+      // not, and stashing would only put a duplicate frame on the wire. Note
+      // the OTHER ordering — deck-core ignores any payload arriving before it
+      // asked (`!migrationRequested`), so when the socket opens first the
+      // connect-time reply is discarded and the migration completes on
+      // deck-core's own read, sent moments later with the socket already open.
+      // Both reads are load-bearing, one per ordering; do not de-duplicate
+      // them.
+      //
+      // This explanation is only true while the `open` handler is what covers
+      // the dropped read. A change to who issues the migration read, or to when
+      // it is issued, must revisit this comment rather than leave a confident
+      // wrong one behind.
+      this.logger.info("Global-settings read requested while the host socket was not open");
+
+      return;
+    }
+
     this.send({
       event: "getGlobalSettings",
       context: this.params.pluginUuid,

--- a/packages/deck-adapter-mirabox/src/vsd-client.ts
+++ b/packages/deck-adapter-mirabox/src/vsd-client.ts
@@ -268,7 +268,9 @@ export class VSDClient {
       // the dropped read. A change to who issues the migration read, or to when
       // it is issued, must revisit this comment rather than leave a confident
       // wrong one behind.
-      this.logger.info("Global-settings read requested while the host socket was not open");
+      this.logger.info(
+        "Global-settings read requested while the host socket was not open; the connect-time read will ask in its place",
+      );
 
       return;
     }

--- a/packages/deck-adapter-ulanzi/src/ulanzi-client.test.ts
+++ b/packages/deck-adapter-ulanzi/src/ulanzi-client.test.ts
@@ -657,6 +657,12 @@ describe("UlanziClient.requestGlobalSettings before the socket is open (#1041)",
 
     expect(info).toHaveBeenCalledOnce();
     expect(debug).not.toHaveBeenCalled();
+    // The whole message, not just that something was logged: the line has to
+    // tell a support reader the dropped read was COVERED, or it reports a
+    // problem where there is none (#1046 review).
+    expect(info).toHaveBeenCalledWith(
+      "Global-settings read requested while the host socket was not open; the connect-time read will ask in its place",
+    );
   });
 
   it("sends nothing when no socket exists yet, and does not throw", async () => {

--- a/packages/deck-adapter-ulanzi/src/ulanzi-client.ts
+++ b/packages/deck-adapter-ulanzi/src/ulanzi-client.ts
@@ -536,7 +536,9 @@ export class UlanziClient {
       // connect-time reply is discarded and migration completes on deck-core's
       // own read, sent moments later with the socket already open. Both reads
       // are load-bearing, one per ordering; do not de-duplicate them.
-      this.logger.info("Global-settings read requested while the host socket was not open");
+      this.logger.info(
+        "Global-settings read requested while the host socket was not open; the connect-time read will ask in its place",
+      );
 
       return;
     }


### PR DESCRIPTION
## Related Issue

Fixes #1046

## What changed?

`VSDClient.requestGlobalSettings()` sent its frame through `send()`, which discards anything written while the socket is not open. deck-core issues that read for the one-time settings migration as soon as it finds no settings file — before `adapter.connect()` — so it very often landed on the closed-socket path and was discarded **with nothing recorded anywhere**: no frame, no line, no trace that a read had been attempted.

Nothing misbehaved: the `open` handler reissues the same read, and deck-core takes the first payload that arrives. What was missing was any evidence in a Mirabox support log, on precisely the path a user reports when their settings did not carry over.

This mirrors the Ulanzi shape from #1041: an explicit `WS_OPEN` guard, an early return, and a line naming the connect-time reissue as what covers it. Deliberately **not** a stash-and-flush — the `open` handler already asks the same question, so a stash would only duplicate the frame; the comment says so, since `setGlobalSettings` directly below it genuinely does need one.

**Logged at INFO, where the issue's Proposed-change section says debug.** A debug line would be suppressed for exactly the user whose log we need: `VSDPlatformAdapter.logLevel` defaults to `LogLevel.Info`, and the persisted `debugLogging` is applied only after the store is ready — strictly later than this read. Ulanzi already made the same call for the same reason, stated inline. Following the literal wording would have satisfied the issue's Proposed change and defeated its Problem statement.

A second commit adds the JSDoc the Ulanzi sibling carries to `VSDPlatformAdapter.getGlobalSettings()`, which was the one place the two deliberate near-duplicates had drifted.

**Coupling worth knowing:** #1056 changes when the migration read is issued and adds an `onHostReady` notification to this same `open` handler. If that lands, the "no stash because the open handler reissues" comment must be re-read rather than assumed still true — the comment says so itself.

## How to test

Tested on real Mirabox hardware via StreamDock, both cases, before this PR was opened.

**The observation trap, first:** the line appears **only** when a migration read is actually issued — a start with no settings file, or the give-up retry. On an ordinary start the correct result is its **absence**, so that is a case in its own right rather than a failure to find something.

**Case A — ordinary start (line must be absent).** Start StreamDock normally, then read `<plugin>/log/<YYYY.M.D>.log`. Passed, and the log gives a positive reason rather than a silence:

```text
16:01:37.026  Global settings loaded from the settings file
```

No migration read was issued, so there was nothing to report.

**Case B — migration start (line must be present).** With StreamDock closed, move `%LOCALAPPDATA%\iRaceDeck\Settings\Mirabox\global-settings.json` aside, start StreamDock, then restore the file afterwards. Passed:

```text
16:04:21.618  No settings file yet; requesting the deck host's settings for a one-time migration
16:04:21.619  Global-settings read requested while the host socket was not open
16:04:24.638  Connected to VSD Craft
16:04:24.693  Migrated global settings from the deck host
```

Once, at INFO (no debug toggle needed), 1 ms after the request and **3.0 s before the socket opened**, with the connect-time reissue completing the migration exactly as the design describes. That four-line block is the whole issue.

> **The block above is the hardware run verbatim, and it predates a review change.** CodeRabbit rightly pointed out that the line named the drop without naming what covered it, so the message is now `Global-settings read requested while the host socket was not open; the connect-time read will ask in its place` (in both clients — they carried the identical string). The quoted output is left exactly as it was emitted rather than edited to match: it is evidence, not documentation. Everything about the ordering and timing it shows is unchanged.

**On the automated coverage, stated honestly:** four tests were added, matching the four the Ulanzi client carries, but only the INFO assertion actually covers the guard. Verified by removing the guard: that test alone fails and the other three still pass, because `send()`'s own `readyState` check keeps the frame off the wire either way. The other three pin shape — no throw with no socket, no stash, and the CONNECTING branch.

`deck-adapter-mirabox`: 58 tests before, 62 after. Full suite 9218 → 9222 across the same 325 files, measured against a freshly built `master` at `fb3dd8db`.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — n/a by construction: the change is inside `deck-adapter-mirabox`, and the equivalent guard already exists in `deck-adapter-ulanzi` (#1041). Elgato needs none; its SDK awaits the connection internally.
- [x] No unrelated changes included

No changelog entry: the issue states this is diagnostic-only with no user-facing change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved global settings requests when a connection is unavailable or still connecting.
  * Prevented dropped or duplicate requests and ensured the request is sent once the connection opens.
  * Added informative logging for deferred requests.
  * Improved consistency across supported device adapters when settings are requested before connection.

* **Documentation**
  * Clarified the behavior and startup usage of global settings retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->