### PR TITLE
ci: run format, lint and tests on master and release branches (#1070)

### DIFF
--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -20,8 +20,9 @@ If you are picking up an issue, read this first.
 | 8   | Manual testing                                             | **blocks the PR**       | below                                                                       |
 | 9   | Push, open the PR                                          | —                       | `@.claude/rules/build-and-commit.md`                                        |
 | 10  | Babysit the review                                         | every thread answered   | below                                                                       |
-| 11  | Merge                                                      | approved + checks green | `@.claude/rules/build-and-commit.md`                                        |
-| 12  | Remove the worktree                                        | —                       | `@.claude/rules/build-and-commit.md`                                        |
+| 11  | Merge                                                      | approved + checks green **at the current head** | `@.claude/rules/build-and-commit.md`                    |
+| 12  | Watch the post-merge run to completion                     | a red result goes to the coordinator            | below                                                   |
+| 13  | Remove the worktree                                        | —                                               | `@.claude/rules/build-and-commit.md`                    |
 
 ## Why these gates exist
 
@@ -46,6 +47,8 @@ Settled by the maintainer: an issue is solved in a sibling worktree, never insid
 **Assume nothing is watching, confirm, then run everything yourself.** The repo does ship watchers and one may be running against a linked worktree, so check before firing a full build into a tree something else is writing.
 
 The green set is the CI set plus the pre-commit checks: `install`, `build`, `typecheck`, `format`, `lint`, `test`. CI runs format, lint and test as **separate** jobs, so a clean `lint` proves nothing about `format`. Read the build output rather than its exit code — `@.claude/rules/build-and-commit.md` explains why that distinction bites here.
+
+**A green PR check is not a statement about the merged result.** It proves something about your branch merged against the master that existed when the check ran. Under squash-merge the commit that lands is a tree nothing has ever built or tested, and when two PRs are in flight the gap opens silently — both green, the merge textually clean, and nothing red anywhere to notice. Since #1070 all four CI workflows also run on pushes to `master` and `release/*`, so the merged result is checked too — but *after* the merge, not before it. That is what step 12 is for.
 
 ### If a user can see it, the website describes it (6)
 
@@ -87,6 +90,20 @@ One trap with no other home: `gh pr checks` exits non-zero (8) while any check i
 
 Once CodeRabbit has approved and the checks are green, **the agent driving the work merges** — the maintainer is not a second reviewer to wait for. A *review* step never merges; that separation is what `@.claude/rules/build-and-commit.md` protects, and it owns the merge mechanics.
 
+**An approval and a green check are both head-specific, and both are re-verified at the moment of merging.** Neither travels with the branch — a push invalidates both, while the PR still displays the old approval beside the new head. Compare the approving review's `commit_id` against the PR's `headRefOid`, and read the check states for that same sha. What a stale read looks like is not an obvious error: it is a *real* approval and a *real* all-green that belong to the previous head. The PR's own `mergeStateStatus` is a cheap cross-check — `BLOCKED` while you believe everything is green means you are reading the wrong head. And `gh pr checks` exits non-zero (8) while anything is still pending, so treat that exit as "not finished", never as "failed".
+
 Issue work reaches a target branch only through an approved PR. Two documented paths do not: a maintainer-directed **Master** work mode, and a release **back-merge**. Neither is an excuse to skip the PR on issue work.
+
+### The merge is not finished until the post-merge run is (12)
+
+Since #1070 every CI workflow also runs on pushes to `master` and `release/*` — the only thing that ever checks the tree a squash-merge actually produces. That signal is worth nothing if nobody is looking at it, which is how a new check gets added and quietly ignored.
+
+**Niklas owns a red master.** The agent that merged is the instrument that watches and reports; it does not own the outcome and does not decide what to do about one.
+
+- **Whoever merges watches that run to completion.** Pressing the merge button does not end the step.
+- **A red result goes to the coordinator immediately, and the coordinator takes it to Niklas.** No agent decides on its own to fix it, revert it, or let it stand.
+- **If the merging session ends before the run finishes, the watch passes to the coordinator** — the one party that outlives a worker session.
+
+There is deliberately no flake caveat here. Measured on 2026-09-01, the last 60 `ci-test` runs were 58 successes, one `action_required`, and one genuine test failure on a development branch — first attempt, fixed by later commits rather than by a re-run. On that evidence a red run means something, so treat one as real until shown otherwise, not the other way round.
 
 Then remove the worktree — and if a deck host is linked to it, relink to `master` first, or you will silently break the maintainer's installed plugin.

--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -21,7 +21,7 @@ If you are picking up an issue, read this first.
 | 9   | Push, open the PR                                          | —                       | `@.claude/rules/build-and-commit.md`                                        |
 | 10  | Babysit the review                                         | every thread answered   | below                                                                       |
 | 11  | Merge                                                      | approved + checks green **at the current head** | `@.claude/rules/build-and-commit.md`                    |
-| 12  | Watch the post-merge run to completion                     | a red result goes to the coordinator            | below                                                   |
+| 12  | Watch **all four** post-merge runs to completion           | a red result goes to the coordinator            | below                                                   |
 | 13  | Remove the worktree                                        | —                                               | `@.claude/rules/build-and-commit.md`                    |
 
 ## Why these gates exist
@@ -100,7 +100,7 @@ Since #1070 every CI workflow also runs on pushes to `master` and `release/*` �
 
 **Niklas owns a red master.** The agent that merged is the instrument that watches and reports; it does not own the outcome and does not decide what to do about one.
 
-- **Whoever merges watches that run to completion.** Pressing the merge button does not end the step.
+- **Whoever merges watches all four runs to completion.** `ci-format`, `ci-lint`, `ci-test` and `ci-typecheck` are four separate workflows on the same push, so one green run answers for one of them and nothing else — and the first thing to check is that all four appeared at all. Pressing the merge button does not end the step.
 - **A red result goes to the coordinator immediately, and the coordinator takes it to Niklas.** No agent decides on its own to fix it, revert it, or let it stand.
 - **If the merging session ends before the run finishes, the watch passes to the coordinator** — the one party that outlives a worker session.
 

--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v6
         with:

--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -1,7 +1,21 @@
 name: Format
 
+# Also runs on pushes to master and release branches. A pull_request check only
+# proves something about the branch merged against the master that existed when
+# it ran, never about the master that results — and under squash-merge that
+# result is a tree nothing has ever built or tested (#1070). Matches the
+# branch list ci-typecheck.yml already uses, for the reason stated there:
+# release branches take feature PRs of their own and reach master through a
+# back-merge, so a post-merge gap there is the same gap one branch removed.
 on:
   pull_request:
+  push:
+    branches: [master, 'release/*']
+
+# This job only reads the repository, so it gets the minimum token scope and the
+# checkout credential is not left in .git/config for later steps to reach.
+permissions:
+  contents: read
 
 jobs:
   format:

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v6
         with:

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,7 +1,21 @@
 name: Lint
 
+# Also runs on pushes to master and release branches. A pull_request check only
+# proves something about the branch merged against the master that existed when
+# it ran, never about the master that results — and under squash-merge that
+# result is a tree nothing has ever built or tested (#1070). Matches the
+# branch list ci-typecheck.yml already uses, for the reason stated there:
+# release branches take feature PRs of their own and reach master through a
+# back-merge, so a post-merge gap there is the same gap one branch removed.
 on:
   pull_request:
+  push:
+    branches: [master, 'release/*']
+
+# This job only reads the repository, so it gets the minimum token scope and the
+# checkout credential is not left in .git/config for later steps to reach.
+permissions:
+  contents: read
 
 jobs:
   lint:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v6
         with:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,7 +1,21 @@
 name: Tests
 
+# Also runs on pushes to master and release branches. A pull_request check only
+# proves something about the branch merged against the master that existed when
+# it ran, never about the master that results — and under squash-merge that
+# result is a tree nothing has ever built or tested (#1070). Matches the
+# branch list ci-typecheck.yml already uses, for the reason stated there:
+# release branches take feature PRs of their own and reach master through a
+# back-merge, so a post-merge gap there is the same gap one branch removed.
 on:
   pull_request:
+  push:
+    branches: [master, 'release/*']
+
+# This job only reads the repository, so it gets the minimum token scope and the
+# checkout credential is not left in .git/config for later steps to reach.
+permissions:
+  contents: read
 
 jobs:
   test:

--- a/.github/workflows/ci-typecheck.yml
+++ b/.github/workflows/ci-typecheck.yml
@@ -1,15 +1,15 @@
 name: Typecheck
 
-# Unlike the other three workflows, this one also runs on pushes to master.
 # A green PR check only proves something about the branch merged against the
 # master that existed when it ran, never about the master that results (#1070).
 # The defect this job exists to catch — cross-package type errors — is exactly
 # what two PRs merging in quick succession produce, so a gate that never sees
-# the merged result would miss its highest-value case. Adding the trigger here
-# does not create a convention for who fixes a red master; that belongs to #1070.
-# `release/*` is included for the same reason: release branches take feature PRs
-# of their own and reach master through a back-merge, so a post-merge gap there
-# is the same gap one branch removed.
+# the merged result would miss its highest-value case. `release/*` is included
+# for the same reason: release branches take feature PRs of their own and reach
+# master through a back-merge, so a post-merge gap there is the same gap one
+# branch removed. This job carried the push trigger alone until #1070 gave the
+# other three the same one; who answers for a red master is a convention now
+# stated in `.claude/rules/issue-workflow.md`, not a property of this file.
 on:
   pull_request:
   push:
@@ -17,8 +17,8 @@ on:
 
 # The job only reads the repository and runs a compiler, so it is given the
 # minimum token scope and the checkout credential is not left in .git/config for
-# later steps to reach. The three sibling CI workflows predate this and do not
-# set either; matching them would mean copying a weaker default forward.
+# later steps to reach. All four CI workflows now do this; the other three
+# adopted it in #1070 rather than carrying a weaker default forward.
 permissions:
   contents: read
 


### PR DESCRIPTION
## Related Issue

Fixes #1070

## What changed?

`ci-format.yml`, `ci-lint.yml` and `ci-test.yml` triggered on `pull_request` only, so nothing ran on a push to `master`. Every check therefore proved something about a branch merged against the master that existed when it ran — never about the master that results, which under squash-merge is a tree nothing has ever built or tested. `ci-typecheck.yml` already carried the push trigger and was the only workflow with a `push` event on master.

**The trigger.** All three take `[master, 'release/*']` — the branch list `ci-typecheck.yml` actually shipped, not the `[master]` in the issue's proposed-fix snippet, which is now out of date. Release branches take feature PRs of their own and reach master through a back-merge, so a post-merge gap there is the same gap one branch removed.

**Permissions.** All three also take `permissions: contents: read`, which typecheck introduced and whose comment noted the siblings lacked it. All four workflows now carry identical `on:` and `permissions:` blocks (verified by parsing each file rather than by reading them).

**Three corrected comments in `ci-typecheck.yml`.** This change made them false, so they are fixed in the same commit rather than left asserting the old world: "Unlike the other three workflows, this one also runs on pushes to master", "that belongs to #1070", and "The three sibling CI workflows predate this and do not set either". A file that describes the previous state is how the next reader inherits it.

**The convention (`.claude/rules/issue-workflow.md`).** Adding the trigger creates a signal nobody was accountable for, and the failure mode the issue names is not a missing check but an ignored one. So the rule is delegation rather than bare ownership: **the maintainer owns a red master; the agent that merged is the instrument that watches and reports.** A merge is finished when its post-merge run completes, not when the button is pressed; a red result is escalated rather than acted on unilaterally; and if the merging session ends first, the watch passes to the coordinator. The wording was approved by the maintainer before being committed, since it binds him too.

Two supporting edits to the same file. Step 11's gate becomes "approved + checks green **at the current head**" — an approval and a green check are both head-specific and neither travels with the branch, and a stale read is not an obvious error but a *genuine* approval and a *genuine* all-green belonging to the previous head. The rule names `commit_id`, `headRefOid` and `mergeStateStatus` rather than any `gh` invocation, because field names outlive command syntax. And the "Nothing verifies your work but you" section gains the line it was missing: a green PR check is a statement about your branch merged against the master that existed when it ran, never about the master that results.

**No flake caveat, and that is a measurement rather than an assumption.** Measured 2026-09-01 over the last 60 `ci-test` runs (2026-08-20 → 2026-09-01, all 60 `pull_request` events): **58 successes, 1 `action_required`, 1 failure**. The single failure is run `33165479651` on `ir-1040` — **attempt 1**, failing at the `Run pnpm test` step, with the two later runs on that branch on **different shas**. That last detail is the whole point: it distinguishes a developer fixing a real break from a re-run passing on the same tree. "One failure in 60" on its own would not have justified writing "a red run means something" into a rule that binds people; attempt-1-plus-different-shas does. The measurement is dated in the rule text for the same reason a claim like "CI is reliable" would be worse — a dated measurement cannot rot into a false statement.

**`paths-ignore` is deliberately not included.** The issue makes the argument itself: about half of master's commits touch only docs, `.claude/`, README or the website, so a `paths-ignore` would skip roughly half the runs — but a subtly wrong one reintroduces precisely the blind spot this closes. The simple version is correct on its own, and cost is not a factor (public repo, standard runners, nothing billed).

**Step renumbering was checked for stale references.** Adding step 12 moves worktree removal from 12 to 13, so any existing citation of "step 12" would have silently become wrong — the same class of stale pointer this PR fixes one file along in `ci-typecheck.yml`. Grepped `.claude/`, `docs/superpowers/specs/` and `README.md` before committing: clean. `plugin-structure.md`'s "step 12" refers to its own plugin-init sequence and is unrelated; every other step citation points at step 7, which did not move.

## How to test

**The rules half** is prose with nothing to execute; it was read and approved by the maintainer before it was committed.

**The workflow half cannot be proven before merge, and that is inherent rather than an omission.** A `push:` trigger only demonstrates itself by firing on a real push to the branch it names, which by definition happens after this merges. What can be checked now:

- All four workflow files parse and carry identical `on:` and `permissions:` blocks.
- The full green set was run by hand on this branch: `pnpm install`, `build` 22/22, `typecheck` 37/37, `format` clean, `lint` clean, `test` 327 files / 9325 tests. Those totals are exactly master's baseline, which is the expected result for a change touching only YAML and one rules file — and a check that nothing else moved.

**After merge — this is the actual acceptance test.** The merge commit lands the new triggers, so the master push it produces is the first one evaluated against them. **All four workflows should appear on that push, not just Typecheck.** Seeing Typecheck alone would mean the new triggers did not take, which is the one way this change can fail silently and the only moment it is observable. That run will be watched to completion under the convention this PR adds — making this merge the first exercise of its own rule.

## Checklist

- [x] Linked to an approved issue
- [ ] New code has unit tests — n/a, no code: three CI trigger blocks and one rules file
- [ ] Changes registered in all applicable plugins (Stream Deck, Mirabox) — n/a, no plugin surface
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Formatting, linting, testing, and type-checking workflows now run for pull requests and updates to `master` and `release/*` branches.
  * Workflow permissions are restricted to read-only repository access, and checkout credentials are not retained after workflow runs.

* **Documentation**
  * Updated workflow guidance to clarify merge verification, post-merge monitoring, failure escalation, and handoff procedures.
  * Documented post-merge checks and branch trigger behavior for improved workflow visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->