### PR TITLE
fix(changelog): stamp the 3.1.0 release date on master (#1098)

### DIFF
--- a/packages/iracing-actions/src/actions/data/changelog.json
+++ b/packages/iracing-actions/src/actions/data/changelog.json
@@ -19,7 +19,7 @@
     },
     {
       "version": "3.1.0",
-      "date": null,
+      "date": "2026-09-02",
       "categories": [
         {
           "title": "Features",

--- a/packages/website/src/content/docs/changelog.mdx
+++ b/packages/website/src/content/docs/changelog.mdx
@@ -19,7 +19,7 @@ _Unreleased_
 
 ## 3.1.0
 
-_Unreleased_
+_2026-09-02_
 
 **Features**
 


### PR DESCRIPTION
## Related Issue

Fixes #1098

## What changed?

3.1.0 was released and tagged (`v3.1.0`, `abeb0d36`) on `release/3.1`, where the `before:bump` release hook stamped the changelog date and regenerated the shipped notes. Master never received that stamp — the release commit is the only commit `release/3.1` has that master lacks, and it is otherwise entirely version strings master must keep at `3.2.0-dev.0` / `3.2.0.2064`.

This takes just the two date lines, matching the values the hook already produced:

- `packages/website/src/content/docs/changelog.mdx` — `_Unreleased_` → `_2026-09-02_` under `## 3.1.0`
- `packages/iracing-actions/src/actions/data/changelog.json` — the 3.1.0 entry's `"date": null` → `"date": "2026-09-02"`

Left alone, the 3.2.0 build would ship a What's New pane telling users that a version they already have is unreleased, and the website changelog would say the same.

**Both files carry a second unreleased marker**, for the in-development 3.2.0 section, which must stay `_Unreleased_` / `null`. The edits are anchored to the 3.1.0 sections precisely so that entry cannot be stamped by accident — a naive search-and-replace would have hit 3.2.0 first, since it sits above 3.1.0 in both files.

The two date values were verified against the tag `v3.1.0` rather than the `release/3.1` branch, which is being retired. Nothing else was taken from that branch. This adds no changelog entry of its own: it corrects an existing entry rather than shipping a user-facing change.

## How to test

Nothing is runnable here — this is data. What was verified instead:

- `pnpm generate:changelog-data` leaves `changelog.json` byte-identical after the edit, so the two files agree.
- All three plugin builds compile the stamped date into their What's New pane: `settings-window.html` in the Stream Deck, Mirabox and Ulanzi outputs each contain `2026-09-02` (the Ulanzi output is `com.ulanzi.iracedeck.ulanziPlugin`, not a `.sdPlugin` folder).
- The website builds and the `/changelog/` page renders the 3.1.0 section dated rather than unreleased.

Both verifying instruments were positive-controlled rather than merely run, since a passing check that cannot fail proves nothing:

- Corrupting the `changelog.json` date to `1999-01-01` and regenerating restored `2026-09-02`, proving the generator genuinely drives that field from the `.mdx`.
- The same corruption made `scripts/generate-changelog-data.test.mjs` fail with `changelog.json is out of date … Run pnpm generate:changelog-data`, proving the freshness test discriminates rather than passing for an unrelated reason.

Full green set, run by hand at base `522a69e0`: install; build 22/22; typecheck 41/41; format; lint; test **338 files / 9510 tests passed**. `scripts/lib/changelog-parse.test.mjs` parses the real changelog, so the date-line format is covered — it and the freshness test were also run targeted (24 tests) to confirm they actually execute rather than being assumed to.

Code review run at level **low** (a date correction to an existing entry plus its regenerated artifact — not a change to the changelog format or its parser, which would be xhigh): **no findings**.

## Checklist

- [x] Linked to an approved issue
- [ ] New code has unit tests — no new code; the existing parser and freshness tests cover both changed lines, and both were positive-controlled above
- [x] Changes registered in all applicable plugins (Stream Deck, Mirabox) — verified in all three, Ulanzi included
- [x] No unrelated changes included — exactly two lines; nothing else was brought across from `release/3.1`

https://claude.ai/code/session_01Ev9Q13RmMMjZdrWu8uktuC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the release date for version 3.1.0 to September 2, 2026.
  * Replaced the “Unreleased” status with the confirmed release date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->