### PR TITLE
chore(tsconfig): let the base config govern, clearing the TS2823 errors (#988)

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -9,6 +9,11 @@
 - Use clear, descriptive filenames and group related utilities under packages.
 - Use exact dependency versions (no `^` or `~` prefixes). The `.npmrc` has `save-exact=true` to enforce this for `pnpm add`.
 
+TypeScript configuration
+
+- `tsconfig.base.json` is the single source of compiler options. A package's own `tsconfig.json` carries only what is genuinely local to it — paths such as `outDir`, `rootDir` and `include`, its `lib`, and any option it deliberately sets **differently** from the base (the plugins' `declaration: false`, for example).
+- Never repeat a base value verbatim in a package config. A duplicate silently stops the base governing that package, so editing the base later does nothing and nothing goes red — which is exactly how the repo-wide `TS2823` errors survived a fix aimed at the base (#988). `scripts/tsconfig-base-inheritance.test.mjs` enforces this; if it fails, delete the duplicated key rather than the assertion.
+
 Formatting
 
 - Project formatter/linter configuration is authoritative. Don’t reformat unrelated files in a single change.

--- a/packages/audio-native/tsconfig.json
+++ b/packages/audio-native/tsconfig.json
@@ -2,9 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
-    "declaration": true,
-    "declarationMap": true
+    "rootDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "build"]

--- a/packages/audio-scenarios/tsconfig.json
+++ b/packages/audio-scenarios/tsconfig.json
@@ -1,12 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "customConditions": [
-      "node"
-    ],
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "noImplicitOverride": true,
     "resolveJsonModule": true,
     "outDir": "dist",
     "rootDir": "src"

--- a/packages/audio-service/tsconfig.json
+++ b/packages/audio-service/tsconfig.json
@@ -1,12 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "customConditions": [
-      "node"
-    ],
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "noImplicitOverride": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/deck-adapter-elgato/tsconfig.json
+++ b/packages/deck-adapter-elgato/tsconfig.json
@@ -1,12 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "customConditions": [
-      "node"
-    ],
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "noImplicitOverride": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/deck-adapter-mirabox/tsconfig.json
+++ b/packages/deck-adapter-mirabox/tsconfig.json
@@ -1,12 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "customConditions": [
-      "node"
-    ],
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "noImplicitOverride": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/deck-adapter-ulanzi/tsconfig.json
+++ b/packages/deck-adapter-ulanzi/tsconfig.json
@@ -1,12 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "customConditions": [
-      "node"
-    ],
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "noImplicitOverride": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/deck-core/tsconfig.json
+++ b/packages/deck-core/tsconfig.json
@@ -1,12 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "customConditions": [
-      "node"
-    ],
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "noImplicitOverride": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/event-bus/tsconfig.json
+++ b/packages/event-bus/tsconfig.json
@@ -1,12 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "customConditions": [
-      "node"
-    ],
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "noImplicitOverride": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/icon-composer/tsconfig.json
+++ b/packages/icon-composer/tsconfig.json
@@ -1,12 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "customConditions": [
-      "node"
-    ],
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "noImplicitOverride": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/iracing-native/tsconfig.json
+++ b/packages/iracing-native/tsconfig.json
@@ -2,9 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
-    "declaration": true,
-    "declarationMap": true
+    "rootDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "build"]

--- a/packages/iracing-plugin-mirabox/tsconfig.json
+++ b/packages/iracing-plugin-mirabox/tsconfig.json
@@ -1,12 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "customConditions": [
-      "node"
-    ],
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "noImplicitOverride": true,
     "declaration": false,
     "declarationMap": false
   },

--- a/packages/iracing-plugin-stream-deck/tsconfig.json
+++ b/packages/iracing-plugin-stream-deck/tsconfig.json
@@ -1,12 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "customConditions": [
-      "node"
-    ],
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "noImplicitOverride": true,
     "declaration": false,
     "declarationMap": false
   },

--- a/packages/iracing-plugin-ulanzi/tsconfig.json
+++ b/packages/iracing-plugin-ulanzi/tsconfig.json
@@ -1,12 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "customConditions": [
-      "node"
-    ],
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "noImplicitOverride": true,
     "declaration": false,
     "declarationMap": false
   },

--- a/packages/iracing-sdk/tsconfig.json
+++ b/packages/iracing-sdk/tsconfig.json
@@ -2,9 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
-    "declaration": true,
-    "declarationMap": true
+    "rootDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist"]

--- a/packages/pi-components/tsconfig.json
+++ b/packages/pi-components/tsconfig.json
@@ -2,9 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["ES2022", "DOM"],
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "noImplicitOverride": true,
     "noEmit": true
   },
   "include": ["src/**/*.ts"]

--- a/packages/rasterizer/tsconfig.json
+++ b/packages/rasterizer/tsconfig.json
@@ -1,12 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "customConditions": [
-      "node"
-    ],
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "noImplicitOverride": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/scenario-harness/tsconfig.json
+++ b/packages/scenario-harness/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "customConditions": ["node"],
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "noImplicitOverride": true,
     "resolveJsonModule": true,
     "outDir": "dist",
     "rootDir": "src"

--- a/packages/sim-events-iracing/tsconfig.json
+++ b/packages/sim-events-iracing/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "customConditions": ["node"],
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "noImplicitOverride": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/track-data/tsconfig.json
+++ b/packages/track-data/tsconfig.json
@@ -1,12 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "customConditions": [
-      "node"
-    ],
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "noImplicitOverride": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/scripts/tsconfig-base-inheritance.test.mjs
+++ b/scripts/tsconfig-base-inheritance.test.mjs
@@ -1,19 +1,46 @@
 import { readdirSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isDeepStrictEqual } from "node:util";
 
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 // scripts/tsconfig-base-inheritance.test.mjs lives in scripts/, so the repo root is one up.
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const basePath = resolve(repoRoot, "tsconfig.base.json");
 
-const BASE_REL_PATH = "tsconfig.base.json";
-const EXTENDS_BASE = "../../tsconfig.base.json";
+// Packages that deliberately do not extend our base, and why. Listed so that a
+// package vanishing from the discovery below is a failure rather than a silent
+// loss of coverage.
+const PACKAGES_NOT_EXTENDING_BASE = new Map([["website", "extends astro/tsconfigs/strict"]]);
+
+// Directories that never hold a project config worth checking.
+const SKIP_DIRS = new Set(["node_modules", "dist", "build", ".turbo"]);
+
+// Options whose values TypeScript matches case-INSENSITIVELY, so a duplicate
+// differing only in case is still a duplicate. Verified against tsc 5.9.3:
+// `"module": "ESNEXT"` resolves to `esnext`, exactly the inherited value, which
+// means the base has silently stopped governing it — the #988 defect.
+//
+// Kept as an explicit list rather than lowercasing every string, because plenty
+// of option values ARE case-sensitive (`customConditions`, and any path). Folding
+// case on those would report a genuine difference as a duplicate and invite
+// someone to delete a key that is doing real work. Missing an enum here costs a
+// miss; guessing wrong the other way costs a wrong removal.
+const CASE_INSENSITIVE_OPTIONS = new Set([
+  "importsNotUsedAsValues",
+  "jsx",
+  "module",
+  "moduleDetection",
+  "moduleResolution",
+  "newLine",
+  "target",
+]);
 
 // Guards one invariant, and deliberately only one (#988): no package tsconfig
-// re-declares a compiler option whose value is already identical to the one it
-// inherits from `tsconfig.base.json`.
+// re-declares a compiler option whose value it already inherits from
+// `tsconfig.base.json`.
 //
 // Why it is worth a test rather than a convention. Before #988, 16 of the 21
 // package tsconfigs repeated `"module": "ES2022"` verbatim from the base, along
@@ -28,52 +55,89 @@ const EXTENDS_BASE = "../../tsconfig.base.json";
 // found by someone measuring the resolved config, and the natural way to add a
 // package here is to copy an existing one, which reintroduces the duplication.
 //
-// Genuinely local settings — `outDir`, `rootDir`, `lib`, `declaration`,
-// `include`, or any value that deliberately DIFFERS from the base — are not
-// touched by this rule. Only exact duplicates of an inherited value are wrong.
-function readJson(relPath) {
-  return JSON.parse(readFileSync(join(repoRoot, relPath), "utf-8"));
+// Genuinely local settings — `outDir`, `rootDir`, `lib`, `include`, or any value
+// that deliberately DIFFERS from the base — are untouched by this rule. Only a
+// duplicate of an inherited value is wrong.
+
+// tsconfig is JSONC: comments and trailing commas are legal and tsc accepts
+// them. Parse with TypeScript's own reader so this test accepts exactly what the
+// compiler does, rather than failing on a comment someone was right to add.
+function readTsconfig(absPath) {
+  const { config, error } = ts.parseConfigFileTextToJson(absPath, readFileSync(absPath, "utf-8"));
+  if (error) {
+    const detail = ts.flattenDiagnosticMessageText(error.messageText, " ");
+    throw new Error(`${absPath} is not valid tsconfig JSON: ${detail}`);
+  }
+  return config ?? {};
 }
 
-const baseCompilerOptions = readJson(BASE_REL_PATH).compilerOptions ?? {};
+// `extends` may be a string or, since TS 5.0, an array. Resolve every entry
+// relative to the config's own directory so a nested config is matched by path
+// rather than by a hardcoded number of `../` segments.
+function extendsBase(absPath, config) {
+  const entries = Array.isArray(config.extends) ? config.extends : [config.extends];
+  return entries.some((entry) => typeof entry === "string" && resolve(dirname(absPath), entry) === basePath);
+}
 
-// Discover the configs dynamically so a new package is covered the day it is
-// added, rather than needing to be listed here.
-function discoverPackageTsconfigs() {
+function findTsconfigs(absDir) {
   const found = [];
-  for (const entry of readdirSync(join(repoRoot, "packages"), { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    for (const file of readdirSync(join(repoRoot, "packages", entry.name))) {
-      if (!file.startsWith("tsconfig") || !file.endsWith(".json")) continue;
-      const relPath = `packages/${entry.name}/${file}`;
-      // Only configs that actually inherit from our base can duplicate it.
-      // `packages/website` extends astro's config and is out of scope.
-      if (readJson(relPath).extends === EXTENDS_BASE) found.push(relPath);
+  for (const entry of readdirSync(absDir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) found.push(...findTsconfigs(join(absDir, entry.name)));
+    } else if (/^tsconfig.*\.json$/.test(entry.name)) {
+      found.push(join(absDir, entry.name));
     }
   }
-  return found.sort();
+  return found;
 }
 
-const packageTsconfigs = discoverPackageTsconfigs();
+const packagesDir = join(repoRoot, "packages");
+const allTsconfigs = findTsconfigs(packagesDir).sort();
+const baseCompilerOptions = readTsconfig(basePath).compilerOptions ?? {};
+const inheritingTsconfigs = allTsconfigs.filter((absPath) => extendsBase(absPath, readTsconfig(absPath)));
+
+const relative = (absPath) => absPath.slice(repoRoot.length + 1).replaceAll("\\", "/");
+const packageOf = (absPath) => relative(absPath).split("/")[1];
+
+function isDuplicate(key, value) {
+  if (!(key in baseCompilerOptions)) return false;
+  const baseValue = baseCompilerOptions[key];
+  if (CASE_INSENSITIVE_OPTIONS.has(key) && typeof value === "string" && typeof baseValue === "string") {
+    return value.toLowerCase() === baseValue.toLowerCase();
+  }
+  return isDeepStrictEqual(value, baseValue);
+}
 
 describe("package tsconfigs inherit from tsconfig.base.json rather than repeating it", () => {
-  it("discovers the base options and the package configs that extend them", () => {
+  it("reads the base options", () => {
     expect(Object.keys(baseCompilerOptions).length).toBeGreaterThan(0);
-    expect(packageTsconfigs.length).toBeGreaterThan(0);
   });
 
-  it.each(packageTsconfigs)("re-declares no value identical to the base: %s", (relPath) => {
-    const compilerOptions = readJson(relPath).compilerOptions ?? {};
-    const redundant = Object.keys(compilerOptions).filter(
-      (key) => key in baseCompilerOptions && isDeepStrictEqual(compilerOptions[key], baseCompilerOptions[key]),
+  // Coverage guard. Without it, a change to the discovery above could quietly
+  // shrink the checked set to a handful while every remaining case still passes.
+  it("examines every package that extends the base", () => {
+    const covered = new Set(inheritingTsconfigs.map(packageOf));
+    const missing = [...new Set(allTsconfigs.map(packageOf))].filter(
+      (name) => !covered.has(name) && !PACKAGES_NOT_EXTENDING_BASE.has(name),
     );
+    expect(
+      missing,
+      `these packages have a tsconfig that is not being checked: ${missing.join(", ")}. Either it stopped ` +
+        `extending ${relative(basePath)}, or discovery in this test has broken. Add it to ` +
+        `PACKAGES_NOT_EXTENDING_BASE with a reason only if it genuinely does not extend the base.`,
+    ).toEqual([]);
+  });
+
+  it.each(inheritingTsconfigs.map(relative))("re-declares no value it already inherits: %s", (relPath) => {
+    const compilerOptions = readTsconfig(join(repoRoot, relPath)).compilerOptions ?? {};
+    const redundant = Object.keys(compilerOptions).filter((key) => isDuplicate(key, compilerOptions[key]));
 
     expect(
       redundant,
-      `${relPath} repeats ${redundant.map((key) => `"${key}"`).join(", ")} with the same value as ` +
-        `${BASE_REL_PATH}. Delete the duplicate so the base governs it — a repeated value means ` +
-        `editing the base silently does nothing for this package (#988). Keep the key only if you ` +
-        `intend it to DIFFER from the base.`,
+      `${relPath} repeats ${redundant.map((key) => `"${key}"`).join(", ")} with the value it already ` +
+        `inherits from ${relative(basePath)}. Delete the duplicate so the base governs it — a repeated ` +
+        `value means editing the base silently does nothing for this package (#988). Keep the key only ` +
+        `if you intend it to DIFFER from the base.`,
     ).toEqual([]);
   });
 });

--- a/scripts/tsconfig-base-inheritance.test.mjs
+++ b/scripts/tsconfig-base-inheritance.test.mjs
@@ -1,0 +1,79 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+// scripts/tsconfig-base-inheritance.test.mjs lives in scripts/, so the repo root is one up.
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const BASE_REL_PATH = "tsconfig.base.json";
+const EXTENDS_BASE = "../../tsconfig.base.json";
+
+// Guards one invariant, and deliberately only one (#988): no package tsconfig
+// re-declares a compiler option whose value is already identical to the one it
+// inherits from `tsconfig.base.json`.
+//
+// Why it is worth a test rather than a convention. Before #988, 16 of the 21
+// package tsconfigs repeated `"module": "ES2022"` verbatim from the base, along
+// with `moduleResolution`, `customConditions` and `noImplicitOverride`. That is
+// invisible while the values agree — and it silently stops the base governing
+// anything. Clearing the repo-wide TS2823 import-attribute errors by raising
+// `module` in the base alone would have been a no-op for every one of those 16
+// packages, including all three plugins, which is exactly where the errors were.
+//
+// The failure mode is what makes it worth guarding mechanically: nothing goes
+// red, no build breaks, and the change simply has no effect. It is only ever
+// found by someone measuring the resolved config, and the natural way to add a
+// package here is to copy an existing one, which reintroduces the duplication.
+//
+// Genuinely local settings — `outDir`, `rootDir`, `lib`, `declaration`,
+// `include`, or any value that deliberately DIFFERS from the base — are not
+// touched by this rule. Only exact duplicates of an inherited value are wrong.
+function readJson(relPath) {
+  return JSON.parse(readFileSync(join(repoRoot, relPath), "utf-8"));
+}
+
+const baseCompilerOptions = readJson(BASE_REL_PATH).compilerOptions ?? {};
+
+// Discover the configs dynamically so a new package is covered the day it is
+// added, rather than needing to be listed here.
+function discoverPackageTsconfigs() {
+  const found = [];
+  for (const entry of readdirSync(join(repoRoot, "packages"), { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    for (const file of readdirSync(join(repoRoot, "packages", entry.name))) {
+      if (!file.startsWith("tsconfig") || !file.endsWith(".json")) continue;
+      const relPath = `packages/${entry.name}/${file}`;
+      // Only configs that actually inherit from our base can duplicate it.
+      // `packages/website` extends astro's config and is out of scope.
+      if (readJson(relPath).extends === EXTENDS_BASE) found.push(relPath);
+    }
+  }
+  return found.sort();
+}
+
+const packageTsconfigs = discoverPackageTsconfigs();
+
+describe("package tsconfigs inherit from tsconfig.base.json rather than repeating it", () => {
+  it("discovers the base options and the package configs that extend them", () => {
+    expect(Object.keys(baseCompilerOptions).length).toBeGreaterThan(0);
+    expect(packageTsconfigs.length).toBeGreaterThan(0);
+  });
+
+  it.each(packageTsconfigs)("re-declares no value identical to the base: %s", (relPath) => {
+    const compilerOptions = readJson(relPath).compilerOptions ?? {};
+    const redundant = Object.keys(compilerOptions).filter(
+      (key) => key in baseCompilerOptions && isDeepStrictEqual(compilerOptions[key], baseCompilerOptions[key]),
+    );
+
+    expect(
+      redundant,
+      `${relPath} repeats ${redundant.map((key) => `"${key}"`).join(", ")} with the same value as ` +
+        `${BASE_REL_PATH}. Delete the duplicate so the base governs it — a repeated value means ` +
+        `editing the base silently does nothing for this package (#988). Keep the key only if you ` +
+        `intend it to DIFFER from the base.`,
+    ).toEqual([]);
+  });
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,7 @@
     "customConditions": [
       "node"
     ],
-    "module": "ES2022",
+    "module": "esnext",
     "moduleResolution": "Bundler",
     "noImplicitOverride": true,
     "declaration": true,


### PR DESCRIPTION
## Related Issue

Fixes #988

## What changed?

`tsc --noEmit` could not run clean anywhere in the workspace — three `TS2823` import-attribute errors per plugin, across five files using `with { type: "json" }` against a `"module"` of `ES2022`, which predates the syntax. That blocks #987 and the cheaper `noEmitOnError` build gate alike.

**The fix the issue proposed would not have worked.** Raising `module` in `tsconfig.base.json` is a no-op for every file that had an error: 16 of the 21 package tsconfigs re-declared `"module": "ES2022"` themselves, shadowing the base — including all three plugins. (The issue's own *Affected artifacts* list said "and any package tsconfig that overrides `module`"; the proposal did not, and the proposal is what gets implemented.)

So the base is made to actually govern:

- `tsconfig.base.json` sets `"module": "esnext"` — one line.
- **69 redundant keys removed across 19 packages** (`module`, `moduleResolution`, `customConditions`, `noImplicitOverride`, `declaration`, `declarationMap`), every one an exact duplicate of the inherited value.
- `scripts/tsconfig-base-inheritance.test.mjs` guards the invariant so the duplication cannot grow back.
- `.claude/rules/code-style.md` documents it and names the test.

`node20` / `nodenext` are not available: both collide with the repo-wide `moduleResolution: "Bundler"` (TS5095 / TS5109). `preserve` was rejected for implicitly flipping `esModuleInterop` and `allowSyntheticDefaultImports` — a second, unmeasured change riding along.

### The shipped output is provably unchanged

This touches the config every package extends, which is the scariest-sounding part of the change, so it is the most heavily evidenced part.

**Every emitted file in all three plugin trees is byte-identical to master's — 5094 files, zero differences.** Not just `bin/plugin.js`: `ui/pi-components.js`, all three bridge bundles, 111 generated PI HTML pages, the manifests, layouts and assets.

That comparison is only worth something if the build reproduces, so **a determinism control was run first**: two consecutive uncached `build:force` runs with no source change at all produce byte-identical trees. Without that, "identical" would be equally consistent with a comparison too blunt to see a difference.

The compared set was enumerated rather than assumed — a file walk that quietly missed `ui/` would have produced the same cheerful "IDENTICAL".

Both the equivalence and the determinism control were **re-established against `1a0830ac`** after #1056 landed, rather than carried over from the earlier base they were first measured on. And the proof is reproducible by anyone from master plus this branch's diff — build both, hash every emitted file, compare. A screenshot of a result is not evidence for a claim like this; a reproducible procedure is.

### Resolved-config equivalence

`tsc --showConfig` was captured for **all 25 project configs before any edit**, on a pristine tree, and again afterwards. Exactly 24 differ, by exactly one line each:

```text
< "module": "es2022",
> "module": "esnext",
```

Nothing else moves anywhere — which is what proves the 69 removed keys were inert rather than merely believed to be. The check was itself positive-controlled: removing a genuinely non-redundant option (`declaration: false`, where the base says `true`) makes it fire.

### The guard test was hardened against three measured escapes

Code review found three ways it could miss the duplication it exists to catch. Each was **reproduced before being accepted**, and each fix was then watched to fail on purpose:

| | Before | After |
|---|---|---|
| `"module": "ESNEXT"` — a case-variant duplicate | **passed**, evaded the guard entirely | fails, names the key |
| A legal JSONC comment in any tsconfig | `SyntaxError`; the file went from 25 cases to `no tests` | 26 pass, guard still runs |
| A package dropping out of discovery | invisible | fails, naming the package |

The first is the one that matters: TypeScript matches enum option values case-insensitively, so `"module": "ESNEXT"` resolves to exactly the inherited `esnext` — the base has silently stopped governing — while `isDeepStrictEqual` saw two different strings. That is #988's exact regression walking past the test built to catch it. Enum options are now compared case-insensitively via an **explicit list** rather than by lowercasing every string, because `customConditions` and any path value are genuinely case-sensitive and folding case there would report a real difference as a duplicate.

The guard is not decoration: it failed on its first run, catching three packages this change had missed, because the removal pass only examined the four keys identified by hand and never looked at `declaration`.

## How to test

**There is nothing to test by hand, and that is a measured claim rather than a request for trust.** The built artifacts are byte-identical to master's across all 5094 emitted files, so starting this build is starting master's build. The outcome of a smoke test is determined by construction.

To verify the change itself:

```bash
pnpm install && pnpm build
pnpm test                    # 326 files / 9265 tests
pnpm lint && pnpm format

# the actual goal — clean, where master reports 3 TS2823 each:
pnpm exec tsc --noEmit -p packages/iracing-plugin-stream-deck/tsconfig.json
pnpm exec tsc --noEmit -p packages/iracing-plugin-mirabox/tsconfig.json
pnpm exec tsc --noEmit -p packages/iracing-plugin-ulanzi/tsconfig.json

# and the guard, which should fail if you re-add any duplicated base value:
pnpm test scripts/tsconfig-base-inheritance.test.mjs
```

Green on `1a0830ac`: build 22/22 with `0 cached`, all three plugins `errors=0`, lint 0, format clean, 326 files / 9265 tests — the 9239 master baseline plus this PR's 26 guard cases.

## Notes for the reviewer

- **`pi-components` is not fixed here.** It is a fourth rollup-only package with 9 pre-existing errors of a different class (`TS2307`/`TS7016`/`TS7006`/`TS2352`), unrelated to `TS2823` and unaffected by this change — it reports the identical 9 with and without it. That belongs to #987, which now carries it.
- **`@iracedeck/iracing-actions` still has no tsconfig**, so its test files are typechecked by nothing. Its sources are covered transitively through the plugin programs. Out of scope here; recorded on #987 so closing that issue is not mistaken for closing the whole gap.
- No changelog entry: internal build configuration with provably no user-visible effect.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — config-only; all three plugin tsconfigs updated and all three builds verified byte-identical
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized TypeScript settings across packages by centralizing shared compiler options.
  * Updated the module target to use the latest JavaScript module format.
  * Reduced redundant package-specific configuration.

* **Tests**
  * Added automated checks to detect duplicated or inconsistent TypeScript settings.

* **Documentation**
  * Documented configuration inheritance guidelines for TypeScript projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->