### PR TITLE
fix(turbo): stop the website tasks serving stale output from cache (#1085)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -29,7 +29,8 @@
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/packages/icons/**",
         "$TURBO_ROOT$/packages/iracing-actions/icons/**",
-        "$TURBO_ROOT$/packages/iracing-actions/src/**"
+        "$TURBO_ROOT$/packages/iracing-actions/src/**",
+        "$TURBO_ROOT$/packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/manifest.json"
       ]
     },
     "@iracedeck/website#build": {
@@ -40,7 +41,8 @@
         "$TURBO_ROOT$/scripts/lib/changelog-*.mjs",
         "$TURBO_ROOT$/packages/icons/**",
         "$TURBO_ROOT$/packages/iracing-actions/icons/**",
-        "$TURBO_ROOT$/packages/iracing-actions/src/**"
+        "$TURBO_ROOT$/packages/iracing-actions/src/**",
+        "$TURBO_ROOT$/packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/manifest.json"
       ],
       "outputs": ["dist/**"]
     },

--- a/turbo.json
+++ b/turbo.json
@@ -35,7 +35,13 @@
     "@iracedeck/website#build": {
       "dependsOn": ["^build"],
       "env": ["PUBLIC_IRACEDECK_VERSION"],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/scripts/lib/changelog-*.mjs"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/scripts/lib/changelog-*.mjs",
+        "$TURBO_ROOT$/packages/icons/**",
+        "$TURBO_ROOT$/packages/iracing-actions/icons/**",
+        "$TURBO_ROOT$/packages/iracing-actions/src/**"
+      ],
       "outputs": ["dist/**"]
     },
     "dev": {


### PR DESCRIPTION
## Related Issue

Fixes #1085

## What changed?

`@iracedeck/website#build` declared `inputs` covering `$TURBO_DEFAULT$` and the changelog scripts, but its generators also read files in packages the website does not depend on. Those paths were not in the cache key, so **editing an icon and rebuilding replayed from cache, producing a site built from the previous icon set.**

Four paths are added to `#build`, and the same four to `#typecheck`.

**Why `#typecheck` is in this PR too.** #1077 fixed the identical hole in `#typecheck` (which had no `inputs` override at all, so the gate could report green having checked nothing) and this issue was filed off that discovery. But that fix listed three paths, and this PR was originally going to mirror it. **The list was incomplete, so mirroring it would have inherited the omission** — see the fourth path below. Both tasks run the same generator, so both were wrong in the same way, and splitting the fix would leave a known-wrong list on master.

## The fourth path, and how the list was established

The path list was derived **from the generators**, by enumerating every path each step of the website's build reads outside `packages/website` — not from the existing `inputs` array, which is what was incomplete.

`packages/website/scripts/generate-icon-gallery.mts` reads **four** roots, not three:

| Constant | Path | Previously in the key? |
|---|---|---|
| `ICONS_ROOT` | `packages/icons` | no (fixed by #1077 for `#typecheck`) |
| `ACTIONS_ROOT` | `packages/iracing-actions/src/actions` | no (same) |
| `DYNAMIC_ROOT` | `packages/iracing-actions/icons` | no (same) |
| **`MANIFEST_PATH`** | **`packages/iracing-plugin-stream-deck/com.iracedeck.sd.core.sdPlugin/manifest.json`** | **no — missed by #1077 as well** |

The generator parses that manifest to decide which actions exist. `iracing-plugin-stream-deck` is not a website dependency, so there is no `^build` edge, and editing the manifest changed neither task's hash.

The other two build steps were enumerated the same way and need nothing:

- **`generate:changelog-json`** imports only `scripts/lib/changelog-data.mjs`, which imports `changelog-inline-html.mjs` and `changelog-parse.mjs`. All three match the pre-existing `changelog-*.mjs` glob, which this PR **extends rather than replaces**. Its input file, `CHANGELOG_SOURCE_PATH`, is `packages/website/src/content/docs/changelog.mdx` — in-package, so `$TURBO_DEFAULT$` covers it.
- **`astro build`** reads website sources plus *declared* workspace dependencies, which turbo already hashes.

**`#typecheck` deliberately does not carry the `changelog-*.mjs` entry, and that asymmetry is correct rather than an oversight.** Its script is `pnpm generate:gallery && astro check` — it never runs `generate:changelog-json`, because that generator's only output is `public/changelog.json`, a statically served asset no source imports (removed from the typecheck script in #1077). A path that a task does not read does not belong in its key.

**One hazard checked before using the manifest as an input:** it sits inside `com.iracedeck.sd.*.sdPlugin/**`, which is the plugin build task's declared `outputs` glob — so if the build *wrote* it, this input would depend on another task's output. It does not. `rollup.config.mjs` only `addWatchFile`s it, there is no `writeFileSync`/`copyFileSync` targeting it, and a full plugin build leaves its git hash byte-identical. It is a tracked source file that happens to live in an output directory.

## How to test

**Prove cache-key membership by comparing turbo task hashes (`--dry=json`) with unique probe content — not by reading `cache hit` / `cache miss` from the log.**

That distinction is load-bearing and cost me three wrong measurements. Appending the *same* probe text twice produces a tree whose hash turbo has already cached, so the second run is a legitimate cache hit that says nothing about whether the path is in the key. Reading those log lines briefly produced the confident and false result "icons is not in the cache key", contradicting a result proved earlier the same day.

Measured by hash, with unique content per probe:

```
                                          #build      #typecheck
packages/icons/…                          CHANGED     CHANGED
packages/iracing-actions/icons/…          CHANGED     CHANGED
packages/iracing-actions/src/…            CHANGED     CHANGED
…sd.core.sdPlugin/manifest.json           CHANGED     CHANGED
scripts/lib/changelog-data.mjs            CHANGED     SAME  (correct — see above)
```

And the other direction: with the manifest line removed, editing the manifest leaves **both** hashes unchanged — the gap, confirmed rather than assumed.

Green set by hand: build 22/22, typecheck 41/41, format clean, lint clean, 327 files / 9333 tests.

`turbo.json` was edited as text rather than parsed and re-dumped, so the file's other inline arrays are untouched.

## Audited, and clean

The issue asked whether any other task reads across a package boundary without a dependency edge. **No — the website is the only one**, established by measurement rather than by reading the dependency graph.

The obvious suspect was the plugins, whose rollup configs reach into `../iracing-actions/src`. They **declare** that dependency, and turbo hashes workspace dependencies: editing `comms-catalog.ts` changes the stream-deck plugin's build hash, and so does editing an `@iracedeck/icons` file, which the plugin reaches only transitively.

That holds **even though `iracing-actions` has no build script at all** — so a declared dependency with no task still contributes to the hash. A missing task does not open this hole; reading a package you do not declare does.

## Declined, and filed separately

**Root `package.json` is not in either task's key**, verified by hash. `astro.config.mjs` falls back to reading it for `PUBLIC_IRACEDECK_VERSION` when that env var is unset *or empty*, and the value is baked into the downloads page.

Not fixed here, deliberately: it is a different class from this PR's defect — a root file reached through an env fallback, not an undeclared package path — and the right fix is plausibly `globalDependencies`, or making the release workflow always pass a version, rather than an `inputs` entry. Choosing between those inside a 7-line PR whose virtue is being narrow and measured would pick a design nobody has decided. It is being filed as its own issue.

It is also narrow in practice: the release workflow sets `PUBLIC_IRACEDECK_VERSION`, which *is* in the task's `env` and therefore in the key, so the normal release path is correct. The fallback runs only on a local deploy or a manual dispatch with no version input — and a normal release bumps `packages/website/package.json` in the same commit, invalidating the cache incidentally.

## Checklist

- [x] Linked to an approved issue
- [ ] New code has unit tests — n/a, no code: two `inputs` arrays in `turbo.json`. The claim is about cache-key membership, verified by task-hash comparison in both directions rather than by a test
- [ ] Changes registered in all applicable plugins (Stream Deck, Mirabox) — n/a, no plugin surface
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved website build and type-check reliability when icons, action sources, or the Stream Deck plugin manifest change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->