### PR TITLE
chore(typecheck): bind the coverage guard to the script it vouches for (#1086)

### DIFF
--- a/scripts/typecheck-script-coverage.test.mjs
+++ b/scripts/typecheck-script-coverage.test.mjs
@@ -88,6 +88,38 @@ function filesInProgram(packageName, configRelPath) {
 // A chained script is not, even when one segment is `tsc`, because an earlier
 // segment can generate source files that the compiler includes at runtime and a
 // static parse of the config cannot see.
+// `tsc` flags that consume the NEXT token as their value. Anything absent from
+// this set is treated as boolean, so its value would look like a positional file
+// and force a refusal — an unrecognised shape falls to tier 2 and gets MEASURED
+// rather than guessed at. Omissions here therefore cost a slow check, never a
+// wrong claim, which is the direction this list has to be wrong in.
+const TSC_VALUE_FLAGS = new Set([
+  "-p",
+  "--project",
+  "-o",
+  "--outFile",
+  "--outDir",
+  "--rootDir",
+  "--rootDirs",
+  "--declarationDir",
+  "--tsBuildInfoFile",
+  "-t",
+  "--target",
+  "-m",
+  "--module",
+  "--moduleResolution",
+  "--lib",
+  "--types",
+  "--typeRoots",
+  "--baseUrl",
+  "--jsxFactory",
+  "--jsxFragmentFactory",
+  "--jsxImportSource",
+  "--newLine",
+  "--locale",
+  "--plugins",
+]);
+
 export function deriveTypecheckConfig(script) {
   const segments = script
     .split("&&")
@@ -103,39 +135,86 @@ export function deriveTypecheckConfig(script) {
     return { derivable: false, reason: `it runs \`${tokens[0]}\`, whose file set is not this config's to state` };
   }
 
-  const inline = tokens.find((t) => t.startsWith("--project="));
-  if (inline) {
-    const value = inline.slice("--project=".length);
-    return value
-      ? { derivable: true, configPath: value }
-      : { derivable: false, reason: "`--project=` carries no config path" };
-  }
+  let configPath = null;
 
-  const flag = tokens.findIndex((t) => t === "-p" || t === "--project");
-  if (flag !== -1) {
-    const value = tokens[flag + 1];
-    if (!value || value.startsWith("-")) {
-      return { derivable: false, reason: `\`${tokens[flag]}\` is not followed by a config path` };
+  for (let i = 1; i < tokens.length; i++) {
+    const token = tokens[i];
+
+    if (token.startsWith("--project=")) {
+      const value = token.slice("--project=".length);
+      if (!value) return { derivable: false, reason: "`--project=` carries no config path" };
+      configPath = value;
+      continue;
     }
-    return { derivable: true, configPath: value };
+
+    if (token.startsWith("-")) {
+      if (TSC_VALUE_FLAGS.has(token)) {
+        const value = tokens[i + 1];
+        if (value === undefined || value.startsWith("-")) {
+          return { derivable: false, reason: `\`${token}\` is not followed by a value` };
+        }
+        if (token === "-p" || token === "--project") configPath = value;
+        i++; // the value belongs to this flag, not to the file list
+      }
+      continue;
+    }
+
+    // A positional argument, and it is disqualifying: when input files are given
+    // on the command line, tsc IGNORES tsconfig.json entirely. Measured on 5.9.3
+    // — `tsc --noEmit src/index.ts --listFiles` compiles `src/index.ts` alone and
+    // leaves `src/index.test.ts` out of the program, while `-p tsconfig.json`
+    // includes it. Returning `tsconfig.json` here would verify a config the
+    // script never loads, which is this file's own defect committed by its fix.
+    return {
+      derivable: false,
+      reason: `it passes \`${token}\` positionally, and tsc ignores tsconfig.json when given input files`,
+    };
   }
 
   // `tsc` with no project flag resolves `tsconfig.json` from the working
   // directory. That is documented, stable compiler behaviour, so naming it here
   // is a derivation rather than the assumption this change exists to remove.
-  return { derivable: true, configPath: "tsconfig.json" };
+  return { derivable: true, configPath: configPath ?? "tsconfig.json" };
 }
 
 function typecheckScriptOf(name) {
   return readJson(`packages/${name}/package.json`).scripts?.typecheck;
 }
 
-// Run a package's REAL typecheck script. `shell: true` because pnpm is a `.cmd`
-// shim on Windows; the arguments are fixed literals, so nothing user-supplied
-// reaches the shell.
+// How long a single real typecheck script may take. This is enforced by
+// `spawnSync`, NOT by the Vitest test timeout below: Vitest cannot interrupt a
+// synchronous `spawnSync`, so a hung script would block the worker until the CI
+// job limit and the test-level timeout would be decorative. Generous against the
+// ~8.5s a real `astro check` run takes.
+const SCRIPT_TIMEOUT_MS = 120_000;
+
+// Run a package's REAL typecheck script — directly through pnpm, deliberately
+// NOT through turbo. `turbo run typecheck --filter=…` is cached: measured, a
+// second invocation returns exit 0 in 599ms with `cache hit, replaying logs`
+// without running `astro check` at all. The clean run is the exposure, since
+// nothing about it is novel, and a replayed exit 0 is not evidence that the
+// script passes. A cached green would be this guard's own failure mode arriving
+// through the back door, so the invocation must stay direct.
+//
+// `shell: true` because pnpm is a `.cmd` shim on Windows; the arguments are
+// fixed literals, so nothing user-supplied reaches the shell.
 function runTypecheck(cwd) {
-  const result = spawnSync("pnpm", ["run", "typecheck"], { cwd, encoding: "utf-8", shell: true });
-  return { status: result.status, output: `${result.stdout ?? ""}${result.stderr ?? ""}` };
+  const result = spawnSync("pnpm", ["run", "typecheck"], {
+    cwd,
+    encoding: "utf-8",
+    shell: true,
+    timeout: SCRIPT_TIMEOUT_MS,
+    // Default is 1 MiB. A truncated capture would fail the marker assertions for
+    // a reason other than the one they report — the exact confusion this file is
+    // about, one layer down.
+    maxBuffer: 32 * 1024 * 1024,
+  });
+
+  // A spawn failure (or a timeout kill) leaves `status` null and both streams
+  // empty, which would otherwise be reported as "the workspace is not built".
+  // Surface the cause so the message names what actually happened.
+  const failure = result.error ? `\n[spawn failed] ${result.error.message}` : "";
+  return { status: result.status, output: `${result.stdout ?? ""}${result.stderr ?? ""}${failure}` };
 }
 
 // Named so its purpose is unmistakable in a `git status` listing: an orphaned
@@ -170,9 +249,11 @@ const probe: "${PROBE_EXPECTED_MARKER}" = "${PROBE_ACTUAL_MARKER}";
 export default probe;
 `;
 
-// Two runs of a real typecheck, so the timeout has to clear both plus pnpm's own
-// start-up. Measured 2026-09-01: ~7.5s per `astro check` run on a built tree.
-const PROBE_TIMEOUT_MS = 180_000;
+// Two runs of a real typecheck, so this has to clear BOTH `SCRIPT_TIMEOUT_MS`
+// budgets plus pnpm's start-up, or the outer timeout could fire while an inner
+// one was still doing its job and report the wrong failure. Measured
+// 2026-09-01: ~8.5s per `astro check` run on a built tree.
+const PROBE_TIMEOUT_MS = 2 * SCRIPT_TIMEOUT_MS + 60_000;
 
 // `.tsx` is matched too. Nothing in the repo uses it today, but a package whose
 // only sources were `.tsx` would otherwise be invisible to the guard — the same
@@ -426,6 +507,19 @@ describe("a package's typecheck covers its own test files", () => {
         // file the way the derivable branch does, so a config excluding
         // individual tests by name could still pass here.
         const probePath = onDisk[0].replace(/\/[^/]+$/, `/${PROBE_BASENAME}`);
+
+        // This test writes a file into the repository and deletes it again, so
+        // prove the target is inside the package BEFORE either happens. Today
+        // `testFilesOnDisk` only ever returns paths under `pkgDir`, so this
+        // cannot fire — which is the point: if that stops being true, the failure
+        // should be a loud assertion rather than a write, and a delete, somewhere
+        // else in the tree.
+        const pkgPrefix = `${toPosix(pkgDir)}/`;
+        expect(
+          probePath.startsWith(pkgPrefix),
+          `refusing to write the probe: ${probePath} is not inside ${pkgPrefix}`,
+        ).toBe(true);
+
         try {
           writeFileSync(probePath, PROBE_SOURCE);
           const probed = runTypecheck(pkgDir);
@@ -513,5 +607,29 @@ describe("deriveTypecheckConfig", () => {
   it("refuses a project flag with no path rather than guessing one", () => {
     expect(deriveTypecheckConfig("tsc --noEmit -p").derivable).toBe(false);
     expect(deriveTypecheckConfig("tsc --noEmit -p --pretty").derivable).toBe(false);
+  });
+
+  // Measured on TypeScript 5.9.3: `tsc --noEmit src/index.ts --listFiles`
+  // compiles that file alone and leaves `src/index.test.ts` out of the program,
+  // while `-p tsconfig.json` includes it. So defaulting to `tsconfig.json` for a
+  // script with positional inputs would verify a config the script never loads.
+  it("refuses positional file arguments, which make tsc ignore tsconfig.json", () => {
+    const result = deriveTypecheckConfig("tsc --noEmit src/index.ts");
+    expect(result.derivable).toBe(false);
+    expect(result.reason).toContain("positionally");
+  });
+
+  it("does not mistake a value-taking flag's value for a positional file", () => {
+    expect(deriveTypecheckConfig("tsc --noEmit --outDir dist -p tsconfig.json")).toEqual({
+      derivable: true,
+      configPath: "tsconfig.json",
+    });
+  });
+
+  // An unrecognised flag is treated as boolean, so its value reads as positional
+  // and the script is refused. That is the safe direction: an omission from
+  // TSC_VALUE_FLAGS costs a slow tier-2 measurement, never a wrong claim.
+  it("refuses rather than guesses when a flag it does not know takes a value", () => {
+    expect(deriveTypecheckConfig("tsc --noEmit --someFutureFlag value -p tsconfig.json").derivable).toBe(false);
   });
 });

--- a/scripts/typecheck-script-coverage.test.mjs
+++ b/scripts/typecheck-script-coverage.test.mjs
@@ -469,9 +469,16 @@ describe("a package's typecheck covers its own test files", () => {
   // rather than a no-op. On a repo where every script is a plain `tsc -p`, this
   // block correctly disappears.
   if (measured.length > 0) {
-    it.each(measured)(
-      "proves by running its own typecheck that it checks its test files: %s",
-      (name) => {
+    // The case list carries the refusal reason so the test's own NAME says why
+    // this package took the expensive path. `TSC_VALUE_FLAGS` is deliberately
+    // incomplete (see above), so a package can move from derived to measured by
+    // someone adding a flag it does not list — and the only other symptom would
+    // be `pnpm test` getting ~8.5s slower with nothing saying why. Naming the
+    // reason cannot rot the way a pinned list of expected-measured packages
+    // would when a second legitimately non-`tsc` package arrives.
+    it.each(measured.map((name) => ({ name, why: deriveTypecheckConfig(typecheckScriptOf(name)).reason })))(
+      "proves coverage by running its own typecheck: $name (not statically derivable: $why)",
+      ({ name }) => {
         const pkgDir = join(repoRoot, "packages", name);
         const onDisk = testFilesOnDisk(pkgDir);
         if (onDisk.length === 0) return;

--- a/scripts/typecheck-script-coverage.test.mjs
+++ b/scripts/typecheck-script-coverage.test.mjs
@@ -145,10 +145,28 @@ function runTypecheck(cwd) {
 // `vitest.config.ts` excludes this exact filename so an orphan is never collected.
 const PROBE_BASENAME = "__typecheck_coverage_probe__.test.ts";
 
+// The probe's types are string literals carrying distinctive markers, so a
+// checker that rejects it must quote them in its own diagnostic:
+//
+//   error ts(2322): Type '"__ird_probe_actual__"' is not assignable to
+//                   type '"__ird_probe_expected__"'.
+//
+// That is what lets the assertion below require evidence the checker PARSED AND
+// UNDERSTOOD the file rather than merely listed its path — a tool echoing its
+// input file list produces the filename and cannot produce the markers.
+//
+// It binds to no tool's output format: not error codes, not `line:col`, not a
+// file count. It relies only on a checker having to DESCRIBE a mismatch to be
+// useful, and with literal types the literal values ARE the types. A checker
+// that reported errors without naming types would turn this red rather than
+// green, which is the direction a wrong assumption here has to fail in.
+const PROBE_EXPECTED_MARKER = "__ird_probe_expected__";
+const PROBE_ACTUAL_MARKER = "__ird_probe_actual__";
+
 const PROBE_SOURCE = `// TEMPORARY file written by scripts/typecheck-script-coverage.test.mjs.
 // It is deleted in a \`finally\`. If you are reading this in your working tree,
 // that run crashed — delete it. It is untracked and means nothing on its own.
-const probe: number = "deliberately not a number";
+const probe: "${PROBE_EXPECTED_MARKER}" = "${PROBE_ACTUAL_MARKER}";
 export default probe;
 `;
 
@@ -427,6 +445,21 @@ describe("a package's typecheck covers its own test files", () => {
               `${PROBE_BASENAME} — so the failure cannot be attributed to the probe and proves ` +
               `nothing about coverage. Output:\n${probed.output}`,
           ).toContain(PROBE_BASENAME);
+
+          // Naming the file is not enough on its own: a tool that echoed its
+          // input file list would satisfy it while having checked nothing. The
+          // markers only appear if the checker read the probe's types and
+          // described the mismatch, so requiring them is the difference between
+          // "the probe was listed" and "the probe was understood".
+          for (const marker of [PROBE_EXPECTED_MARKER, PROBE_ACTUAL_MARKER]) {
+            expect(
+              probed.output,
+              `packages/${name}'s typecheck named ${PROBE_BASENAME} but its output never quotes ` +
+                `${marker}, which a checker rejecting the probe's type mismatch would have to. ` +
+                `So the run saw the file without demonstrably checking it — that is not proof of ` +
+                `coverage. Output:\n${probed.output}`,
+            ).toContain(marker);
+          }
         } finally {
           rmSync(probePath, { force: true });
         }

--- a/scripts/typecheck-script-coverage.test.mjs
+++ b/scripts/typecheck-script-coverage.test.mjs
@@ -120,6 +120,33 @@ const TSC_VALUE_FLAGS = new Set([
   "--plugins",
 ]);
 
+// Flags that make `tsc` report success WITHOUT type-checking, or that change the
+// invocation into something other than a check. Deriving a config for one of
+// these would report a package covered on the strength of a run that checks
+// nothing — the defect this whole file is about, wearing a compiler flag.
+//
+// Measured on 5.9.3 with a real type error present in the program:
+//   tsc --noEmit -p tsconfig.json                 -> exit 2, 1 error
+//   tsc --noEmit --noCheck -p tsconfig.json       -> exit 0, 0 errors
+//   tsc --noEmit --listFilesOnly -p tsconfig.json -> exit 0, 0 errors
+//
+// These refuse to derive rather than throwing, so they fall to tier 2 and get
+// MEASURED — where the probe correctly fails to be caught and the guard reports
+// the coverage as genuinely absent. Refusing here diagnoses itself; a hard error
+// would only say the parser was unhappy.
+const TSC_SUPPRESSING_FLAGS = new Set([
+  "--noCheck",
+  "--listFilesOnly",
+  "--showConfig",
+  "--init",
+  "--help",
+  "-h",
+  "--version",
+  "-v",
+  "--build",
+  "-b",
+]);
+
 export function deriveTypecheckConfig(script) {
   const segments = script
     .split("&&")
@@ -145,6 +172,13 @@ export function deriveTypecheckConfig(script) {
       if (!value) return { derivable: false, reason: "`--project=` carries no config path" };
       configPath = value;
       continue;
+    }
+
+    if (TSC_SUPPRESSING_FLAGS.has(token)) {
+      return {
+        derivable: false,
+        reason: `it passes \`${token}\`, so the run does not type-check what the config contains`,
+      };
     }
 
     if (token.startsWith("-")) {
@@ -620,6 +654,19 @@ describe("deriveTypecheckConfig", () => {
   // compiles that file alone and leaves `src/index.test.ts` out of the program,
   // while `-p tsconfig.json` includes it. So defaulting to `tsconfig.json` for a
   // script with positional inputs would verify a config the script never loads.
+  // Measured on 5.9.3 with a real type error in the program: `-p tsconfig.json`
+  // exits 2 with 1 error, while `--noCheck` and `--listFilesOnly` both exit 0
+  // with 0 errors. Deriving a config for either would report a package covered
+  // on the strength of a run that checks nothing.
+  it.each(["--noCheck", "--listFilesOnly", "--showConfig", "--build"])(
+    "refuses %s, which makes tsc report success without type-checking",
+    (flag) => {
+      const result = deriveTypecheckConfig(`tsc --noEmit ${flag} -p tsconfig.json`);
+      expect(result.derivable).toBe(false);
+      expect(result.reason).toContain(flag);
+    },
+  );
+
   it("refuses positional file arguments, which make tsc ignore tsconfig.json", () => {
     const result = deriveTypecheckConfig("tsc --noEmit src/index.ts");
     expect(result.derivable).toBe(false);

--- a/scripts/typecheck-script-coverage.test.mjs
+++ b/scripts/typecheck-script-coverage.test.mjs
@@ -1,4 +1,5 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -50,9 +51,9 @@ const TYPECHECK_EXCLUDES_TESTS = new Map([
 // basePath", which would report every test file as covered — so a broken tsconfig
 // would turn this check green precisely when something is wrong. Measured: a
 // tsconfig with a bad `extends` gave 47 passed before this guard was added.
-function filesInProgram(packageName) {
+function filesInProgram(packageName, configRelPath) {
   const dir = toPosix(join(repoRoot, "packages", packageName));
-  const configPath = `${dir}/tsconfig.json`;
+  const configPath = `${dir}/${configRelPath}`;
   const { config, error } = ts.parseConfigFileTextToJson(configPath, readFileSync(configPath, "utf-8"));
   if (error || !config) {
     const detail = error ? ts.flattenDiagnosticMessageText(error.messageText, " ") : "no config object";
@@ -65,6 +66,95 @@ function filesInProgram(packageName) {
   }
   return new Set(parsed.fileNames.map(toPosix));
 }
+
+// The script this guard vouches for, PARSED rather than assumed (#1086).
+//
+// The guard's claim is about `pnpm typecheck`; what it could previously verify
+// was a `tsconfig.json` it picked by hardcoded filename. Those are different
+// claims and nothing connected them: a package adopting `tsconfig.typecheck.json`
+// would be reported fully covered while its script checked a different file set,
+// and a script running a tool that is not `tsc` at all would be reported covered
+// on the strength of a config it never names.
+//
+// Worth recording what was true when this was written, because it explains why
+// the defect was invisible: every `typecheck` script in the repo was byte-identical
+// `tsc --noEmit -p tsconfig.json`, so the old inference could not be wrong
+// anywhere. The premise was unfalsifiable rather than verified, and #1077 created
+// the first counter-example by giving the website `pnpm generate:gallery && astro check`.
+//
+// Returns the config to verify against, or the reason it cannot be derived — in
+// which case the caller must MEASURE rather than infer (see the probe below).
+// Deliberately conservative: only a single-command `tsc` invocation is derivable.
+// A chained script is not, even when one segment is `tsc`, because an earlier
+// segment can generate source files that the compiler includes at runtime and a
+// static parse of the config cannot see.
+export function deriveTypecheckConfig(script) {
+  const segments = script
+    .split("&&")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (segments.length !== 1) {
+    return { derivable: false, reason: `it chains ${segments.length} commands, so a static parse cannot stand in` };
+  }
+
+  const tokens = segments[0].split(/\s+/).filter(Boolean);
+  if (tokens[0] !== "tsc") {
+    return { derivable: false, reason: `it runs \`${tokens[0]}\`, whose file set is not this config's to state` };
+  }
+
+  const inline = tokens.find((t) => t.startsWith("--project="));
+  if (inline) {
+    const value = inline.slice("--project=".length);
+    return value
+      ? { derivable: true, configPath: value }
+      : { derivable: false, reason: "`--project=` carries no config path" };
+  }
+
+  const flag = tokens.findIndex((t) => t === "-p" || t === "--project");
+  if (flag !== -1) {
+    const value = tokens[flag + 1];
+    if (!value || value.startsWith("-")) {
+      return { derivable: false, reason: `\`${tokens[flag]}\` is not followed by a config path` };
+    }
+    return { derivable: true, configPath: value };
+  }
+
+  // `tsc` with no project flag resolves `tsconfig.json` from the working
+  // directory. That is documented, stable compiler behaviour, so naming it here
+  // is a derivation rather than the assumption this change exists to remove.
+  return { derivable: true, configPath: "tsconfig.json" };
+}
+
+function typecheckScriptOf(name) {
+  return readJson(`packages/${name}/package.json`).scripts?.typecheck;
+}
+
+// Run a package's REAL typecheck script. `shell: true` because pnpm is a `.cmd`
+// shim on Windows; the arguments are fixed literals, so nothing user-supplied
+// reaches the shell.
+function runTypecheck(cwd) {
+  const result = spawnSync("pnpm", ["run", "typecheck"], { cwd, encoding: "utf-8", shell: true });
+  return { status: result.status, output: `${result.stdout ?? ""}${result.stderr ?? ""}` };
+}
+
+// Named so its purpose is unmistakable in a `git status` listing: an orphaned
+// probe means a run crashed between writing and deleting it. It is untracked, so
+// it can never modify existing content — `git status --porcelain` stays a
+// trustworthy contamination signal, which is what it is used for around here.
+// `vitest.config.ts` excludes this exact filename so an orphan is never collected.
+const PROBE_BASENAME = "__typecheck_coverage_probe__.test.ts";
+
+const PROBE_SOURCE = `// TEMPORARY file written by scripts/typecheck-script-coverage.test.mjs.
+// It is deleted in a \`finally\`. If you are reading this in your working tree,
+// that run crashed — delete it. It is untracked and means nothing on its own.
+const probe: number = "deliberately not a number";
+export default probe;
+`;
+
+// Two runs of a real typecheck, so the timeout has to clear both plus pnpm's own
+// start-up. Measured 2026-09-01: ~7.5s per `astro check` run on a built tree.
+const PROBE_TIMEOUT_MS = 180_000;
 
 // `.tsx` is matched too. Nothing in the repo uses it today, but a package whose
 // only sources were `.tsx` would otherwise be invisible to the guard — the same
@@ -208,21 +298,49 @@ describe("every package with TypeScript is covered by pnpm typecheck", () => {
 // complete and is not. The first catches a package the gate never runs on; this
 // catches one the gate runs on while checking none of its tests — `typecheck`
 // present, reported covered, and the test files not in the program at all.
+// Since #1086 the claim is bound to the SCRIPT rather than to a hardcoded
+// filename, and it is established one of exactly two ways.
+//
+// Where the script is a plain `tsc -p <config>`, that config is parsed. Cheap,
+// and faithful: measured against `tsc --listFiles` on 2026-09-01,
+// `parseJsonConfigFileContent` reports exactly the in-package file set the
+// compiler really loads, so running the compiler here would buy no fidelity.
+//
+// Where the script is anything else, nothing about its file set can be inferred
+// from a config it never names — so the guard MEASURES, by running the real
+// script and proving by effect that a test-shaped file is checked.
+//
+// There is deliberately no third way. A "checked by something else" allow-list
+// was considered and rejected: it would have asserted that `astro check` covers
+// the website's test files on nobody's authority, which is verification-shaped
+// while still inferring — the exact defect this file exists to remove.
 describe("a package's typecheck covers its own test files", () => {
   const checkable = typeScriptPackages.filter(
-    (name) => !NO_TYPECHECK_SCRIPT.has(name) && existsSync(join(repoRoot, "packages", name, "tsconfig.json")),
+    (name) => !NO_TYPECHECK_SCRIPT.has(name) && typecheckScriptOf(name) !== undefined,
   );
+
+  const derivable = checkable.filter((name) => deriveTypecheckConfig(typecheckScriptOf(name)).derivable);
+  const measured = checkable.filter((name) => !deriveTypecheckConfig(typecheckScriptOf(name)).derivable);
 
   it("has no stale test-exclusion entries", () => {
     const stale = [...TYPECHECK_EXCLUDES_TESTS.keys()].filter((name) => !checkable.includes(name));
     expect(stale, `TYPECHECK_EXCLUDES_TESTS names ${stale.join(", ")}, which is no longer checkable.`).toEqual([]);
   });
 
-  it.each(checkable)("checks every test file it ships: %s", (name) => {
+  it("splits every checkable package into exactly one of the two ways", () => {
+    expect(
+      [...derivable, ...measured].sort(),
+      "a package must be either statically derivable or measured — neither silently dropped nor counted twice",
+    ).toEqual([...checkable].sort());
+  });
+
+  it.each(derivable)("checks every test file it ships: %s", (name) => {
     const onDisk = testFilesOnDisk(join(repoRoot, "packages", name));
     if (onDisk.length === 0) return;
 
-    const inProgram = filesInProgram(name);
+    const script = typecheckScriptOf(name);
+    const { configPath } = deriveTypecheckConfig(script);
+    const inProgram = filesInProgram(name, configPath);
     const missing = onDisk.filter((f) => !inProgram.has(f)).map((f) => f.slice(repoRoot.length + 1));
     const excused = TYPECHECK_EXCLUDES_TESTS.get(name);
 
@@ -240,10 +358,127 @@ describe("a package's typecheck covers its own test files", () => {
     expect(
       missing,
       `packages/${name} has a typecheck script, so the coverage guard above reports it covered — ` +
-        `but its tsconfig leaves ${missing.length} of its own test files out of the program, so ` +
-        `\`pnpm typecheck\` checks none of them: ${missing.join(", ")}. Presence of a script is not ` +
-        `coverage. Remove the exclusion, or add the package to TYPECHECK_EXCLUDES_TESTS with the ` +
-        `number of errors the exclusion is hiding.`,
+        `but the config that script actually names (${configPath}, from \`${script}\`) leaves ` +
+        `${missing.length} of its own test files out of the program, so \`pnpm typecheck\` checks ` +
+        `none of them: ${missing.join(", ")}. Presence of a script is not coverage. Remove the ` +
+        `exclusion, or add the package to TYPECHECK_EXCLUDES_TESTS with the number of errors the ` +
+        `exclusion is hiding.`,
     ).toEqual([]);
+  });
+
+  // Registered only when something needs it, because `it.each([])` is an error
+  // rather than a no-op. On a repo where every script is a plain `tsc -p`, this
+  // block correctly disappears.
+  if (measured.length > 0) {
+    it.each(measured)(
+      "proves by running its own typecheck that it checks its test files: %s",
+      (name) => {
+        const pkgDir = join(repoRoot, "packages", name);
+        const onDisk = testFilesOnDisk(pkgDir);
+        if (onDisk.length === 0) return;
+
+        const script = typecheckScriptOf(name);
+        const { reason } = deriveTypecheckConfig(script);
+
+        // Side one. The script must pass on an unmodified tree. Without this,
+        // "the tool ignores test files" and "the workspace is not built" are the
+        // same non-zero exit, and the guard would confidently report the wrong
+        // one — this issue's own defect reappearing inside its fix.
+        const clean = runTypecheck(pkgDir);
+        expect(
+          clean.status,
+          `packages/${name}'s typecheck (\`${script}\`) does not pass on an unmodified tree, so its ` +
+            `coverage is UNPROVEN rather than absent — this is not a coverage failure. The usual ` +
+            `cause is an unbuilt workspace: run \`pnpm build\`, then \`pnpm test\` again. Output:\n` +
+            clean.output,
+        ).toBe(0);
+
+        // Side two. With a test-shaped file that cannot possibly typecheck, it
+        // must fail — AND the output must name the probe. An exit code alone
+        // cannot tell "the probe was checked and failed" from "something else
+        // failed", and a guard that cannot tell those apart is the thing being
+        // fixed here rather than the fix.
+        //
+        // The probe goes beside a real test file so it is picked up exactly the
+        // way a test file is. Placed anywhere else it would prove a weaker claim
+        // than the one this block makes.
+        //
+        // Known limit, stated rather than papered over: this proves a test-shaped
+        // file in that directory is checked. It does not enumerate every test
+        // file the way the derivable branch does, so a config excluding
+        // individual tests by name could still pass here.
+        const probePath = onDisk[0].replace(/\/[^/]+$/, `/${PROBE_BASENAME}`);
+        try {
+          writeFileSync(probePath, PROBE_SOURCE);
+          const probed = runTypecheck(pkgDir);
+
+          expect(
+            probed.status,
+            `packages/${name} runs \`${script}\`, which cannot be statically derived (${reason}), so ` +
+              `coverage has to be proven by effect. A file that cannot typecheck was placed beside ` +
+              `its own tests at ${probePath.slice(repoRoot.length + 1)} and the script still passed — ` +
+              `so whatever it runs is NOT checking files shaped like this package's tests, and a ` +
+              `green \`pnpm typecheck\` says nothing about them.`,
+          ).not.toBe(0);
+
+          expect(
+            probed.output,
+            `packages/${name}'s typecheck failed with the probe in place, but its output never names ` +
+              `${PROBE_BASENAME} — so the failure cannot be attributed to the probe and proves ` +
+              `nothing about coverage. Output:\n${probed.output}`,
+          ).toContain(PROBE_BASENAME);
+        } finally {
+          rmSync(probePath, { force: true });
+        }
+      },
+      PROBE_TIMEOUT_MS,
+    );
+  }
+});
+
+// The derivation is the load-bearing half of #1086 and it runs against real
+// scripts only for the shapes this repo happens to use today — every one of them
+// a plain `tsc -p`. These pin the shapes it must keep getting right, including
+// the two that must FAIL to derive, since a derivation that never refuses would
+// silently return to inferring.
+describe("deriveTypecheckConfig", () => {
+  it("derives the config a plain tsc invocation names", () => {
+    expect(deriveTypecheckConfig("tsc --noEmit -p tsconfig.json")).toEqual({
+      derivable: true,
+      configPath: "tsconfig.json",
+    });
+  });
+
+  it("derives a non-default config filename", () => {
+    expect(deriveTypecheckConfig("tsc --noEmit -p tsconfig.typecheck.json")).toEqual({
+      derivable: true,
+      configPath: "tsconfig.typecheck.json",
+    });
+  });
+
+  it("accepts both spellings of the project flag", () => {
+    expect(deriveTypecheckConfig("tsc --project build.json").configPath).toBe("build.json");
+    expect(deriveTypecheckConfig("tsc --project=build.json").configPath).toBe("build.json");
+  });
+
+  it("resolves bare tsc to the config the compiler itself would load", () => {
+    expect(deriveTypecheckConfig("tsc --noEmit")).toEqual({ derivable: true, configPath: "tsconfig.json" });
+  });
+
+  it("refuses a tool it cannot reason about", () => {
+    const result = deriveTypecheckConfig("astro check");
+    expect(result.derivable).toBe(false);
+    expect(result.reason).toContain("astro");
+  });
+
+  it("refuses a chained script even when one segment is tsc", () => {
+    // An earlier segment can generate sources the compiler will include at
+    // runtime, which a static parse of the config cannot see.
+    expect(deriveTypecheckConfig("pnpm generate:gallery && tsc -p tsconfig.json").derivable).toBe(false);
+  });
+
+  it("refuses a project flag with no path rather than guessing one", () => {
+    expect(deriveTypecheckConfig("tsc --noEmit -p").derivable).toBe(false);
+    expect(deriveTypecheckConfig("tsc --noEmit -p --pretty").derivable).toBe(false);
   });
 });

--- a/scripts/typecheck-script-coverage.test.mjs
+++ b/scripts/typecheck-script-coverage.test.mjs
@@ -147,6 +147,30 @@ const TSC_SUPPRESSING_FLAGS = new Set([
   "-b",
 ]);
 
+// Boolean `tsc` flags this parser will vouch for: each one leaves type-checking
+// of the program intact, so a config parsed alongside it still describes what
+// the run checks. Kept deliberately short. An unlisted flag is REFUSED, not
+// assumed harmless — see the allow-list reasoning at the refusal below.
+const TSC_SAFE_BOOLEAN_FLAGS = new Set([
+  "--noEmit",
+  "--noEmitOnError",
+  "--pretty",
+  "--noErrorTruncation",
+  "--skipLibCheck",
+  "--strict",
+  "--incremental",
+  "--composite",
+  "--declaration",
+  "--emitDeclarationOnly",
+  "--sourceMap",
+  "--declarationMap",
+  "--listEmittedFiles",
+  "--explainFiles",
+  "--diagnostics",
+  "--extendedDiagnostics",
+  "--traceResolution",
+]);
+
 export function deriveTypecheckConfig(script) {
   const segments = script
     .split("&&")
@@ -189,8 +213,29 @@ export function deriveTypecheckConfig(script) {
         }
         if (token === "-p" || token === "--project") configPath = value;
         i++; // the value belongs to this flag, not to the file list
+        continue;
       }
-      continue;
+
+      if (TSC_SAFE_BOOLEAN_FLAGS.has(token)) continue;
+
+      // Everything else is refused, and this being an ALLOW-list is the point.
+      // The previous version accepted any unrecognised `-flag` as a harmless
+      // boolean, which is why `--noCheck` was caught only because somebody named
+      // it — a suppressing flag nobody has thought of yet would have passed the
+      // same way. The parser was blocklist-shaped in exactly the half where
+      // nothing downstream trips: an unknown VALUE flag was already refused, but
+      // only by accident, because its value then read as a positional file. A
+      // boolean has no value to trip that, so it has to be refused deliberately.
+      //
+      // An unlisted flag now costs a tier-2 measurement, never a wrong claim.
+      // Adding one to TSC_SAFE_BOOLEAN_FLAGS is a claim that it does not
+      // suppress checking — establish that the way the suppressing ones were
+      // established, by injecting a type error and confirming the run still
+      // fails, rather than from the flag's name.
+      return {
+        derivable: false,
+        reason: `it passes \`${token}\`, which this parser cannot vouch for as leaving type-checking intact`,
+      };
     }
 
     // A positional argument, and it is disqualifying: when input files are given
@@ -685,5 +730,23 @@ describe("deriveTypecheckConfig", () => {
   // TSC_VALUE_FLAGS costs a slow tier-2 measurement, never a wrong claim.
   it("refuses rather than guesses when a flag it does not know takes a value", () => {
     expect(deriveTypecheckConfig("tsc --noEmit --someFutureFlag value -p tsconfig.json").derivable).toBe(false);
+  });
+
+  // The parser is allow-list shaped for BOOLEANS too, which is the structural
+  // half. An unknown value-flag was already refused, but only incidentally —
+  // its value read as a positional file. A boolean has no value to trip that, so
+  // an unrecognised one used to pass silently, which is why `--noCheck` was
+  // caught only because a reviewer named it rather than by the design.
+  it("refuses an unknown boolean flag rather than assuming it is harmless", () => {
+    const result = deriveTypecheckConfig("tsc --noEmit --someFutureBooleanFlag -p tsconfig.json");
+    expect(result.derivable).toBe(false);
+    expect(result.reason).toContain("--someFutureBooleanFlag");
+  });
+
+  it("still derives the shape every package in this repo actually uses", () => {
+    expect(deriveTypecheckConfig("tsc --noEmit -p tsconfig.json")).toEqual({
+      derivable: true,
+      configPath: "tsconfig.json",
+    });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import { resolve } from "node:path";
 // `configLoader: 'native'` Node strips the types itself and cannot infer which
 // named imports are types, so a plain `Plugin` becomes a value import of an
 // export that does not exist. Vite's compatibility warning does not cover this.
-import { defineConfig, type Plugin } from "vitest/config";
+import { defaultExclude, defineConfig, type Plugin } from "vitest/config";
 
 /**
  * Vitest plugin to load SVG files as raw strings.
@@ -63,5 +63,18 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./test-setup.ts"],
     include: ["packages/*/src/**/*.test.ts", "scripts/**/*.test.mjs"],
+    // `scripts/typecheck-script-coverage.test.mjs` proves a package's typecheck
+    // really checks its tests by writing a file that cannot compile beside them,
+    // running the package's own script, and deleting it again (#1086). The probe
+    // has to be named `*.test.ts` to be included exactly the way a real test file
+    // is — a probe the compiler picks up differently would prove a weaker claim
+    // than the guard makes — which puts it squarely inside `include` above.
+    //
+    // The exact basename is excluded, never a pattern: a broad exclude that
+    // quietly swallowed a genuine test file would be a worse version of the bug
+    // being fixed. `defaultExclude` is spread rather than replaced, because
+    // assigning `exclude` overrides vitest's defaults (node_modules, dist, …)
+    // instead of adding to them.
+    exclude: [...defaultExclude, "**/__typecheck_coverage_probe__.test.ts"],
   },
 });


### PR DESCRIPTION
## Related Issue

Fixes #1086

## What changed?

`scripts/typecheck-script-coverage.test.mjs` established coverage by parsing `tsconfig.json` — picked by hardcoded filename — and never read the `typecheck` script it was vouching for. Those are different claims: a package adopting `tsconfig.typecheck.json` would be reported fully covered while its script checked a different file set, and a script running a tool that is not `tsc` at all would be reported covered on the strength of a config it never names.

**A reviewer looking for a live breakage on master will not find one, and that is expected.** When this was written every `typecheck` script in the repo was byte-identical `tsc --noEmit -p tsconfig.json`, so the old inference could not be wrong anywhere — the premise was unfalsifiable rather than verified. #1077 created the first counter-example by giving the website `pnpm generate:gallery && astro check`. That has since merged, so the divergence is now real and this guard has a live consumer.

The claim is now bound to the script, established one of exactly two ways:

- **Derivable** (`tsc -p <config>`): that config is parsed. Faithful, and checked rather than assumed — measured against `tsc --listFiles`, `parseJsonConfigFileContent` reports exactly the in-package file set the compiler really loads, so running the compiler here would buy no fidelity. Derivation deliberately refuses a chained script even when a segment is `tsc`, because an earlier segment can generate sources a static parse cannot see.
- **Anything else**: the guard *measures*. It runs the real script twice — clean, expecting success, then with a file that cannot compile placed beside the package's own tests, expecting failure whose output both names the probe and quotes the probe's markers.

There is deliberately no third way, and no "checked by something else" allow-list.

### Why the probe carries markers

The probe declares `const probe: "__ird_probe_expected__" = "__ird_probe_actual__";`, so a checker that rejects it must quote both markers in its own diagnostic. Requiring only the filename would be satisfied by a tool that echoed its input file list while checking nothing — it would prove the probe was *seen*, not *understood*. This binds to no output format (not error codes, not `line:col`, not a file count); it relies only on a checker having to describe a mismatch to be useful, and with literal types the literal values *are* the types. A checker that reported errors without naming types turns this red rather than green, which is the direction a wrong assumption here has to fail in.

Markers do **not** replace the clean run. They prove the checker understood the probe; only the clean run proves the failure was *caused* by it. Without the clean run, "the tool ignores test files" and "the workspace is not built" are the same non-zero exit.

## How to test

`pnpm test` — but a green run proves less than it looks, so the controls are listed. Each was run by forcing the condition and watching the guard fail, because none of these paths is exercised by an ordinary green run:

| Control | Forced condition | Observed |
|---|---|---|
| Probe path runs at all | a package given a non-derivable script that still runs `tsc` | `✓ proves by running its own typecheck… 1212ms` — ran **by name** |
| Coverage genuinely absent | script → `echo I-check-nothing` | fails: "the script still passed — so whatever it runs is NOT checking files shaped like this package's tests" |
| Prerequisite vs coverage | script → `exit 1` | fails with the **different** UNPROVEN message naming `pnpm build` |
| Derived config is really used | script → `-p tsconfig.probe.json`, that config excluding tests | fails naming `tsconfig.probe.json`; a hardcoded read would have passed |
| Markers required, not just filename | probe body swapped for one whose diagnostic names the file but quotes neither marker | fails: "named the file but its output never quotes `__ird_probe_expected__` — the run saw the file without demonstrably checking it" |

The first control is worth a note: its test count is **identical** whether the package lands in the derivable or measured branch, because one `it.each` case simply swaps for another. "55 passed, unchanged" could not distinguish the two cases, so the probe was only established to run by finding the test by name in verbose output.

The `vitest.config.ts` exclude was checked both ways too: with it, an orphaned probe is not collected (327 files); without it, vitest collects it and errors `No test suite found` (328 files, 1 failed). So the exclude is load-bearing rather than incidental — and an orphan is loud either way, never silent.

### Cost, and that it was chosen

`pnpm test` goes from **7.52s to ~19.5–21s, roughly 2.6–2.8×**, driven by two `astro check` runs. The range is deliberate: two builds of the same design measured 21.10s and 19.47s, which is run-to-run variance, and a single figure would look more precise than the measurement is.

**This was chosen knowingly.** A lazy variant — probe first, run clean only to diagnose a failure — was measured at roughly 1.7×, and was rejected because it carries a narrow false-green path (a tool that echoes file contents and fails unrelatedly would read as proof) in the one file whose entire subject is guards claiming more than they check. The guarantee was preferred over the ~8.5s. Please don't re-propose the cheaper design without that context.

A **declaration** ("this package is checked by something else") was also rejected, on a category difference rather than on cost: the `TYPECHECK_EXCLUDES_TESTS` precedent *verifies its fact and dates only its magnitude* — `expect(missing.length).toBeGreaterThan(0)` re-establishes every run that the exclusion is real, and only the error count is prose. A declaration would *date its fact and check nothing*, and the event that would invalidate it is a weekly grouped Dependabot bump of `astro` / `@astrojs/check` that goes green precisely because nothing verifies it.

### One workflow change worth knowing

This couples `pnpm test` to a **built workspace** for any measured package — website's script runs `generate:gallery`, which imports built output. CI runs install → build → test and the documented green set builds first, so in practice it is always built; but `pnpm test` alone on a fresh clone now fails where it did not. The assertion says so explicitly and names `pnpm build` rather than reporting it as a coverage failure.

**CI wall clock, now measured — and it reframes the cost.** The `pnpm test` step on this PR ran **44s**, against **38s** on the immediate master baseline (`3112a61f`). But the eight most recent `ci-test` runs *without* this change span **33s–50s**, so the added time sits inside the runner's own variance rather than standing out from it.

So the honest reading is that this is a **local-loop cost, not a CI cost**: locally the suite is ~7.5s and the probe is proportionally enormous (~2.6–2.8×); on CI the step is already 33–50s from a cold runner and +6s disappears into the noise. Treat the 44s as **one measurement, not a distribution** — this branch has had a single `ci-test` run.

### A pre-existing suite flake, flagged against this change rather than found after it

`pnpm test` on this branch failed once with `[vitest-pool]: Worker forks emitted error. Caused by: Worker exited unexpectedly` — one test file lost, zero `FAIL` lines, exit 1. Two immediate re-runs were green (9344/9344).

**This flake predates this change and is not caused by it**: its first observation was on `ir-1082`, a Markdown-only branch containing no subprocess test at all. Whether this change makes it *more likely* is **unknown** — this PR does add a test that spawns `pnpm` twice — and two observations cannot answer that. A 20-vs-20 run comparison was considered and rejected as underpowered: at the observed base rate it would yield zero-or-one failure per arm, and every plausible outcome is consistent with no effect, doubling and halving alike. The question belongs to #1084, which is being worked separately; this note exists so it is not discovered after merge and mistaken for a regression.

One new fact went to that issue: the two occurrences lost **different** files (25 tests, then 42), each time exactly one file — so the crash is not tied to one particular import.

### The probe survived a real crash, not a simulated one

That failing run is the strongest evidence for the cleanup path: a worker died mid-suite and **no orphaned probe file was left behind** — `find` for the probe name returned nothing and `git status --porcelain` was clean. Keeping `git status` trustworthy is why the probe is an untracked new file rather than an edit to a tracked one, and that property has now held under an actual unexpected process death rather than a controlled one.

## Checklist

- [x] Linked to an approved issue
- [x] New code has unit tests — 7 cases pin `deriveTypecheckConfig`, including the two shapes that must *refuse* to derive
- [ ] Changes registered in all applicable plugins (Stream Deck, Mirabox) — N/A, repo tooling only
- [x] No unrelated changes included

https://claude.ai/code/session_01Ev9Q13RmMMjZdrWu8uktuC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved typecheck coverage validation for command-line options, positional inputs, and project configuration paths.
  * Added checks for custom configurations, chained commands, unsupported tools, cleanup, malformed values, timeouts, and diagnostic reporting.
  * Expanded execution safeguards with larger output capture and clearer failure diagnostics.
* **Chores**
  * Updated test configuration to preserve standard exclusions while excluding generated typecheck coverage files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

