### PR TITLE
ci(typecheck): typecheck the plugin packages in CI (#987)

### DIFF
--- a/.claude/rules/build-and-commit.md
+++ b/.claude/rules/build-and-commit.md
@@ -21,10 +21,10 @@ pnpm relink:stream-deck     # Unlink + link (useful when switching worktrees)
 
 ### Build verification
 
-**Always review the full build output.** The build may succeed (exit code 0) while still emitting TypeScript warnings from `@rollup/plugin-typescript`. These warnings indicate real type errors that must be fixed before committing.
+**Always review the full build output.** Since #987 all four rollup configs set `noEmitOnError`, so a TypeScript diagnostic in a rollup-built package is a hard build failure rather than a warning on a green build — that is what the flag is for. Reading the output still matters, because a build can fail or misbehave for reasons that are not type errors.
 
 - Run the build and capture all output (do not just check the exit code or tail the last few lines).
-- Search the output for `TS[0-9]+:` patterns (e.g., `TS2345`, `TS2322`) — these are TypeScript diagnostics that need fixing.
+- Search the output for `TS[0-9]+:` patterns (e.g., `TS2345`, `TS2322`). Before #987 these could appear as *warnings* on a build that exited 0 and shipped broken output; they are now fatal, so finding one means the build failed.
 - Ignore `Circular dependency` warnings from `zod` internals and `npm warn Unknown env config` — these are known and harmless.
 - Common cause: `vi.fn(() => null)` in test files infers return type as `null`, making `mockReturnValue({...})` a type error. Fix by widening the return type: `vi.fn((): Record<string, unknown> | null => null)`.
 
@@ -114,7 +114,7 @@ Before every commit, the following must succeed:
 
 Do not commit if any step fails. Fix the issue first.
 
-**Why typecheck is separate from build.** Until #987 a green `pnpm build` said nothing about the type correctness of the rollup-built packages: `@rollup/plugin-typescript` reports type errors as rollup *warnings* and emits anyway unless `noEmitOnError` is set, so a build could report success while shipping a bundle that throws at startup. The three plugin configs now set `noEmitOnError`, which closes that at authoring time — but `pnpm typecheck` remains the gate that covers every package uniformly and is what a red CI run reproduces.
+**Why typecheck is separate from build.** Until #987 a green `pnpm build` said nothing about the type correctness of the rollup-built packages: `@rollup/plugin-typescript` reports type errors as rollup *warnings* and emits anyway unless `noEmitOnError` is set, so a build could report success while shipping a bundle that throws at startup. All four rollup configs — the three plugins and `pi-components` — now set `noEmitOnError`, which closes that at authoring time. `pnpm typecheck` is the explicit gate and is what a red CI run reproduces; see `@.claude/rules/testing.md` for what it does and does not cover.
 
 ### Logical Commits
 

--- a/.claude/rules/build-and-commit.md
+++ b/.claude/rules/build-and-commit.md
@@ -110,8 +110,11 @@ Before every commit, the following must succeed:
 
 1. **Install**: `pnpm install` — ensures dependencies are up to date.
 2. **Build**: `pnpm build` — must complete without TypeScript errors (see **Build verification** above).
+3. **Typecheck**: `pnpm typecheck` — the explicit type gate, and the same command CI runs.
 
-Do not commit if either step fails. Fix the issue first.
+Do not commit if any step fails. Fix the issue first.
+
+**Why typecheck is separate from build.** Until #987 a green `pnpm build` said nothing about the type correctness of the rollup-built packages: `@rollup/plugin-typescript` reports type errors as rollup *warnings* and emits anyway unless `noEmitOnError` is set, so a build could report success while shipping a bundle that throws at startup. The three plugin configs now set `noEmitOnError`, which closes that at authoring time — but `pnpm typecheck` remains the gate that covers every package uniformly and is what a red CI run reproduces.
 
 ### Logical Commits
 

--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -14,7 +14,7 @@ If you are picking up an issue, read this first.
 | 2   | Write the spec, commit to `master`                         | unless exempt           | `@.claude/rules/specs-and-plans.md`                                         |
 | 3   | Create the worktree `../ir-<issue>`                        | —                       | `@.claude/rules/build-and-commit.md`                                        |
 | 4   | Implement, committing as you go                            | —                       | the topic rules for what you touched                                        |
-| 5   | `install` → `build` → `format` → `lint` → `test`, by hand  | all green               | `@.claude/rules/testing.md`, `@.claude/rules/code-style.md`                  |
+| 5   | `install` → `build` → `typecheck` → `format` → `lint` → `test`, by hand | all green    | `@.claude/rules/testing.md`, `@.claude/rules/code-style.md`                  |
 | 6   | Document it on the website                                 | required if user-facing | `@.claude/rules/website-action-docs.md`, `@.claude/rules/changelog.md`       |
 | 7   | **Ask** to run the code review, then run it                | the ask                 | `@.claude/rules/code-review.md`                                             |
 | 8   | Manual testing                                             | **blocks the PR**       | below                                                                       |
@@ -45,7 +45,7 @@ Settled by the maintainer: an issue is solved in a sibling worktree, never insid
 
 **Assume nothing is watching, confirm, then run everything yourself.** The repo does ship watchers and one may be running against a linked worktree, so check before firing a full build into a tree something else is writing.
 
-The green set is the CI set plus the pre-commit checks: `install`, `build`, `format`, `lint`, `test`. CI runs format, lint and test as **separate** jobs, so a clean `lint` proves nothing about `format`. Read the build output rather than its exit code — `@.claude/rules/build-and-commit.md` explains why that distinction bites here.
+The green set is the CI set plus the pre-commit checks: `install`, `build`, `typecheck`, `format`, `lint`, `test`. CI runs format, lint and test as **separate** jobs, so a clean `lint` proves nothing about `format`. Read the build output rather than its exit code — `@.claude/rules/build-and-commit.md` explains why that distinction bites here.
 
 ### If a user can see it, the website describes it (6)
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -11,7 +11,10 @@ Common commands
 ```bash
 pnpm test
 pnpm test:watch
+pnpm typecheck              # tsc --noEmit across every package (#987)
 ```
+
+`pnpm test` does not typecheck: Vitest transforms through esbuild, which strips types without checking them. Neither did `pnpm build`, for the rollup-built packages — that gap is what #987 closed. `pnpm typecheck` is the explicit gate; its turbo task declares `dependsOn: ["^build"]` because packages resolve each other's types through emitted `dist/`, so it builds what it needs and needs no separate build step first.
 
 ## Root `vitest.config.ts` — native config loader
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -18,8 +18,8 @@ pnpm typecheck              # the type gate: tsc --noEmit per package (#987)
 
 **What it does not reach**, so nobody mistakes a green run for full coverage. `scripts/typecheck-script-coverage.test.mjs` guarantees every package with a `tsconfig.json` is in the gate; it cannot speak for the rest:
 
-- **Packages with no `tsconfig.json`** — `iracing-actions`, `audio-assets`, `icons`. `iracing-actions` is the significant one: its sources are checked only incidentally, by being pulled into the three plugin programs, and its test files are checked by nothing.
-- **Tests excluded by a package's own config** — `deck-adapter-mirabox` and `deck-adapter-ulanzi` both set `"exclude": ["src/**/*.test.ts"]`, so their typecheck covers no test file. `deck-adapter-elgato` has no such exclude, so the three siblings are not consistent.
+- **Packages with no `tsconfig.json`** — `iracing-actions`, `audio-assets`, `icons`. `iracing-actions` is the significant one: its sources are checked only incidentally, by being pulled into the three plugin programs, and its test files are checked by nothing. Tracked in #1078.
+- **Tests excluded by a package's own config** — `deck-adapter-mirabox` and `deck-adapter-ulanzi` both set `"exclude": ["src/**/*.test.ts"]`, so their typecheck covers no test file. `deck-adapter-elgato` has no such exclude, so the three siblings are not consistent. Tracked in #1078.
 
 Both gaps predate #987 and it does not widen them; they are recorded here because a gate is only useful if its edges are known.
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -11,10 +11,17 @@ Common commands
 ```bash
 pnpm test
 pnpm test:watch
-pnpm typecheck              # tsc --noEmit across every package (#987)
+pnpm typecheck              # the type gate: tsc --noEmit per package (#987)
 ```
 
 `pnpm test` does not typecheck: Vitest transforms through esbuild, which strips types without checking them. Neither did `pnpm build`, for the rollup-built packages — that gap is what #987 closed. `pnpm typecheck` is the explicit gate; its turbo task declares `dependsOn: ["^build"]` because packages resolve each other's types through emitted `dist/`, so it builds what it needs and needs no separate build step first.
+
+**What it does not reach**, so nobody mistakes a green run for full coverage. `scripts/typecheck-script-coverage.test.mjs` guarantees every package with a `tsconfig.json` is in the gate; it cannot speak for the rest:
+
+- **Packages with no `tsconfig.json`** — `iracing-actions`, `audio-assets`, `icons`. `iracing-actions` is the significant one: its sources are checked only incidentally, by being pulled into the three plugin programs, and its test files are checked by nothing.
+- **Tests excluded by a package's own config** — `deck-adapter-mirabox` and `deck-adapter-ulanzi` both set `"exclude": ["src/**/*.test.ts"]`, so their typecheck covers no test file. `deck-adapter-elgato` has no such exclude, so the three siblings are not consistent.
+
+Both gaps predate #987 and it does not widen them; they are recorded here because a gate is only useful if its edges are known.
 
 ## Root `vitest.config.ts` — native config loader
 

--- a/.github/workflows/ci-typecheck.yml
+++ b/.github/workflows/ci-typecheck.yml
@@ -15,12 +15,21 @@ on:
   push:
     branches: [master, 'release/*']
 
+# The job only reads the repository and runs a compiler, so it is given the
+# minimum token scope and the checkout credential is not left in .git/config for
+# later steps to reach. The three sibling CI workflows predate this and do not
+# set either; matching them would mean copying a weaker default forward.
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v6
         with:

--- a/.github/workflows/ci-typecheck.yml
+++ b/.github/workflows/ci-typecheck.yml
@@ -7,10 +7,13 @@ name: Typecheck
 # what two PRs merging in quick succession produce, so a gate that never sees
 # the merged result would miss its highest-value case. Adding the trigger here
 # does not create a convention for who fixes a red master; that belongs to #1070.
+# `release/*` is included for the same reason: release branches take feature PRs
+# of their own and reach master through a back-merge, so a post-merge gap there
+# is the same gap one branch removed.
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, 'release/*']
 
 jobs:
   typecheck:

--- a/.github/workflows/ci-typecheck.yml
+++ b/.github/workflows/ci-typecheck.yml
@@ -1,0 +1,37 @@
+name: Typecheck
+
+# Unlike the other three workflows, this one also runs on pushes to master.
+# A green PR check only proves something about the branch merged against the
+# master that existed when it ran, never about the master that results (#1070).
+# The defect this job exists to catch — cross-package type errors — is exactly
+# what two PRs merging in quick succession produce, so a gate that never sees
+# the merged result would miss its highest-value case. Adding the trigger here
+# does not create a convention for who fixes a red master; that belongs to #1070.
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.0.0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - run: pnpm install
+
+      # No explicit build step: the `typecheck` turbo task declares
+      # `dependsOn: ["^build"]`, because packages resolve each other's types
+      # through emitted `dist/`. So this is the same one command a developer
+      # runs locally, and a red run here reproduces with `pnpm typecheck`.
+      - run: pnpm typecheck

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lint:fix": "eslint --fix \"packages/*/src/**\" vitest.config.ts",
     "format": "prettier --check \"**/*.ts\" \"**/*.json\"",
     "format:fix": "prettier --write \"**/*.ts\" \"**/*.json\"",
+    "typecheck": "turbo run typecheck",
     "test": "vitest run --configLoader native",
     "test:watch": "vitest --configLoader native",
     "precommit": "pnpm lint:fix && pnpm format:fix && pnpm install && pnpm clean && pnpm build",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typecheck": "turbo run typecheck",
     "test": "vitest run --configLoader native",
     "test:watch": "vitest --configLoader native",
-    "precommit": "pnpm lint:fix && pnpm format:fix && pnpm install && pnpm clean && pnpm build",
+    "precommit": "pnpm lint:fix && pnpm format:fix && pnpm install && pnpm clean && pnpm build && pnpm typecheck",
     "start:stream-deck": "start /B \"\" \"C:\\Program Files\\Elgato\\StreamDeck\\StreamDeck.exe",
     "stop:stream-deck": "taskkill /IM StreamDeck.exe /F || exit 0",
     "link:stream-deck": "streamdeck link .\\packages\\iracing-plugin-stream-deck\\com.iracedeck.sd.core.sdPlugin",

--- a/packages/audio-native/package.json
+++ b/packages/audio-native/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "install": "echo Run build manually in audio-native to avoid extra builds",
     "build": "node scripts/build.mjs",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "clean": "node scripts/clean.mjs",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/audio-scenarios/package.json
+++ b/packages/audio-scenarios/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "clean": "rimraf dist",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/audio-service/package.json
+++ b/packages/audio-service/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "clean": "rimraf dist",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/deck-adapter-elgato/package.json
+++ b/packages/deck-adapter-elgato/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "clean": "rimraf dist"
   },
   "dependencies": {

--- a/packages/deck-adapter-mirabox/package.json
+++ b/packages/deck-adapter-mirabox/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "clean": "rimraf dist",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/deck-adapter-ulanzi/package.json
+++ b/packages/deck-adapter-ulanzi/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "clean": "rimraf dist",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/deck-core/package.json
+++ b/packages/deck-core/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "clean": "rimraf dist"
   },
   "dependencies": {

--- a/packages/event-bus/package.json
+++ b/packages/event-bus/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "clean": "rimraf dist",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/icon-composer/package.json
+++ b/packages/icon-composer/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "clean": "rimraf dist"
   },
   "devDependencies": {

--- a/packages/iracing-native/package.json
+++ b/packages/iracing-native/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "install": "echo Run build manually in iracing-native to avoid extra builds",
     "build": "node scripts/build.mjs",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "clean": "node scripts/clean.mjs",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/iracing-plugin-mirabox/package.json
+++ b/packages/iracing-plugin-mirabox/package.json
@@ -6,6 +6,7 @@
   "packageManager": "pnpm@10.0.0",
   "scripts": {
     "build": "rollup -c && npm run postbuild",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "postbuild": "cd com.iracedeck.sd.core.sdPlugin/bin && npm install",
     "watch": "rollup -c -w",
     "clean": "rimraf com.iracedeck.sd.core.sdPlugin/bin/plugin.js com.iracedeck.sd.core.sdPlugin/bin/plugin.js.map",

--- a/packages/iracing-plugin-mirabox/rollup.config.mjs
+++ b/packages/iracing-plugin-mirabox/rollup.config.mjs
@@ -346,6 +346,12 @@ const config = {
       mapRoot: isWatching ? "./" : undefined,
       // Include both the plugin source and the raw-TypeScript actions package
       include: ["src/**/*.ts", "../iracing-actions/src/**/*.ts"],
+      // Without this, @rollup/plugin-typescript reports every type error as a
+      // rollup WARNING and emits anyway (see its `emitDiagnostic`), so the build
+      // succeeds while shipping broken output — an undefined identifier reached
+      // a released bundle that way (#987). Fail at authoring time instead of
+      // relying on CI to notice afterwards.
+      noEmitOnError: true,
     }),
     nodeResolve({
       browser: false,

--- a/packages/iracing-plugin-stream-deck/package.json
+++ b/packages/iracing-plugin-stream-deck/package.json
@@ -6,6 +6,7 @@
   "packageManager": "pnpm@10.0.0",
   "scripts": {
     "build": "rollup -c && npm run postbuild",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "postbuild": "cd com.iracedeck.sd.core.sdPlugin/bin && npm install",
     "watch": "rollup -c -w --watch.onEnd=\"streamdeck restart com.iracedeck.sd.core\"",
     "clean": "rimraf com.iracedeck.sd.core.sdPlugin/bin/plugin.js com.iracedeck.sd.core.sdPlugin/bin/plugin.js.map",

--- a/packages/iracing-plugin-stream-deck/rollup.config.mjs
+++ b/packages/iracing-plugin-stream-deck/rollup.config.mjs
@@ -305,6 +305,12 @@ const config = {
       mapRoot: isWatching ? "./" : undefined,
       // Include both the plugin source and the raw-TypeScript actions package
       include: ["src/**/*.ts", "../iracing-actions/src/**/*.ts"],
+      // Without this, @rollup/plugin-typescript reports every type error as a
+      // rollup WARNING and emits anyway (see its `emitDiagnostic`), so the build
+      // succeeds while shipping broken output — an undefined identifier reached
+      // a released bundle that way (#987). Fail at authoring time instead of
+      // relying on CI to notice afterwards.
+      noEmitOnError: true,
     }),
     nodeResolve({
       browser: false,

--- a/packages/iracing-plugin-ulanzi/package.json
+++ b/packages/iracing-plugin-ulanzi/package.json
@@ -6,6 +6,7 @@
   "packageManager": "pnpm@10.0.0",
   "scripts": {
     "build": "rollup -c && npm run postbuild",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "postbuild": "cd com.ulanzi.iracedeck.ulanziPlugin/bin && npm install",
     "watch": "rollup -c -w",
     "clean": "rimraf com.ulanzi.iracedeck.ulanziPlugin/bin/plugin.js com.ulanzi.iracedeck.ulanziPlugin/bin/plugin.js.map",

--- a/packages/iracing-plugin-ulanzi/rollup.config.mjs
+++ b/packages/iracing-plugin-ulanzi/rollup.config.mjs
@@ -301,6 +301,12 @@ const config = {
       mapRoot: isWatching ? "./" : undefined,
       // Include both the plugin source and the raw-TypeScript actions package
       include: ["src/**/*.ts", "../iracing-actions/src/**/*.ts"],
+      // Without this, @rollup/plugin-typescript reports every type error as a
+      // rollup WARNING and emits anyway (see its `emitDiagnostic`), so the build
+      // succeeds while shipping broken output — an undefined identifier reached
+      // a released bundle that way (#987). Fail at authoring time instead of
+      // relying on CI to notice afterwards.
+      noEmitOnError: true,
     }),
     nodeResolve({
       browser: false,

--- a/packages/iracing-sdk/package.json
+++ b/packages/iracing-sdk/package.json
@@ -8,6 +8,7 @@
   "packageManager": "pnpm@10.0.0",
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "clean": "rimraf dist",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "clean": "rimraf dist"
   },
   "devDependencies": {

--- a/packages/pi-components/package.json
+++ b/packages/pi-components/package.json
@@ -9,11 +9,13 @@
   },
   "scripts": {
     "build": "rollup -c",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "clean": "rimraf browser/pi-components.js browser/ulanzi-pi-bridge.js browser/settings-window-bridge.js browser/pi-settings-bridge.js",
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "@iracedeck/deck-core": "workspace:*",
     "@rollup/plugin-terser": "1.0.0",
     "@rollup/plugin-typescript": "12.3.0",
     "@tsconfig/node22": "22.0.6",

--- a/packages/pi-components/rollup.config.mjs
+++ b/packages/pi-components/rollup.config.mjs
@@ -2,6 +2,17 @@ import terser from "@rollup/plugin-terser";
 import typescript from "@rollup/plugin-typescript";
 
 /**
+ * Every browser bundle compiles through this rather than calling `typescript()`
+ * directly. Without `noEmitOnError`, @rollup/plugin-typescript reports type
+ * errors as rollup WARNINGS and emits anyway (see its `emitDiagnostic`), so a
+ * build reports success while shipping broken output — that is how an undefined
+ * identifier once reached a released plugin bundle (#987). These four bundles
+ * are the PI framework every plugin loads, so the same failure here breaks a
+ * Property Inspector with nothing pointing at the cause.
+ */
+const tsBundle = (tsconfig) => typescript({ tsconfig, noEmitOnError: true });
+
+/**
  * Rollup config for building the PI browser bundles into browser/ so consumer
  * plugins can copy them alongside the vendored sdpi-components.js into their own
  * ui/ folder:
@@ -35,7 +46,7 @@ export default [
       name: "IRaceDeckPI",
       sourcemap: false,
     },
-    plugins: [typescript({ tsconfig: "./tsconfig.pi.json" }), terserPlugin],
+    plugins: [tsBundle("./tsconfig.pi.json"), terserPlugin],
   },
   {
     input: "src/ulanzi-bridge/index.ts",
@@ -45,7 +56,7 @@ export default [
       name: "IRaceDeckUlanziBridge",
       sourcemap: false,
     },
-    plugins: [typescript({ tsconfig: "./tsconfig.ulanzi.json" }), terserPlugin],
+    plugins: [tsBundle("./tsconfig.ulanzi.json"), terserPlugin],
   },
   {
     input: "src/settings-window-bridge/index.ts",
@@ -55,7 +66,7 @@ export default [
       name: "IRaceDeckSettingsWindowBridge",
       sourcemap: false,
     },
-    plugins: [typescript({ tsconfig: "./tsconfig.settings-window.json" }), terserPlugin],
+    plugins: [tsBundle("./tsconfig.settings-window.json"), terserPlugin],
   },
   {
     input: "src/pi-settings-bridge/index.ts",
@@ -65,6 +76,6 @@ export default [
       name: "IRaceDeckPiSettingsBridge",
       sourcemap: false,
     },
-    plugins: [typescript({ tsconfig: "./tsconfig.pi-settings-bridge.json" }), terserPlugin],
+    plugins: [tsBundle("./tsconfig.pi-settings-bridge.json"), terserPlugin],
   },
 ];

--- a/packages/pi-components/src/ulanzi-bridge/index.test.ts
+++ b/packages/pi-components/src/ulanzi-bridge/index.test.ts
@@ -186,7 +186,11 @@ describe("installUlanziBridge", () => {
         search: "?address=127.0.0.1&port=49200&uuid=com.x.action&key=5&actionid=abc&device=D200X&language=en",
       },
       WebSocket: FakeNativeWebSocket,
-      connectElgatoStreamDeckSocket: vi.fn(() => {
+      // Typed with sdpi's real connect signature so `mock.calls` is a tuple
+      // rather than `[]` — otherwise reading the arguments needs a cast.
+      connectElgatoStreamDeckSocket: vi.fn<
+        (port: string, context: string, registerEvent: string, info: string, actionInfo: string) => void
+      >(() => {
         // The monkeypatch must be active while sdpi opens its socket.
         bridgeDuringConnect = new (fakeWin.WebSocket as unknown as typeof WebSocket)("ws://localhost:49200");
       }),
@@ -195,13 +199,7 @@ describe("installUlanziBridge", () => {
     installUlanziBridge(fakeWin as unknown as Window & typeof globalThis);
 
     expect(fakeWin.connectElgatoStreamDeckSocket).toHaveBeenCalledOnce();
-    const [port, context, registerEvent, info, actionInfo] = fakeWin.connectElgatoStreamDeckSocket.mock.calls[0] as [
-      string,
-      string,
-      string,
-      string,
-      string,
-    ];
+    const [port, context, registerEvent, info, actionInfo] = fakeWin.connectElgatoStreamDeckSocket.mock.calls[0];
 
     expect(port).toBe("49200");
     expect(context).toBe("com.x.action___5___abc");

--- a/packages/pi-components/tsconfig.json
+++ b/packages/pi-components/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["ES2022", "DOM"],
+    "allowJs": true,
     "noEmit": true
   },
   "include": ["src/**/*.ts"]

--- a/packages/rasterizer/package.json
+++ b/packages/rasterizer/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "clean": "rimraf dist"
   },
   "dependencies": {

--- a/packages/scenario-harness/package.json
+++ b/packages/scenario-harness/package.json
@@ -8,6 +8,7 @@
   "types": "dist/main.d.ts",
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "clean": "rimraf dist",
     "dev": "tsx watch src/main.ts",
     "start": "node dist/main.js",

--- a/packages/sim-events-iracing/package.json
+++ b/packages/sim-events-iracing/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "clean": "rimraf dist",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/track-data/package.json
+++ b/packages/track-data/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "clean": "rimraf dist",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -739,6 +739,9 @@ importers:
 
   packages/pi-components:
     devDependencies:
+      '@iracedeck/deck-core':
+        specifier: workspace:*
+        version: link:../deck-core
       '@rollup/plugin-terser':
         specifier: 1.0.0
         version: 1.0.0(rollup@4.63.0)

--- a/scripts/typecheck-script-coverage.test.mjs
+++ b/scripts/typecheck-script-coverage.test.mjs
@@ -54,18 +54,39 @@ const TYPECHECK_EXCLUDES_TESTS = new Map([
 // Resolve a tsconfig the way tsc does, rather than pattern-matching its `exclude`
 // array: `parseJsonConfigFileContent` applies the same include/exclude/files
 // semantics the compiler will, so this reports what is genuinely in the program.
+// A config this cannot resolve must THROW, never degrade to a default. An empty
+// config object makes `parseJsonConfigFileContent` fall back to "every .ts under
+// basePath", which would report every test file as covered — so a broken tsconfig
+// would turn this check green precisely when something is wrong. Measured: a
+// tsconfig with a bad `extends` gave 47 passed before this guard was added.
 function filesInProgram(packageName) {
-  const dir = join(repoRoot, "packages", packageName);
-  const configPath = join(dir, "tsconfig.json");
-  const { config } = ts.parseConfigFileTextToJson(configPath, readFileSync(configPath, "utf-8"));
-  return new Set(ts.parseJsonConfigFileContent(config ?? {}, ts.sys, dir).fileNames.map(toPosix));
+  const dir = toPosix(join(repoRoot, "packages", packageName));
+  const configPath = `${dir}/tsconfig.json`;
+  const { config, error } = ts.parseConfigFileTextToJson(configPath, readFileSync(configPath, "utf-8"));
+  if (error || !config) {
+    const detail = error ? ts.flattenDiagnosticMessageText(error.messageText, " ") : "no config object";
+    throw new Error(`${configPath} could not be parsed: ${detail}`);
+  }
+  const parsed = ts.parseJsonConfigFileContent(config, ts.sys, dir);
+  if (parsed.errors.length > 0) {
+    const detail = parsed.errors.map((d) => ts.flattenDiagnosticMessageText(d.messageText, " ")).join("; ");
+    throw new Error(`${configPath} did not resolve cleanly: ${detail}`);
+  }
+  return new Set(parsed.fileNames.map(toPosix));
 }
+
+// `.tsx` is matched too. Nothing in the repo uses it today, but a package whose
+// only sources were `.tsx` would otherwise be invisible to the guard — the same
+// silent escape this whole file exists to prevent, one file extension along.
+const isTypeScriptSource = (name) =>
+  (name.endsWith(".ts") && !name.endsWith(".d.ts")) || (name.endsWith(".tsx") && !name.endsWith(".d.tsx"));
+const isTestFile = (name) => name.endsWith(".test.ts") || name.endsWith(".test.tsx");
 
 function testFilesOnDisk(absDir, found = []) {
   for (const entry of readdirSync(absDir, { withFileTypes: true })) {
     if (entry.name === "node_modules" || entry.name === "dist" || entry.name === "build") continue;
     if (entry.isDirectory()) testFilesOnDisk(join(absDir, entry.name), found);
-    else if (entry.name.endsWith(".test.ts")) found.push(toPosix(join(absDir, entry.name)));
+    else if (isTestFile(entry.name)) found.push(toPosix(join(absDir, entry.name)));
   }
   return found;
 }
@@ -84,7 +105,7 @@ function hasTypeScriptSources(absDir) {
     if (entry.name === "node_modules" || entry.name === "dist" || entry.name === "build") continue;
     if (entry.isDirectory()) {
       if (hasTypeScriptSources(join(absDir, entry.name))) return true;
-    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) {
+    } else if (isTypeScriptSource(entry.name)) {
       return true;
     }
   }

--- a/scripts/typecheck-script-coverage.test.mjs
+++ b/scripts/typecheck-script-coverage.test.mjs
@@ -1,0 +1,74 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+// scripts/typecheck-script-coverage.test.mjs lives in scripts/, so the repo root is one up.
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// Packages that deliberately have no `typecheck` script, and why. An entry here
+// is a decision on the record; an absence from the list is a failure. That is the
+// difference between an exclusion and a hole — a new package cannot join this
+// list by being forgotten.
+const NO_TYPECHECK_SCRIPT = new Map([
+  [
+    "website",
+    "Astro project: plain `tsc` cannot check it (23 errors, all inside node_modules — " +
+      "Starlight sources, `?raw` vite imports, two colliding copies of satteri). " +
+      "It needs `astro check` via @astrojs/check, which is not installed.",
+  ],
+]);
+
+// Guards one invariant (#987): every package with a `tsconfig.json` has a
+// `typecheck` script, so `pnpm typecheck` actually covers it.
+//
+// Why it is worth a test. `turbo run typecheck` skips a package with no such
+// script **silently** — no error, no warning, exit 0. So coverage can shrink to
+// nothing while the gate still reports success, which is the same class of defect
+// #987 exists to close: a green signal that means less than it appears to. The
+// natural way to add a package is to copy an existing one, and copying the
+// tsconfig without the script is exactly how a package slips out of the gate.
+//
+// This asserts presence, not the command's text. A package needing a different
+// checker (as `website` would) is a decision for the allow-list above, not a
+// reason to loosen the rule for everyone.
+function readJson(relPath) {
+  return JSON.parse(readFileSync(join(repoRoot, relPath), "utf-8"));
+}
+
+const packagesWithTsconfig = readdirSync(join(repoRoot, "packages"), { withFileTypes: true })
+  .filter((entry) => entry.isDirectory() && existsSync(join(repoRoot, "packages", entry.name, "tsconfig.json")))
+  .map((entry) => entry.name)
+  .sort();
+
+describe("every package with a tsconfig is covered by pnpm typecheck", () => {
+  it("finds the packages to check", () => {
+    expect(packagesWithTsconfig.length).toBeGreaterThan(0);
+  });
+
+  it.each(packagesWithTsconfig)("has a typecheck script: %s", (name) => {
+    const scripts = readJson(`packages/${name}/package.json`).scripts ?? {};
+    const excused = NO_TYPECHECK_SCRIPT.get(name);
+
+    if (excused) {
+      // Guard the exclusion in both directions: once the package can be checked,
+      // this should fail so the allow-list entry is removed rather than outliving
+      // the reason it was added.
+      expect(
+        scripts.typecheck,
+        `${name} is listed in NO_TYPECHECK_SCRIPT (${excused}) but now HAS a typecheck ` +
+          `script. Remove it from the allow-list — the exclusion has outlived its reason.`,
+      ).toBeUndefined();
+      return;
+    }
+
+    expect(
+      scripts.typecheck,
+      `packages/${name} has a tsconfig.json but no "typecheck" script, so \`pnpm typecheck\` ` +
+        `skips it silently and it is not covered by the gate (#987). Add ` +
+        `"typecheck": "tsc --noEmit -p tsconfig.json", or add it to NO_TYPECHECK_SCRIPT ` +
+        `with a reason if it genuinely cannot be checked that way.`,
+    ).toBeDefined();
+  });
+});

--- a/scripts/typecheck-script-coverage.test.mjs
+++ b/scripts/typecheck-script-coverage.test.mjs
@@ -18,6 +18,15 @@ const NO_TYPECHECK_SCRIPT = new Map([
       "Starlight sources, `?raw` vite imports, two colliding copies of satteri). " +
       "It needs `astro check` via @astrojs/check, which is not installed.",
   ],
+  [
+    "iracing-actions",
+    "No tsconfig of its own: its sources are compiled inside each plugin's program. " +
+      "Giving it one is real work rather than an oversight — a naive probe config " +
+      "reports ~991 errors, dominated by unresolved module and asset imports. Its 76 " +
+      "test files are therefore checked by nothing. Predates #987.",
+  ],
+  ["audio-assets", "No tsconfig: 10 `.ts` files under src/generate/ run through tsx. Predates #987."],
+  ["icons", "No tsconfig: SVG library with a single freshness test. Predates #987."],
 ]);
 
 // Guards one invariant (#987): every package with a `tsconfig.json` has a
@@ -37,17 +46,48 @@ function readJson(relPath) {
   return JSON.parse(readFileSync(join(repoRoot, relPath), "utf-8"));
 }
 
-const packagesWithTsconfig = readdirSync(join(repoRoot, "packages"), { withFileTypes: true })
-  .filter((entry) => entry.isDirectory() && existsSync(join(repoRoot, "packages", entry.name, "tsconfig.json")))
+// Discovery is keyed on "has TypeScript at all", NOT on "has a tsconfig.json".
+// Keying it on the tsconfig was the obvious shortcut and it let three packages
+// escape the guard entirely rather than appear as exclusions — `iracing-actions`
+// most importantly, whose 76 test files nothing checks. A package with no config
+// is exactly the one at risk, so it must show up here and be answered for.
+function hasTypeScriptSources(absDir) {
+  for (const entry of readdirSync(absDir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "dist" || entry.name === "build") continue;
+    if (entry.isDirectory()) {
+      if (hasTypeScriptSources(join(absDir, entry.name))) return true;
+    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const typeScriptPackages = readdirSync(join(repoRoot, "packages"), { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
   .map((entry) => entry.name)
+  .filter(
+    (name) =>
+      existsSync(join(repoRoot, "packages", name, "tsconfig.json")) ||
+      hasTypeScriptSources(join(repoRoot, "packages", name)),
+  )
   .sort();
 
 describe("every package with a tsconfig is covered by pnpm typecheck", () => {
   it("finds the packages to check", () => {
-    expect(packagesWithTsconfig.length).toBeGreaterThan(0);
+    expect(typeScriptPackages.length).toBeGreaterThan(0);
   });
 
-  it.each(packagesWithTsconfig)("has a typecheck script: %s", (name) => {
+  it("has no stale allow-list entries", () => {
+    const stale = [...NO_TYPECHECK_SCRIPT.keys()].filter((name) => !typeScriptPackages.includes(name));
+    expect(
+      stale,
+      `NO_TYPECHECK_SCRIPT names ${stale.join(", ")}, which no longer exists as a TypeScript ` +
+        `package. An entry that matches nothing is not an exclusion, it is a comment — remove it.`,
+    ).toEqual([]);
+  });
+
+  it.each(typeScriptPackages)("has a typecheck script: %s", (name) => {
     const scripts = readJson(`packages/${name}/package.json`).scripts ?? {};
     const excused = NO_TYPECHECK_SCRIPT.get(name);
 
@@ -63,12 +103,15 @@ describe("every package with a tsconfig is covered by pnpm typecheck", () => {
       return;
     }
 
+    const hasTsconfig = existsSync(join(repoRoot, "packages", name, "tsconfig.json"));
     expect(
       scripts.typecheck,
-      `packages/${name} has a tsconfig.json but no "typecheck" script, so \`pnpm typecheck\` ` +
-        `skips it silently and it is not covered by the gate (#987). Add ` +
-        `"typecheck": "tsc --noEmit -p tsconfig.json", or add it to NO_TYPECHECK_SCRIPT ` +
-        `with a reason if it genuinely cannot be checked that way.`,
+      `packages/${name} has TypeScript sources but no "typecheck" script, so \`pnpm typecheck\` ` +
+        `skips it silently and it is not covered by the gate (#987). ` +
+        (hasTsconfig
+          ? `Add "typecheck": "tsc --noEmit -p tsconfig.json".`
+          : `It has no tsconfig.json either, so it needs one before it can be checked.`) +
+        ` Or add it to NO_TYPECHECK_SCRIPT with a reason if it genuinely cannot be checked.`,
     ).toBeDefined();
   });
 });

--- a/scripts/typecheck-script-coverage.test.mjs
+++ b/scripts/typecheck-script-coverage.test.mjs
@@ -1,11 +1,16 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 // scripts/typecheck-script-coverage.test.mjs lives in scripts/, so the repo root is one up.
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// `join` yields the platform separator while tsc reports forward slashes, so both
+// sides of every path comparison below go through this.
+const toPosix = (p) => p.split(sep).join("/");
 
 // Packages that deliberately have no `typecheck` script, and why. An entry here
 // is a decision on the record; an absence from the list is a failure. That is the
@@ -16,32 +21,55 @@ const NO_TYPECHECK_SCRIPT = new Map([
     "website",
     "Astro project: plain `tsc` cannot check it (23 errors, all inside node_modules — " +
       "Starlight sources, `?raw` vite imports, two colliding copies of satteri). " +
-      "It needs `astro check` via @astrojs/check, which is not installed.",
+      "It needs `astro check` via @astrojs/check, which is not installed. Tracked in #1077.",
   ],
   [
     "iracing-actions",
     "No tsconfig of its own: its sources are compiled inside each plugin's program. " +
       "Giving it one is real work rather than an oversight — a naive probe config " +
       "reports ~991 errors, dominated by unresolved module and asset imports. Its 76 " +
-      "test files are therefore checked by nothing. Predates #987.",
+      "test files are therefore checked by nothing. Predates #987; tracked in #1078.",
   ],
-  ["audio-assets", "No tsconfig: 10 `.ts` files under src/generate/ run through tsx. Predates #987."],
-  ["icons", "No tsconfig: SVG library with a single freshness test. Predates #987."],
+  ["audio-assets", "No tsconfig: 10 `.ts` files under src/generate/ run through tsx. Predates #987; tracked in #1078."],
+  ["icons", "No tsconfig: SVG library with a single freshness test. Predates #987; tracked in #1078."],
 ]);
 
-// Guards one invariant (#987): every package with a `tsconfig.json` has a
-// `typecheck` script, so `pnpm typecheck` actually covers it.
-//
-// Why it is worth a test. `turbo run typecheck` skips a package with no such
-// script **silently** — no error, no warning, exit 0. So coverage can shrink to
-// nothing while the gate still reports success, which is the same class of defect
-// #987 exists to close: a green signal that means less than it appears to. The
-// natural way to add a package is to copy an existing one, and copying the
-// tsconfig without the script is exactly how a package slips out of the gate.
-//
-// This asserts presence, not the command's text. A package needing a different
-// checker (as `website` would) is a decision for the allow-list above, not a
-// reason to loosen the rule for everyone.
+// Packages whose `typecheck` runs but does NOT cover their own test files, with
+// the size of what each is hiding. An exception that states its own magnitude and
+// its own expiry condition is a debt with a maturity date; one that says "excluded,
+// see docs" is where things go to be forgotten.
+const TYPECHECK_EXCLUDES_TESTS = new Map([
+  [
+    "deck-adapter-mirabox",
+    'tsconfig sets "exclude": ["src/**/*.test.ts"]. Removing it surfaces 34 pre-existing ' +
+      "errors in its 4 test files. Predates #987; tracked in #1078.",
+  ],
+  [
+    "deck-adapter-ulanzi",
+    'tsconfig sets "exclude": ["src/**/*.test.ts"]. Removing it surfaces 29 pre-existing ' +
+      "errors in its 4 test files. Predates #987; tracked in #1078.",
+  ],
+]);
+
+// Resolve a tsconfig the way tsc does, rather than pattern-matching its `exclude`
+// array: `parseJsonConfigFileContent` applies the same include/exclude/files
+// semantics the compiler will, so this reports what is genuinely in the program.
+function filesInProgram(packageName) {
+  const dir = join(repoRoot, "packages", packageName);
+  const configPath = join(dir, "tsconfig.json");
+  const { config } = ts.parseConfigFileTextToJson(configPath, readFileSync(configPath, "utf-8"));
+  return new Set(ts.parseJsonConfigFileContent(config ?? {}, ts.sys, dir).fileNames.map(toPosix));
+}
+
+function testFilesOnDisk(absDir, found = []) {
+  for (const entry of readdirSync(absDir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "dist" || entry.name === "build") continue;
+    if (entry.isDirectory()) testFilesOnDisk(join(absDir, entry.name), found);
+    else if (entry.name.endsWith(".test.ts")) found.push(toPosix(join(absDir, entry.name)));
+  }
+  return found;
+}
+
 function readJson(relPath) {
   return JSON.parse(readFileSync(join(repoRoot, relPath), "utf-8"));
 }
@@ -73,7 +101,21 @@ const typeScriptPackages = readdirSync(join(repoRoot, "packages"), { withFileTyp
   )
   .sort();
 
-describe("every package with a tsconfig is covered by pnpm typecheck", () => {
+// First invariant (#987): every package that has TypeScript at all is in the gate —
+// either by carrying a `typecheck` script, or by being a named exclusion above.
+//
+// Why it is worth a test. `turbo run typecheck` skips a package with no such script
+// **silently** — no error, no warning, exit 0. So coverage can shrink to nothing
+// while the gate still reports success, which is the same class of defect #987
+// exists to close: a green signal that means less than it appears to. The natural
+// way to add a package is to copy an existing one, and copying a package's shape
+// without its script is exactly how one slips out of the gate.
+//
+// Discovery deliberately does NOT key on `tsconfig.json`. That was the first
+// version and it let three packages escape entirely rather than appear as
+// exclusions, `iracing-actions` among them — a package with no config is precisely
+// the one at risk, so it has to show up here and be answered for.
+describe("every package with TypeScript is covered by pnpm typecheck", () => {
   it("finds the packages to check", () => {
     expect(typeScriptPackages.length).toBeGreaterThan(0);
   });
@@ -113,5 +155,49 @@ describe("every package with a tsconfig is covered by pnpm typecheck", () => {
           : `It has no tsconfig.json either, so it needs one before it can be checked.`) +
         ` Or add it to NO_TYPECHECK_SCRIPT with a reason if it genuinely cannot be checked.`,
     ).toBeDefined();
+  });
+});
+
+// Second invariant, same concern as the first (#987): coverage that appears
+// complete and is not. The first catches a package the gate never runs on; this
+// catches one the gate runs on while checking none of its tests — `typecheck`
+// present, reported covered, and the test files not in the program at all.
+describe("a package's typecheck covers its own test files", () => {
+  const checkable = typeScriptPackages.filter(
+    (name) => !NO_TYPECHECK_SCRIPT.has(name) && existsSync(join(repoRoot, "packages", name, "tsconfig.json")),
+  );
+
+  it("has no stale test-exclusion entries", () => {
+    const stale = [...TYPECHECK_EXCLUDES_TESTS.keys()].filter((name) => !checkable.includes(name));
+    expect(stale, `TYPECHECK_EXCLUDES_TESTS names ${stale.join(", ")}, which is no longer checkable.`).toEqual([]);
+  });
+
+  it.each(checkable)("checks every test file it ships: %s", (name) => {
+    const onDisk = testFilesOnDisk(join(repoRoot, "packages", name));
+    if (onDisk.length === 0) return;
+
+    const inProgram = filesInProgram(name);
+    const missing = onDisk.filter((f) => !inProgram.has(f)).map((f) => f.slice(repoRoot.length + 1));
+    const excused = TYPECHECK_EXCLUDES_TESTS.get(name);
+
+    if (excused) {
+      // Reverse direction: once the package stops excluding its tests, this entry
+      // must fail rather than quietly outliving the reason it was added.
+      expect(
+        missing.length,
+        `${name} is listed in TYPECHECK_EXCLUDES_TESTS (${excused}) but now checks every test ` +
+          `file it ships. Remove the entry — the exception has outlived its reason.`,
+      ).toBeGreaterThan(0);
+      return;
+    }
+
+    expect(
+      missing,
+      `packages/${name} has a typecheck script, so the coverage guard above reports it covered — ` +
+        `but its tsconfig leaves ${missing.length} of its own test files out of the program, so ` +
+        `\`pnpm typecheck\` checks none of them: ${missing.join(", ")}. Presence of a script is not ` +
+        `coverage. Remove the exclusion, or add the package to TYPECHECK_EXCLUDES_TESTS with the ` +
+        `number of errors the exclusion is hiding.`,
+    ).toEqual([]);
   });
 });

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,9 @@
         "com.ulanzi.*.ulanziPlugin/**"
       ]
     },
+    "typecheck": {
+      "dependsOn": ["^build"]
+    },
     "@iracedeck/audio-assets#build": {
       "inputs": ["voice/**", "src/build/**", "src/presets.mjs"],
       "outputs": [".cache/**"]


### PR DESCRIPTION
## Related Issue

Fixes #987

## What changed?

The three plugins and `pi-components` build through rollup, which transpiles without checking, and CI ran only ESLint, Prettier and Vitest — whose esbuild path is also transpile-only. So a green build and a green CI run said nothing about the type correctness of the four packages where cross-package integration actually surfaces.

### The defect that ships today, reproduced on demand

`@rollup/plugin-typescript` routes every diagnostic through `context.warn` unless `noEmitOnError` is set — **errors included** — so the build emits and exits 0. Planting the exact defect from #987 (an identifier never imported) and running it both ways:

```text
WITH noEmitOnError      build exit=1
                        RollupError: TS2304: Cannot find name 'MISSING_IDENTIFIER_PROBE'
                        (names the file and line: src/plugin.ts:1134)

WITHOUT it (today)      build exit=0
                        TS2304 appears once — as a warning
                        the identifier is in the emitted plugin.js: 1 occurrence
```

The second half is the argument. **This is not "we added a gate"; it is "here is a green build shipping a startup `ReferenceError`, on demand."** Verified separately for `iracing-plugin-stream-deck` and for `pi-components`, whose `browser/pi-components.js` — the PI framework every plugin loads — was equally able to ship an undefined identifier. Both restored and rebuilt afterwards, probes verified gone.

The counterfactual is what isolates the cause: it shows the flag is load-bearing rather than merely present alongside a passing build.

### The gate

- **`typecheck` script in 20 packages**, and a root `pnpm typecheck` over them via turbo.
- **The turbo task declares `dependsOn: ["^build"]`**, because packages resolve each other's *types* through emitted `dist/`. Putting the constraint there rather than in the workflow means CI runs the same one command a developer does, so a red run reproduces locally with `pnpm typecheck` — no folklore about building first.
- **`noEmitOnError` on all four rollup configs.** `pi-components` gets a small `tsBundle` helper so the option and its reasoning live in one place rather than four.
- **A Typecheck workflow**, triggering on `pull_request` **and** on pushes to `master` and `release/*`. A PR check only proves something about the branch merged against the master that existed when it ran (#1070); the defect class this gate targets is exactly what two PRs merging in succession produce, so a gate that never sees the merged result would miss its highest-value case. Release branches take feature PRs of their own and reach master by back-merge, so the same argument covers them. This does **not** create a convention for who fixes a red master — that belongs to #1070.

### Every exclusion is a named entry that expires

Two guards, each asserting one invariant, and **both fail in the reverse direction** — which is what separates this from a suppression list:

| Guard | Catches | Reverse direction |
|---|---|---|
| Every package with TypeScript is in the gate | a package the gate never runs on | an excluded package gaining a `typecheck` script fails as *outlived* |
| A package's typecheck covers its own test files | a package it runs on while checking none of its tests | an excused package that stops excluding fails as *outlived* |

`turbo run typecheck` skips a package with no script **silently** — no error, exit 0 — so coverage could shrink to nothing while the gate still reported success. That is this issue's own defect one level up, which is why it is guarded mechanically rather than by care.

Every entry carries the size of what it hides and its maturity date: **#1077** (website — Astro, `astro check` needs an uninstalled dependency) and **#1078** (`iracing-actions` has no tsconfig; two adapters exclude their own tests, hiding 34 and 29 errors). `.claude/rules/testing.md` names the same two, so the guard and the docs cannot drift about what is excluded.

The second invariant resolves each tsconfig through TypeScript's own `parseJsonConfigFileContent` rather than pattern-matching its `exclude` array, so it reports what is genuinely in the program under the compiler's own semantics.

### pi-components: eight errors, three causes

Nothing had ever typechecked it. The eight errors were not eight defects:

- **`allowJs`** on its typecheck-only project clears five — the four `TS7016` from untyped `src/build/*.mjs`, and the `TS7006` that followed from one of them. Reading the real sources beats hand-written `.d.mts` declarations, which are a second description of something that already describes itself. **This cannot affect any build output**: the four bundles use the sub-configs, never this `noEmit: true` project.
- **Two `TS2307`** — the package imported `@iracedeck/deck-core` from two test files while declaring it nowhere, resolving only through workspace hoisting. Declared as a devDependency; no cycle. Test-only, so not shipped.
- **One `TS2352`** — fixed at the cause. A bare `vi.fn()` has no call signature, so `mock.calls[0]` was `[]` and the test cast it to a five-tuple. Giving the mock sdpi's real connect signature makes the cast **disappear** rather than compile. Silencing a type error in the PR that exists to stop type errors being silenced would be self-defeating.

### A rule file was asserting the opposite of this PR

`.claude/rules/build-and-commit.md`'s **Build verification** section told every contributor that "the build may succeed (exit code 0) while still emitting TypeScript warnings" and to grep the output for `TS[0-9]+:`. With `noEmitOnError` those are fatal.

Worth stating plainly: **I corrected a different, smaller false claim in the same file first, and left this one — 93 lines above it — until code review found it.** So the file contradicted itself, in the pre-commit checklist everyone follows, about this exact defect class. That is the strongest available evidence that the gate needed to exist, and it is not evidence I produced.

`precommit` also ran `build` without `typecheck` while the docs had just started listing it as step 3; fixed.

## How to test

```bash
pnpm install && pnpm build
pnpm typecheck              # 37 tasks — 20 typechecks plus the builds turbo pulls in
pnpm test                   # 327 files / 9325 tests
pnpm lint && pnpm format
```

To see the gate work rather than pass, plant a type error in any plugin's `plugin.ts` and confirm both `pnpm typecheck` and `pnpm build` go red naming the file — then remove it.

Green on `f493d92f`: build 22/22 with `0 cached`, typecheck 37/37, lint 0, format clean, **327 files / 9325 tests** — the 9278 master baseline plus this PR's 47 guard cases.

Rebased onto `f493d92f` after #960 merged, and the counterfactual above was **re-run on the rebased head** rather than carried forward — a control measured against a base nobody merges from is a claim about a tree that will not exist. Identical result. In CI the new job took **1m28s**, finishing before the existing test job's 2m9s, so it adds no wall clock to PR feedback.

## Notes for the reviewer

- The five commits are kept separate so the response to code review is visible as such; squash collapses them anyway.
- Code review raised **seven** findings and all seven held. Three mattered: the docs self-contradiction above; the coverage guard being keyed on `existsSync(tsconfig.json)`, which let three packages escape it entirely rather than appear as exclusions; and presence-is-not-coverage. Fixed in `b5609f5c` and `624f7434`.
- No changelog entry: internal CI and tooling, no user-visible effect.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests — two guards, 47 cases, each controlled by being made to fail on purpose in both directions before being trusted green
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — and Ulanzi; `noEmitOnError` on all four rollup configs, `typecheck` in all 20 checkable packages
- [x] No unrelated changes included
